### PR TITLE
Optimize LoRA adapter loading to initialize once at startup

### DIFF
--- a/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
@@ -36,7 +36,7 @@ struct ChatCompletionsController: RouteCollection {
             
             let foundationService: FoundationModelService
             if #available(macOS 26.0, *) {
-                foundationService = try FoundationModelService.getShared()
+                foundationService = try await FoundationModelService.createWithSharedAdapter(instructions: instructions)
             } else {
                 throw FoundationModelError.notAvailable
             }

--- a/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
@@ -36,7 +36,7 @@ struct ChatCompletionsController: RouteCollection {
             
             let foundationService: FoundationModelService
             if #available(macOS 26.0, *) {
-                foundationService = try await FoundationModelService(instructions: instructions, adapter: adapter)
+                foundationService = try FoundationModelService.getShared()
             } else {
                 throw FoundationModelError.notAvailable
             }

--- a/Sources/MacLocalAPI/Models/FoundationModelService.swift
+++ b/Sources/MacLocalAPI/Models/FoundationModelService.swift
@@ -34,6 +34,10 @@ class FoundationModelService {
     // Shared singleton instance
     static var shared: FoundationModelService?
     
+    // Shared adapter for reuse across instances
+    static var sharedAdapter: SystemLanguageModel.Adapter?
+    static var sharedAdapterPath: String?
+    
     init(instructions: String = "You are a helpful assistant", adapter: String? = nil) async throws {
         #if canImport(FoundationModels)
         // Check if adapter path is provided
@@ -64,6 +68,12 @@ class FoundationModelService {
                 let adapter = try SystemLanguageModel.Adapter(fileURL: adapterURL)
                 let customModel = SystemLanguageModel(adapter: adapter)
                 
+                // Store adapter for reuse if this is the first time loading
+                if Self.sharedAdapter == nil {
+                    Self.sharedAdapter = adapter
+                    Self.sharedAdapterPath = adapterPath
+                }
+                
                 self.session = LanguageModelSession(model: customModel) {
                     instructions
                 }
@@ -81,6 +91,26 @@ class FoundationModelService {
             }
         } else {
             // No adapter specified, use default model
+            self.session = LanguageModelSession {
+                instructions
+            }
+        }
+        #else
+        throw FoundationModelError.notAvailable
+        #endif
+    }
+    
+    // Private initializer for creating instances with shared adapter
+    private init(instructions: String, useSharedAdapter: Bool) async throws {
+        #if canImport(FoundationModels)
+        if useSharedAdapter, let sharedAdapter = Self.sharedAdapter {
+            // Use the shared adapter
+            let customModel = SystemLanguageModel(adapter: sharedAdapter)
+            self.session = LanguageModelSession(model: customModel) {
+                instructions
+            }
+        } else {
+            // No shared adapter available, use default model
             self.session = LanguageModelSession {
                 instructions
             }
@@ -422,6 +452,11 @@ class FoundationModelService {
             throw FoundationModelError.sessionCreationFailed
         }
         return shared
+    }
+    
+    // Create a new instance that reuses the shared adapter (for per-request use)
+    static func createWithSharedAdapter(instructions: String = "You are a helpful assistant") async throws -> FoundationModelService {
+        return try await FoundationModelService(instructions: instructions, useSharedAdapter: true)
     }
 }
 

--- a/Sources/MacLocalAPI/Models/FoundationModelService.swift
+++ b/Sources/MacLocalAPI/Models/FoundationModelService.swift
@@ -31,6 +31,9 @@ class FoundationModelService {
     private var session: LanguageModelSession?
     #endif
     
+    // Shared singleton instance
+    static var shared: FoundationModelService?
+    
     init(instructions: String = "You are a helpful assistant", adapter: String? = nil) async throws {
         #if canImport(FoundationModels)
         // Check if adapter path is provided
@@ -406,6 +409,19 @@ class FoundationModelService {
         #else
         return false
         #endif
+    }
+    
+    // Initialize the shared instance once at server startup
+    static func initialize(instructions: String = "You are a helpful assistant", adapter: String? = nil) async throws {
+        shared = try await FoundationModelService(instructions: instructions, adapter: adapter)
+    }
+    
+    // Get the shared instance
+    static func getShared() throws -> FoundationModelService {
+        guard let shared = shared else {
+            throw FoundationModelError.sessionCreationFailed
+        }
+        return shared
     }
 }
 

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -71,6 +71,12 @@ class Server {
     func start() async throws {
         print("🚀 afm server starting on http://localhost:\(port)")
         print("📱 Using Apple Foundation Models (requires macOS 26+ with Apple Intelligence)")
+        
+        // Initialize the Foundation Model Service once at startup
+        if #available(macOS 26.0, *) {
+            try await FoundationModelService.initialize(instructions: instructions, adapter: adapter)
+        }
+        
         print("🔗 OpenAI API compatible endpoints:")
         print("   POST http://localhost:\(port)/v1/chat/completions")
         print("   GET  http://localhost:\(port)/v1/models")


### PR DESCRIPTION
## Summary
- Fix LoRA adapter loading performance issue where adapters were loaded on every API request
- **CRITICAL FIX**: Restore conversation continuity that was broken by singleton pattern
- Implement hybrid approach: LoRA efficiency + conversation continuity

## Problem Identified
The original LoRA optimization broke conversation continuity because:
- All requests shared the same persistent `LanguageModelSession`
- Client message history conflicted with session's internal transcript
- Follow-up messages in conversations stopped working

## Solution: Hybrid Approach
- **LoRA Efficiency**: Adapter loads once at startup, stored in `sharedAdapter`
- **Conversation Continuity**: Each request creates fresh `FoundationModelService` instance
- **Performance**: New instances reuse pre-loaded adapter without reload overhead

## Changes Made

### FoundationModelService
- Added `sharedAdapter` storage for loaded LoRA adapters
- Added `createWithSharedAdapter()` factory method for per-request instances  
- Added private initializer to reuse shared adapters
- Store loaded adapter during initialization for reuse

### ChatCompletionsController
- **FIXED**: Changed from `getShared()` to `createWithSharedAdapter()`
- Each API request now gets fresh instance with clean transcript
- Eliminates transcript conflicts that broke conversations

### Server
- Initialize FoundationModelService once during startup
- LoRA adapter loads once with single success message

## Test Plan
- [x] Build succeeds without errors
- [x] Server mode: LoRA adapter loads once at startup with single success message
- [x] **Conversation continuity restored**: Follow-up messages work properly
- [x] Single-prompt mode: Creates temporary instance, no infinite loops
- [x] Custom instructions (-i) properly passed through all code paths
- [x] Adapter loading (-a) works with custom instructions
- [x] No performance regression from per-request instances

## Before
- LoRA adapter loaded on every API request
- Multiple "Successfully loaded LoRA adapter" messages
- High GPU usage on each request
- **Conversation continuity broken** - follow-up messages failed

## After  
- LoRA adapter loads once during server startup
- Single success message at startup
- **Conversation continuity restored** - follow-up messages work
- Improved performance and resource usage
- Fresh session per request eliminates transcript conflicts

## Impact
This fix resolves both the performance issue (repeated LoRA loading) AND the critical conversation continuity regression, restoring full functionality while maintaining optimization benefits.

🤖 Generated with [Claude Code](https://claude.ai/code)