### PR TITLE
Fix VLM prefix cache crash on sequential requests

### DIFF
--- a/Scripts/patches/Qwen3_5MoEVL.swift
+++ b/Scripts/patches/Qwen3_5MoEVL.swift
@@ -1055,8 +1055,17 @@ private class Qwen3_5VLTextModel: Module, KVCacheDimensionProvider {
 
         var positionIds = providedPositionIds
 
+        // Use full-attention layer offset for position tracking.
+        // MambaCache layers always have offset=0 (they're recurrent, not positional),
+        // so cache.first/last.offset is unreliable in hybrid Mamba+Attention models.
+        let faIdx = args.fullAttentionInterval - 1
+        let cacheOffset: Int = {
+            guard let cache, faIdx < cache.count else { return 0 }
+            return cache[faIdx].offset
+        }()
+
         if positionIds == nil && (mask == nil || mask?.ndim == 2) {
-            if (cache?.first?.offset ?? 0) == 0 || ropeDeltas == nil || cache == nil {
+            if cacheOffset == 0 || ropeDeltas == nil || cache == nil {
                 if let inputIds {
                     let (computed, deltas) = Qwen3VLLanguage.getRopeIndex(
                         inputIds: inputIds,
@@ -1073,11 +1082,10 @@ private class Qwen3_5VLTextModel: Module, KVCacheDimensionProvider {
                 } else if let cache, ropeDeltas == nil {
                     let batch = inputEmbeddings!.dim(0)
                     let seqLength = inputEmbeddings!.dim(1)
-                    let currentOffset = cache.first?.offset ?? 0
 
                     var base = MLXArray(0 ..< seqLength).asType(.int32)
                     base = tiled(base[.newAxis, 0...], repetitions: [batch, 1])
-                    let offsetValue = MLXArray(currentOffset).asType(.int32)
+                    let offsetValue = MLXArray(cacheOffset).asType(.int32)
                     base = base + offsetValue
 
                     positionIds = base[.newAxis, 0..., 0...]
@@ -1087,9 +1095,7 @@ private class Qwen3_5VLTextModel: Module, KVCacheDimensionProvider {
                 let batch = (inputIds ?? inputEmbeddings!).dim(0)
                 let seqLength = (inputIds ?? inputEmbeddings!).dim(1)
 
-                let lastCacheOffset = cache.last?.offset ?? 0
-
-                var delta = MLXArray(lastCacheOffset).asType(.int32) + ropeDeltas.asType(.int32)
+                var delta = MLXArray(cacheOffset).asType(.int32) + ropeDeltas.asType(.int32)
 
                 var base = MLXArray(0 ..< seqLength).asType(.int32)
                 base = base[.newAxis, 0...]

--- a/Sources/MacLocalAPI/Models/MLXModelService.swift
+++ b/Sources/MacLocalAPI/Models/MLXModelService.swift
@@ -345,9 +345,10 @@ final class MLXModelService: @unchecked Sendable {
                         // Reuse cached KV cache, trimmed to prefix length
                         generationCache = promptCache.cache
                         self.trimCacheToLength(generationCache, keepTokens: prefixLen)
-                        // Build suffix-only input
+                        // Build suffix-only input — reshape to [1, N] to preserve batch dim
+                        // (VLM models expect 2D token arrays from the tokenizer)
                         let suffixTokens = Array(inputTokens[prefixLen...])
-                        generateInput = LMInput(text: .init(tokens: MLXArray(suffixTokens)))
+                        generateInput = LMInput(text: .init(tokens: MLXArray(suffixTokens).reshaped(1, suffixTokens.count)))
                         cachedTokenCount = prefixLen
                         if debugLogging {
                             print("[KVCache] Prefix match: \(prefixLen)/\(inputTokens.count) tokens cached, processing \(suffixTokens.count) suffix tokens")
@@ -598,7 +599,7 @@ final class MLXModelService: @unchecked Sendable {
                                     generationCache = promptCache.cache
                                     self.trimCacheToLength(generationCache, keepTokens: prefixLen)
                                     let suffixTokens = Array(inputTokens[prefixLen...])
-                                    generateInput = LMInput(text: .init(tokens: MLXArray(suffixTokens)))
+                                    generateInput = LMInput(text: .init(tokens: MLXArray(suffixTokens).reshaped(1, suffixTokens.count)))
                                     streamCachedTokens = prefixLen
                                     if debugLogging {
                                         print("[KVCache] Prefix match: \(prefixLen)/\(inputTokens.count) tokens cached, processing \(suffixTokens.count) suffix tokens")


### PR DESCRIPTION
## Summary
- **Fix crash**: Suffix tokens for prefix cache reuse were created as 1D `[N]` arrays, but VLM models expect 2D `[batch, seq_len]` input — `.dim(1)` crashed with `SmallVector out of range` on the 1D array
- **Fix position IDs**: `Qwen3_5MoEVL` used `cache?.first?.offset` (MambaCache, always 0) for position tracking — fixed to use `cache[faIdx].offset` (full-attention layer) for correct positions in hybrid Mamba+Attention models
- Prefix caching now works correctly for both LLM and VLM modes on hybrid models (e.g. Qwen3.5-35B-A3B)

Fixes #41

## Test plan
- [x] VLM + `--enable-prefix-caching`: 3 sequential requests pass (was crashing on 2nd)
- [x] Cache reuse verified: request 1 TTFT=2.4s → request 2 TTFT=0.08s (30x speedup)
- [x] `mlx-model-test.sh` with `--vlm --enable-prefix-caching`: 2/2 passed
- [x] LLM + `--enable-prefix-caching`: still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix prefix cache reuse for hybrid Qwen3.5 VLM models to prevent crashes and ensure correct position tracking.

Bug Fixes:
- Prevent crashes in VLM prefix caching by reshaping suffix token arrays to include the batch dimension.
- Correct position ID computation in Qwen3.5 MoE VLM hybrid Mamba+Attention models by using the full-attention layer cache offset instead of the Mamba cache offset.