### PR TITLE
Add support for permissive guardrails

### DIFF
--- a/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
@@ -7,13 +7,15 @@ struct ChatCompletionsController: RouteCollection {
     private let adapter: String?
     private let temperature: Double?
     private let randomness: String?
+    private let permissiveGuardrails: Bool
     
-    init(streamingEnabled: Bool = true, instructions: String = "You are a helpful assistant", adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil) {
+    init(streamingEnabled: Bool = true, instructions: String = "You are a helpful assistant", adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil, permissiveGuardrails: Bool) {
         self.streamingEnabled = streamingEnabled
         self.instructions = instructions
         self.adapter = adapter
         self.temperature = temperature
         self.randomness = randomness
+        self.permissiveGuardrails = permissiveGuardrails
     }
     func boot(routes: RoutesBuilder) throws {
         let v1 = routes.grouped("v1")
@@ -40,7 +42,7 @@ struct ChatCompletionsController: RouteCollection {
             
             let foundationService: FoundationModelService
             if #available(macOS 26.0, *) {
-                foundationService = try await FoundationModelService.createWithSharedAdapter(instructions: instructions, temperature: temperature, randomness: randomness)
+                foundationService = try await FoundationModelService.createWithSharedAdapter(instructions: instructions, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails)
             } else {
                 throw FoundationModelError.notAvailable
             }

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -16,8 +16,9 @@ class Server {
     private let adapter: String?
     private let temperature: Double?
     private let randomness: String?
+    private let permissiveGuardrails: Bool
     
-    init(port: Int, hostname: String, verbose: Bool, streamingEnabled: Bool, instructions: String, adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil) async throws {
+    init(port: Int, hostname: String, verbose: Bool, streamingEnabled: Bool, instructions: String, adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil, permissiveGuardrails: Bool) async throws {
         self.port = port
         self.hostname = hostname
         self.verbose = verbose
@@ -26,6 +27,7 @@ class Server {
         self.adapter = adapter
         self.temperature = temperature
         self.randomness = randomness
+        self.permissiveGuardrails = permissiveGuardrails
         
         // Create environment without command line arguments to prevent Vapor from parsing them
         var env = Environment(name: "development", arguments: ["afm"])
@@ -70,7 +72,7 @@ class Server {
             )
         }
         
-        let chatController = ChatCompletionsController(streamingEnabled: streamingEnabled, instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness)
+        let chatController = ChatCompletionsController(streamingEnabled: streamingEnabled, instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails)
         try app.register(collection: chatController)
     }
     
@@ -80,7 +82,7 @@ class Server {
         
         // Initialize the Foundation Model Service once at startup
         if #available(macOS 26.0, *) {
-            try await FoundationModelService.initialize(instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness)
+            try await FoundationModelService.initialize(instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails)
         }
         
         print("🔗 OpenAI API compatible endpoints:")

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -43,6 +43,9 @@ struct ServeCommand: ParsableCommand {
 
     @Option(name: [.short, .long], help: "Sampling mode: 'greedy', 'random', 'random:top-p=<0.0-1.0>', 'random:top-k=<int>', with optional ':seed=<int>'")
     var randomness: String?
+    
+    @Flag(name: [.customShort("P"), .long], help: "Permissive guardrails for unsafe or inappropriate responses")
+    var permissiveGuardrails: Bool = false
 
     func run() throws {
         // Validate temperature parameter
@@ -77,7 +80,7 @@ struct ServeCommand: ParsableCommand {
         // Start server in async context
         _ = Task {
             do {
-                let server = try await Server(port: port, hostname: hostname, verbose: verbose, streamingEnabled: !noStreaming, instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness)
+                let server = try await Server(port: port, hostname: hostname, verbose: verbose, streamingEnabled: !noStreaming, instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails)
                 globalServer = server
                 try await server.start()
             } catch {
@@ -151,6 +154,9 @@ struct RootCommand: ParsableCommand {
 
     @Option(name: [.short, .long], help: "Sampling mode: 'greedy', 'random', 'random:top-p=<0.0-1.0>', 'random:top-k=<int>', with optional ':seed=<int>'")
     var randomness: String?
+    
+    @Flag(name: [.customShort("P"), .long], help: "Permissive guardrails for unsafe or inappropriate responses")
+    var permissiveGuardrails: Bool = false
 
     func run() throws {
         // Validate temperature parameter
@@ -263,7 +269,7 @@ extension RootCommand {
             do {
                 if #available(macOS 26.0, *) {
                     DebugLogger.log("macOS 26+ detected, initializing FoundationModelService...")
-                    let foundationService = try await FoundationModelService(instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness)
+                    let foundationService = try await FoundationModelService(instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails)
                     DebugLogger.log("FoundationModelService initialized successfully")
                     let message = Message(role: "user", content: prompt)
                     DebugLogger.log("Generating response...")


### PR DESCRIPTION
https://developer.apple.com/documentation/foundationmodels/improving-the-safety-of-generative-model-output

By default, the system model will throw `guardrailViolation` if it thinks the content is unsafe. The guardrails "aim to block harmful or sensitive content, such as self-harm, violence, and adult materials, from both model input and output."

But I want to use the model to inspect content to find out whether it's harmful or sensitive. Fortunately, Apple predicted this use case, and provided a way to set permissive guardrails.

This PR adds a `--permissive-guardrails` CLI parameter, which will set `.permissiveContentTransformations` on the `SystemLanguageModel` if set. If it's not set, we'll just use the default guardrails.

## Summary by Sourcery

Support an optional permissive guardrails mode to allow inspection of potentially harmful or sensitive content by configuring the SystemLanguageModel with permissive content transformations

New Features:
- Add --permissive-guardrails CLI flag to enable permissive guardrails mode

Enhancements:
- Propagate permissiveGuardrails parameter through Server, ChatCompletionsController, and FoundationModelService
- Configure SystemLanguageModel to use .permissiveContentTransformations when permissiveGuardrails is true