### PR TITLE
fix: vision subcommand calls async run() instead of sync default

### DIFF
--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -640,8 +640,22 @@ if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "mlx" {
 } else if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "vision" {
     let args = Array(CommandLine.arguments.dropFirst(2))
     do {
-        var cmd = try VisionCommand.parseAsRoot(args)
-        try cmd.run()
+        let cmd = try VisionCommand.parse(args)
+        let group = DispatchGroup()
+        var caughtError: Error?
+        group.enter()
+        Task {
+            do {
+                try await cmd.run()
+            } catch {
+                caughtError = error
+            }
+            group.leave()
+        }
+        group.wait()
+        if let error = caughtError {
+            throw error
+        }
     } catch {
         VisionCommand.exit(withError: error)
     }


### PR DESCRIPTION
## Problem

`afm vision -f image.png` prints help text and exits 0 instead of performing OCR.

## Root Cause

`VisionCommand.run()` is declared as `async throws`:

```swift
// VisionCommand.swift
func run() async throws {
    // actual OCR logic
}
```

But the manual dispatch in `main.swift` calls it synchronously:

```swift
var cmd = try VisionCommand.parseAsRoot(args)
try cmd.run()  // calls default sync ParsableCommand.run(), not the async override
```

Swift's `ParsableCommand` protocol provides a default `run()` that prints help. Since the call site is synchronous, Swift resolves to the default sync implementation instead of the `async` override — so the actual vision logic never executes.

## Fix

Wrap the async call in a `DispatchGroup`/`Task` pattern (matching the existing pattern used in `MlxCommand`'s single-prompt mode):

```swift
var cmd = try VisionCommand.parse(args)
let group = DispatchGroup()
var caughtError: Error?
group.enter()
Task {
    do {
        try await cmd.run()
    } catch {
        caughtError = error
    }
    group.leave()
}
group.wait()
if let error = caughtError {
    throw error
}
```

Also switched from `parseAsRoot()` to `parse()` to get a typed `VisionCommand` instance, ensuring Swift dispatches to the correct `run()` method.

## Testing

- **Before:** `afm vision -f image.png` → prints help, exit 0
- **After:** `afm vision -f image.png` → extracts text from image

Tested on macOS 26.0, Apple Silicon (M4 Max), afm v0.9.4.

## Summary by Sourcery

Bug Fixes:
- Ensure the vision subcommand correctly parses arguments into a VisionCommand instance and awaits its async run() implementation so OCR is performed rather than printing help and exiting successfully.