### PR TITLE
Fix XML tool call params serialized as strings instead of arrays/objects

### DIFF
--- a/Sources/MacLocalAPI/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/MLXChatCompletionsController.swift
@@ -480,7 +480,7 @@ struct MLXChatCompletionsController: RouteCollection {
                                             let funcName = incrementalToolIndex < collectedToolCalls.count ? collectedToolCalls[incrementalToolIndex].function.name : ""
                                             emitKey = self.remapSingleKey(rawKey, toolName: funcName, tools: chatRequest.tools)
                                         }
-                                        let jsonValue = Self.jsonEncodeString(value)
+                                        let jsonValue = Self.jsonEncodeValue(value)
                                         let fragment: String
                                         if incrementalParamCount == 0 {
                                             fragment = "{\"\(Self.jsonEscapeKey(emitKey))\":\(jsonValue)"
@@ -668,7 +668,7 @@ struct MLXChatCompletionsController: RouteCollection {
                                             emitKey = self.remapSingleKey(rawKey, toolName: funcName, tools: chatRequest.tools)
                                         }
 
-                                        let jsonValue = Self.jsonEncodeString(value)
+                                        let jsonValue = Self.jsonEncodeValue(value)
                                         let fragment: String
                                         if incrementalParamCount == 0 {
                                             fragment = "{\"\(Self.jsonEscapeKey(emitKey))\":\(jsonValue)"
@@ -1245,6 +1245,19 @@ struct MLXChatCompletionsController: RouteCollection {
             )
         }
         return ChoiceLogprobs(content: content)
+    }
+
+    /// JSON-encode a parameter value: if it parses as a JSON array or object,
+    /// return it as-is (structured); otherwise encode as a JSON string.
+    static func jsonEncodeValue(_ s: String) -> String {
+        if let data = s.data(using: .utf8),
+           let parsed = try? JSONSerialization.jsonObject(with: data),
+           (parsed is [Any] || parsed is [String: Any]),
+           let reencoded = try? JSONSerialization.data(withJSONObject: parsed),
+           let result = String(data: reencoded, encoding: .utf8) {
+            return result
+        }
+        return jsonEncodeString(s)
     }
 
     /// JSON-encode a string value with proper escaping, including surrounding quotes.

--- a/Sources/MacLocalAPI/Models/MLXModelService.swift
+++ b/Sources/MacLocalAPI/Models/MLXModelService.swift
@@ -1048,7 +1048,15 @@ final class MLXModelService: @unchecked Sendable {
             // duplicate parameters where the second is malformed/empty.
             // See: https://github.com/anomalyco/opencode/issues/6918
             if !val.isEmpty, arguments[key] == nil {
-                arguments[key] = val
+                // Try to parse as JSON (array/object) so it's preserved as
+                // structured data rather than flattened to a string.
+                if let data = val.data(using: .utf8),
+                   let parsed = try? JSONSerialization.jsonObject(with: data),
+                   (parsed is [Any] || parsed is [String: Any]) {
+                    arguments[key] = parsed
+                } else {
+                    arguments[key] = val
+                }
             }
         }
 
@@ -1072,7 +1080,13 @@ final class MLXModelService: @unchecked Sendable {
                     if val.hasSuffix("\n") { val = String(val.dropLast()) }
                 }
                 if !val.isEmpty {
-                    arguments[key] = val
+                    if let data = val.data(using: .utf8),
+                       let parsed = try? JSONSerialization.jsonObject(with: data),
+                       (parsed is [Any] || parsed is [String: Any]) {
+                        arguments[key] = parsed
+                    } else {
+                        arguments[key] = val
+                    }
                     if debugLogging {
                         print("[ToolCallParser] Salvaged unclosed parameter '\(key)' (\(val.count) chars)")
                     }


### PR DESCRIPTION
## Summary
- Fixes `parseXMLFunction` (non-streaming) and incremental XML parameter parser (streaming) to preserve JSON arrays/objects as structured data instead of flattening to strings
- Adds `jsonEncodeValue()` helper that detects structured JSON and passes it through, falling back to `jsonEncodeString()` for plain strings
- Only affects `xmlFunction` tool call format (Qwen3-Coder-Next, etc.) — other formats already use JSON-native parsing

Closes #36

## Test plan
- [x] Non-streaming `curl` test: `todos` parameter returned as JSON array (not string)
- [x] Streaming `curl` test: assembled SSE chunks produce valid JSON array
- [x] End-to-end: OpenCode + Qwen3-Coder-Next-4bit `todowrite` tool works without `invalid_type` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve structured JSON parameters when parsing and emitting XML-based tool calls so that arrays and objects are not flattened into strings.

Bug Fixes:
- Ensure XML tool call arguments parsed from non-streaming responses keep JSON arrays/objects as structured values instead of plain strings.
- Ensure salvaged/incremental XML tool call parameters in streaming responses preserve JSON arrays/objects.
- Correct JSON encoding of XML tool parameters to emit arrays/objects as native JSON when possible rather than always encoding as strings.