### PR TITLE
Add stop sequences support for response generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,29 +11,40 @@ This documentation covers:
 - Maximum response tokens configuration
 - Usage examples and best practices
 
-### Future Implementation Roadmap
+### Advanced Sampling Features
 
-The following advanced sampling parameters will be implemented in future versions:
+The following advanced sampling parameters are now available:
 
 #### Top-P Sampling (Nucleus Sampling)
 - [random(probabilityThreshold:seed:)](https://developer.apple.com/documentation/foundationmodels/generationoptions/samplingmode/random(probabilitythreshold:seed:))
 - Controls diversity by only considering tokens whose cumulative probability is below the threshold
-- Planned parameter: `--top-p <value>` (0.0-1.0 range)
+- Usage: `--randomness "random:top-p=0.9"` (0.0-1.0 range)
 - More dynamic than top-k as it adapts to the confidence distribution
 
 #### Top-K Sampling
 - [random(top:seed:)](https://developer.apple.com/documentation/foundationmodels/generationoptions/samplingmode/random(top:seed:))
 - Limits token selection to the K most likely tokens
-- Planned parameter: `--top-k <value>` (integer value)
+- Usage: `--randomness "random:top-k=50"` (integer value)
 - Provides consistent limitation regardless of probability distribution
 
-These will extend the current `--randomness` parameter to provide more granular control over the sampling behavior.
+#### Stop Sequences
+- Specify strings where the model should stop generating text
+- CLI Parameter: `--stop "###,END"` (comma-separated list of stop sequences)
+- API Parameter: `"stop": ["###", "END"]` (array of strings)
+- When any stop sequence is encountered, generation stops at that point
+- The stop sequence itself is excluded from the output
+- Multiple stop sequences can be specified
+- Works in both streaming and non-streaming modes
+
+These parameters provide granular control over the sampling behavior and output formatting.
 
 ### Implementation Notes
-- Temperature: Controls randomness/creativity in responses (0.0 = deterministic, 1.0 = highly creative)
-- Randomness: "greedy" for deterministic output, "random" for varied output
+- **Temperature**: Controls randomness/creativity in responses (0.0 = deterministic, 1.0 = highly creative)
+- **Randomness**: "greedy" for deterministic output, "random" for varied output, or advanced sampling modes
+- **Stop Sequences**: Truncate output at specified strings, useful for structured output formats
 - Apple defaults are used when parameters are not specified
 - All parameters are optional and validated at CLI parsing level
+- Stop sequences from CLI and API requests are merged, with duplicates removed
 
 ### Build Commands
 ```bash
@@ -75,13 +86,25 @@ Debug logging shows:
 # Test with temperature only
 ./afm -t 1.0 -s "test prompt"
 
-# Test with both parameters
+# Test with temperature and randomness
 ./afm -t 0.5 -r greedy -s "test prompt"
+
+# Test with top-p sampling
+./afm -r "random:top-p=0.9" -s "test prompt"
+
+# Test with top-k sampling
+./afm -r "random:top-k=50" -s "test prompt"
+
+# Test with stop sequences
+./afm --stop "###,END" -s "Write a story. ###"
+
+# Test with multiple parameters
+./afm -t 0.7 -r "random:top-p=0.95" --stop "---" -s "test prompt"
 
 # Test validation (should fail)
 ./afm -t 1.5 -s "test prompt"  # Temperature out of range
 ./afm -r invalid -s "test prompt"  # Invalid randomness value
 
 # Test with debug logging
-AFM_DEBUG=1 ./afm -t 1.0 -r greedy -s "test prompt"
+AFM_DEBUG=1 ./afm -t 1.0 -r greedy --stop "###" -s "test prompt"
 ```

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -17,8 +17,9 @@ class Server {
     private let temperature: Double?
     private let randomness: String?
     private let permissiveGuardrails: Bool
-    
-    init(port: Int, hostname: String, verbose: Bool, streamingEnabled: Bool, instructions: String, adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil, permissiveGuardrails: Bool = false) async throws {
+    private let stop: String?
+
+    init(port: Int, hostname: String, verbose: Bool, streamingEnabled: Bool, instructions: String, adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil, permissiveGuardrails: Bool = false, stop: String? = nil) async throws {
         self.port = port
         self.hostname = hostname
         self.verbose = verbose
@@ -28,7 +29,8 @@ class Server {
         self.temperature = temperature
         self.randomness = randomness
         self.permissiveGuardrails = permissiveGuardrails
-        
+        self.stop = stop
+
         // Create environment without command line arguments to prevent Vapor from parsing them
         var env = Environment(name: "development", arguments: ["afm"])
         try LoggingSystem.bootstrap(from: &env)
@@ -72,7 +74,7 @@ class Server {
             )
         }
         
-        let chatController = ChatCompletionsController(streamingEnabled: streamingEnabled, instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails)
+        let chatController = ChatCompletionsController(streamingEnabled: streamingEnabled, instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails, stop: stop)
         try app.register(collection: chatController)
     }
     


### PR DESCRIPTION
This commit implements stop sequences functionality, allowing users to specify strings where the model should stop generating text. This is a standard OpenAI API feature that enhances output control.

Features:
- CLI parameter: --stop "seq1,seq2" (comma-separated stop sequences)
- API parameter: "stop": ["seq1", "seq2"] (array of strings)
- Works in both streaming and non-streaming modes
- Stop sequences from CLI and API are merged with duplicates removed
- The stop sequence itself is excluded from the output
- Stops at the earliest occurrence when multiple sequences match

Implementation:
- Added --stop parameter to RootCommand and ServeCommand in main.swift
- Updated Server.swift to accept and pass stop parameter
- Updated ChatCompletionsController with mergeStopSequences helper
- Updated FoundationModelService with applyStopSequences method
- Enhanced CLAUDE.md documentation with examples and usage

Use cases:
- Structured output formatting (JSON, XML, etc.)
- Limiting response length at specific markers
- Multi-step generation with clear boundaries
- Code generation with stop markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement configurable stop sequences for response generation by extending CLI and API interfaces, merging inputs, and truncating outputs at specified markers.

New Features:
- Add support for stop sequences in both CLI (--stop) and API ("stop") parameters
- Merge and dedupe stop sequences from CLI and API inputs
- Truncate generated output at the earliest stop sequence and exclude the sequence itself
- Enable stop sequences in both streaming and non-streaming response modes

Documentation:
- Update documentation with stop sequence usage examples and parameter details