### PR TITLE
Add LoRA adapter support with -a/--adapter parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ xcuserdata/
 test-curl-commands.md
 test-table.png
 test.pdf
+
+# LoRA adapter files for testing
+*.fmadapter
+test_lora.fmadapter

--- a/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
@@ -4,10 +4,12 @@ import Foundation
 struct ChatCompletionsController: RouteCollection {
     private let streamingEnabled: Bool
     private let instructions: String
+    private let adapter: String?
     
-    init(streamingEnabled: Bool = true, instructions: String = "You are a helpful assistant") {
+    init(streamingEnabled: Bool = true, instructions: String = "You are a helpful assistant", adapter: String? = nil) {
         self.streamingEnabled = streamingEnabled
         self.instructions = instructions
+        self.adapter = adapter
     }
     func boot(routes: RoutesBuilder) throws {
         let v1 = routes.grouped("v1")
@@ -34,7 +36,7 @@ struct ChatCompletionsController: RouteCollection {
             
             let foundationService: FoundationModelService
             if #available(macOS 26.0, *) {
-                foundationService = try await FoundationModelService(instructions: instructions)
+                foundationService = try await FoundationModelService(instructions: instructions, adapter: adapter)
             } else {
                 throw FoundationModelError.notAvailable
             }

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -12,12 +12,14 @@ class Server {
     private let verbose: Bool
     private let streamingEnabled: Bool
     private let instructions: String
+    private let adapter: String?
     
-    init(port: Int, verbose: Bool, streamingEnabled: Bool, instructions: String) async throws {
+    init(port: Int, verbose: Bool, streamingEnabled: Bool, instructions: String, adapter: String? = nil) async throws {
         self.port = port
         self.verbose = verbose
         self.streamingEnabled = streamingEnabled
         self.instructions = instructions
+        self.adapter = adapter
         
         // Create environment without command line arguments to prevent Vapor from parsing them
         var env = Environment(name: "development", arguments: ["afm"])
@@ -62,7 +64,7 @@ class Server {
             )
         }
         
-        let chatController = ChatCompletionsController(streamingEnabled: streamingEnabled, instructions: instructions)
+        let chatController = ChatCompletionsController(streamingEnabled: streamingEnabled, instructions: instructions, adapter: adapter)
         try app.register(collection: chatController)
     }
     


### PR DESCRIPTION
## Summary
• Add `-a`/`--adapter` CLI parameter to load .fmadapter files for LoRA fine-tuning
• Support for both server mode and single command mode
• Graceful fallback to default model when adapter loading fails
• Comprehensive validation and error handling for adapter files

## Implementation Details
• **FoundationModelService**: Core adapter loading using `SystemLanguageModel.Adapter(fileURL:)`
• **CLI Integration**: Added adapter parameter to main commands (excluding vision)
• **Error Handling**: File validation, extension checking, graceful fallbacks
• **Server Mode**: Adapter support throughout the request pipeline

## Test Plan
- [x] Single command mode with valid adapter
- [x] Single command mode with invalid/missing adapter (graceful fallback)
- [x] CLI help displays adapter option correctly
- [x] Build completes without errors
- [x] Vision command excludes adapter option (not supported by Apple Vision)

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add LoRA adapter support by introducing an -a/--adapter CLI option that is propagated through single-command and server modes, enabling .fmadapter loading in the model service with validation and graceful fallback.

New Features:
- Introduce -a/--adapter CLI option to specify .fmadapter files for LoRA fine-tuning
- Extend FoundationModelService to load and apply LoRA adapters using SystemLanguageModel.Adapter

Enhancements:
- Validate adapter file existence and extension before loading
- Fallback to the default language model on adapter load failures
- Propagate adapter parameter through Server, ChatCompletionsController, and single-prompt workflows