### PR TITLE
Fix: Resolve SmallVector crash on sequential MLX requests

### DIFF
--- a/Scripts/build-from-scratch.sh
+++ b/Scripts/build-from-scratch.sh
@@ -154,14 +154,20 @@ if [ -f "$BUILDINFO" ]; then
 fi
 
 log_step "Building afm ($BUILD_CONFIG)"
+# Disable MemberImportVisibility — async-kit (transitive from Vapor) is missing
+# explicit imports for DequeModule/OrderedCollections, which Swift 6 enforces.
 if [ "$BUILD_CONFIG" = "release" ]; then
   swift build -c release \
     --product afm \
     -Xswiftc -O \
     -Xswiftc -whole-module-optimization \
-    -Xswiftc -cross-module-optimization
+    -Xswiftc -cross-module-optimization \
+    -Xswiftc -disable-upcoming-feature \
+    -Xswiftc MemberImportVisibility
 else
-  swift build -c "$BUILD_CONFIG"
+  swift build -c "$BUILD_CONFIG" \
+    -Xswiftc -disable-upcoming-feature \
+    -Xswiftc MemberImportVisibility
 fi
 
 BIN_PATH_1="$ROOT_DIR/.build/arm64-apple-macosx/$BUILD_CONFIG/afm"

--- a/Scripts/patches/Evaluate.swift
+++ b/Scripts/patches/Evaluate.swift
@@ -479,7 +479,8 @@ public struct TokenIterator: Sequence, IteratorProtocol {
     let model: any LanguageModel
     var state: LMOutput.State?
 
-    var y: LMInput.Text
+    // Optional so teardown() can drop the final token array explicitly.
+    var y: LMInput.Text?
     var cache: [KVCache]
     var processor: LogitProcessor?
     let sampler: LogitSampler
@@ -530,7 +531,8 @@ public struct TokenIterator: Sequence, IteratorProtocol {
         parameters: GenerateParameters
     ) throws {
         self.model = model
-        self.y = .init(tokens: prompt)
+        let promptText = LMInput.Text(tokens: prompt)
+        self.y = promptText
         self.cache = cache ?? model.newCache(parameters: parameters)
 
         self.processor = parameters.processor()
@@ -547,7 +549,7 @@ public struct TokenIterator: Sequence, IteratorProtocol {
         self.temperatureForLogprobs = parameters.temperature
 
         self.promptPrefillTime = try measure {
-            try prepare(input: .init(text: y), windowSize: parameters.prefillStepSize)
+            try prepare(input: .init(text: promptText), windowSize: parameters.prefillStepSize)
         }
     }
 
@@ -635,13 +637,15 @@ public struct TokenIterator: Sequence, IteratorProtocol {
             y = tokens
 
             // evaluate the remainder of the prompt -- this primes the pump
-            let token = step(previous: y)
+            let token = step(previous: tokens)
             y = .init(tokens: token)
-            asyncEval(y.tokens)
+            asyncEval(token)
 
         case .logits(let result):
             y = .init(tokens: convertToToken(logits: result.logits))
-            asyncEval(y.tokens)
+            if let y {
+                asyncEval(y.tokens)
+            }
 
             break
         }
@@ -738,14 +742,15 @@ public struct TokenIterator: Sequence, IteratorProtocol {
             return nil
         }
 
+        guard let previousY = y else {
+            return nil
+        }
+
         let tStart: UInt64 = Self.perfEnabled ? DispatchTime.now().uptimeNanoseconds : 0
 
         // Promote pending logprob info: the logprob computed during the PREVIOUS
         // step() corresponds to the token we are about to return (previousY).
         lastLogprobInfo = pendingLogprobInfo
-
-        // save current value -- this will be returned
-        let previousY = y
 
         // compute the next state and async eval the next token
         let token = step(previous: previousY)
@@ -813,6 +818,17 @@ public struct TokenIterator: Sequence, IteratorProtocol {
         [PERF]   overhead      : \(String(format: "%8.1f", overheadMs))ms  \(pct(overheadMs))  (\(String(format: "%.3f", overheadMs / Double(perfTokenCount)))ms/tok)
         [PERF]   GPU sync probe@100: \(String(format: "%.3f", toMs(perfGpuSyncNs)))ms (0=async working, >0=GPU was still busy)
         """)
+    }
+
+    /// Explicitly release iterator-held generation state so ARC can drop
+    /// MLX-backed arrays before the final stream synchronization.
+    public mutating func teardown() {
+        cache = []
+        state = nil
+        y = nil
+        processor = nil
+        pendingLogprobInfo = nil
+        lastLogprobInfo = nil
     }
 }
 
@@ -1314,6 +1330,11 @@ public func generateTask(
             print("[PERF] Loop overhead: detokenize+yield=\(String(format: "%.1f", detokMs))ms (\(String(format: "%.2f", detokMs / Double(iterator.perfTokenCount)))ms/tok)")
         }
         iterator.printPerfSummary()
+
+        // Explicitly release iterator-held GPU arrays (cache, last token, state)
+        // before synchronizing. This ensures no stale references survive into
+        // the next request's generation pass.
+        iterator.teardown()
 
         let now = Date.timeIntervalSinceReferenceDate
         let generateTime = now - start

--- a/Sources/MacLocalAPI/Models/MLXModelService.swift
+++ b/Sources/MacLocalAPI/Models/MLXModelService.swift
@@ -89,6 +89,7 @@ private final class PromptCacheBox: @unchecked Sendable {
 }
 
 private let debugLogging = ProcessInfo.processInfo.environment["AFM_DEBUG"].map { $0 == "1" } ?? false
+private let clearGPUCachePerRequest = ProcessInfo.processInfo.environment["AFM_CLEAR_GPU_CACHE"].map { $0 == "1" } ?? false
 
 final class MLXModelService: @unchecked Sendable {
     private let resolver: MLXCacheResolver
@@ -381,48 +382,60 @@ final class MLXModelService: @unchecked Sendable {
             var visibleContentStart: String.Index? = nil  // Index where content after </think> begins
             let genStart = Date()
             var firstTokenTime: Date?
-            for await piece in try MLXLMCommon.generate(input: generateInput, cache: generationCache, parameters: params, context: context) {
-                if debugLogging {
-                    print("[DEBUG] Generation piece: \(piece)")
-                }
-                if case .chunk(let text) = piece {
-                    if firstTokenTime == nil { firstTokenTime = Date() }
-                    // Track <think> boundaries — stop sequences only apply outside
-                    if text.contains("<think>") { insideThink = true }
-                    if text.contains("</think>") { insideThink = false }
-                    out += text
-                    // Record where visible content starts (after </think>)
-                    if !insideThink && visibleContentStart == nil {
-                        if let thinkEnd = out.range(of: "</think>") {
-                            visibleContentStart = thinkEnd.upperBound
-                        } else {
-                            visibleContentStart = out.startIndex
-                        }
-                    }
-                    // Only check stop sequences against visible content (after </think>)
-                    if !activeStops.isEmpty && !insideThink, let vcStart = visibleContentStart {
-                        let visibleContent = String(out[vcStart...])
-                        if let match = activeStops.first(where: { visibleContent.contains($0) }) {
-                            if let range = visibleContent.range(of: match) {
-                                let keepEnd = out.index(vcStart, offsetBy: visibleContent.distance(from: visibleContent.startIndex, to: range.lowerBound))
-                                out = String(out[..<keepEnd])
-                            }
-                            break
-                        }
-                    }
-                } else if case .tokenLogprobs(let lps) = piece {
-                    collectedLogprobs.append(contentsOf: lps)
-                } else if case .toolCall(let tc) = piece {
+            do {
+                for await piece in try MLXLMCommon.generate(input: generateInput, cache: generationCache, parameters: params, context: context) {
                     if debugLogging {
-                        print("[DEBUG] Tool call detected: \(tc.function.name)(\(tc.function.arguments))")
+                        print("[DEBUG] Generation piece: \(piece)")
                     }
-                    collectedToolCalls.append(tc)
-                } else if case .info(let info) = piece {
-                    completionInfo = info
+                    if case .chunk(let text) = piece {
+                        if firstTokenTime == nil { firstTokenTime = Date() }
+                        // Track <think> boundaries — stop sequences only apply outside
+                        if text.contains("<think>") { insideThink = true }
+                        if text.contains("</think>") { insideThink = false }
+                        out += text
+                        // Record where visible content starts (after </think>)
+                        if !insideThink && visibleContentStart == nil {
+                            if let thinkEnd = out.range(of: "</think>") {
+                                visibleContentStart = thinkEnd.upperBound
+                            } else {
+                                visibleContentStart = out.startIndex
+                            }
+                        }
+                        // Only check stop sequences against visible content (after </think>)
+                        if !activeStops.isEmpty && !insideThink, let vcStart = visibleContentStart {
+                            let visibleContent = String(out[vcStart...])
+                            if let match = activeStops.first(where: { visibleContent.contains($0) }) {
+                                if let range = visibleContent.range(of: match) {
+                                    let keepEnd = out.index(vcStart, offsetBy: visibleContent.distance(from: visibleContent.startIndex, to: range.lowerBound))
+                                    out = String(out[..<keepEnd])
+                                }
+                                break
+                            }
+                        }
+                    } else if case .tokenLogprobs(let lps) = piece {
+                        collectedLogprobs.append(contentsOf: lps)
+                    } else if case .toolCall(let tc) = piece {
+                        if debugLogging {
+                            print("[DEBUG] Tool call detected: \(tc.function.name)(\(tc.function.arguments))")
+                        }
+                        collectedToolCalls.append(tc)
+                    } else if case .info(let info) = piece {
+                        completionInfo = info
+                    }
                 }
+            } catch {
+                // On generation error, invalidate prompt cache inside the
+                // serialized block so no stale state leaks to the next request.
+                promptCache.invalidate()
+                throw error
             }
 
             Stream.gpu.synchronize()
+            // Optional per-request GPU memory cleanup (gated to avoid throughput hit).
+            // Enable with AFM_CLEAR_GPU_CACHE=1 if you see memory-related crashes.
+            if clearGPUCachePerRequest {
+                Memory.clearCache()
+            }
             if debugLogging {
                 let ttft = firstTokenTime.map { $0.timeIntervalSince(genStart) } ?? 0
                 let total = Date().timeIntervalSince(genStart)
@@ -505,7 +518,15 @@ final class MLXModelService: @unchecked Sendable {
         chatTemplateKwargs: [String: AnyCodable]? = nil
     ) async throws -> (modelID: String, stream: AsyncThrowingStream<StreamChunk, Error>, promptTokens: Int, toolCallStartTag: String?, toolCallEndTag: String?) {
         try beginOperation()
-        defer { endOperation() }
+        var endOperationOnExit = true
+        defer {
+            if endOperationOnExit {
+                endOperation()
+            }
+        }
+        // Streaming keeps the operation open until the background Task finishes.
+        // The fallback defer above only handles setup failures before the Task
+        // is created; the Task itself owns the normal endOperation() call.
 
         let modelID = try await ensureLoaded(model: model, countOperation: false)
         guard let container = withStateLock({ currentContainer }) else { throw MLXServiceError.noModelLoaded }
@@ -536,6 +557,7 @@ final class MLXModelService: @unchecked Sendable {
         let promptCache = self.promptCache
         let stream = AsyncThrowingStream<StreamChunk, Error> { continuation in
             let task = Task {
+                defer { self.endOperation() }
                 do {
                     try await container.perform { context in
                         let input = try await context.processor.prepare(input: userInput)
@@ -618,68 +640,75 @@ final class MLXModelService: @unchecked Sendable {
                         var firstTokenTime: Date?
 
                         var pendingLogprobs: [TokenLogprobData]? = nil
-                        for await piece in try MLXLMCommon.generate(input: generateInput, cache: generationCache, parameters: params, context: context) {
-                            if Task.isCancelled {
-                                print("[MLX] Generation cancelled by client")
-                                break
-                            }
-                            if case .tokenLogprobs(let lps) = piece {
-                                pendingLogprobs = lps
-                            } else if case .chunk(let text) = piece {
-                                if firstTokenTime == nil { firstTokenTime = Date() }
-                                let resolved: [ResolvedLogprob]?
-                                if let lps = pendingLogprobs {
-                                    resolved = self.resolveLogprobs(lps, tokenizer: context.tokenizer)
-                                } else {
-                                    resolved = nil
+                        do {
+                            for await piece in try MLXLMCommon.generate(input: generateInput, cache: generationCache, parameters: params, context: context) {
+                                if Task.isCancelled {
+                                    print("[MLX] Generation cancelled by client")
+                                    break
                                 }
+                                if case .tokenLogprobs(let lps) = piece {
+                                    pendingLogprobs = lps
+                                } else if case .chunk(let text) = piece {
+                                    if firstTokenTime == nil { firstTokenTime = Date() }
+                                    let resolved: [ResolvedLogprob]?
+                                    if let lps = pendingLogprobs {
+                                        resolved = self.resolveLogprobs(lps, tokenizer: context.tokenizer)
+                                    } else {
+                                        resolved = nil
+                                    }
 
-                                // Track <think> boundaries for stop sequence scoping
-                                let wasInsideThink = insideThink
-                                if text.contains("<think>") { insideThink = true }
-                                if text.contains("</think>") { insideThink = false }
+                                    // Track <think> boundaries for stop sequence scoping
+                                    let wasInsideThink = insideThink
+                                    if text.contains("<think>") { insideThink = true }
+                                    if text.contains("</think>") { insideThink = false }
 
-                                if !activeStops.isEmpty && !insideThink {
-                                    // If we just transitioned out of think, only buffer text after </think>
-                                    if wasInsideThink, let thinkEndRange = text.range(of: "</think>") {
-                                        let afterThink = String(text[thinkEndRange.upperBound...])
-                                        if !afterThink.isEmpty {
-                                            stopBuffer += afterThink
+                                    if !activeStops.isEmpty && !insideThink {
+                                        // If we just transitioned out of think, only buffer text after </think>
+                                        if wasInsideThink, let thinkEndRange = text.range(of: "</think>") {
+                                            let afterThink = String(text[thinkEndRange.upperBound...])
+                                            if !afterThink.isEmpty {
+                                                stopBuffer += afterThink
+                                            }
+                                        } else {
+                                            stopBuffer += text
+                                        }
+                                        // Check for a complete stop string match
+                                        if let match = activeStops.first(where: { stopBuffer.contains($0) }) {
+                                            // Emit text up to the stop string
+                                            if let range = stopBuffer.range(of: match) {
+                                                let before = String(stopBuffer[..<range.lowerBound])
+                                                if !before.isEmpty {
+                                                    continuation.yield(StreamChunk(text: before, logprobs: resolved))
+                                                }
+                                            }
+                                            break
+                                        }
+                                        // Flush safe portion of the buffer (keep tail that could be partial stop match)
+                                        if stopBuffer.count > maxStopLen {
+                                            let flushEnd = stopBuffer.index(stopBuffer.endIndex, offsetBy: -maxStopLen)
+                                            let flushText = String(stopBuffer[..<flushEnd])
+                                            stopBuffer = String(stopBuffer[flushEnd...])
+                                            continuation.yield(StreamChunk(text: flushText, logprobs: resolved))
                                         }
                                     } else {
-                                        stopBuffer += text
+                                        // Inside <think> or no stop sequences — pass through
+                                        continuation.yield(StreamChunk(text: text, logprobs: resolved))
                                     }
-                                    // Check for a complete stop string match
-                                    if let match = activeStops.first(where: { stopBuffer.contains($0) }) {
-                                        // Emit text up to the stop string
-                                        if let range = stopBuffer.range(of: match) {
-                                            let before = String(stopBuffer[..<range.lowerBound])
-                                            if !before.isEmpty {
-                                                continuation.yield(StreamChunk(text: before, logprobs: resolved))
-                                            }
-                                        }
-                                        break
-                                    }
-                                    // Flush safe portion of the buffer (keep tail that could be partial stop match)
-                                    if stopBuffer.count > maxStopLen {
-                                        let flushEnd = stopBuffer.index(stopBuffer.endIndex, offsetBy: -maxStopLen)
-                                        let flushText = String(stopBuffer[..<flushEnd])
-                                        stopBuffer = String(stopBuffer[flushEnd...])
-                                        continuation.yield(StreamChunk(text: flushText, logprobs: resolved))
-                                    }
-                                } else {
-                                    // Inside <think> or no stop sequences — pass through
-                                    continuation.yield(StreamChunk(text: text, logprobs: resolved))
+                                    pendingLogprobs = nil
+                                } else if case .toolCall(let tc) = piece {
+                                    // Emit tool call as a stream chunk with empty text
+                                    let responseTC = Self.convertToolCall(tc, index: 0)
+                                    continuation.yield(StreamChunk(text: "", toolCalls: [responseTC]))
+                                } else if case .info(let info) = piece {
+                                    // Emit real token counts and timing as a final info chunk
+                                    continuation.yield(StreamChunk(text: "", promptTokens: info.promptTokenCount, completionTokens: info.generationTokenCount, promptTime: info.promptTime, generateTime: info.generateTime))
                                 }
-                                pendingLogprobs = nil
-                            } else if case .toolCall(let tc) = piece {
-                                // Emit tool call as a stream chunk with empty text
-                                let responseTC = Self.convertToolCall(tc, index: 0)
-                                continuation.yield(StreamChunk(text: "", toolCalls: [responseTC]))
-                            } else if case .info(let info) = piece {
-                                // Emit real token counts and timing as a final info chunk
-                                continuation.yield(StreamChunk(text: "", promptTokens: info.promptTokenCount, completionTokens: info.generationTokenCount, promptTime: info.promptTime, generateTime: info.generateTime))
                             }
+                        } catch {
+                            // On generation error, invalidate prompt cache inside the
+                            // serialized block so no stale state leaks to the next request.
+                            promptCache.invalidate()
+                            throw error
                         }
                         // Flush any remaining buffered text (no stop match found)
                         if !activeStops.isEmpty && !stopBuffer.isEmpty {
@@ -687,6 +716,14 @@ final class MLXModelService: @unchecked Sendable {
                         }
                         // Synchronize GPU after generation completes (or breaks early).
                         Stream.gpu.synchronize()
+                        // Optional per-request GPU memory cleanup (gated to avoid throughput hit).
+                        if clearGPUCachePerRequest {
+                            Memory.clearCache()
+                        }
+                        // Invalidate prompt cache on cancellation to prevent stale state
+                        if Task.isCancelled {
+                            promptCache.invalidate()
+                        }
                         if debugLogging {
                             let ttft = firstTokenTime.map { $0.timeIntervalSince(genStart) } ?? 0
                             let total = Date().timeIntervalSince(genStart)
@@ -697,10 +734,11 @@ final class MLXModelService: @unchecked Sendable {
                         if useCache && !inputTokens.isEmpty && !Task.isCancelled {
                             self.savePromptCacheState(cache: generationCache, promptTokens: inputTokens, modelID: modelID)
                         }
-                    }
+                    } // container.perform
                     self.cleanupTempFiles(mediaTempFiles)
                     continuation.finish()
                 } catch {
+                    self.promptCache.invalidate()
                     self.cleanupTempFiles(mediaTempFiles)
                     continuation.finish(throwing: error)
                 }
@@ -730,6 +768,7 @@ final class MLXModelService: @unchecked Sendable {
             toolTags = nil
         }
 
+        endOperationOnExit = false
         return (modelID, stream, promptTokens, toolTags?.start, toolTags?.end)
     }
 


### PR DESCRIPTION
This commit includes vendor patch updates to Evaluate.swift for explicit iterator teardown, serialization lifecycle fixes in MLXModelService.swift, and build fixes for Swift 6 MemberImportVisibility. Closes Issue #41.

### Summary
Fix `SmallVector out of range` (`array.cpp:306`) crashes that reliably occurred on the second sequential generation request. 

This crash was caused by MLX's lazy evaluation strategy combined with Swift's ARC keeping stale GPU array references (`cache`, `state`, `y`) alive across generation boundaries. As the second request began evaluating new graphs, the lingering references from the first request caused memory corruption in the C++ backend. 

Additionally, this PR fixes an operation accounting leak in the streaming path, safely gates the optional GPU cache clearing mitigation, and resolves an `async-kit` dependency build failure on macOS 26 / Swift 6.

### What changed

**Vendor Patch: [Evaluate.swift]**
*   **Explicit State Teardown**: Added a `teardown()` method to `TokenIterator` to explicitly traverse and `nil` out all internal state holding MLX-backed arrays (`y`, `cache`, `state`, `processor`, `pendingLogprobInfo`, `lastLogprobInfo`).
*   **Safe Iterator Access**: `TokenIterator.y` is now `Optional`, and `next()` uses a `guard let` to safely unwrap it or return `nil` if teardown has already executed.
*   **Forced Lifetime Enforcement**: `generateTask()` now explicitly calls `iterator.teardown()` *before* the final `Stream().synchronize()`. This guarantees all GPU arrays are fully realized and released on the vendor side before the request finishes and ARC takes over.

**Service Layer: [MLXModelService.swift]**
*   **Thread-Safe GPU Clearing**: The global cache clear (gated by `AFM_CLEAR_GPU_CACHE=1`) is safely moved *inside* the execution serialization boundary. This ensures it happens synchronously inside the actor lock and doesn't mutate global allocator state while another request is building its graph.
*   **Balanced Operation Accounting**: Fixed the active operation count leaking during streaming requests. Replaced a single `defer` with a dual-defer pattern: 
    * A fallback method-level defer that fires if setup throws before the background task is created.
    * A Task-level defer that assumes ownership of the stream lifetime and fires when the stream concludes naturally, errors out, or is cancelled.
*   **Safe Cache Manipulation**: Error handling, cancellation checks, and prompt cache generation state saving are now strictly enclosed within the serialization boundary.

**Build fixes**
*   **Swift 6 Compatibility**: Added compiler flags (`-disable-upcoming-feature MemberImportVisibility`) to suppress strict concurrency compiler errors stemming from the transitive Vapor dependency `async-kit`.

### Test plan
* [x] Run a clean build to ensure the `async-kit` error is bypassed and all vendor patches apply successfully.
* [x] Start the server using the `afm mlx` command with a model like Qwen3.5-35B-A3B-4bit.
* [x] Send a standard (non-streaming) completion request.
* [x] Send a *second* sequential standard request or multiple in quick succession — **Verify** the server no longer hangs or throws `Fatal error: SmallVector out of range`.
* [x] Test a mix of streaming and non-streaming requests sequentially to verify that the active operation count stays balanced, no memory corruption occurs, and the server shuts down gracefully on termination.
* [x] Start server with `AFM_CLEAR_GPU_CACHE=1` and verify the explicit memory flush path runs safely without intercepting active evaluations.

🤖 Generated with Google Antigravity. Fixes implemented by Claude Opus 4.6 and GPT-5.4 xhigh. 

## Summary by Sourcery

Fix MLX generation crashes and leaks between sequential requests, improve prompt cache and GPU memory handling, and add Swift 6 build compatibility flags.

Bug Fixes:
- Prevent stale MLX GPU generation state from leaking across requests by explicitly tearing down iterator state and guarding iterator access.
- Avoid leaking active operation counts during streaming responses by ensuring endOperation() is balanced between setup failures and background tasks.
- Ensure prompt cache is invalidated on generation errors or cancellations so corrupted state is not reused on subsequent requests.

Enhancements:
- Add an optional per-request GPU cache clearing path gated by an AFM_CLEAR_GPU_CACHE environment flag.
- Improve generation streaming control flow to better scope stop-sequence handling and cancellation within the serialized container context.

Build:
- Add Swift compiler flags to disable the upcoming MemberImportVisibility feature so builds succeed with async-kit under Swift 6.