### PR TITLE
Fix CodeQL Swift build analysis failures

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,47 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '42 3 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: macos-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'swift' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Swift
+      uses: swift-actions/setup-swift@v1
+      with:
+        swift-version: "5.9"
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        queries: security-and-quality
+
+    - name: Manual Build
+      run: |
+        swift build --configuration release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary
- Adds CodeQL analysis workflow with manual Swift build steps
- Fixes GitHub Actions Swift build failures that were preventing security analysis
- Uses Swift 5.9 and manual build instead of autobuild to match project requirements

## Test plan
- [ ] Verify CodeQL analysis runs successfully on this PR
- [ ] Confirm Swift build completes without errors
- [ ] Check that security analysis results are generated

🤖 Generated with [Claude Code](https://claude.ai/code)