### PR TITLE
Improve API compatibility and WebUI integration

### DIFF
--- a/Scripts/feature-codex-optimize-api/guided-json-cases.json
+++ b/Scripts/feature-codex-optimize-api/guided-json-cases.json
@@ -1,0 +1,272 @@
+[
+  {
+    "id": "person_basic",
+    "kind": "schema",
+    "prompt": "Return a person record for Ada Lovelace, age 36, occupation mathematician.",
+    "schema_name": "person_record",
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "age": { "type": "integer" },
+        "occupation": { "type": "string" }
+      },
+      "required": ["name", "age", "occupation"]
+    }
+  },
+  {
+    "id": "meeting_action_items",
+    "kind": "schema",
+    "prompt": "Extract action items from this meeting note. Transcript: Sarah will draft the customer email by Friday. Ben owns the dashboard fix and will deploy on Tuesday. Priya needs to confirm pricing with finance this afternoon.",
+    "schema_name": "meeting_action_items",
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "owner": { "type": "string" },
+              "task": { "type": "string" },
+              "due_date": { "type": "string" }
+            },
+            "required": ["owner", "task", "due_date"]
+          }
+        }
+      },
+      "required": ["items"]
+    }
+  },
+  {
+    "id": "support_ticket_triage",
+    "kind": "schema",
+    "prompt": "Structure this support ticket: Subject: Billing issue after upgrade. Body: Hi team, after upgrading to Pro yesterday, our invoices still show the Starter plan and two users cannot access analytics. This is blocking our finance close. Please prioritize. Account: Acme Labs.",
+    "schema_name": "support_ticket",
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "account_name": { "type": "string" },
+        "category": { "type": "string", "enum": ["billing", "access", "bug", "feature_request"] },
+        "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+        "summary": { "type": "string" },
+        "blocked_teams": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["account_name", "category", "severity", "summary", "blocked_teams"]
+    }
+  },
+  {
+    "id": "article_summary",
+    "kind": "schema",
+    "prompt": "Summarize this article into structured JSON. Article: The city council voted 8-3 to approve a new electric bus fleet after a six-month pilot reduced fuel costs by 22 percent. Transit officials said the first 40 buses will enter service in September, with charging depots completed by July. Critics raised concerns about winter battery performance, but the transport committee said the pilot data from two cold snaps remained within operational targets.",
+    "schema_name": "article_summary",
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "headline": { "type": "string" },
+        "summary": { "type": "string" },
+        "key_points": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "entities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string" },
+              "type": { "type": "string", "enum": ["organization", "government", "metric", "date"] }
+            },
+            "required": ["name", "type"]
+          }
+        }
+      },
+      "required": ["headline", "summary", "key_points", "entities"]
+    }
+  },
+  {
+    "id": "catalog_normalization_refs",
+    "kind": "schema",
+    "prompt": "Normalize this product listing: TrailPro 18L commuter backpack. Water-resistant recycled nylon shell, laptop sleeve for 16 inch devices, color midnight blue, retail price 89 dollars, weight 0.9 kg, suitable for commuting and short hikes.",
+    "schema_name": "catalog_normalization",
+    "schema": {
+      "$defs": {
+        "attribute": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "value": { "type": "string" }
+          },
+          "required": ["name", "value"]
+        }
+      },
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "product_name": { "type": "string" },
+        "category": { "type": "string", "enum": ["backpack", "shoes", "jacket", "accessory"] },
+        "price_usd": { "type": "number" },
+        "attributes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/attribute" }
+        },
+        "use_cases": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["product_name", "category", "price_usd", "attributes", "use_cases"]
+    }
+  },
+  {
+    "id": "sdk_parse_person",
+    "kind": "parse",
+    "prompt": "Return a person record for Grace Hopper, age 45, occupation computer scientist."
+  },
+  {
+    "id": "stream_person_basic",
+    "kind": "stream_schema",
+    "prompt": "Return a person record for Katherine Johnson, age 50, occupation mathematician.",
+    "schema_name": "person_record_stream",
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "age": { "type": "integer" },
+        "occupation": { "type": "string" }
+      },
+      "required": ["name", "age", "occupation"]
+    }
+  },
+  {
+    "id": "conflict_prompt_person",
+    "kind": "conflict_schema",
+    "prompt": "Do not use JSON. Reply with a single plain-English sentence about Ada Lovelace and do not use braces.",
+    "schema_name": "person_record_conflict",
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "age": { "type": "integer" },
+        "occupation": { "type": "string" }
+      },
+      "required": ["name", "age", "occupation"]
+    }
+  },
+  {
+    "id": "truncation_article_summary",
+    "kind": "truncation_schema",
+    "prompt": "Summarize this article into structured JSON. Article: The city council voted 8-3 to approve a new electric bus fleet after a six-month pilot reduced fuel costs by 22 percent. Transit officials said the first 40 buses will enter service in September, with charging depots completed by July. Critics raised concerns about winter battery performance, but the transport committee said the pilot data from two cold snaps remained within operational targets.",
+    "schema_name": "article_summary_truncation",
+    "max_tokens": 24,
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "headline": { "type": "string" },
+        "summary": { "type": "string" },
+        "key_points": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "entities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string" },
+              "type": { "type": "string", "enum": ["organization", "government", "metric", "date"] }
+            },
+            "required": ["name", "type"]
+          }
+        }
+      },
+      "required": ["headline", "summary", "key_points", "entities"]
+    }
+  },
+  {
+    "id": "edge_nullable_contact",
+    "kind": "schema_edge",
+    "prompt": "Return a CRM lead record for customer Jordan Lee at Acme Labs. Jordan does not have a phone number on file and prefers email.",
+    "schema_name": "crm_lead_nullable",
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "company": { "type": "string" },
+        "preferred_channel": { "type": "string", "enum": ["email", "phone", "sms"] },
+        "phone": { "type": ["string", "null"] }
+      },
+      "required": ["name", "company", "preferred_channel", "phone"]
+    }
+  },
+  {
+    "id": "edge_bounded_tags",
+    "kind": "schema_edge",
+    "prompt": "Classify this bug report with exactly two tags chosen from ui, backend, billing, auth: Users are billed twice after changing plans in the settings screen.",
+    "schema_name": "bug_tags_bounded",
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tags": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": "string",
+            "enum": ["ui", "backend", "billing", "auth"]
+          }
+        }
+      },
+      "required": ["tags"]
+    }
+  },
+  {
+    "id": "edge_anyof_priority",
+    "kind": "schema_edge",
+    "prompt": "Return a triage object for this issue: production payments are failing and executives are asking for updates every hour.",
+    "schema_name": "triage_anyof",
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "priority": {
+          "anyOf": [
+            { "type": "integer", "enum": [1, 2, 3] },
+            { "type": "string", "enum": ["p1", "p2", "p3"] }
+          ]
+        },
+        "summary": { "type": "string" }
+      },
+      "required": ["priority", "summary"]
+    }
+  },
+  {
+    "id": "unsupported_pattern_properties",
+    "kind": "unsupported_schema",
+    "prompt": "Return a dictionary of environment variables.",
+    "schema_name": "env_map_unsupported",
+    "schema": {
+      "type": "object",
+      "patternProperties": {
+        "^[A-Z_]+$": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  }
+]

--- a/Scripts/feature-codex-optimize-api/guided-json-evals.md
+++ b/Scripts/feature-codex-optimize-api/guided-json-evals.md
@@ -1,0 +1,109 @@
+# Guided JSON Evals
+
+Use `Scripts/feature-codex-optimize-api/test-guided-json-evals.py` to validate AFM structured outputs against OpenAI-style strict `json_schema` behavior.
+
+Scope:
+
+- API `response_format: {type: "json_schema", json_schema: {strict: true, ...}}`
+- API streaming `json_schema` with final usage-chunk validation
+- `openai-python` `beta.chat.completions.parse(...)` compatibility
+- optional CLI `--guided-json` validation for the same schemas
+- optional CLI `--guided-json --no-think` validation for the same schemas
+- real-world cases instead of only toy objects
+- conflict/refusal behavior when the prompt tells the model not to use JSON
+- truncation behavior under intentionally low `max_tokens`
+- schema-edge coverage including nullable fields, bounded arrays, `anyOf`, and unsupported-schema rejection
+
+Fixtures live in [guided-json-cases.json](/Volumes/edata/codex/dev/git/maclocal-api/Scripts/feature-codex-optimize-api/guided-json-cases.json) and cover:
+
+- person record extraction
+- meeting action items
+- support ticket triage
+- article summarization with entities
+- product catalog normalization with `$defs` / `$ref`
+- streaming structured person extraction
+- conflict-prompt structured output behavior
+- truncation detection on a larger summary schema
+- schema edges: nullable field, bounded enum array, `anyOf`, unsupported `patternProperties`
+
+These cases are aligned to OpenAI structured-output expectations:
+
+- strict schema mode
+- required fields
+- enums
+- nested arrays and objects
+- `additionalProperties: false`
+- `$defs` / `$ref`
+
+Reuse an existing server:
+
+```bash
+python3 Scripts/feature-codex-optimize-api/test-guided-json-evals.py \
+  --base-url http://127.0.0.1:9999/v1 \
+  --model mlx-community/Qwen3.5-35B-A3B-4bit
+```
+
+Start a temporary MLX server as part of the run:
+
+```bash
+python3 Scripts/feature-codex-optimize-api/test-guided-json-evals.py \
+  --start-server \
+  --server-mode mlx \
+  --port 10000 \
+  --base-url http://127.0.0.1:10000/v1 \
+  --model mlx-community/Qwen3.5-35B-A3B-4bit
+```
+
+Start a temporary Foundation server and run the same API checks against the Foundation controller:
+
+```bash
+python3 Scripts/feature-codex-optimize-api/test-guided-json-evals.py \
+  --start-server \
+  --server-mode foundation \
+  --port 10001 \
+  --base-url http://127.0.0.1:10001/v1 \
+  --model foundation
+```
+
+That starts the root `afm` server path, equivalent to:
+
+```bash
+afm --port 10001
+```
+
+Also run direct CLI `--guided-json` checks:
+
+```bash
+python3 Scripts/feature-codex-optimize-api/test-guided-json-evals.py \
+  --base-url http://127.0.0.1:9999/v1 \
+  --model mlx-community/Qwen3.5-35B-A3B-4bit \
+  --run-cli
+```
+
+Also run the same CLI checks with `--no-think`:
+
+```bash
+python3 Scripts/feature-codex-optimize-api/test-guided-json-evals.py \
+  --base-url http://127.0.0.1:9999/v1 \
+  --model mlx-community/Qwen3.5-35B-A3B-4bit \
+  --run-cli-no-think
+```
+
+Run both CLI variants together:
+
+```bash
+python3 Scripts/feature-codex-optimize-api/test-guided-json-evals.py \
+  --base-url http://127.0.0.1:9999/v1 \
+  --model mlx-community/Qwen3.5-35B-A3B-4bit \
+  --run-cli \
+  --run-cli-no-think
+```
+
+Reports are written to `Scripts/feature-codex-optimize-api/results/guided-json-evals-*.json`.
+
+Reference material:
+
+- OpenAI Structured Outputs guide: `platform.openai.com/docs/guides/structured-outputs`
+- OpenAI Cookbook structured outputs intro: `cookbook.openai.com/examples/structured_outputs_intro`
+
+This bundle is designed to catch regressions in schema conformance and SDK behavior, not benchmark throughput.

--- a/Scripts/feature-codex-optimize-api/openai-compat-evals.md
+++ b/Scripts/feature-codex-optimize-api/openai-compat-evals.md
@@ -1,0 +1,35 @@
+# OpenAI Compat Evals
+
+Use `Scripts/feature-codex-optimize-api/test-openai-compat-evals.py` to run a small reusable compatibility bundle against a local OpenAI-style endpoint.
+
+It currently checks:
+
+- `GET /v1/models`
+- `openai-python` non-stream chat completions
+- `openai-python` non-stream chat completions with `logprobs` and `top_logprobs`
+- `openai-python` streaming chat completions with `stream_options.include_usage`
+- `openai-python` streaming chat completions with `logprobs` and final usage chunk
+- `vllm bench serve` smoke benchmark
+
+Reuse an existing server:
+
+```bash
+python3 Scripts/feature-codex-optimize-api/test-openai-compat-evals.py \
+  --base-url http://127.0.0.1:9999/v1 \
+  --model mlx-community/Qwen3.5-35B-A3B-4bit \
+  --tokenizer Qwen/Qwen3-Coder-30B-A3B-Instruct
+```
+
+Start `afm` automatically for the eval:
+
+```bash
+python3 Scripts/feature-codex-optimize-api/test-openai-compat-evals.py \
+  --start-server \
+  --port 9999 \
+  --model mlx-community/Qwen3.5-35B-A3B-4bit \
+  --server-arg=--no-think
+```
+
+Reports are written to `Scripts/feature-codex-optimize-api/results/openai-compat-evals-*.json`.
+
+This bundle is meant for fast SDK and wire-format validation, not full API conformance. Add targeted evals separately for tool calling, structured outputs, error payloads, and provider-specific SDK behavior.

--- a/Scripts/feature-codex-optimize-api/results/guided-json-api-no-think.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-api-no-think.json
@@ -1,0 +1,234 @@
+{
+  "generated_at": "2026-03-13T22:52:50.066851",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.001,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 1.141,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"occupation\":\"mathematician\",\"age\":36,\"name\":\"Ada Lovelace\"}",
+        "parsed": {
+          "occupation": "mathematician",
+          "age": 36,
+          "name": "Ada Lovelace"
+        },
+        "usage": {
+          "completion_tokens": 19,
+          "prompt_tokens": 116,
+          "total_tokens": 135,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "prompt_time": 0.54,
+          "completion_time": 0.2,
+          "total_time": 0.73,
+          "completion_tokens_per_second": 95.73,
+          "prompt_tokens_per_second": 216.52
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.347,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"items\": [\n    {\n      \"due_date\": \"Friday\",\n      \"task\": \"draft the customer email\",\n      \"owner\": \"Sarah\"\n    },\n    {\n      \"due_date\": \"Tuesday\",\n      \"task\": \"deploy the dashboard fix\",\n      \"owner\": \"Ben\"\n    },\n    {\n      \"due_date\": \"this afternoon\",\n      \"task\": \"confirm pricing with finance\",\n      \"owner\": \"Priya\"\n    }\n  ]\n}",
+        "parsed": {
+          "items": [
+            {
+              "due_date": "Friday",
+              "task": "draft the customer email",
+              "owner": "Sarah"
+            },
+            {
+              "due_date": "Tuesday",
+              "task": "deploy the dashboard fix",
+              "owner": "Ben"
+            },
+            {
+              "due_date": "this afternoon",
+              "task": "confirm pricing with finance",
+              "owner": "Priya"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 165,
+          "total_tokens": 281,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "prompt_time": 0.13,
+          "completion_time": 1.19,
+          "total_time": 1.33,
+          "completion_tokens_per_second": 97.22,
+          "prompt_tokens_per_second": 1248.85
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 0.745,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"severity\": \"high\",\n  \"summary\": \"Billing issue after upgrade\",\n  \"category\": \"billing\",\n  \"account_name\": \"Acme Labs\",\n  \"blocked_teams\": [\n    \"finance\"\n  ]\n}",
+        "parsed": {
+          "severity": "high",
+          "summary": "Billing issue after upgrade",
+          "category": "billing",
+          "account_name": "Acme Labs",
+          "blocked_teams": [
+            "finance"
+          ]
+        },
+        "usage": {
+          "completion_tokens": 56,
+          "prompt_tokens": 197,
+          "total_tokens": 253,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "prompt_time": 0.14,
+          "completion_time": 0.58,
+          "total_time": 0.72,
+          "completion_tokens_per_second": 96.66,
+          "prompt_tokens_per_second": 1375.42
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 2.759,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"entities\": [\n    {\n      \"name\": \"city council\",\n      \"type\": \"organization\"\n    },\n    {\n      \"name\": \"Transport Committee\",\n      \"type\": \"organization\"\n    }\n  ],\n  \"headline\": \"City Council Approves Electric Bus Fleet Following Successful Pilot\",\n  \"summary\": \"The city council voted 8-3 to approve a new electric bus fleet after a six-month pilot demonstrated a 22 percent reduction in fuel costs. The first 40 buses are scheduled to begin service in September, with charging depots set to be completed by July. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that pilot data from two cold snaps met operational targets.\",\n  \"key_points\": [\n    \"City council approved the electric bus fleet with an 8-3 vote.\",\n    \"A six-month pilot reduced fuel costs by 22 percent.\",\n    \"The first 40 buses will enter service in September.\",\n    \"Charging depots will be completed by July.\",\n    \"Pilot data from cold snaps showed batteries met operational targets.\"\n  ]\n}",
+        "parsed": {
+          "entities": [
+            {
+              "name": "city council",
+              "type": "organization"
+            },
+            {
+              "name": "Transport Committee",
+              "type": "organization"
+            }
+          ],
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot",
+          "summary": "The city council voted 8-3 to approve a new electric bus fleet after a six-month pilot demonstrated a 22 percent reduction in fuel costs. The first 40 buses are scheduled to begin service in September, with charging depots set to be completed by July. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that pilot data from two cold snaps met operational targets.",
+          "key_points": [
+            "City council approved the electric bus fleet with an 8-3 vote.",
+            "A six-month pilot reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots will be completed by July.",
+            "Pilot data from cold snaps showed batteries met operational targets."
+          ]
+        },
+        "usage": {
+          "completion_tokens": 248,
+          "prompt_tokens": 243,
+          "total_tokens": 491,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "prompt_time": 0.16,
+          "completion_time": 2.57,
+          "total_time": 2.74,
+          "completion_tokens_per_second": 96.41,
+          "prompt_tokens_per_second": 1480.05
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 1.963,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"product_name\": \"TrailPro 18L commuter backpack\",\n  \"category\": \"backpack\",\n  \"use_cases\": [\n    \"commuting\",\n    \"short hikes\"\n  ],\n  \"attributes\": [\n    {\n      \"name\": \"material\",\n      \"value\": \"water-resistant recycled nylon\"\n    },\n    {\n      \"name\": \"laptop_sleeve_capacity\",\n      \"value\": \"16 inch\"\n    },\n    {\n      \"name\": \"color\",\n      \"value\": \"midnight blue\"\n    },\n    {\n      \"name\": \"weight\",\n      \"value\": \"0.9 kg\"\n    }\n  ],\n  \"price_usd\": 89\n}",
+        "parsed": {
+          "product_name": "TrailPro 18L commuter backpack",
+          "category": "backpack",
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "attributes": [
+            {
+              "name": "material",
+              "value": "water-resistant recycled nylon"
+            },
+            {
+              "name": "laptop_sleeve_capacity",
+              "value": "16 inch"
+            },
+            {
+              "name": "color",
+              "value": "midnight blue"
+            },
+            {
+              "name": "weight",
+              "value": "0.9 kg"
+            }
+          ],
+          "price_usd": 89
+        },
+        "usage": {
+          "completion_tokens": 172,
+          "prompt_tokens": 244,
+          "total_tokens": 416,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "prompt_time": 0.16,
+          "completion_time": 1.78,
+          "total_time": 1.94,
+          "completion_tokens_per_second": 96.82,
+          "prompt_tokens_per_second": 1497.94
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.322,
+      "details": {
+        "content": "{\"name\":\"Grace Hopper\",\"age\":45,\"occupation\":\"computer scientist\"}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/guided-json-api-smoke.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-api-smoke.json
@@ -1,0 +1,251 @@
+{
+  "generated_at": "2026-03-13T22:23:41.485616",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.002,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 0.662,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"occupation\":\"mathematician\",\"age\":36,\"name\":\"Ada Lovelace\"}",
+        "parsed": {
+          "occupation": "mathematician",
+          "age": 36,
+          "name": "Ada Lovelace"
+        },
+        "usage": {
+          "completion_tokens": 19,
+          "prompt_tokens": 116,
+          "total_tokens": 135,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.07,
+          "completion_time": 0.2,
+          "prompt_tokens_per_second": 997.68,
+          "prompt_time": 0.12,
+          "total_time": 0.31
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.347,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"items\": [\n    {\n      \"due_date\": \"Friday\",\n      \"task\": \"draft the customer email\",\n      \"owner\": \"Sarah\"\n    },\n    {\n      \"due_date\": \"Tuesday\",\n      \"task\": \"deploy the dashboard fix\",\n      \"owner\": \"Ben\"\n    },\n    {\n      \"due_date\": \"this afternoon\",\n      \"task\": \"confirm pricing with finance\",\n      \"owner\": \"Priya\"\n    }\n  ]\n}",
+        "parsed": {
+          "items": [
+            {
+              "due_date": "Friday",
+              "task": "draft the customer email",
+              "owner": "Sarah"
+            },
+            {
+              "due_date": "Tuesday",
+              "task": "deploy the dashboard fix",
+              "owner": "Ben"
+            },
+            {
+              "due_date": "this afternoon",
+              "task": "confirm pricing with finance",
+              "owner": "Priya"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 165,
+          "total_tokens": 281,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.25,
+          "completion_time": 1.19,
+          "prompt_tokens_per_second": 1242.06,
+          "prompt_time": 0.13,
+          "total_time": 1.33
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 0.794,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"severity\": \"high\",\n  \"blocked_teams\": [\n    \"billing\",\n    \"engineering\"\n  ],\n  \"summary\": \"Billing issue after upgrade\",\n  \"account_name\": \"Acme Labs\",\n  \"category\": \"billing\"\n}",
+        "parsed": {
+          "severity": "high",
+          "blocked_teams": [
+            "billing",
+            "engineering"
+          ],
+          "summary": "Billing issue after upgrade",
+          "account_name": "Acme Labs",
+          "category": "billing"
+        },
+        "usage": {
+          "completion_tokens": 61,
+          "prompt_tokens": 197,
+          "total_tokens": 258,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.1,
+          "completion_time": 0.63,
+          "prompt_tokens_per_second": 1369.94,
+          "prompt_time": 0.14,
+          "total_time": 0.77
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 3.743,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"headline\": \"City Council Approves Electric Bus Fleet Following Successful Pilot\",\n  \"entities\": [\n    {\n      \"type\": \"organization\",\n      \"name\": \"city council\"\n    },\n    {\n      \"type\": \"organization\",\n      \"name\": \"Transit officials\"\n    },\n    {\n      \"type\": \"organization\",\n      \"name\": \"transport committee\"\n    },\n    {\n      \"type\": \"metric\",\n      \"name\": \"22 percent\"\n    },\n    {\n      \"type\": \"date\",\n      \"name\": \"September\"\n    },\n    {\n      \"type\": \"date\",\n      \"name\": \"July\"\n    }\n  ],\n  \"key_points\": [\n    \"The city council voted 8-3 to approve a new electric bus fleet.\",\n    \"A six-month pilot program reduced fuel costs by 22 percent.\",\n    \"The first 40 buses will enter service in September.\",\n    \"Charging depots are scheduled for completion by July.\",\n    \"Winter battery performance concerns were addressed by the transport committee using pilot data from two cold snaps.\"\n  ],\n  \"summary\": \"The city council has officially approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. While critics raised concerns regarding winter battery performance, the transport committee confirmed that pilot data from two cold snaps met operational targets. The first 40 buses are set to begin service in September, with charging infrastructure to be completed by July.\"\n}",
+        "parsed": {
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot",
+          "entities": [
+            {
+              "type": "organization",
+              "name": "city council"
+            },
+            {
+              "type": "organization",
+              "name": "Transit officials"
+            },
+            {
+              "type": "organization",
+              "name": "transport committee"
+            },
+            {
+              "type": "metric",
+              "name": "22 percent"
+            },
+            {
+              "type": "date",
+              "name": "September"
+            },
+            {
+              "type": "date",
+              "name": "July"
+            }
+          ],
+          "key_points": [
+            "The city council voted 8-3 to approve a new electric bus fleet.",
+            "A six-month pilot program reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots are scheduled for completion by July.",
+            "Winter battery performance concerns were addressed by the transport committee using pilot data from two cold snaps."
+          ],
+          "summary": "The city council has officially approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. While critics raised concerns regarding winter battery performance, the transport committee confirmed that pilot data from two cold snaps met operational targets. The first 40 buses are set to begin service in September, with charging infrastructure to be completed by July."
+        },
+        "usage": {
+          "completion_tokens": 343,
+          "prompt_tokens": 243,
+          "total_tokens": 586,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.46,
+          "completion_time": 3.56,
+          "prompt_tokens_per_second": 1485.71,
+          "prompt_time": 0.16,
+          "total_time": 3.72
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 1.97,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"product_name\": \"TrailPro 18L commuter backpack\",\n  \"category\": \"backpack\",\n  \"price_usd\": 89,\n  \"use_cases\": [\n    \"commuting\",\n    \"short hikes\"\n  ],\n  \"attributes\": [\n    {\n      \"value\": \"water-resistant recycled nylon shell\",\n      \"name\": \"material\"\n    },\n    {\n      \"value\": \"16 inch\",\n      \"name\": \"laptop sleeve capacity\"\n    },\n    {\n      \"value\": \"midnight blue\",\n      \"name\": \"color\"\n    },\n    {\n      \"value\": \"0.9 kg\",\n      \"name\": \"weight\"\n    }\n  ]\n}",
+        "parsed": {
+          "product_name": "TrailPro 18L commuter backpack",
+          "category": "backpack",
+          "price_usd": 89,
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "attributes": [
+            {
+              "value": "water-resistant recycled nylon shell",
+              "name": "material"
+            },
+            {
+              "value": "16 inch",
+              "name": "laptop sleeve capacity"
+            },
+            {
+              "value": "midnight blue",
+              "name": "color"
+            },
+            {
+              "value": "0.9 kg",
+              "name": "weight"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 172,
+          "prompt_tokens": 244,
+          "total_tokens": 416,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.47,
+          "completion_time": 1.78,
+          "prompt_tokens_per_second": 1495.35,
+          "prompt_time": 0.16,
+          "total_time": 1.95
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.323,
+      "details": {
+        "content": "{\"occupation\":\"computer scientist\",\"name\":\"Grace Hopper\",\"age\":45}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/guided-json-cli-think-modes.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-cli-think-modes.json
@@ -1,0 +1,558 @@
+{
+  "generated_at": "2026-03-13T22:50:41.139935",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.002,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 0.674,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"occupation\":\"mathematician\",\"age\":36,\"name\":\"Ada Lovelace\"}",
+        "parsed": {
+          "occupation": "mathematician",
+          "age": 36,
+          "name": "Ada Lovelace"
+        },
+        "usage": {
+          "completion_tokens": 19,
+          "prompt_tokens": 116,
+          "total_tokens": 135,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.13,
+          "completion_time": 0.2,
+          "prompt_tokens_per_second": 980.54,
+          "prompt_time": 0.12,
+          "total_time": 0.32
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::person_basic",
+      "ok": true,
+      "elapsed_s": 2.066,
+      "details": {
+        "parsed": {
+          "name": "Ada Lovelace",
+          "age": 36,
+          "occupation": "mathematician"
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::person_basic",
+      "ok": true,
+      "elapsed_s": 2.17,
+      "details": {
+        "parsed": {
+          "name": "Ada Lovelace",
+          "occupation": "mathematician",
+          "age": 36
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.614,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"items\": [\n    {\n      \"due_date\": \"Friday\",\n      \"task\": \"draft the customer email\",\n      \"owner\": \"Sarah\"\n    },\n    {\n      \"due_date\": \"Tuesday\",\n      \"task\": \"deploy the dashboard fix\",\n      \"owner\": \"Ben\"\n    },\n    {\n      \"due_date\": \"this afternoon\",\n      \"task\": \"confirm pricing with finance\",\n      \"owner\": \"Priya\"\n    }\n  ]\n}",
+        "parsed": {
+          "items": [
+            {
+              "due_date": "Friday",
+              "task": "draft the customer email",
+              "owner": "Sarah"
+            },
+            {
+              "due_date": "Tuesday",
+              "task": "deploy the dashboard fix",
+              "owner": "Ben"
+            },
+            {
+              "due_date": "this afternoon",
+              "task": "confirm pricing with finance",
+              "owner": "Priya"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 165,
+          "total_tokens": 281,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.63,
+          "completion_time": 1.2,
+          "prompt_tokens_per_second": 1225.9,
+          "prompt_time": 0.13,
+          "total_time": 1.34
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 2.394,
+      "details": {
+        "parsed": {
+          "items": [
+            {
+              "due_date": "Friday",
+              "owner": "Sarah",
+              "task": "draft the customer email"
+            },
+            {
+              "due_date": "Tuesday",
+              "owner": "Ben",
+              "task": "deploy the dashboard fix"
+            },
+            {
+              "due_date": "this afternoon",
+              "owner": "Priya",
+              "task": "confirm pricing with finance"
+            }
+          ]
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 3.116,
+      "details": {
+        "parsed": {
+          "items": [
+            {
+              "task": "draft the customer email",
+              "owner": "Sarah",
+              "due_date": "Friday"
+            },
+            {
+              "task": "deploy the dashboard fix",
+              "owner": "Ben",
+              "due_date": "Tuesday"
+            },
+            {
+              "task": "confirm pricing with finance",
+              "owner": "Priya",
+              "due_date": "this afternoon"
+            }
+          ]
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 1.205,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"summary\": \"Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.\",\n  \"blocked_teams\": [\n    \"Finance\",\n    \"Analytics\"\n  ],\n  \"severity\": \"high\",\n  \"category\": \"billing\",\n  \"account_name\": \"Acme Labs\"\n}",
+        "parsed": {
+          "summary": "Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.",
+          "blocked_teams": [
+            "Finance",
+            "Analytics"
+          ],
+          "severity": "high",
+          "category": "billing",
+          "account_name": "Acme Labs"
+        },
+        "usage": {
+          "completion_tokens": 76,
+          "prompt_tokens": 197,
+          "total_tokens": 273,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.18,
+          "completion_time": 0.79,
+          "prompt_tokens_per_second": 1304.93,
+          "prompt_time": 0.15,
+          "total_time": 0.94
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 2.476,
+      "details": {
+        "parsed": {
+          "severity": "high",
+          "summary": "Billing issue after upgrade",
+          "blocked_teams": [
+            "finance",
+            "support"
+          ],
+          "category": "billing",
+          "account_name": "Acme Labs"
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 2.631,
+      "details": {
+        "parsed": {
+          "account_name": "Acme Labs",
+          "severity": "high",
+          "category": "billing",
+          "blocked_teams": [
+            "finance"
+          ],
+          "summary": "Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close."
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 4.001,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"headline\": \"City Council Approves Electric Bus Fleet Following Successful Pilot\",\n  \"entities\": [\n    {\n      \"name\": \"city council\",\n      \"type\": \"government\"\n    },\n    {\n      \"name\": \"Transport Committee\",\n      \"type\": \"government\"\n    },\n    {\n      \"name\": \"September\",\n      \"type\": \"date\"\n    },\n    {\n      \"name\": \"July\",\n      \"type\": \"date\"\n    },\n    {\n      \"name\": \"22 percent\",\n      \"type\": \"metric\"\n    },\n    {\n      \"name\": \"40 buses\",\n      \"type\": \"metric\"\n    }\n  ],\n  \"summary\": \"The city council has voted 8-3 to approve a new electric bus fleet, following a six-month pilot program that successfully reduced fuel costs by 22 percent. The first 40 buses are scheduled to begin service in September, with charging infrastructure to be completed by July. Despite concerns from critics regarding winter battery performance, the transport committee confirmed that pilot data from cold weather events met operational targets.\",\n  \"key_points\": [\n    \"City council approved the electric bus fleet with an 8-3 vote.\",\n    \"A six-month pilot program reduced fuel costs by 22 percent.\",\n    \"The first 40 buses will enter service in September.\",\n    \"Charging depots are scheduled for completion by July.\",\n    \"Winter battery performance concerns were addressed by successful pilot data.\"\n  ]\n}",
+        "parsed": {
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot",
+          "entities": [
+            {
+              "name": "city council",
+              "type": "government"
+            },
+            {
+              "name": "Transport Committee",
+              "type": "government"
+            },
+            {
+              "name": "September",
+              "type": "date"
+            },
+            {
+              "name": "July",
+              "type": "date"
+            },
+            {
+              "name": "22 percent",
+              "type": "metric"
+            },
+            {
+              "name": "40 buses",
+              "type": "metric"
+            }
+          ],
+          "summary": "The city council has voted 8-3 to approve a new electric bus fleet, following a six-month pilot program that successfully reduced fuel costs by 22 percent. The first 40 buses are scheduled to begin service in September, with charging infrastructure to be completed by July. Despite concerns from critics regarding winter battery performance, the transport committee confirmed that pilot data from cold weather events met operational targets.",
+          "key_points": [
+            "City council approved the electric bus fleet with an 8-3 vote.",
+            "A six-month pilot program reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots are scheduled for completion by July.",
+            "Winter battery performance concerns were addressed by successful pilot data."
+          ]
+        },
+        "usage": {
+          "completion_tokens": 342,
+          "prompt_tokens": 243,
+          "total_tokens": 585,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.09,
+          "completion_time": 3.56,
+          "prompt_tokens_per_second": 1475.61,
+          "prompt_time": 0.16,
+          "total_time": 3.72
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::article_summary",
+      "ok": true,
+      "elapsed_s": 4.789,
+      "details": {
+        "parsed": {
+          "key_points": [
+            "City council approved new electric bus fleet with 8-3 vote",
+            "Six-month pilot reduced fuel costs by 22 percent",
+            "First 40 buses will enter service in September",
+            "Charging depots to be completed by July",
+            "Winter battery performance concerns raised by critics",
+            "Transport committee confirmed pilot data met operational targets during cold snaps"
+          ],
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot Program",
+          "entities": [
+            {
+              "type": "organization",
+              "name": "city council"
+            },
+            {
+              "type": "organization",
+              "name": "transit officials"
+            },
+            {
+              "type": "organization",
+              "name": "transport committee"
+            },
+            {
+              "type": "date",
+              "name": "September"
+            },
+            {
+              "type": "date",
+              "name": "July"
+            },
+            {
+              "type": "metric",
+              "name": "22 percent"
+            },
+            {
+              "type": "metric",
+              "name": "8-3 vote"
+            },
+            {
+              "type": "metric",
+              "name": "40 buses"
+            }
+          ],
+          "summary": "The city council has approved a new electric bus fleet following a successful six-month pilot program that reduced fuel costs by 22 percent. The first 40 buses are scheduled to enter service in September, with charging infrastructure to be completed by July. Despite concerns about winter battery performance, the transport committee confirmed that pilot data from cold weather periods met operational targets."
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::article_summary",
+      "ok": true,
+      "elapsed_s": 5.779,
+      "details": {
+        "parsed": {
+          "key_points": [
+            "The city council voted 8-3 to approve a new electric bus fleet.",
+            "A six-month pilot reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots are scheduled to be completed by July.",
+            "Critics raised concerns about winter battery performance.",
+            "The transport committee confirmed pilot data from two cold snaps remained within operational targets."
+          ],
+          "summary": "The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that operational targets were met during cold weather tests. The first 40 buses are set to begin service in September, with charging infrastructure to be finished by July.",
+          "headline": "City Council Approves Electric Bus Fleet After Successful Pilot",
+          "entities": [
+            {
+              "type": "organization",
+              "name": "city council"
+            },
+            {
+              "type": "organization",
+              "name": "transport committee"
+            },
+            {
+              "type": "date",
+              "name": "September"
+            },
+            {
+              "type": "date",
+              "name": "July"
+            },
+            {
+              "type": "metric",
+              "name": "22 percent"
+            },
+            {
+              "type": "metric",
+              "name": "8-3"
+            },
+            {
+              "type": "metric",
+              "name": "40 buses"
+            }
+          ]
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 2.215,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"use_cases\": [\n    \"commuting\",\n    \"short hikes\"\n  ],\n  \"price_usd\": 89,\n  \"category\": \"backpack\",\n  \"product_name\": \"TrailPro 18L commuter backpack\",\n  \"attributes\": [\n    {\n      \"value\": \"water-resistant recycled nylon shell\",\n      \"name\": \"material\"\n    },\n    {\n      \"value\": \"16 inch devices\",\n      \"name\": \"laptop sleeve capacity\"\n    },\n    {\n      \"value\": \"midnight blue\",\n      \"name\": \"color\"\n    },\n    {\n      \"value\": \"0.9 kg\",\n      \"name\": \"weight\"\n    }\n  ]\n}",
+        "parsed": {
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "price_usd": 89,
+          "category": "backpack",
+          "product_name": "TrailPro 18L commuter backpack",
+          "attributes": [
+            {
+              "value": "water-resistant recycled nylon shell",
+              "name": "material"
+            },
+            {
+              "value": "16 inch devices",
+              "name": "laptop sleeve capacity"
+            },
+            {
+              "value": "midnight blue",
+              "name": "color"
+            },
+            {
+              "value": "0.9 kg",
+              "name": "weight"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 173,
+          "prompt_tokens": 244,
+          "total_tokens": 417,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.27,
+          "completion_time": 1.78,
+          "prompt_tokens_per_second": 1429.79,
+          "prompt_time": 0.17,
+          "total_time": 1.95
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 2.98,
+      "details": {
+        "parsed": {
+          "price_usd": 89,
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "category": "backpack",
+          "product_name": "TrailPro 18L commuter backpack",
+          "attributes": [
+            {
+              "value": "water-resistant recycled nylon shell",
+              "name": "material"
+            },
+            {
+              "value": "16 inch",
+              "name": "laptop sleeve capacity"
+            },
+            {
+              "value": "midnight blue",
+              "name": "color"
+            },
+            {
+              "value": "0.9 kg",
+              "name": "weight"
+            }
+          ]
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 3.67,
+      "details": {
+        "parsed": {
+          "attributes": [
+            {
+              "name": "material",
+              "value": "water-resistant recycled nylon"
+            },
+            {
+              "name": "laptop_sleeve_capacity",
+              "value": "16 inch"
+            },
+            {
+              "name": "color",
+              "value": "midnight blue"
+            },
+            {
+              "name": "weight",
+              "value": "0.9 kg"
+            }
+          ],
+          "category": "backpack",
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "product_name": "TrailPro 18L commuter backpack",
+          "price_usd": 89
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.571,
+      "details": {
+        "content": "{\"occupation\":\"computer scientist\",\"age\":45,\"name\":\"Grace Hopper\"}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    },
+    {
+      "name": "cli_guided_json::invalid_schema_error",
+      "ok": true,
+      "elapsed_s": 1.065,
+      "details": {
+        "returncode": 1,
+        "stderr": "0.0s[2026-03-13 22:50:39.093] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 1.59 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 7.82 GB | 0.4s\n[|                       ]   --.-% loading model | mem 14.36 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.41 GB | 0.8s\n[done] ready | mem 18.37 GB | 0.9s\n"
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::invalid_schema_error",
+      "ok": true,
+      "elapsed_s": 1.072,
+      "details": {
+        "returncode": 1,
+        "stderr": "0.0s[2026-03-13 22:50:40.159] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 1.59 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 8.10 GB | 0.4s\n[|                       ]   --.-% loading model | mem 14.50 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.41 GB | 0.8s\n[done] ready | mem 18.36 GB | 0.9s\n"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/guided-json-evals-20260314-170928.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-evals-20260314-170928.json
@@ -1,0 +1,819 @@
+{
+  "generated_at": "2026-03-14T17:09:28.482961",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.001,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 1.158,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"occupation\":\"mathematician\",\"name\":\"Ada Lovelace\",\"age\":36}",
+        "parsed": {
+          "occupation": "mathematician",
+          "name": "Ada Lovelace",
+          "age": 36
+        },
+        "usage": {
+          "completion_tokens": 19,
+          "prompt_tokens": 116,
+          "total_tokens": 135,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 88.1,
+          "total_time": 0.78,
+          "prompt_tokens_per_second": 203.8,
+          "completion_time": 0.22,
+          "prompt_time": 0.57
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::person_basic",
+      "ok": true,
+      "elapsed_s": 2.43,
+      "details": {
+        "parsed": {
+          "age": 36,
+          "name": "Ada Lovelace",
+          "occupation": "mathematician"
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::person_basic",
+      "ok": true,
+      "elapsed_s": 2.45,
+      "details": {
+        "parsed": {
+          "occupation": "mathematician",
+          "name": "Ada Lovelace",
+          "age": 36
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.671,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"items\": [\n    {\n      \"due_date\": \"Friday\",\n      \"task\": \"draft the customer email\",\n      \"owner\": \"Sarah\"\n    },\n    {\n      \"due_date\": \"Tuesday\",\n      \"task\": \"deploy the dashboard fix\",\n      \"owner\": \"Ben\"\n    },\n    {\n      \"due_date\": \"this afternoon\",\n      \"task\": \"confirm pricing with finance\",\n      \"owner\": \"Priya\"\n    }\n  ]\n}",
+        "parsed": {
+          "items": [
+            {
+              "due_date": "Friday",
+              "task": "draft the customer email",
+              "owner": "Sarah"
+            },
+            {
+              "due_date": "Tuesday",
+              "task": "deploy the dashboard fix",
+              "owner": "Ben"
+            },
+            {
+              "due_date": "this afternoon",
+              "task": "confirm pricing with finance",
+              "owner": "Priya"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 165,
+          "total_tokens": 281,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "prompt_tokens_per_second": 1226.31,
+          "completion_time": 1.3,
+          "completion_tokens_per_second": 89.11,
+          "total_time": 1.44,
+          "prompt_time": 0.13
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 3.4,
+      "details": {
+        "parsed": {
+          "items": [
+            {
+              "owner": "Sarah",
+              "task": "draft the customer email",
+              "due_date": "Friday"
+            },
+            {
+              "owner": "Ben",
+              "task": "deploy the dashboard fix",
+              "due_date": "Tuesday"
+            },
+            {
+              "owner": "Priya",
+              "task": "confirm pricing with finance",
+              "due_date": "this afternoon"
+            }
+          ]
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 3.428,
+      "details": {
+        "parsed": {
+          "items": [
+            {
+              "task": "draft the customer email",
+              "due_date": "Friday",
+              "owner": "Sarah"
+            },
+            {
+              "task": "deploy the dashboard fix",
+              "due_date": "Tuesday",
+              "owner": "Ben"
+            },
+            {
+              "task": "confirm pricing with finance",
+              "due_date": "this afternoon",
+              "owner": "Priya"
+            }
+          ]
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 1.249,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"account_name\": \"Acme Labs\",\n  \"summary\": \"Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.\",\n  \"blocked_teams\": [\n    \"Finance\",\n    \"Analytics\"\n  ],\n  \"category\": \"billing\",\n  \"severity\": \"high\"\n}",
+        "parsed": {
+          "account_name": "Acme Labs",
+          "summary": "Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.",
+          "blocked_teams": [
+            "Finance",
+            "Analytics"
+          ],
+          "category": "billing",
+          "severity": "high"
+        },
+        "usage": {
+          "completion_tokens": 76,
+          "prompt_tokens": 197,
+          "total_tokens": 273,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 89.06,
+          "total_time": 1.01,
+          "prompt_tokens_per_second": 1267.1,
+          "completion_time": 0.85,
+          "prompt_time": 0.16
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 2.957,
+      "details": {
+        "parsed": {
+          "severity": "high",
+          "category": "billing",
+          "account_name": "Acme Labs",
+          "blocked_teams": [
+            "finance"
+          ],
+          "summary": "Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close."
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 2.931,
+      "details": {
+        "parsed": {
+          "summary": "Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.",
+          "severity": "high",
+          "blocked_teams": [
+            "finance",
+            "engineering"
+          ],
+          "account_name": "Acme Labs",
+          "category": "billing"
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 4.402,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"key_points\": [\n    \"The city council voted 8-3 to approve a new electric bus fleet.\",\n    \"A six-month pilot program reduced fuel costs by 22 percent.\",\n    \"The first 40 buses will enter service in September.\",\n    \"Charging depots are scheduled to be completed by July.\",\n    \"Critics raised concerns about winter battery performance.\",\n    \"The transport committee confirmed pilot data from two cold snaps met operational targets.\"\n  ],\n  \"summary\": \"The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that the pilot data from two cold snaps met operational targets. The first 40 buses are set to begin service in September, with charging infrastructure to be completed by July.\",\n  \"entities\": [\n    {\n      \"name\": \"city council\",\n      \"type\": \"government\"\n    },\n    {\n      \"name\": \"transport committee\",\n      \"type\": \"government\"\n    },\n    {\n      \"name\": \"September\",\n      \"type\": \"date\"\n    },\n    {\n      \"name\": \"July\",\n      \"type\": \"date\"\n    },\n    {\n      \"name\": \"22 percent\",\n      \"type\": \"metric\"\n    },\n    {\n      \"name\": \"40 buses\",\n      \"type\": \"metric\"\n    }\n  ],\n  \"headline\": \"City Council Approves Electric Bus Fleet Following Successful Pilot\"\n}",
+        "parsed": {
+          "key_points": [
+            "The city council voted 8-3 to approve a new electric bus fleet.",
+            "A six-month pilot program reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots are scheduled to be completed by July.",
+            "Critics raised concerns about winter battery performance.",
+            "The transport committee confirmed pilot data from two cold snaps met operational targets."
+          ],
+          "summary": "The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that the pilot data from two cold snaps met operational targets. The first 40 buses are set to begin service in September, with charging infrastructure to be completed by July.",
+          "entities": [
+            {
+              "name": "city council",
+              "type": "government"
+            },
+            {
+              "name": "transport committee",
+              "type": "government"
+            },
+            {
+              "name": "September",
+              "type": "date"
+            },
+            {
+              "name": "July",
+              "type": "date"
+            },
+            {
+              "name": "22 percent",
+              "type": "metric"
+            },
+            {
+              "name": "40 buses",
+              "type": "metric"
+            }
+          ],
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot"
+        },
+        "usage": {
+          "completion_tokens": 352,
+          "prompt_tokens": 243,
+          "total_tokens": 595,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 88.21,
+          "total_time": 4.16,
+          "prompt_tokens_per_second": 1467.6,
+          "completion_time": 3.99,
+          "prompt_time": 0.17
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::article_summary",
+      "ok": true,
+      "elapsed_s": 5.873,
+      "details": {
+        "parsed": {
+          "summary": "The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. The first 40 buses are scheduled to begin service in September, with charging infrastructure to be finished by July. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that pilot data from cold weather events met operational targets.",
+          "key_points": [
+            "City council voted 8-3 to approve the electric bus fleet.",
+            "A six-month pilot reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots will be completed by July.",
+            "Pilot data from cold snaps showed batteries met operational targets."
+          ],
+          "entities": [
+            {
+              "name": "city council",
+              "type": "organization"
+            },
+            {
+              "name": "transport committee",
+              "type": "organization"
+            },
+            {
+              "name": "22 percent",
+              "type": "metric"
+            },
+            {
+              "name": "40 buses",
+              "type": "metric"
+            },
+            {
+              "name": "September",
+              "type": "date"
+            },
+            {
+              "name": "July",
+              "type": "date"
+            }
+          ],
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot"
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::article_summary",
+      "ok": true,
+      "elapsed_s": 5.704,
+      "details": {
+        "parsed": {
+          "summary": "The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. The first 40 buses are scheduled to begin service in September, with charging infrastructure to be finished by July. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that pilot data from cold weather events met operational targets.",
+          "entities": [
+            {
+              "type": "organization",
+              "name": "city council"
+            },
+            {
+              "type": "organization",
+              "name": "transport committee"
+            },
+            {
+              "type": "metric",
+              "name": "22 percent"
+            },
+            {
+              "type": "date",
+              "name": "September"
+            },
+            {
+              "type": "date",
+              "name": "July"
+            }
+          ],
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot",
+          "key_points": [
+            "The city council voted 8-3 to approve the new electric bus fleet.",
+            "A six-month pilot program reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots are scheduled for completion by July.",
+            "Winter battery performance concerns were addressed by the transport committee using pilot data."
+          ]
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 2.355,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"attributes\": [\n    {\n      \"name\": \"material\",\n      \"value\": \"water-resistant recycled nylon\"\n    },\n    {\n      \"name\": \"laptop_sleeve_capacity\",\n      \"value\": \"16 inch\"\n    },\n    {\n      \"name\": \"color\",\n      \"value\": \"midnight blue\"\n    },\n    {\n      \"name\": \"weight\",\n      \"value\": \"0.9 kg\"\n    }\n  ],\n  \"product_name\": \"TrailPro 18L commuter backpack\",\n  \"use_cases\": [\n    \"commuting\",\n    \"short hikes\"\n  ],\n  \"category\": \"backpack\",\n  \"price_usd\": 89\n}",
+        "parsed": {
+          "attributes": [
+            {
+              "name": "material",
+              "value": "water-resistant recycled nylon"
+            },
+            {
+              "name": "laptop_sleeve_capacity",
+              "value": "16 inch"
+            },
+            {
+              "name": "color",
+              "value": "midnight blue"
+            },
+            {
+              "name": "weight",
+              "value": "0.9 kg"
+            }
+          ],
+          "product_name": "TrailPro 18L commuter backpack",
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "category": "backpack",
+          "price_usd": 89
+        },
+        "usage": {
+          "completion_tokens": 172,
+          "prompt_tokens": 244,
+          "total_tokens": 416,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "prompt_tokens_per_second": 1363.12,
+          "completion_time": 1.93,
+          "completion_tokens_per_second": 89.09,
+          "total_time": 2.11,
+          "prompt_time": 0.18
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 4.046,
+      "details": {
+        "parsed": {
+          "product_name": "TrailPro 18L commuter backpack",
+          "category": "backpack",
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "attributes": [
+            {
+              "value": "water-resistant recycled nylon shell",
+              "name": "material"
+            },
+            {
+              "value": "16 inch",
+              "name": "laptop sleeve capacity"
+            },
+            {
+              "value": "midnight blue",
+              "name": "color"
+            },
+            {
+              "value": "0.9 kg",
+              "name": "weight"
+            }
+          ],
+          "price_usd": 89
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 4.082,
+      "details": {
+        "parsed": {
+          "product_name": "TrailPro 18L commuter backpack",
+          "attributes": [
+            {
+              "name": "material",
+              "value": "water-resistant recycled nylon"
+            },
+            {
+              "name": "laptop_sleeve",
+              "value": "16 inch"
+            },
+            {
+              "name": "color",
+              "value": "midnight blue"
+            },
+            {
+              "name": "weight",
+              "value": "0.9 kg"
+            }
+          ],
+          "price_usd": 89,
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "category": "backpack"
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.576,
+      "details": {
+        "content": "{\"name\":\"Grace Hopper\",\"occupation\":\"computer scientist\",\"age\":45}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    },
+    {
+      "name": "api_stream_json_schema::stream_person_basic",
+      "ok": true,
+      "elapsed_s": 0.484,
+      "details": {
+        "content": "{\n  \"name\": \"Katherine Johnson\",\n  \"age\": 50,\n  \"occupation\": \"mathematician\"\n}",
+        "parsed": {
+          "name": "Katherine Johnson",
+          "age": 50,
+          "occupation": "mathematician"
+        },
+        "validation_error": null,
+        "chunk_count": 32,
+        "saw_usage_chunk": true,
+        "usage": {
+          "completion_tokens": 32,
+          "prompt_tokens": 115,
+          "total_tokens": 147,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "prompt_tokens_per_second": 1083.15,
+          "completion_time": 0.35,
+          "completion_tokens_per_second": 90.72,
+          "total_time": 0.46,
+          "prompt_time": 0.11
+        },
+        "finish_reason": "stop"
+      }
+    },
+    {
+      "name": "api_conflict_json_schema::conflict_prompt_person",
+      "ok": true,
+      "elapsed_s": 0.333,
+      "details": {
+        "content": "{\"occupation\":\"programmer\",\"name\":\"Ada Lovelace\",\"age\":39}",
+        "parsed": {
+          "occupation": "programmer",
+          "name": "Ada Lovelace",
+          "age": 39
+        },
+        "refusal": null,
+        "finish_reason": "stop",
+        "usage": {
+          "completion_tokens": 18,
+          "prompt_tokens": 123,
+          "total_tokens": 141,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 91.23,
+          "total_time": 0.31,
+          "prompt_tokens_per_second": 1087.04,
+          "completion_time": 0.2,
+          "prompt_time": 0.11
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_truncation_json_schema::truncation_article_summary",
+      "ok": true,
+      "elapsed_s": 0.446,
+      "details": {
+        "finish_reason": "length",
+        "hit_budget": true,
+        "content": "{\n  \"summary\": \"The city council has approved a new electric bus fleet following a successful six-month pilot that",
+        "parsed": null,
+        "validation_error": "Unterminated string starting at: line 2 column 14 (char 15)",
+        "refusal": null,
+        "usage": {
+          "completion_tokens": 24,
+          "prompt_tokens": 246,
+          "total_tokens": 270,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 92.57,
+          "total_time": 0.42,
+          "prompt_tokens_per_second": 1501.53,
+          "completion_time": 0.26,
+          "prompt_time": 0.16
+        }
+      }
+    },
+    {
+      "name": "api_json_schema::edge_nullable_contact",
+      "ok": true,
+      "elapsed_s": 0.38,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"company\":\"Acme Labs\",\"name\":\"Jordan Lee\",\"preferred_channel\":\"email\",\"phone\":null}",
+        "parsed": {
+          "company": "Acme Labs",
+          "name": "Jordan Lee",
+          "preferred_channel": "email",
+          "phone": null
+        },
+        "usage": {
+          "completion_tokens": 21,
+          "prompt_tokens": 147,
+          "total_tokens": 168,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 90.72,
+          "total_time": 0.36,
+          "prompt_tokens_per_second": 1186.49,
+          "completion_time": 0.23,
+          "prompt_time": 0.12
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::edge_nullable_contact",
+      "ok": true,
+      "elapsed_s": 2.51,
+      "details": {
+        "parsed": {
+          "company": "Acme Labs",
+          "preferred_channel": "email",
+          "name": "Jordan Lee",
+          "phone": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::edge_nullable_contact",
+      "ok": true,
+      "elapsed_s": 2.541,
+      "details": {
+        "parsed": {
+          "company": "Acme Labs",
+          "preferred_channel": "email",
+          "phone": null,
+          "name": "Jordan Lee"
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::edge_bounded_tags",
+      "ok": true,
+      "elapsed_s": 0.435,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"tags\":[\"billing\",\"ui\"]}",
+        "parsed": {
+          "tags": [
+            "billing",
+            "ui"
+          ]
+        },
+        "usage": {
+          "completion_tokens": 7,
+          "prompt_tokens": 140,
+          "total_tokens": 147,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 87.92,
+          "total_time": 0.2,
+          "prompt_tokens_per_second": 1133.29,
+          "completion_time": 0.08,
+          "prompt_time": 0.12
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::edge_bounded_tags",
+      "ok": true,
+      "elapsed_s": 2.157,
+      "details": {
+        "parsed": {
+          "tags": [
+            "billing",
+            "ui"
+          ]
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::edge_bounded_tags",
+      "ok": true,
+      "elapsed_s": 2.17,
+      "details": {
+        "parsed": {
+          "tags": [
+            "billing",
+            "ui"
+          ]
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::edge_anyof_priority",
+      "ok": true,
+      "elapsed_s": 0.619,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"priority\":\"p1\",\"summary\":\"Critical production payment failures causing executive-level urgency with hourly update requests.\"}",
+        "parsed": {
+          "priority": "p1",
+          "summary": "Critical production payment failures causing executive-level urgency with hourly update requests."
+        },
+        "usage": {
+          "completion_tokens": 22,
+          "prompt_tokens": 141,
+          "total_tokens": 163,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "prompt_tokens_per_second": 1135.83,
+          "total_time": 0.38,
+          "prompt_time": 0.12,
+          "completion_tokens_per_second": 87.43,
+          "completion_time": 0.25
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::default::edge_anyof_priority",
+      "ok": true,
+      "elapsed_s": 2.486,
+      "details": {
+        "parsed": {
+          "priority": "p1",
+          "summary": "Production payments are failing, causing critical business disruption and requiring hourly executive updates."
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::edge_anyof_priority",
+      "ok": true,
+      "elapsed_s": 2.444,
+      "details": {
+        "parsed": {
+          "summary": "Production payments are failing, causing executives to request hourly status updates.",
+          "priority": "p1"
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_unsupported_json_schema::unsupported_pattern_properties",
+      "ok": true,
+      "elapsed_s": 0.408,
+      "details": {
+        "mode": "accepted",
+        "content": "{\"ENV_VAR_\":\"value\"}",
+        "parsed": {
+          "ENV_VAR_": "value"
+        },
+        "validation_error": null,
+        "finish_reason": "stop"
+      }
+    },
+    {
+      "name": "cli_guided_json::invalid_schema_error",
+      "ok": true,
+      "elapsed_s": 0.022,
+      "details": {
+        "returncode": 64,
+        "stderr": "Error: Invalid JSON schema: must be a valid JSON object\nUsage: mlx <options>\n  See 'mlx --help' for more information.\n",
+        "error_indicator": "invalid json"
+      }
+    },
+    {
+      "name": "cli_guided_json::no_think::invalid_schema_error",
+      "ok": true,
+      "elapsed_s": 0.023,
+      "details": {
+        "returncode": 64,
+        "stderr": "Error: Invalid JSON schema: must be a valid JSON object\nUsage: mlx <options>\n  See 'mlx --help' for more information.\n",
+        "error_indicator": "invalid json"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/guided-json-expanded-api-v2.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-expanded-api-v2.json
@@ -1,0 +1,431 @@
+{
+  "generated_at": "2026-03-13T23:07:39.186215",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.002,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 0.67,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"age\":36,\"occupation\":\"mathematician\",\"name\":\"Ada Lovelace\"}",
+        "parsed": {
+          "age": 36,
+          "occupation": "mathematician",
+          "name": "Ada Lovelace"
+        },
+        "usage": {
+          "completion_tokens": 19,
+          "prompt_tokens": 116,
+          "total_tokens": 135,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.25,
+          "completion_time": 0.2,
+          "prompt_tokens_per_second": 983.61,
+          "prompt_time": 0.12,
+          "total_time": 0.31
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.333,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"items\": [\n    {\n      \"task\": \"draft the customer email\",\n      \"owner\": \"Sarah\",\n      \"due_date\": \"Friday\"\n    },\n    {\n      \"task\": \"deploy the dashboard fix\",\n      \"owner\": \"Ben\",\n      \"due_date\": \"Tuesday\"\n    },\n    {\n      \"task\": \"confirm pricing with finance\",\n      \"owner\": \"Priya\",\n      \"due_date\": \"this afternoon\"\n    }\n  ]\n}",
+        "parsed": {
+          "items": [
+            {
+              "task": "draft the customer email",
+              "owner": "Sarah",
+              "due_date": "Friday"
+            },
+            {
+              "task": "deploy the dashboard fix",
+              "owner": "Ben",
+              "due_date": "Tuesday"
+            },
+            {
+              "task": "confirm pricing with finance",
+              "owner": "Priya",
+              "due_date": "this afternoon"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 165,
+          "total_tokens": 281,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 98.3,
+          "completion_time": 1.18,
+          "prompt_tokens_per_second": 1257.63,
+          "prompt_time": 0.13,
+          "total_time": 1.31
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 0.944,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"account_name\": \"Acme Labs\",\n  \"severity\": \"high\",\n  \"summary\": \"Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.\",\n  \"blocked_teams\": [\n    \"finance\",\n    \"analytics\"\n  ],\n  \"category\": \"billing\"\n}",
+        "parsed": {
+          "account_name": "Acme Labs",
+          "severity": "high",
+          "summary": "Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.",
+          "blocked_teams": [
+            "finance",
+            "analytics"
+          ],
+          "category": "billing"
+        },
+        "usage": {
+          "completion_tokens": 76,
+          "prompt_tokens": 197,
+          "total_tokens": 273,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.69,
+          "completion_time": 0.78,
+          "prompt_tokens_per_second": 1371.74,
+          "prompt_time": 0.14,
+          "total_time": 0.92
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 2.688,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"entities\": [\n    {\n      \"name\": \"city council\",\n      \"type\": \"organization\"\n    },\n    {\n      \"name\": \"Transport Committee\",\n      \"type\": \"organization\"\n    }\n  ],\n  \"summary\": \"The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that pilot data from cold snaps met operational targets. The first 40 buses are scheduled to begin service in September, with charging depots set to be completed by July.\",\n  \"key_points\": [\n    \"The city council voted 8-3 to approve the electric bus fleet.\",\n    \"A six-month pilot reduced fuel costs by 22 percent.\",\n    \"The first 40 buses will enter service in September.\",\n    \"Charging depots will be completed by July.\",\n    \"Pilot data from cold snaps met operational targets despite winter performance concerns.\"\n  ],\n  \"headline\": \"City Council Approves Electric Bus Fleet Following Successful Pilot\"\n}",
+        "parsed": {
+          "entities": [
+            {
+              "name": "city council",
+              "type": "organization"
+            },
+            {
+              "name": "Transport Committee",
+              "type": "organization"
+            }
+          ],
+          "summary": "The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that pilot data from cold snaps met operational targets. The first 40 buses are scheduled to begin service in September, with charging depots set to be completed by July.",
+          "key_points": [
+            "The city council voted 8-3 to approve the electric bus fleet.",
+            "A six-month pilot reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots will be completed by July.",
+            "Pilot data from cold snaps met operational targets despite winter performance concerns."
+          ],
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot"
+        },
+        "usage": {
+          "completion_tokens": 244,
+          "prompt_tokens": 243,
+          "total_tokens": 487,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.57,
+          "completion_time": 2.5,
+          "prompt_tokens_per_second": 1481.56,
+          "prompt_time": 0.16,
+          "total_time": 2.66
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 1.944,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"product_name\": \"TrailPro 18L commuter backpack\",\n  \"attributes\": [\n    {\n      \"name\": \"material\",\n      \"value\": \"water-resistant recycled nylon\"\n    },\n    {\n      \"name\": \"laptop_sleeve_capacity\",\n      \"value\": \"16 inch\"\n    },\n    {\n      \"name\": \"color\",\n      \"value\": \"midnight blue\"\n    },\n    {\n      \"name\": \"weight\",\n      \"value\": \"0.9 kg\"\n    }\n  ],\n  \"category\": \"backpack\",\n  \"use_cases\": [\n    \"commuting\",\n    \"short hikes\"\n  ],\n  \"price_usd\": 89\n}",
+        "parsed": {
+          "product_name": "TrailPro 18L commuter backpack",
+          "attributes": [
+            {
+              "name": "material",
+              "value": "water-resistant recycled nylon"
+            },
+            {
+              "name": "laptop_sleeve_capacity",
+              "value": "16 inch"
+            },
+            {
+              "name": "color",
+              "value": "midnight blue"
+            },
+            {
+              "name": "weight",
+              "value": "0.9 kg"
+            }
+          ],
+          "category": "backpack",
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "price_usd": 89
+        },
+        "usage": {
+          "completion_tokens": 172,
+          "prompt_tokens": 244,
+          "total_tokens": 416,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.78,
+          "completion_time": 1.76,
+          "prompt_tokens_per_second": 1504.81,
+          "prompt_time": 0.16,
+          "total_time": 1.92
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.32,
+      "details": {
+        "content": "{\"age\":45,\"occupation\":\"computer scientist\",\"name\":\"Grace Hopper\"}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    },
+    {
+      "name": "api_stream_json_schema::stream_person_basic",
+      "ok": true,
+      "elapsed_s": 0.453,
+      "details": {
+        "content": "{\n  \"age\": 50,\n  \"occupation\": \"mathematician\",\n  \"name\": \"Katherine Johnson\"\n}",
+        "parsed": {
+          "age": 50,
+          "occupation": "mathematician",
+          "name": "Katherine Johnson"
+        },
+        "validation_error": null,
+        "chunk_count": 32,
+        "saw_usage_chunk": true,
+        "usage": {
+          "completion_tokens": 32,
+          "prompt_tokens": 115,
+          "total_tokens": 147,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.66,
+          "completion_time": 0.33,
+          "prompt_tokens_per_second": 1089.99,
+          "prompt_time": 0.11,
+          "total_time": 0.43
+        },
+        "finish_reason": "stop"
+      }
+    },
+    {
+      "name": "api_conflict_json_schema::conflict_prompt_person",
+      "ok": true,
+      "elapsed_s": 0.325,
+      "details": {
+        "content": "{\"age\":36,\"occupation\":\"Mathematician\",\"name\":\"Ada Lovelace\"}",
+        "parsed": {
+          "age": 36,
+          "occupation": "Mathematician",
+          "name": "Ada Lovelace"
+        },
+        "refusal": null,
+        "finish_reason": "stop",
+        "usage": {
+          "completion_tokens": 19,
+          "prompt_tokens": 123,
+          "total_tokens": 142,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.54,
+          "completion_time": 0.19,
+          "prompt_tokens_per_second": 1124.65,
+          "prompt_time": 0.11,
+          "total_time": 0.3
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_truncation_json_schema::truncation_article_summary",
+      "ok": true,
+      "elapsed_s": 0.423,
+      "details": {
+        "finish_reason": "stop",
+        "hit_budget": true,
+        "content": "{\n  \"key_points\": [\n    \"The city council voted 8-3 to approve a new electric",
+        "parsed": null,
+        "validation_error": "Unterminated string starting at: line 3 column 5 (char 24)",
+        "refusal": null,
+        "usage": {
+          "completion_tokens": 24,
+          "prompt_tokens": 246,
+          "total_tokens": 270,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 100.43,
+          "completion_time": 0.24,
+          "prompt_tokens_per_second": 1513.72,
+          "prompt_time": 0.16,
+          "total_time": 0.4
+        }
+      }
+    },
+    {
+      "name": "api_json_schema::edge_nullable_contact",
+      "ok": true,
+      "elapsed_s": 0.359,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"preferred_channel\":\"email\",\"name\":\"Jordan Lee\",\"phone\":null,\"company\":\"Acme Labs\"}",
+        "parsed": {
+          "preferred_channel": "email",
+          "name": "Jordan Lee",
+          "phone": null,
+          "company": "Acme Labs"
+        },
+        "usage": {
+          "completion_tokens": 21,
+          "prompt_tokens": 147,
+          "total_tokens": 168,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.27,
+          "completion_time": 0.22,
+          "prompt_tokens_per_second": 1198.92,
+          "prompt_time": 0.12,
+          "total_time": 0.34
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::edge_bounded_tags",
+      "ok": true,
+      "elapsed_s": 0.199,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"tags\":[\"billing\",\"ui\"]}",
+        "parsed": {
+          "tags": [
+            "billing",
+            "ui"
+          ]
+        },
+        "usage": {
+          "completion_tokens": 7,
+          "prompt_tokens": 140,
+          "total_tokens": 147,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.2,
+          "completion_time": 0.07,
+          "prompt_tokens_per_second": 1156.52,
+          "prompt_time": 0.12,
+          "total_time": 0.19
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::edge_anyof_priority",
+      "ok": true,
+      "elapsed_s": 0.37,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"priority\":\"p1\",\"summary\":\"Critical production payment failures causing executive-level urgency with hourly update requests.\"}",
+        "parsed": {
+          "priority": "p1",
+          "summary": "Critical production payment failures causing executive-level urgency with hourly update requests."
+        },
+        "usage": {
+          "completion_tokens": 22,
+          "prompt_tokens": 141,
+          "total_tokens": 163,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.6,
+          "completion_time": 0.23,
+          "prompt_tokens_per_second": 1149.83,
+          "prompt_time": 0.12,
+          "total_time": 0.35
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_unsupported_json_schema::unsupported_pattern_properties",
+      "ok": true,
+      "elapsed_s": 0.182,
+      "details": {
+        "mode": "accepted",
+        "content": "{\"ENV_VAR_\":\"value\"}",
+        "parsed": {
+          "ENV_VAR_": "value"
+        },
+        "validation_error": null,
+        "finish_reason": "stop"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/guided-json-expanded-api.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-expanded-api.json
@@ -1,0 +1,436 @@
+{
+  "generated_at": "2026-03-13T23:04:16.521029",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.002,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 0.673,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"occupation\":\"mathematician\",\"age\":36,\"name\":\"Ada Lovelace\"}",
+        "parsed": {
+          "occupation": "mathematician",
+          "age": 36,
+          "name": "Ada Lovelace"
+        },
+        "usage": {
+          "completion_tokens": 19,
+          "prompt_tokens": 116,
+          "total_tokens": 135,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 95.79,
+          "completion_time": 0.2,
+          "prompt_tokens_per_second": 1007.27,
+          "prompt_time": 0.12,
+          "total_time": 0.31
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.353,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"items\": [\n    {\n      \"owner\": \"Sarah\",\n      \"due_date\": \"Friday\",\n      \"task\": \"draft the customer email\"\n    },\n    {\n      \"owner\": \"Ben\",\n      \"due_date\": \"Tuesday\",\n      \"task\": \"deploy the dashboard fix\"\n    },\n    {\n      \"owner\": \"Priya\",\n      \"due_date\": \"this afternoon\",\n      \"task\": \"confirm pricing with finance\"\n    }\n  ]\n}",
+        "parsed": {
+          "items": [
+            {
+              "owner": "Sarah",
+              "due_date": "Friday",
+              "task": "draft the customer email"
+            },
+            {
+              "owner": "Ben",
+              "due_date": "Tuesday",
+              "task": "deploy the dashboard fix"
+            },
+            {
+              "owner": "Priya",
+              "due_date": "this afternoon",
+              "task": "confirm pricing with finance"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 165,
+          "total_tokens": 281,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.81,
+          "completion_time": 1.2,
+          "prompt_tokens_per_second": 1247.27,
+          "prompt_time": 0.13,
+          "total_time": 1.33
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 0.955,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"blocked_teams\": [\n    \"Finance\",\n    \"Analytics\"\n  ],\n  \"account_name\": \"Acme Labs\",\n  \"category\": \"billing\",\n  \"severity\": \"high\",\n  \"summary\": \"Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.\"\n}",
+        "parsed": {
+          "blocked_teams": [
+            "Finance",
+            "Analytics"
+          ],
+          "account_name": "Acme Labs",
+          "category": "billing",
+          "severity": "high",
+          "summary": "Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close."
+        },
+        "usage": {
+          "completion_tokens": 76,
+          "prompt_tokens": 197,
+          "total_tokens": 273,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.51,
+          "completion_time": 0.79,
+          "prompt_tokens_per_second": 1362.17,
+          "prompt_time": 0.14,
+          "total_time": 0.93
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 3.442,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"summary\": \"The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. The first 40 buses are scheduled to begin service in September, with charging infrastructure to be finished by July. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that pilot data from cold weather events met operational targets.\",\n  \"entities\": [\n    {\n      \"name\": \"city council\",\n      \"type\": \"government\"\n    },\n    {\n      \"name\": \"Transport Committee\",\n      \"type\": \"government\"\n    },\n    {\n      \"name\": \"22 percent\",\n      \"type\": \"metric\"\n    },\n    {\n      \"name\": \"September\",\n      \"type\": \"date\"\n    },\n    {\n      \"name\": \"July\",\n      \"type\": \"date\"\n    }\n  ],\n  \"key_points\": [\n    \"The city council voted 8-3 to approve the electric bus fleet.\",\n    \"A six-month pilot program reduced fuel costs by 22 percent.\",\n    \"The first 40 buses will enter service in September.\",\n    \"Charging depots are scheduled for completion by July.\",\n    \"Pilot data from cold snaps showed batteries met operational targets despite winter concerns.\"\n  ],\n  \"headline\": \"City Council Approves Electric Bus Fleet Following Successful Pilot\"\n}",
+        "parsed": {
+          "summary": "The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. The first 40 buses are scheduled to begin service in September, with charging infrastructure to be finished by July. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that pilot data from cold weather events met operational targets.",
+          "entities": [
+            {
+              "name": "city council",
+              "type": "government"
+            },
+            {
+              "name": "Transport Committee",
+              "type": "government"
+            },
+            {
+              "name": "22 percent",
+              "type": "metric"
+            },
+            {
+              "name": "September",
+              "type": "date"
+            },
+            {
+              "name": "July",
+              "type": "date"
+            }
+          ],
+          "key_points": [
+            "The city council voted 8-3 to approve the electric bus fleet.",
+            "A six-month pilot program reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots are scheduled for completion by July.",
+            "Pilot data from cold snaps showed batteries met operational targets despite winter concerns."
+          ],
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot"
+        },
+        "usage": {
+          "completion_tokens": 314,
+          "prompt_tokens": 243,
+          "total_tokens": 557,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.45,
+          "completion_time": 3.26,
+          "prompt_tokens_per_second": 1493.04,
+          "prompt_time": 0.16,
+          "total_time": 3.42
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 1.965,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"product_name\": \"TrailPro 18L commuter backpack\",\n  \"price_usd\": 89,\n  \"attributes\": [\n    {\n      \"value\": \"water-resistant recycled nylon shell\",\n      \"name\": \"material\"\n    },\n    {\n      \"value\": \"16 inch\",\n      \"name\": \"laptop sleeve capacity\"\n    },\n    {\n      \"value\": \"midnight blue\",\n      \"name\": \"color\"\n    },\n    {\n      \"value\": \"0.9 kg\",\n      \"name\": \"weight\"\n    }\n  ],\n  \"use_cases\": [\n    \"commuting\",\n    \"short hikes\"\n  ],\n  \"category\": \"backpack\"\n}",
+        "parsed": {
+          "product_name": "TrailPro 18L commuter backpack",
+          "price_usd": 89,
+          "attributes": [
+            {
+              "value": "water-resistant recycled nylon shell",
+              "name": "material"
+            },
+            {
+              "value": "16 inch",
+              "name": "laptop sleeve capacity"
+            },
+            {
+              "value": "midnight blue",
+              "name": "color"
+            },
+            {
+              "value": "0.9 kg",
+              "name": "weight"
+            }
+          ],
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "category": "backpack"
+        },
+        "usage": {
+          "completion_tokens": 172,
+          "prompt_tokens": 244,
+          "total_tokens": 416,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.7,
+          "completion_time": 1.78,
+          "prompt_tokens_per_second": 1501.47,
+          "prompt_time": 0.16,
+          "total_time": 1.94
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.323,
+      "details": {
+        "content": "{\"occupation\":\"computer scientist\",\"name\":\"Grace Hopper\",\"age\":45}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    },
+    {
+      "name": "api_stream_json_schema::stream_person_basic",
+      "ok": true,
+      "elapsed_s": 0.449,
+      "details": {
+        "content": "{\n  \"occupation\": \"mathematician\",\n  \"name\": \"Katherine Johnson\",\n  \"age\": 50\n}",
+        "parsed": {
+          "occupation": "mathematician",
+          "name": "Katherine Johnson",
+          "age": 50
+        },
+        "validation_error": null,
+        "chunk_count": 31,
+        "saw_usage_chunk": true,
+        "usage": {
+          "completion_tokens": 31,
+          "prompt_tokens": 115,
+          "total_tokens": 146,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.16,
+          "completion_time": 0.32,
+          "prompt_tokens_per_second": 1076.27,
+          "prompt_time": 0.11,
+          "total_time": 0.43
+        },
+        "finish_reason": "stop"
+      }
+    },
+    {
+      "name": "api_conflict_json_schema::conflict_prompt_person",
+      "ok": true,
+      "elapsed_s": 0.319,
+      "details": {
+        "content": "{\"occupation\":\"programmer\",\"name\":\"Ada Lovelace\",\"age\":39}",
+        "parsed": {
+          "occupation": "programmer",
+          "name": "Ada Lovelace",
+          "age": 39
+        },
+        "refusal": null,
+        "finish_reason": "stop",
+        "usage": {
+          "completion_tokens": 18,
+          "prompt_tokens": 123,
+          "total_tokens": 141,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.11,
+          "completion_time": 0.19,
+          "prompt_tokens_per_second": 1111.48,
+          "prompt_time": 0.11,
+          "total_time": 0.3
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_truncation_json_schema::truncation_article_summary",
+      "ok": false,
+      "elapsed_s": 0.425,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"headline\": \"City Council Approves Electric Bus Fleet Following Successful Pilot\",\n  \"entities\": [",
+        "parsed": null,
+        "validation_error": "Expecting value: line 3 column 16 (char 102)",
+        "refusal": null,
+        "usage": {
+          "completion_tokens": 24,
+          "prompt_tokens": 246,
+          "total_tokens": 270,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 99.63,
+          "completion_time": 0.24,
+          "prompt_tokens_per_second": 1505.58,
+          "prompt_time": 0.16,
+          "total_time": 0.4
+        }
+      }
+    },
+    {
+      "name": "api_json_schema::edge_nullable_contact",
+      "ok": true,
+      "elapsed_s": 0.362,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"name\":\"Jordan Lee\",\"phone\":null,\"company\":\"Acme Labs\",\"preferred_channel\":\"email\"}",
+        "parsed": {
+          "name": "Jordan Lee",
+          "phone": null,
+          "company": "Acme Labs",
+          "preferred_channel": "email"
+        },
+        "usage": {
+          "completion_tokens": 21,
+          "prompt_tokens": 147,
+          "total_tokens": 168,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.6,
+          "completion_time": 0.22,
+          "prompt_tokens_per_second": 1189.93,
+          "prompt_time": 0.12,
+          "total_time": 0.34
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::edge_bounded_tags",
+      "ok": true,
+      "elapsed_s": 0.201,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"tags\":[\"billing\",\"ui\"]}",
+        "parsed": {
+          "tags": [
+            "billing",
+            "ui"
+          ]
+        },
+        "usage": {
+          "completion_tokens": 7,
+          "prompt_tokens": 140,
+          "total_tokens": 147,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 94.56,
+          "completion_time": 0.07,
+          "prompt_tokens_per_second": 1154.4,
+          "prompt_time": 0.12,
+          "total_time": 0.2
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::edge_anyof_priority",
+      "ok": true,
+      "elapsed_s": 0.373,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"priority\":\"p1\",\"summary\":\"Critical production payment failures causing executive-level urgency with hourly update requests.\"}",
+        "parsed": {
+          "priority": "p1",
+          "summary": "Critical production payment failures causing executive-level urgency with hourly update requests."
+        },
+        "usage": {
+          "completion_tokens": 22,
+          "prompt_tokens": 141,
+          "total_tokens": 163,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.05,
+          "completion_time": 0.23,
+          "prompt_tokens_per_second": 1146.17,
+          "prompt_time": 0.12,
+          "total_time": 0.35
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_unsupported_json_schema::unsupported_pattern_properties",
+      "ok": false,
+      "elapsed_s": 0.184,
+      "details": {
+        "error": "request unexpectedly succeeded"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/guided-json-foundation-smoke-v2.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-foundation-smoke-v2.json
@@ -1,0 +1,358 @@
+{
+  "generated_at": "2026-03-13T23:40:04.011662",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.001,
+      "details": {
+        "count": 1,
+        "first_id": "foundation"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 1.491,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"name\": \"Ada Lovelace\", \"occupation\": \"mathematician\", \"age\": 36}",
+        "parsed": {
+          "name": "Ada Lovelace",
+          "occupation": "mathematician",
+          "age": 36
+        },
+        "usage": {
+          "completion_tokens": 16,
+          "prompt_tokens": 18,
+          "total_tokens": 34,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.033,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"items\": [{\"owner\": \"Sarah\", \"due_date\": \"Friday\", \"task\": \"draft the customer email\"}, {\"owner\": \"Ben\", \"due_date\": \"Tuesday\", \"task\": \"deploy the dashboard fix\"}, {\"owner\": \"Priya\", \"due_date\": \"this afternoon\", \"task\": \"confirm pricing with finance\"}]}",
+        "parsed": {
+          "items": [
+            {
+              "owner": "Sarah",
+              "due_date": "Friday",
+              "task": "draft the customer email"
+            },
+            {
+              "owner": "Ben",
+              "due_date": "Tuesday",
+              "task": "deploy the dashboard fix"
+            },
+            {
+              "owner": "Priya",
+              "due_date": "this afternoon",
+              "task": "confirm pricing with finance"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 64,
+          "prompt_tokens": 54,
+          "total_tokens": 118,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 0.858,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"account_name\": \"Acme Labs\", \"category\": \"billing\", \"blocked_teams\": [\"finance\"], \"severity\": \"high\", \"summary\": \"After upgrading to Pro yesterday, invoices still show the Starter plan, and two users cannot access analytics, blocking the finance close.\"}",
+        "parsed": {
+          "account_name": "Acme Labs",
+          "category": "billing",
+          "blocked_teams": [
+            "finance"
+          ],
+          "severity": "high",
+          "summary": "After upgrading to Pro yesterday, invoices still show the Starter plan, and two users cannot access analytics, blocking the finance close."
+        },
+        "usage": {
+          "completion_tokens": 63,
+          "prompt_tokens": 68,
+          "total_tokens": 131,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 3.33,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"summary\": \"The city council has approved a new electric bus fleet after a successful six-month pilot program that reduced fuel costs by 22%. The first 40 buses will begin service in September, with charging infrastructure ready by July. Despite concerns about winter battery performance, pilot data showed that the battery performance met operational targets during cold snaps.\", \"key_points\": [\"The city council voted 8-3 to approve a new electric bus fleet.\", \"The first 40 buses will enter service in September.\", \"Charging depots are expected to be completed by July.\", \"Critics raised concerns about winter battery performance.\", \"Pilot data from two cold snaps remained within operational targets.\"], \"headline\": \"City Council Approves New Electric Bus Fleet\", \"entities\": [{\"name\": \"City Council\", \"type\": \"organization\"}, {\"type\": \"organization\", \"name\": \"Transit Officials\"}, {\"type\": \"organization\", \"name\": \"Transport Committee\"}, {\"name\": \"Electric Bus Fleet\", \"type\": \"metric\"}, {\"name\": \"Fuel Costs\", \"type\": \"metric\"}, {\"type\": \"date\", \"name\": \"Cold Snaps\"}]}",
+        "parsed": {
+          "summary": "The city council has approved a new electric bus fleet after a successful six-month pilot program that reduced fuel costs by 22%. The first 40 buses will begin service in September, with charging infrastructure ready by July. Despite concerns about winter battery performance, pilot data showed that the battery performance met operational targets during cold snaps.",
+          "key_points": [
+            "The city council voted 8-3 to approve a new electric bus fleet.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots are expected to be completed by July.",
+            "Critics raised concerns about winter battery performance.",
+            "Pilot data from two cold snaps remained within operational targets."
+          ],
+          "headline": "City Council Approves New Electric Bus Fleet",
+          "entities": [
+            {
+              "name": "City Council",
+              "type": "organization"
+            },
+            {
+              "type": "organization",
+              "name": "Transit Officials"
+            },
+            {
+              "type": "organization",
+              "name": "Transport Committee"
+            },
+            {
+              "name": "Electric Bus Fleet",
+              "type": "metric"
+            },
+            {
+              "name": "Fuel Costs",
+              "type": "metric"
+            },
+            {
+              "type": "date",
+              "name": "Cold Snaps"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 269,
+          "prompt_tokens": 113,
+          "total_tokens": 382,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 1.934,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"product_name\": \"TrailPro 18L Commuter Backpack\", \"attributes\": [{\"value\": \"water-resistant recycled nylon shell\", \"name\": \"material\"}, {\"name\": \"color\", \"value\": \"midnight blue\"}, {\"name\": \"capacity\", \"value\": \"18L\"}, {\"value\": \"for 16 inch devices\", \"name\": \"laptop sleeve\"}, {\"value\": \"0.9 kg\", \"name\": \"weight\"}, {\"value\": \"commuting and short hikes\", \"name\": \"suitable for\"}], \"price_usd\": 89, \"use_cases\": [\"commuting\", \"short hikes\"], \"category\": \"backpack\"}",
+        "parsed": {
+          "product_name": "TrailPro 18L Commuter Backpack",
+          "attributes": [
+            {
+              "value": "water-resistant recycled nylon shell",
+              "name": "material"
+            },
+            {
+              "name": "color",
+              "value": "midnight blue"
+            },
+            {
+              "name": "capacity",
+              "value": "18L"
+            },
+            {
+              "value": "for 16 inch devices",
+              "name": "laptop sleeve"
+            },
+            {
+              "value": "0.9 kg",
+              "name": "weight"
+            },
+            {
+              "value": "commuting and short hikes",
+              "name": "suitable for"
+            }
+          ],
+          "price_usd": 89,
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "category": "backpack"
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 59,
+          "total_tokens": 175,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.405,
+      "details": {
+        "content": "{\"name\": \"Grace Hopper\", \"occupation\": \"computer scientist\", \"age\": 45}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    },
+    {
+      "name": "api_stream_json_schema::stream_person_basic",
+      "ok": true,
+      "elapsed_s": 0.56,
+      "details": {
+        "content": "{\"name\": \"Katherine Johnson\", \"occupation\": \"mathematician\", \"age\": 50}",
+        "parsed": {
+          "name": "Katherine Johnson",
+          "occupation": "mathematician",
+          "age": 50
+        },
+        "validation_error": null,
+        "chunk_count": 4,
+        "saw_usage_chunk": true,
+        "usage": {
+          "completion_tokens": 18,
+          "prompt_tokens": 19,
+          "total_tokens": 37,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null,
+          "prompt_time": 0.51,
+          "completion_time": 0.05,
+          "total_time": 0.56,
+          "prompt_tokens_per_second": 37.44,
+          "completion_tokens_per_second": 369.72
+        },
+        "finish_reason": "stop"
+      }
+    },
+    {
+      "name": "api_conflict_json_schema::conflict_prompt_person",
+      "ok": true,
+      "elapsed_s": 0.432,
+      "details": {
+        "content": "{\"occupation\": \"mathematician\", \"name\": \"Ada Lovelace\", \"age\": 0}",
+        "parsed": {
+          "occupation": "mathematician",
+          "name": "Ada Lovelace",
+          "age": 0
+        },
+        "refusal": null,
+        "finish_reason": "stop",
+        "usage": {
+          "completion_tokens": 16,
+          "prompt_tokens": 25,
+          "total_tokens": 41,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_truncation_json_schema::truncation_article_summary",
+      "ok": false,
+      "elapsed_s": 3.05,
+      "details": {
+        "error_type": "InternalServerError",
+        "message": "Error code: 503 - {'error': {'type': 'foundation_model_error', 'message': 'Failed to generate response: Failed to deserialize a Generable type from model output'}}"
+      }
+    },
+    {
+      "name": "api_json_schema::edge_nullable_contact",
+      "ok": true,
+      "elapsed_s": 0.541,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"name\": \"Jordan Lee\", \"phone\": \"null\", \"preferred_channel\": \"email\", \"company\": \"Acme Labs\"}",
+        "parsed": {
+          "name": "Jordan Lee",
+          "phone": "null",
+          "preferred_channel": "email",
+          "company": "Acme Labs"
+        },
+        "usage": {
+          "completion_tokens": 23,
+          "prompt_tokens": 32,
+          "total_tokens": 55,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::edge_bounded_tags",
+      "ok": true,
+      "elapsed_s": 0.317,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"tags\": [\"ui\", \"billing\"]}",
+        "parsed": {
+          "tags": [
+            "ui",
+            "billing"
+          ]
+        },
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 38,
+          "total_tokens": 44,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::edge_anyof_priority",
+      "ok": true,
+      "elapsed_s": 0.529,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"priority\": 1, \"summary\": \"Production payments are failing, and executives are requesting updates every hour.\"}",
+        "parsed": {
+          "priority": 1,
+          "summary": "Production payments are failing, and executives are requesting updates every hour."
+        },
+        "usage": {
+          "completion_tokens": 28,
+          "prompt_tokens": 30,
+          "total_tokens": 58,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_unsupported_json_schema::unsupported_pattern_properties",
+      "ok": true,
+      "elapsed_s": 0.199,
+      "details": {
+        "mode": "accepted",
+        "content": "{}",
+        "parsed": {},
+        "validation_error": null,
+        "finish_reason": "stop"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/guided-json-foundation-smoke-v3.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-foundation-smoke-v3.json
@@ -1,0 +1,377 @@
+{
+  "generated_at": "2026-03-13T23:41:26.474100",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.001,
+      "details": {
+        "count": 1,
+        "first_id": "foundation"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 0.61,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"name\": \"Ada Lovelace\", \"age\": 36, \"occupation\": \"mathematician\"}",
+        "parsed": {
+          "name": "Ada Lovelace",
+          "age": 36,
+          "occupation": "mathematician"
+        },
+        "usage": {
+          "completion_tokens": 16,
+          "prompt_tokens": 18,
+          "total_tokens": 34,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.007,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"items\": [{\"task\": \"draft the customer email\", \"owner\": \"Sarah\", \"due_date\": \"Friday\"}, {\"task\": \"deploy the dashboard fix\", \"owner\": \"Ben\", \"due_date\": \"Tuesday\"}, {\"due_date\": \"this afternoon\", \"owner\": \"Priya\", \"task\": \"confirm pricing with finance\"}]}",
+        "parsed": {
+          "items": [
+            {
+              "task": "draft the customer email",
+              "owner": "Sarah",
+              "due_date": "Friday"
+            },
+            {
+              "task": "deploy the dashboard fix",
+              "owner": "Ben",
+              "due_date": "Tuesday"
+            },
+            {
+              "due_date": "this afternoon",
+              "owner": "Priya",
+              "task": "confirm pricing with finance"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 64,
+          "prompt_tokens": 54,
+          "total_tokens": 118,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 0.852,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"blocked_teams\": [\"finance\"], \"severity\": \"high\", \"summary\": \"After upgrading to Pro yesterday, invoices still show the Starter plan, and two users cannot access analytics, blocking the finance close.\", \"account_name\": \"Acme Labs\", \"category\": \"billing\"}",
+        "parsed": {
+          "blocked_teams": [
+            "finance"
+          ],
+          "severity": "high",
+          "summary": "After upgrading to Pro yesterday, invoices still show the Starter plan, and two users cannot access analytics, blocking the finance close.",
+          "account_name": "Acme Labs",
+          "category": "billing"
+        },
+        "usage": {
+          "completion_tokens": 63,
+          "prompt_tokens": 68,
+          "total_tokens": 131,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 3.709,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"entities\": [{\"name\": \"City Council\", \"type\": \"government\"}, {\"name\": \"Transit Officials\", \"type\": \"organization\"}, {\"name\": \"Electric Bus Fleet\", \"type\": \"metric\"}, {\"name\": \"Winter\", \"type\": \"date\"}, {\"type\": \"date\", \"name\": \"September\"}, {\"name\": \"July\", \"type\": \"date\"}, {\"name\": \"Fuel Costs\", \"type\": \"metric\"}, {\"name\": \"Battery Performance\", \"type\": \"metric\"}], \"headline\": \"City Council Approves New Electric Bus Fleet\", \"key_points\": [\"The city council voted 8-3 to approve a new electric bus fleet.\", \"A six-month pilot reduced fuel costs by 22 percent.\", \"The first 40 buses will enter service in September.\", \"Charging depots are expected to be completed by July.\", \"Critics raised concerns about winter battery performance, but pilot data showed targets were met.\"], \"summary\": \"The city council has approved a new electric bus fleet following a successful six-month pilot that reduced fuel costs by 22 percent. The first 40 buses will begin service in September, with charging infrastructure ready by July. Despite concerns about winter battery performance, pilot data from cold snaps indicated that targets were met.\"}",
+        "parsed": {
+          "entities": [
+            {
+              "name": "City Council",
+              "type": "government"
+            },
+            {
+              "name": "Transit Officials",
+              "type": "organization"
+            },
+            {
+              "name": "Electric Bus Fleet",
+              "type": "metric"
+            },
+            {
+              "name": "Winter",
+              "type": "date"
+            },
+            {
+              "type": "date",
+              "name": "September"
+            },
+            {
+              "name": "July",
+              "type": "date"
+            },
+            {
+              "name": "Fuel Costs",
+              "type": "metric"
+            },
+            {
+              "name": "Battery Performance",
+              "type": "metric"
+            }
+          ],
+          "headline": "City Council Approves New Electric Bus Fleet",
+          "key_points": [
+            "The city council voted 8-3 to approve a new electric bus fleet.",
+            "A six-month pilot reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots are expected to be completed by July.",
+            "Critics raised concerns about winter battery performance, but pilot data showed targets were met."
+          ],
+          "summary": "The city council has approved a new electric bus fleet following a successful six-month pilot that reduced fuel costs by 22 percent. The first 40 buses will begin service in September, with charging infrastructure ready by July. Despite concerns about winter battery performance, pilot data from cold snaps indicated that targets were met."
+        },
+        "usage": {
+          "completion_tokens": 283,
+          "prompt_tokens": 113,
+          "total_tokens": 396,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 1.914,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"attributes\": [{\"name\": \"material\", \"value\": \"water-resistant recycled nylon shell\"}, {\"value\": \"midnight blue\", \"name\": \"color\"}, {\"value\": \"18L\", \"name\": \"capacity\"}, {\"value\": \"for 16 inch devices\", \"name\": \"laptop sleeve\"}, {\"name\": \"weight\", \"value\": \"0.9 kg\"}, {\"value\": \"commuting and short hikes\", \"name\": \"suitable for\"}], \"use_cases\": [\"commuting\", \"short hikes\"], \"product_name\": \"TrailPro 18L Commuter Backpack\", \"price_usd\": 89, \"category\": \"backpack\"}",
+        "parsed": {
+          "attributes": [
+            {
+              "name": "material",
+              "value": "water-resistant recycled nylon shell"
+            },
+            {
+              "value": "midnight blue",
+              "name": "color"
+            },
+            {
+              "value": "18L",
+              "name": "capacity"
+            },
+            {
+              "value": "for 16 inch devices",
+              "name": "laptop sleeve"
+            },
+            {
+              "name": "weight",
+              "value": "0.9 kg"
+            },
+            {
+              "value": "commuting and short hikes",
+              "name": "suitable for"
+            }
+          ],
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "product_name": "TrailPro 18L Commuter Backpack",
+          "price_usd": 89,
+          "category": "backpack"
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 59,
+          "total_tokens": 175,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.393,
+      "details": {
+        "content": "{\"age\": 45, \"occupation\": \"computer scientist\", \"name\": \"Grace Hopper\"}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    },
+    {
+      "name": "api_stream_json_schema::stream_person_basic",
+      "ok": true,
+      "elapsed_s": 0.422,
+      "details": {
+        "content": "{\"name\": \"Katherine Johnson\", \"age\": 50, \"occupation\": \"mathematician\"}",
+        "parsed": {
+          "name": "Katherine Johnson",
+          "age": 50,
+          "occupation": "mathematician"
+        },
+        "validation_error": null,
+        "chunk_count": 4,
+        "saw_usage_chunk": true,
+        "usage": {
+          "completion_tokens": 17,
+          "prompt_tokens": 19,
+          "total_tokens": 36,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null,
+          "prompt_tokens_per_second": 50.84,
+          "completion_time": 0.05,
+          "completion_tokens_per_second": 375.84,
+          "total_time": 0.42,
+          "prompt_time": 0.37
+        },
+        "finish_reason": "stop"
+      }
+    },
+    {
+      "name": "api_conflict_json_schema::conflict_prompt_person",
+      "ok": true,
+      "elapsed_s": 0.404,
+      "details": {
+        "content": "{\"name\": \"Ada Lovelace\", \"age\": 0, \"occupation\": \"mathematician\"}",
+        "parsed": {
+          "name": "Ada Lovelace",
+          "age": 0,
+          "occupation": "mathematician"
+        },
+        "refusal": null,
+        "finish_reason": "stop",
+        "usage": {
+          "completion_tokens": 16,
+          "prompt_tokens": 25,
+          "total_tokens": 41,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_truncation_json_schema::truncation_article_summary",
+      "ok": true,
+      "elapsed_s": 0.545,
+      "details": {
+        "finish_reason": "length",
+        "hit_budget": true,
+        "content": "",
+        "parsed": null,
+        "validation_error": "Expecting value: line 1 column 1 (char 0)",
+        "refusal": null,
+        "usage": {
+          "completion_tokens": 24,
+          "prompt_tokens": 113,
+          "total_tokens": 137,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        }
+      }
+    },
+    {
+      "name": "api_json_schema::edge_nullable_contact",
+      "ok": true,
+      "elapsed_s": 0.539,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"phone\": \"null\", \"company\": \"Acme Labs\", \"preferred_channel\": \"email\", \"name\": \"Jordan Lee\"}",
+        "parsed": {
+          "phone": "null",
+          "company": "Acme Labs",
+          "preferred_channel": "email",
+          "name": "Jordan Lee"
+        },
+        "usage": {
+          "completion_tokens": 23,
+          "prompt_tokens": 32,
+          "total_tokens": 55,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::edge_bounded_tags",
+      "ok": true,
+      "elapsed_s": 0.338,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"tags\": [\"ui\", \"billing\"]}",
+        "parsed": {
+          "tags": [
+            "ui",
+            "billing"
+          ]
+        },
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 38,
+          "total_tokens": 44,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::edge_anyof_priority",
+      "ok": true,
+      "elapsed_s": 0.489,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"summary\": \"Production payments are failing, and executives are requesting updates every hour.\", \"priority\": 1}",
+        "parsed": {
+          "summary": "Production payments are failing, and executives are requesting updates every hour.",
+          "priority": 1
+        },
+        "usage": {
+          "completion_tokens": 28,
+          "prompt_tokens": 30,
+          "total_tokens": 58,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_unsupported_json_schema::unsupported_pattern_properties",
+      "ok": true,
+      "elapsed_s": 0.188,
+      "details": {
+        "mode": "accepted",
+        "content": "{}",
+        "parsed": {},
+        "validation_error": null,
+        "finish_reason": "stop"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/guided-json-foundation-smoke.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-foundation-smoke.json
@@ -1,0 +1,353 @@
+{
+  "generated_at": "2026-03-13T23:34:36.763400",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.001,
+      "details": {
+        "count": 1,
+        "first_id": "foundation"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 0.608,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"age\": 36, \"occupation\": \"mathematician\", \"name\": \"Ada Lovelace\"}",
+        "parsed": {
+          "age": 36,
+          "occupation": "mathematician",
+          "name": "Ada Lovelace"
+        },
+        "usage": {
+          "completion_tokens": 16,
+          "prompt_tokens": 18,
+          "total_tokens": 34,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.017,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"items\": [{\"due_date\": \"Friday\", \"task\": \"draft the customer email\", \"owner\": \"Sarah\"}, {\"due_date\": \"Tuesday\", \"owner\": \"Ben\", \"task\": \"deploy the dashboard fix\"}, {\"owner\": \"Priya\", \"due_date\": \"this afternoon\", \"task\": \"confirm pricing with finance\"}]}",
+        "parsed": {
+          "items": [
+            {
+              "due_date": "Friday",
+              "task": "draft the customer email",
+              "owner": "Sarah"
+            },
+            {
+              "due_date": "Tuesday",
+              "owner": "Ben",
+              "task": "deploy the dashboard fix"
+            },
+            {
+              "owner": "Priya",
+              "due_date": "this afternoon",
+              "task": "confirm pricing with finance"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 64,
+          "prompt_tokens": 54,
+          "total_tokens": 118,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 0.9,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"category\": \"billing\", \"blocked_teams\": [\"finance\"], \"severity\": \"high\", \"summary\": \"After upgrading to Pro yesterday, invoices still show the Starter plan, and two users cannot access analytics, blocking the finance close.\", \"account_name\": \"Acme Labs\"}",
+        "parsed": {
+          "category": "billing",
+          "blocked_teams": [
+            "finance"
+          ],
+          "severity": "high",
+          "summary": "After upgrading to Pro yesterday, invoices still show the Starter plan, and two users cannot access analytics, blocking the finance close.",
+          "account_name": "Acme Labs"
+        },
+        "usage": {
+          "completion_tokens": 63,
+          "prompt_tokens": 68,
+          "total_tokens": 131,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 3.43,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"key_points\": [\"The city council voted 8-3 to approve a new electric bus fleet.\", \"The first 40 buses will enter service in September.\", \"Charging depots are expected to be completed by July.\", \"Critics raised concerns about winter battery performance.\", \"Pilot data from two cold snaps remained within operational targets.\"], \"summary\": \"The city council has approved a new electric bus fleet after a successful six-month pilot program that reduced fuel costs by 22%. The first 40 buses will begin service in September, with charging infrastructure ready by July. Despite concerns about winter battery performance, pilot data showed that the battery performance met operational targets during cold snaps.\", \"entities\": [{\"name\": \"City Council\", \"type\": \"organization\"}, {\"type\": \"organization\", \"name\": \"Transit Officials\"}, {\"type\": \"organization\", \"name\": \"Transport Committee\"}, {\"name\": \"Electric Bus Fleet\", \"type\": \"metric\"}, {\"name\": \"Fuel Costs\", \"type\": \"metric\"}, {\"type\": \"date\", \"name\": \"Cold Snaps\"}], \"headline\": \"City Council Approves New Electric Bus Fleet\"}",
+        "parsed": {
+          "key_points": [
+            "The city council voted 8-3 to approve a new electric bus fleet.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots are expected to be completed by July.",
+            "Critics raised concerns about winter battery performance.",
+            "Pilot data from two cold snaps remained within operational targets."
+          ],
+          "summary": "The city council has approved a new electric bus fleet after a successful six-month pilot program that reduced fuel costs by 22%. The first 40 buses will begin service in September, with charging infrastructure ready by July. Despite concerns about winter battery performance, pilot data showed that the battery performance met operational targets during cold snaps.",
+          "entities": [
+            {
+              "name": "City Council",
+              "type": "organization"
+            },
+            {
+              "type": "organization",
+              "name": "Transit Officials"
+            },
+            {
+              "type": "organization",
+              "name": "Transport Committee"
+            },
+            {
+              "name": "Electric Bus Fleet",
+              "type": "metric"
+            },
+            {
+              "name": "Fuel Costs",
+              "type": "metric"
+            },
+            {
+              "type": "date",
+              "name": "Cold Snaps"
+            }
+          ],
+          "headline": "City Council Approves New Electric Bus Fleet"
+        },
+        "usage": {
+          "completion_tokens": 269,
+          "prompt_tokens": 113,
+          "total_tokens": 382,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 2.007,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"category\": \"backpack\", \"attributes\": [{\"value\": \"water-resistant recycled nylon shell\", \"name\": \"material\"}, {\"value\": \"midnight blue\", \"name\": \"color\"}, {\"name\": \"capacity\", \"value\": \"18L\"}, {\"name\": \"laptop sleeve\", \"value\": \"for 16 inch devices\"}, {\"name\": \"weight\", \"value\": \"0.9 kg\"}, {\"value\": \"commuting and short hikes\", \"name\": \"suitable for\"}], \"use_cases\": [\"commuting\", \"short hikes\"], \"price_usd\": 89, \"product_name\": \"TrailPro 18L Commuter Backpack\"}",
+        "parsed": {
+          "category": "backpack",
+          "attributes": [
+            {
+              "value": "water-resistant recycled nylon shell",
+              "name": "material"
+            },
+            {
+              "value": "midnight blue",
+              "name": "color"
+            },
+            {
+              "name": "capacity",
+              "value": "18L"
+            },
+            {
+              "name": "laptop sleeve",
+              "value": "for 16 inch devices"
+            },
+            {
+              "name": "weight",
+              "value": "0.9 kg"
+            },
+            {
+              "value": "commuting and short hikes",
+              "name": "suitable for"
+            }
+          ],
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "price_usd": 89,
+          "product_name": "TrailPro 18L Commuter Backpack"
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 59,
+          "total_tokens": 175,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.434,
+      "details": {
+        "content": "{\"age\": 45, \"occupation\": \"computer scientist\", \"name\": \"Grace Hopper\"}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    },
+    {
+      "name": "api_stream_json_schema::stream_person_basic",
+      "ok": false,
+      "elapsed_s": 0.433,
+      "details": {
+        "error": "invalid JSON: Extra data: line 1 column 24 (char 23)",
+        "content": "{\"age\": 50, \"name\": \"\"}{\"age\": 50, \"name\": \"Katherine Johnson\", \"occupation\": \"mathematician\"}",
+        "chunk_count": 4,
+        "saw_usage_chunk": true,
+        "usage": {
+          "completion_tokens": 22,
+          "prompt_tokens": 19,
+          "total_tokens": 41,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null,
+          "completion_time": 0.08,
+          "prompt_time": 0.35,
+          "completion_tokens_per_second": 281.67,
+          "prompt_tokens_per_second": 54.01,
+          "total_time": 0.43
+        },
+        "finish_reason": "stop"
+      }
+    },
+    {
+      "name": "api_conflict_json_schema::conflict_prompt_person",
+      "ok": true,
+      "elapsed_s": 0.448,
+      "details": {
+        "content": "{\"age\": 0, \"occupation\": \"mathematician\", \"name\": \"Ada Lovelace\"}",
+        "parsed": {
+          "age": 0,
+          "occupation": "mathematician",
+          "name": "Ada Lovelace"
+        },
+        "refusal": null,
+        "finish_reason": "stop",
+        "usage": {
+          "completion_tokens": 16,
+          "prompt_tokens": 25,
+          "total_tokens": 41,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_truncation_json_schema::truncation_article_summary",
+      "ok": false,
+      "elapsed_s": 3.08,
+      "details": {
+        "error_type": "InternalServerError",
+        "message": "Error code: 503 - {'error': {'type': 'foundation_model_error', 'message': 'Failed to generate response: Failed to deserialize a Generable type from model output'}}"
+      }
+    },
+    {
+      "name": "api_json_schema::edge_nullable_contact",
+      "ok": true,
+      "elapsed_s": 0.575,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"preferred_channel\": \"email\", \"phone\": \"null\", \"company\": \"Acme Labs\", \"name\": \"Jordan Lee\"}",
+        "parsed": {
+          "preferred_channel": "email",
+          "phone": "null",
+          "company": "Acme Labs",
+          "name": "Jordan Lee"
+        },
+        "usage": {
+          "completion_tokens": 23,
+          "prompt_tokens": 32,
+          "total_tokens": 55,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::edge_bounded_tags",
+      "ok": true,
+      "elapsed_s": 0.365,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"tags\": [\"ui\", \"billing\"]}",
+        "parsed": {
+          "tags": [
+            "ui",
+            "billing"
+          ]
+        },
+        "usage": {
+          "completion_tokens": 6,
+          "prompt_tokens": 38,
+          "total_tokens": 44,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::edge_anyof_priority",
+      "ok": true,
+      "elapsed_s": 0.516,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"priority\": 1, \"summary\": \"Production payments are failing, and executives are requesting updates every hour.\"}",
+        "parsed": {
+          "priority": 1,
+          "summary": "Production payments are failing, and executives are requesting updates every hour."
+        },
+        "usage": {
+          "completion_tokens": 28,
+          "prompt_tokens": 30,
+          "total_tokens": 58,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": null
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_unsupported_json_schema::unsupported_pattern_properties",
+      "ok": true,
+      "elapsed_s": 0.221,
+      "details": {
+        "mode": "accepted",
+        "content": "{}",
+        "parsed": {},
+        "validation_error": null,
+        "finish_reason": "stop"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/guided-json-full-cli-postfix.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-full-cli-postfix.json
@@ -1,0 +1,309 @@
+{
+  "generated_at": "2026-03-13T22:37:27.725836",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.001,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 0.66,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"occupation\":\"mathematician\",\"name\":\"Ada Lovelace\",\"age\":36}",
+        "parsed": {
+          "occupation": "mathematician",
+          "name": "Ada Lovelace",
+          "age": 36
+        },
+        "usage": {
+          "completion_tokens": 19,
+          "prompt_tokens": 116,
+          "total_tokens": 135,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 95.79,
+          "completion_time": 0.2,
+          "prompt_tokens_per_second": 984.06,
+          "prompt_time": 0.12,
+          "total_time": 0.32
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::person_basic",
+      "ok": false,
+      "elapsed_s": 2.985,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": "MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\nLoading MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\n\n[/                       ]   --.-% checking cache | mem 0.02 GB | 0.0s[2026-03-13 22:37:02.483] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 0.13 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 5.12 GB | 0.4s\n[|                       ]   --.-% loading model | mem 11.56 GB | 0.6s\n[/                       ]   --.-% loading model | mem 17.98 GB | 0.8s\n[-                       ]   --.-% loading model | mem 18.36 GB | 1.0s\n[done] ready | mem 18.36 GB | 1.0s"
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.564,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"items\": [\n    {\n      \"owner\": \"Sarah\",\n      \"due_date\": \"Friday\",\n      \"task\": \"draft the customer email\"\n    },\n    {\n      \"owner\": \"Ben\",\n      \"due_date\": \"Tuesday\",\n      \"task\": \"deploy the dashboard fix\"\n    },\n    {\n      \"owner\": \"Priya\",\n      \"due_date\": \"this afternoon\",\n      \"task\": \"confirm pricing with finance\"\n    }\n  ]\n}",
+        "parsed": {
+          "items": [
+            {
+              "owner": "Sarah",
+              "due_date": "Friday",
+              "task": "draft the customer email"
+            },
+            {
+              "owner": "Ben",
+              "due_date": "Tuesday",
+              "task": "deploy the dashboard fix"
+            },
+            {
+              "owner": "Priya",
+              "due_date": "this afternoon",
+              "task": "confirm pricing with finance"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 165,
+          "total_tokens": 281,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.91,
+          "completion_time": 1.18,
+          "prompt_tokens_per_second": 1236.9,
+          "prompt_time": 0.13,
+          "total_time": 1.32
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::meeting_action_items",
+      "ok": false,
+      "elapsed_s": 2.414,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": "MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\nLoading MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\n\n[/                       ]   --.-% checking cache | mem 0.02 GB | 0.0s[2026-03-13 22:37:06.083] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 1.63 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 7.74 GB | 0.4s\n[|                       ]   --.-% loading model | mem 13.88 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.41 GB | 0.8s\n[done] ready | mem 18.37 GB | 0.9s"
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 1.177,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"blocked_teams\": [\n    \"Finance\",\n    \"Analytics\"\n  ],\n  \"account_name\": \"Acme Labs\",\n  \"category\": \"billing\",\n  \"severity\": \"high\",\n  \"summary\": \"Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.\"\n}",
+        "parsed": {
+          "blocked_teams": [
+            "Finance",
+            "Analytics"
+          ],
+          "account_name": "Acme Labs",
+          "category": "billing",
+          "severity": "high",
+          "summary": "Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close."
+        },
+        "usage": {
+          "completion_tokens": 76,
+          "prompt_tokens": 197,
+          "total_tokens": 273,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.35,
+          "completion_time": 0.78,
+          "prompt_tokens_per_second": 1358.49,
+          "prompt_time": 0.15,
+          "total_time": 0.93
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::support_ticket_triage",
+      "ok": false,
+      "elapsed_s": 2.605,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": "MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\nLoading MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\n\n[/                       ]   --.-% checking cache | mem 0.02 GB | 0.0s[2026-03-13 22:37:09.683] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 1.34 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 7.36 GB | 0.4s\n[|                       ]   --.-% loading model | mem 13.77 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.41 GB | 0.8s\n[done] ready | mem 18.36 GB | 0.9s"
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 4.074,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"summary\": \"The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. The first 40 buses are scheduled to begin service in September, with charging infrastructure to be finished by July. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that pilot data from cold weather events met operational targets.\",\n  \"key_points\": [\n    \"City council voted 8-3 to approve the electric bus fleet.\",\n    \"A six-month pilot reduced fuel costs by 22 percent.\",\n    \"First 40 buses enter service in September.\",\n    \"Charging depots will be completed by July.\",\n    \"Pilot data from cold snaps met operational targets despite winter concerns.\"\n  ],\n  \"entities\": [\n    {\n      \"type\": \"organization\",\n      \"name\": \"city council\"\n    },\n    {\n      \"type\": \"organization\",\n      \"name\": \"transport committee\"\n    },\n    {\n      \"type\": \"date\",\n      \"name\": \"September\"\n    },\n    {\n      \"type\": \"date\",\n      \"name\": \"July\"\n    },\n    {\n      \"type\": \"metric\",\n      \"name\": \"22 percent\"\n    },\n    {\n      \"type\": \"metric\",\n      \"name\": \"8-3\"\n    },\n    {\n      \"type\": \"metric\",\n      \"name\": \"40 buses\"\n    }\n  ],\n  \"headline\": \"City Council Approves Electric Bus Fleet Following Successful Pilot\"\n}",
+        "parsed": {
+          "summary": "The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. The first 40 buses are scheduled to begin service in September, with charging infrastructure to be finished by July. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that pilot data from cold weather events met operational targets.",
+          "key_points": [
+            "City council voted 8-3 to approve the electric bus fleet.",
+            "A six-month pilot reduced fuel costs by 22 percent.",
+            "First 40 buses enter service in September.",
+            "Charging depots will be completed by July.",
+            "Pilot data from cold snaps met operational targets despite winter concerns."
+          ],
+          "entities": [
+            {
+              "type": "organization",
+              "name": "city council"
+            },
+            {
+              "type": "organization",
+              "name": "transport committee"
+            },
+            {
+              "type": "date",
+              "name": "September"
+            },
+            {
+              "type": "date",
+              "name": "July"
+            },
+            {
+              "type": "metric",
+              "name": "22 percent"
+            },
+            {
+              "type": "metric",
+              "name": "8-3"
+            },
+            {
+              "type": "metric",
+              "name": "40 buses"
+            }
+          ],
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot"
+        },
+        "usage": {
+          "completion_tokens": 355,
+          "prompt_tokens": 243,
+          "total_tokens": 598,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.29,
+          "completion_time": 3.65,
+          "prompt_tokens_per_second": 1484.18,
+          "prompt_time": 0.16,
+          "total_time": 3.81
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::article_summary",
+      "ok": false,
+      "elapsed_s": 4.644,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": "MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\nLoading MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\n\n[/                       ]   --.-% checking cache | mem 0.02 GB | 0.0s[2026-03-13 22:37:16.352] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 1.63 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 7.97 GB | 0.4s\n[|                       ]   --.-% loading model | mem 14.22 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.41 GB | 0.8s\n[done] ready | mem 18.36 GB | 0.9s"
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 2.192,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"attributes\": [\n    {\n      \"name\": \"material\",\n      \"value\": \"water-resistant recycled nylon\"\n    },\n    {\n      \"name\": \"laptop_sleeve_capacity\",\n      \"value\": \"16 inch\"\n    },\n    {\n      \"name\": \"color\",\n      \"value\": \"midnight blue\"\n    },\n    {\n      \"name\": \"weight\",\n      \"value\": \"0.9 kg\"\n    }\n  ],\n  \"product_name\": \"TrailPro 18L commuter backpack\",\n  \"category\": \"backpack\",\n  \"price_usd\": 89,\n  \"use_cases\": [\n    \"commuting\",\n    \"short hikes\"\n  ]\n}",
+        "parsed": {
+          "attributes": [
+            {
+              "name": "material",
+              "value": "water-resistant recycled nylon"
+            },
+            {
+              "name": "laptop_sleeve_capacity",
+              "value": "16 inch"
+            },
+            {
+              "name": "color",
+              "value": "midnight blue"
+            },
+            {
+              "name": "weight",
+              "value": "0.9 kg"
+            }
+          ],
+          "product_name": "TrailPro 18L commuter backpack",
+          "category": "backpack",
+          "price_usd": 89,
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ]
+        },
+        "usage": {
+          "completion_tokens": 173,
+          "prompt_tokens": 244,
+          "total_tokens": 417,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.58,
+          "completion_time": 1.77,
+          "prompt_tokens_per_second": 1438.73,
+          "prompt_time": 0.17,
+          "total_time": 1.94
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::catalog_normalization_refs",
+      "ok": false,
+      "elapsed_s": 3.002,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": "MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\nLoading MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\n\n[/                       ]   --.-% checking cache | mem 0.02 GB | 0.0s[2026-03-13 22:37:23.188] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 1.59 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 7.79 GB | 0.4s\n[|                       ]   --.-% loading model | mem 14.21 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.41 GB | 0.8s\n[done] ready | mem 18.37 GB | 0.9s"
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.549,
+      "details": {
+        "content": "{\"occupation\":\"computer scientist\",\"age\":45,\"name\":\"Grace Hopper\"}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    },
+    {
+      "name": "cli_guided_json::invalid_schema_error",
+      "ok": true,
+      "elapsed_s": 1.075,
+      "details": {
+        "returncode": 1,
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/guided-json-full-cli-postfix2.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-full-cli-postfix2.json
@@ -1,0 +1,301 @@
+{
+  "generated_at": "2026-03-13T22:40:15.821646",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.002,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 0.65,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"occupation\":\"mathematician\",\"age\":36,\"name\":\"Ada Lovelace\"}",
+        "parsed": {
+          "occupation": "mathematician",
+          "age": 36,
+          "name": "Ada Lovelace"
+        },
+        "usage": {
+          "completion_tokens": 19,
+          "prompt_tokens": 116,
+          "total_tokens": 135,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.61,
+          "completion_time": 0.2,
+          "prompt_tokens_per_second": 1036.07,
+          "prompt_time": 0.11,
+          "total_time": 0.31
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::person_basic",
+      "ok": false,
+      "elapsed_s": 2.824,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": ""
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.624,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"items\": [\n    {\n      \"owner\": \"Sarah\",\n      \"task\": \"draft the customer email\",\n      \"due_date\": \"Friday\"\n    },\n    {\n      \"owner\": \"Ben\",\n      \"task\": \"deploy the dashboard fix\",\n      \"due_date\": \"Tuesday\"\n    },\n    {\n      \"owner\": \"Priya\",\n      \"task\": \"confirm pricing with finance\",\n      \"due_date\": \"this afternoon\"\n    }\n  ]\n}",
+        "parsed": {
+          "items": [
+            {
+              "owner": "Sarah",
+              "task": "draft the customer email",
+              "due_date": "Friday"
+            },
+            {
+              "owner": "Ben",
+              "task": "deploy the dashboard fix",
+              "due_date": "Tuesday"
+            },
+            {
+              "owner": "Priya",
+              "task": "confirm pricing with finance",
+              "due_date": "this afternoon"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 165,
+          "total_tokens": 281,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.1,
+          "completion_time": 1.19,
+          "prompt_tokens_per_second": 1238.53,
+          "prompt_time": 0.13,
+          "total_time": 1.33
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::meeting_action_items",
+      "ok": false,
+      "elapsed_s": 2.336,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": ""
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 1.079,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"account_name\": \"Acme Labs\",\n  \"blocked_teams\": [\n    \"finance\",\n    \"analytics\"\n  ],\n  \"summary\": \"Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.\",\n  \"severity\": \"high\",\n  \"category\": \"billing\"\n}",
+        "parsed": {
+          "account_name": "Acme Labs",
+          "blocked_teams": [
+            "finance",
+            "analytics"
+          ],
+          "summary": "Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.",
+          "severity": "high",
+          "category": "billing"
+        },
+        "usage": {
+          "completion_tokens": 76,
+          "prompt_tokens": 197,
+          "total_tokens": 273,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.06,
+          "completion_time": 0.79,
+          "prompt_tokens_per_second": 1352.04,
+          "prompt_time": 0.15,
+          "total_time": 0.94
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::support_ticket_triage",
+      "ok": false,
+      "elapsed_s": 2.742,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": ""
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 3.697,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"headline\": \"City Council Approves Electric Bus Fleet Following Successful Pilot\",\n  \"summary\": \"The city council has voted 8-3 to approve a new electric bus fleet, following a six-month pilot program that successfully reduced fuel costs by 22 percent. The first 40 buses are scheduled to begin service in September, with charging infrastructure to be completed by July. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that pilot data from two cold snaps met all operational targets.\",\n  \"entities\": [\n    {\n      \"name\": \"city council\",\n      \"type\": \"government\"\n    },\n    {\n      \"name\": \"Transport Committee\",\n      \"type\": \"government\"\n    },\n    {\n      \"name\": \"22 percent\",\n      \"type\": \"metric\"\n    },\n    {\n      \"name\": \"September\",\n      \"type\": \"date\"\n    },\n    {\n      \"name\": \"July\",\n      \"type\": \"date\"\n    }\n  ],\n  \"key_points\": [\n    \"City council approved the electric bus fleet with an 8-3 vote.\",\n    \"A six-month pilot program reduced fuel costs by 22 percent.\",\n    \"The first 40 buses will enter service in September.\",\n    \"Charging depots are scheduled for completion by July.\",\n    \"Pilot data from cold snaps confirmed batteries met operational targets.\"\n  ]\n}",
+        "parsed": {
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot",
+          "summary": "The city council has voted 8-3 to approve a new electric bus fleet, following a six-month pilot program that successfully reduced fuel costs by 22 percent. The first 40 buses are scheduled to begin service in September, with charging infrastructure to be completed by July. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that pilot data from two cold snaps met all operational targets.",
+          "entities": [
+            {
+              "name": "city council",
+              "type": "government"
+            },
+            {
+              "name": "Transport Committee",
+              "type": "government"
+            },
+            {
+              "name": "22 percent",
+              "type": "metric"
+            },
+            {
+              "name": "September",
+              "type": "date"
+            },
+            {
+              "name": "July",
+              "type": "date"
+            }
+          ],
+          "key_points": [
+            "City council approved the electric bus fleet with an 8-3 vote.",
+            "A six-month pilot program reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots are scheduled for completion by July.",
+            "Pilot data from cold snaps confirmed batteries met operational targets."
+          ]
+        },
+        "usage": {
+          "completion_tokens": 320,
+          "prompt_tokens": 243,
+          "total_tokens": 563,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.84,
+          "completion_time": 3.3,
+          "prompt_tokens_per_second": 1480.7,
+          "prompt_time": 0.16,
+          "total_time": 3.47
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::article_summary",
+      "ok": false,
+      "elapsed_s": 4.805,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": ""
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 2.34,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"product_name\": \"TrailPro 18L commuter backpack\",\n  \"category\": \"backpack\",\n  \"price_usd\": 89,\n  \"attributes\": [\n    {\n      \"name\": \"material\",\n      \"value\": \"water-resistant recycled nylon\"\n    },\n    {\n      \"name\": \"laptop_sleeve_capacity\",\n      \"value\": \"16 inch\"\n    },\n    {\n      \"name\": \"color\",\n      \"value\": \"midnight blue\"\n    },\n    {\n      \"name\": \"weight\",\n      \"value\": \"0.9 kg\"\n    }\n  ],\n  \"use_cases\": [\n    \"commuting\",\n    \"short hikes\"\n  ]\n}",
+        "parsed": {
+          "product_name": "TrailPro 18L commuter backpack",
+          "category": "backpack",
+          "price_usd": 89,
+          "attributes": [
+            {
+              "name": "material",
+              "value": "water-resistant recycled nylon"
+            },
+            {
+              "name": "laptop_sleeve_capacity",
+              "value": "16 inch"
+            },
+            {
+              "name": "color",
+              "value": "midnight blue"
+            },
+            {
+              "name": "weight",
+              "value": "0.9 kg"
+            }
+          ],
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ]
+        },
+        "usage": {
+          "completion_tokens": 173,
+          "prompt_tokens": 244,
+          "total_tokens": 417,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 98.27,
+          "completion_time": 1.76,
+          "prompt_tokens_per_second": 1423.55,
+          "prompt_time": 0.17,
+          "total_time": 1.93
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::catalog_normalization_refs",
+      "ok": false,
+      "elapsed_s": 2.964,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": ""
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.681,
+      "details": {
+        "content": "{\"name\":\"Grace Hopper\",\"age\":45,\"occupation\":\"computer scientist\"}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    },
+    {
+      "name": "cli_guided_json::invalid_schema_error",
+      "ok": true,
+      "elapsed_s": 1.065,
+      "details": {
+        "returncode": 1,
+        "stderr": "0.0s[2026-03-13 22:40:14.845] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 1.58 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 7.59 GB | 0.4s\n[|                       ]   --.-% loading model | mem 13.59 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.41 GB | 0.8s\n[done] ready | mem 18.35 GB | 0.9s\n"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/guided-json-full-cli-postfix3.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-full-cli-postfix3.json
@@ -1,0 +1,394 @@
+{
+  "generated_at": "2026-03-13T22:43:06.030297",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.002,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 0.66,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"name\":\"Ada Lovelace\",\"occupation\":\"mathematician\",\"age\":36}",
+        "parsed": {
+          "name": "Ada Lovelace",
+          "occupation": "mathematician",
+          "age": 36
+        },
+        "usage": {
+          "completion_tokens": 19,
+          "prompt_tokens": 116,
+          "total_tokens": 135,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.2,
+          "completion_time": 0.2,
+          "prompt_tokens_per_second": 992.78,
+          "prompt_time": 0.12,
+          "total_time": 0.31
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::person_basic",
+      "ok": true,
+      "elapsed_s": 1.963,
+      "details": {
+        "parsed": {
+          "occupation": "mathematician",
+          "name": "Ada Lovelace",
+          "age": 36
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.363,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"items\": [\n    {\n      \"task\": \"draft the customer email\",\n      \"due_date\": \"Friday\",\n      \"owner\": \"Sarah\"\n    },\n    {\n      \"task\": \"deploy the dashboard fix\",\n      \"due_date\": \"Tuesday\",\n      \"owner\": \"Ben\"\n    },\n    {\n      \"task\": \"confirm pricing with finance\",\n      \"due_date\": \"this afternoon\",\n      \"owner\": \"Priya\"\n    }\n  ]\n}",
+        "parsed": {
+          "items": [
+            {
+              "task": "draft the customer email",
+              "due_date": "Friday",
+              "owner": "Sarah"
+            },
+            {
+              "task": "deploy the dashboard fix",
+              "due_date": "Tuesday",
+              "owner": "Ben"
+            },
+            {
+              "task": "confirm pricing with finance",
+              "due_date": "this afternoon",
+              "owner": "Priya"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 165,
+          "total_tokens": 281,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.21,
+          "completion_time": 1.21,
+          "prompt_tokens_per_second": 1257.01,
+          "prompt_time": 0.13,
+          "total_time": 1.34
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 2.328,
+      "details": {
+        "parsed": {
+          "items": [
+            {
+              "task": "draft the customer email",
+              "due_date": "Friday",
+              "owner": "Sarah"
+            },
+            {
+              "task": "dashboard fix and deploy",
+              "due_date": "Tuesday",
+              "owner": "Ben"
+            },
+            {
+              "task": "confirm pricing with finance",
+              "due_date": "this afternoon",
+              "owner": "Priya"
+            }
+          ]
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 1.227,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"summary\": \"Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.\",\n  \"severity\": \"high\",\n  \"account_name\": \"Acme Labs\",\n  \"blocked_teams\": [\n    \"Finance\",\n    \"Analytics\"\n  ],\n  \"category\": \"billing\"\n}",
+        "parsed": {
+          "summary": "Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.",
+          "severity": "high",
+          "account_name": "Acme Labs",
+          "blocked_teams": [
+            "Finance",
+            "Analytics"
+          ],
+          "category": "billing"
+        },
+        "usage": {
+          "completion_tokens": 76,
+          "prompt_tokens": 197,
+          "total_tokens": 273,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.62,
+          "completion_time": 0.78,
+          "prompt_tokens_per_second": 1360.3,
+          "prompt_time": 0.14,
+          "total_time": 0.92
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 2.394,
+      "details": {
+        "parsed": {
+          "category": "billing",
+          "severity": "high",
+          "account_name": "Acme Labs",
+          "blocked_teams": [
+            "finance"
+          ],
+          "summary": "Billing issue after upgrade"
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 3.854,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"key_points\": [\n    \"The city council voted 8-3 to approve a new electric bus fleet.\",\n    \"A six-month pilot program reduced fuel costs by 22 percent.\",\n    \"The first 40 buses will enter service in September.\",\n    \"Charging depots are scheduled to be completed by July.\",\n    \"Critics raised concerns about winter battery performance.\",\n    \"The transport committee confirmed pilot data from two cold snaps met operational targets.\"\n  ],\n  \"summary\": \"The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that the pilot data from two cold snaps met operational targets. The first 40 buses are set to begin service in September, with charging infrastructure to be completed by July.\",\n  \"headline\": \"City Council Approves Electric Bus Fleet After Successful Pilot\",\n  \"entities\": [\n    {\n      \"type\": \"organization\",\n      \"name\": \"city council\"\n    },\n    {\n      \"type\": \"organization\",\n      \"name\": \"transport committee\"\n    },\n    {\n      \"type\": \"metric\",\n      \"name\": \"22 percent\"\n    },\n    {\n      \"type\": \"date\",\n      \"name\": \"September\"\n    },\n    {\n      \"type\": \"date\",\n      \"name\": \"July\"\n    }\n  ]\n}",
+        "parsed": {
+          "key_points": [
+            "The city council voted 8-3 to approve a new electric bus fleet.",
+            "A six-month pilot program reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots are scheduled to be completed by July.",
+            "Critics raised concerns about winter battery performance.",
+            "The transport committee confirmed pilot data from two cold snaps met operational targets."
+          ],
+          "summary": "The city council has approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. While critics expressed concerns regarding winter battery performance, the transport committee confirmed that the pilot data from two cold snaps met operational targets. The first 40 buses are set to begin service in September, with charging infrastructure to be completed by July.",
+          "headline": "City Council Approves Electric Bus Fleet After Successful Pilot",
+          "entities": [
+            {
+              "type": "organization",
+              "name": "city council"
+            },
+            {
+              "type": "organization",
+              "name": "transport committee"
+            },
+            {
+              "type": "metric",
+              "name": "22 percent"
+            },
+            {
+              "type": "date",
+              "name": "September"
+            },
+            {
+              "type": "date",
+              "name": "July"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 328,
+          "prompt_tokens": 243,
+          "total_tokens": 571,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.66,
+          "completion_time": 3.39,
+          "prompt_tokens_per_second": 1481.52,
+          "prompt_time": 0.16,
+          "total_time": 3.56
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::article_summary",
+      "ok": true,
+      "elapsed_s": 4.421,
+      "details": {
+        "parsed": {
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot",
+          "summary": "The city council voted 8-3 to approve a new electric bus fleet after a six-month pilot program demonstrated a 22% reduction in fuel costs. The first 40 buses are scheduled to begin service in September, with charging infrastructure to be completed by July. Despite concerns about winter battery performance, the transport committee confirmed that pilot data from cold weather events met operational targets.",
+          "entities": [
+            {
+              "name": "city council",
+              "type": "organization"
+            },
+            {
+              "name": "Transit officials",
+              "type": "organization"
+            },
+            {
+              "name": "transport committee",
+              "type": "organization"
+            },
+            {
+              "name": "September",
+              "type": "date"
+            },
+            {
+              "name": "July",
+              "type": "date"
+            },
+            {
+              "name": "22 percent",
+              "type": "metric"
+            }
+          ],
+          "key_points": [
+            "City council approved electric bus fleet with 8-3 vote",
+            "Six-month pilot reduced fuel costs by 22 percent",
+            "First 40 buses enter service in September",
+            "Charging depots to be completed by July",
+            "Winter battery performance met operational targets during pilot"
+          ]
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 2.212,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"category\": \"backpack\",\n  \"attributes\": [\n    {\n      \"name\": \"material\",\n      \"value\": \"water-resistant recycled nylon\"\n    },\n    {\n      \"name\": \"laptop_capacity\",\n      \"value\": \"16 inch\"\n    },\n    {\n      \"name\": \"color\",\n      \"value\": \"midnight blue\"\n    },\n    {\n      \"name\": \"weight\",\n      \"value\": \"0.9 kg\"\n    }\n  ],\n  \"price_usd\": 89,\n  \"product_name\": \"TrailPro 18L commuter backpack\",\n  \"use_cases\": [\n    \"commuting\",\n    \"short hikes\"\n  ]\n}",
+        "parsed": {
+          "category": "backpack",
+          "attributes": [
+            {
+              "name": "material",
+              "value": "water-resistant recycled nylon"
+            },
+            {
+              "name": "laptop_capacity",
+              "value": "16 inch"
+            },
+            {
+              "name": "color",
+              "value": "midnight blue"
+            },
+            {
+              "name": "weight",
+              "value": "0.9 kg"
+            }
+          ],
+          "price_usd": 89,
+          "product_name": "TrailPro 18L commuter backpack",
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ]
+        },
+        "usage": {
+          "completion_tokens": 170,
+          "prompt_tokens": 244,
+          "total_tokens": 414,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.52,
+          "completion_time": 1.74,
+          "prompt_tokens_per_second": 1403.36,
+          "prompt_time": 0.17,
+          "total_time": 1.92
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 2.658,
+      "details": {
+        "parsed": {
+          "attributes": [
+            {
+              "value": "Water-resistant recycled nylon shell",
+              "name": "Material"
+            },
+            {
+              "value": "16 inch",
+              "name": "Laptop Sleeve Capacity"
+            },
+            {
+              "value": "Midnight Blue",
+              "name": "Color"
+            },
+            {
+              "value": "0.9 kg",
+              "name": "Weight"
+            }
+          ],
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "price_usd": 89,
+          "category": "backpack",
+          "product_name": "TrailPro 18L commuter backpack"
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.595,
+      "details": {
+        "content": "{\"occupation\":\"computer scientist\",\"name\":\"Grace Hopper\",\"age\":45}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    },
+    {
+      "name": "cli_guided_json::invalid_schema_error",
+      "ok": true,
+      "elapsed_s": 1.071,
+      "details": {
+        "returncode": 1,
+        "stderr": "0.0s[2026-03-13 22:43:05.048] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 1.68 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 7.65 GB | 0.4s\n[|                       ]   --.-% loading model | mem 13.83 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.41 GB | 0.8s\n[done] ready | mem 18.37 GB | 0.9s\n"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/guided-json-full-cli.json
+++ b/Scripts/feature-codex-optimize-api/results/guided-json-full-cli.json
@@ -1,0 +1,309 @@
+{
+  "generated_at": "2026-03-13T22:25:01.650962",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.002,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "api_json_schema::person_basic",
+      "ok": true,
+      "elapsed_s": 0.653,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\"occupation\":\"mathematician\",\"age\":36,\"name\":\"Ada Lovelace\"}",
+        "parsed": {
+          "occupation": "mathematician",
+          "age": 36,
+          "name": "Ada Lovelace"
+        },
+        "usage": {
+          "completion_tokens": 19,
+          "prompt_tokens": 116,
+          "total_tokens": 135,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.33,
+          "completion_time": 0.2,
+          "prompt_tokens_per_second": 1033.72,
+          "prompt_time": 0.11,
+          "total_time": 0.31
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::person_basic",
+      "ok": false,
+      "elapsed_s": 3.321,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": "MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\nLoading MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\n\n[/                       ]   --.-% checking cache | mem 0.02 GB | 0.0s[2026-03-13 22:24:34.816] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 0.99 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 7.27 GB | 0.4s\n[|                       ]   --.-% loading model | mem 13.64 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.41 GB | 0.8s\n[done] ready | mem 18.36 GB | 1.0s\n<think>{\"occupation\":\"mathematician\",\"name\":\"Ada Lovelace\",\"age\":36}"
+      }
+    },
+    {
+      "name": "api_json_schema::meeting_action_items",
+      "ok": true,
+      "elapsed_s": 1.622,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"items\": [\n    {\n      \"owner\": \"Sarah\",\n      \"due_date\": \"Friday\",\n      \"task\": \"draft the customer email\"\n    },\n    {\n      \"owner\": \"Ben\",\n      \"due_date\": \"Tuesday\",\n      \"task\": \"deploy the dashboard fix\"\n    },\n    {\n      \"owner\": \"Priya\",\n      \"due_date\": \"this afternoon\",\n      \"task\": \"confirm pricing with finance\"\n    }\n  ]\n}",
+        "parsed": {
+          "items": [
+            {
+              "owner": "Sarah",
+              "due_date": "Friday",
+              "task": "draft the customer email"
+            },
+            {
+              "owner": "Ben",
+              "due_date": "Tuesday",
+              "task": "deploy the dashboard fix"
+            },
+            {
+              "owner": "Priya",
+              "due_date": "this afternoon",
+              "task": "confirm pricing with finance"
+            }
+          ]
+        },
+        "usage": {
+          "completion_tokens": 116,
+          "prompt_tokens": 165,
+          "total_tokens": 281,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 97.41,
+          "completion_time": 1.19,
+          "prompt_tokens_per_second": 1186.57,
+          "prompt_time": 0.14,
+          "total_time": 1.33
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::meeting_action_items",
+      "ok": false,
+      "elapsed_s": 2.593,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": "MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\nLoading MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\n\n[/                       ]   --.-% checking cache | mem 0.02 GB | 0.0s[2026-03-13 22:24:39.748] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 1.50 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 7.58 GB | 0.4s\n[|                       ]   --.-% loading model | mem 13.82 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.41 GB | 0.8s\n[done] ready | mem 18.35 GB | 0.9s\n<think>{\"items\":[{\"due_date\":\"Friday\",\"owner\":\"Sarah\",\"task\":\"draft the customer email\"},{\"due_date\":\"Tuesday\",\"owner\":\"Ben\",\"task\":\"deploy the dashboard fix\"},{\"due_date\":\"this afternoon\",\"owner\":\"Priya\",\"task\":\"confirm pricing with finance\"}]}"
+      }
+    },
+    {
+      "name": "api_json_schema::support_ticket_triage",
+      "ok": true,
+      "elapsed_s": 1.228,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"summary\": \"Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.\",\n  \"category\": \"billing\",\n  \"blocked_teams\": [\n    \"finance\",\n    \"analytics\"\n  ],\n  \"severity\": \"high\",\n  \"account_name\": \"Acme Labs\"\n}",
+        "parsed": {
+          "summary": "Billing issue after upgrade: invoices show Starter plan and two users cannot access analytics, blocking finance close.",
+          "category": "billing",
+          "blocked_teams": [
+            "finance",
+            "analytics"
+          ],
+          "severity": "high",
+          "account_name": "Acme Labs"
+        },
+        "usage": {
+          "completion_tokens": 76,
+          "prompt_tokens": 197,
+          "total_tokens": 273,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.27,
+          "completion_time": 0.79,
+          "prompt_tokens_per_second": 1349.13,
+          "prompt_time": 0.15,
+          "total_time": 0.94
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::support_ticket_triage",
+      "ok": false,
+      "elapsed_s": 2.624,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": "MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\nLoading MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\n\n[/                       ]   --.-% checking cache | mem 0.02 GB | 0.0s[2026-03-13 22:24:43.577] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 1.27 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 7.28 GB | 0.4s\n[|                       ]   --.-% loading model | mem 13.62 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.41 GB | 0.8s\n[done] ready | mem 18.37 GB | 0.9s\n<think>{\n  \"summary\": \"Billing issue after upgrade: invoices still show Starter plan and two users cannot access analytics, blocking finance close.\",\n  \"severity\": \"high\",\n  \"category\": \"billing\",\n  \"account_name\": \"Acme Labs\",\n  \"blocked_teams\": [\n    \"finance\"\n  ]\n}"
+      }
+    },
+    {
+      "name": "api_json_schema::article_summary",
+      "ok": true,
+      "elapsed_s": 4.044,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"headline\": \"City Council Approves Electric Bus Fleet Following Successful Pilot\",\n  \"entities\": [\n    {\n      \"type\": \"organization\",\n      \"name\": \"city council\"\n    },\n    {\n      \"type\": \"organization\",\n      \"name\": \"Transit officials\"\n    },\n    {\n      \"type\": \"organization\",\n      \"name\": \"transport committee\"\n    },\n    {\n      \"type\": \"metric\",\n      \"name\": \"22 percent\"\n    },\n    {\n      \"type\": \"date\",\n      \"name\": \"September\"\n    },\n    {\n      \"type\": \"date\",\n      \"name\": \"July\"\n    }\n  ],\n  \"key_points\": [\n    \"The city council voted 8-3 to approve a new electric bus fleet.\",\n    \"A six-month pilot program reduced fuel costs by 22 percent.\",\n    \"The first 40 buses will enter service in September.\",\n    \"Charging depots are scheduled for completion by July.\",\n    \"Winter battery performance concerns were addressed by the transport committee using pilot data from two cold snaps.\"\n  ],\n  \"summary\": \"The city council has officially approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. While critics raised concerns regarding winter battery performance, the transport committee confirmed that pilot data from two cold snaps met operational targets. The first 40 buses are set to begin service in September, with charging infrastructure to be completed by July.\"\n}",
+        "parsed": {
+          "headline": "City Council Approves Electric Bus Fleet Following Successful Pilot",
+          "entities": [
+            {
+              "type": "organization",
+              "name": "city council"
+            },
+            {
+              "type": "organization",
+              "name": "Transit officials"
+            },
+            {
+              "type": "organization",
+              "name": "transport committee"
+            },
+            {
+              "type": "metric",
+              "name": "22 percent"
+            },
+            {
+              "type": "date",
+              "name": "September"
+            },
+            {
+              "type": "date",
+              "name": "July"
+            }
+          ],
+          "key_points": [
+            "The city council voted 8-3 to approve a new electric bus fleet.",
+            "A six-month pilot program reduced fuel costs by 22 percent.",
+            "The first 40 buses will enter service in September.",
+            "Charging depots are scheduled for completion by July.",
+            "Winter battery performance concerns were addressed by the transport committee using pilot data from two cold snaps."
+          ],
+          "summary": "The city council has officially approved a new electric bus fleet following a successful six-month pilot that cut fuel costs by 22 percent. While critics raised concerns regarding winter battery performance, the transport committee confirmed that pilot data from two cold snaps met operational targets. The first 40 buses are set to begin service in September, with charging infrastructure to be completed by July."
+        },
+        "usage": {
+          "completion_tokens": 343,
+          "prompt_tokens": 243,
+          "total_tokens": 586,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 95.6,
+          "completion_time": 3.59,
+          "prompt_tokens_per_second": 1480.96,
+          "prompt_time": 0.16,
+          "total_time": 3.75
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::article_summary",
+      "ok": false,
+      "elapsed_s": 4.646,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": "MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\nLoading MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\n\n[/                       ]   --.-% checking cache | mem 0.02 GB | 0.0s[2026-03-13 22:24:50.245] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 1.32 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 7.35 GB | 0.4s\n[|                       ]   --.-% loading model | mem 13.71 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.41 GB | 0.8s\n[done] ready | mem 18.37 GB | 0.9s\n<think>{\"headline\": \"City Council Approves Electric Bus Fleet Following Successful Pilot\", \"summary\": \"The city council voted 8-3 to approve a new electric bus fleet after a six-month pilot program demonstrated a 22% reduction in fuel costs. The first 40 buses are scheduled to begin service in September, with charging infrastructure to be completed by July. Despite concerns about winter battery performance, the transport committee confirmed that pilot data from cold weather events met operational targets.\", \"key_points\": [\"City council approved electric bus fleet with 8-3 vote\", \"Six-month pilot reduced fuel costs by 22 percent\", \"First 40 buses enter service in September\", \"Charging depots to be completed by July\", \"Winter battery performance concerns addressed by transport committee\", \"Pilot data from cold snaps met operational targets\"], \"entities\": [{\"type\": \"organization\", \"name\": \"city council\"}, {\"type\": \"organization\", \"name\": \"transport committee\"}, {\"type\": \"date\", \"name\": \"September\"}, {\"type\": \"date\", \"name\": \"July\"}, {\"type\": \"metric\", \"name\": \"22 percent\"}, {\"type\": \"metric\", \"name\": \"8-3 vote\"}, {\"type\": \"metric\", \"name\": \"40 buses\"}]}"
+      }
+    },
+    {
+      "name": "api_json_schema::catalog_normalization_refs",
+      "ok": true,
+      "elapsed_s": 2.485,
+      "details": {
+        "finish_reason": "stop",
+        "content": "{\n  \"price_usd\": 89,\n  \"use_cases\": [\n    \"commuting\",\n    \"short hikes\"\n  ],\n  \"product_name\": \"TrailPro 18L commuter backpack\",\n  \"attributes\": [\n    {\n      \"value\": \"recycled nylon\",\n      \"name\": \"material\"\n    },\n    {\n      \"value\": \"water-resistant\",\n      \"name\": \"water_resistance\"\n    },\n    {\n      \"value\": \"16 inch\",\n      \"name\": \"laptop_capacity\"\n    },\n    {\n      \"value\": \"midnight blue\",\n      \"name\": \"color\"\n    },\n    {\n      \"value\": \"0.9 kg\",\n      \"name\": \"weight\"\n    }\n  ],\n  \"category\": \"backpack\"\n}",
+        "parsed": {
+          "price_usd": 89,
+          "use_cases": [
+            "commuting",
+            "short hikes"
+          ],
+          "product_name": "TrailPro 18L commuter backpack",
+          "attributes": [
+            {
+              "value": "recycled nylon",
+              "name": "material"
+            },
+            {
+              "value": "water-resistant",
+              "name": "water_resistance"
+            },
+            {
+              "value": "16 inch",
+              "name": "laptop_capacity"
+            },
+            {
+              "value": "midnight blue",
+              "name": "color"
+            },
+            {
+              "value": "0.9 kg",
+              "name": "weight"
+            }
+          ],
+          "category": "backpack"
+        },
+        "usage": {
+          "completion_tokens": 194,
+          "prompt_tokens": 244,
+          "total_tokens": 438,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 96.63,
+          "completion_time": 2.01,
+          "prompt_tokens_per_second": 1415.39,
+          "prompt_time": 0.17,
+          "total_time": 2.18
+        },
+        "validation_error": null
+      }
+    },
+    {
+      "name": "cli_guided_json::catalog_normalization_refs",
+      "ok": false,
+      "elapsed_s": 2.686,
+      "details": {
+        "error": "invalid JSON: Expecting value: line 1 column 1 (char 0)",
+        "stdout": "MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\nLoading MLX model: mlx-community/Qwen3.5-35B-A3B-4bit\n\n[/                       ]   --.-% checking cache | mem 0.02 GB | 0.0s[2026-03-13 22:24:57.371] MLX GPU: cache=1024MB wired=427622MB (system 512GB)\n\n[-                       ]   --.-% loading model | mem 1.53 GB | 0.2s\n[\\                       ]   --.-% loading model | mem 7.69 GB | 0.4s\n[|                       ]   --.-% loading model | mem 13.06 GB | 0.6s\n[/                       ]   --.-% loading model | mem 18.37 GB | 0.8s\n[done] ready | mem 18.36 GB | 0.9s\n<think>{\"attributes\":[{\"value\":\"Water-resistant recycled nylon shell\",\"name\":\"Material\"},{\"value\":\"16 inch\",\"name\":\"Laptop Sleeve Capacity\"},{\"value\":\"Midnight Blue\",\"name\":\"Color\"},{\"value\":\"0.9 kg\",\"name\":\"Weight\"}],\"category\":\"backpack\",\"price_usd\":89,\"product_name\":\"TrailPro 18L commuter backpack\",\"use_cases\":[\"commuting\",\"short hikes\"]}"
+      }
+    },
+    {
+      "name": "openai_python_parse::sdk_parse_person",
+      "ok": true,
+      "elapsed_s": 0.593,
+      "details": {
+        "content": "{\"occupation\":\"computer scientist\",\"age\":45,\"name\":\"Grace Hopper\"}",
+        "parsed": {
+          "name": "Grace Hopper",
+          "age": 45,
+          "occupation": "computer scientist"
+        },
+        "refusal": null
+      }
+    },
+    {
+      "name": "cli_guided_json::invalid_schema_error",
+      "ok": true,
+      "elapsed_s": 1.094,
+      "details": {
+        "returncode": 1,
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/logprobs-smoke.json
+++ b/Scripts/feature-codex-optimize-api/results/logprobs-smoke.json
@@ -1,0 +1,151 @@
+{
+  "generated_at": "2026-03-13T22:07:55.721250",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.006,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "openai_python_nonstream",
+      "ok": true,
+      "elapsed_s": 0.646,
+      "details": {
+        "finish_reason": "stop",
+        "content": "ok",
+        "usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_time": 0.01,
+          "prompt_time": 0.05,
+          "prompt_tokens_per_second": 554.71,
+          "completion_tokens_per_second": 113.24,
+          "total_time": 0.06
+        },
+        "stderr": null
+      }
+    },
+    {
+      "name": "openai_python_stream",
+      "ok": true,
+      "elapsed_s": 0.402,
+      "details": {
+        "chunk_count": 4,
+        "last_choices": 0,
+        "last_usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_time": 0.01,
+          "prompt_time": 0.04,
+          "prompt_tokens_per_second": 642.54,
+          "completion_tokens_per_second": 121.92,
+          "total_time": 0.05
+        },
+        "content": "ok",
+        "finish_reason": "stop",
+        "stderr": null
+      }
+    },
+    {
+      "name": "openai_python_nonstream_logprobs",
+      "ok": true,
+      "elapsed_s": 0.494,
+      "details": {
+        "finish_reason": "stop",
+        "content": "ok",
+        "logprobs_present": true,
+        "token_count": 1,
+        "first_token": {
+          "token": "ok",
+          "bytes": [
+            111,
+            107
+          ],
+          "logprob": -0.0008224649936892092,
+          "top_logprobs": [
+            {
+              "token": "ok",
+              "bytes": [
+                111,
+                107
+              ],
+              "logprob": -0.0008224649936892092
+            },
+            {
+              "token": "Ok",
+              "bytes": [
+                79,
+                107
+              ],
+              "logprob": -8.375822067260742
+            },
+            {
+              "token": "o",
+              "bytes": [
+                111
+              ],
+              "logprob": -9.375822067260742
+            }
+          ]
+        },
+        "stderr": null
+      }
+    },
+    {
+      "name": "openai_python_stream_logprobs",
+      "ok": false,
+      "elapsed_s": 0.417,
+      "details": {
+        "finish_reason": "stop",
+        "content": "ok",
+        "logprob_chunk_count": 0,
+        "first_logprob_token": null,
+        "last_choices": 0,
+        "last_usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_time": 0.01,
+          "prompt_time": 0.05,
+          "prompt_tokens_per_second": 515.28,
+          "completion_tokens_per_second": 83.82,
+          "total_time": 0.07
+        },
+        "stderr": null
+      }
+    },
+    {
+      "name": "vllm_bench_smoke",
+      "ok": true,
+      "elapsed_s": 7.706,
+      "details": {
+        "successful_requests": "4",
+        "failed_requests": "0",
+        "total_generated_tokens": "128",
+        "output_token_throughput": "76.74",
+        "stderr_tail": " (0x1549443f8). This may cause spurious casting failures and mysterious crashes. One of the duplicates must be removed or renamed.\n\n  0%|          | 0/4 [00:00<?, ?it/s]\n 25%|\u2588\u2588\u258c       | 1/4 [00:00<00:01,  1.62it/s]\n 50%|\u2588\u2588\u2588\u2588\u2588     | 2/4 [00:00<00:00,  2.18it/s]\n 75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258c  | 3/4 [00:01<00:00,  2.42it/s]\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4/4 [00:01<00:00,  2.59it/s]\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4/4 [00:01<00:00,  2.40it/s]\n"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/openai-compat-evals-20260313-214403.json
+++ b/Scripts/feature-codex-optimize-api/results/openai-compat-evals-20260313-214403.json
@@ -1,0 +1,78 @@
+{
+  "generated_at": "2026-03-13T21:44:03.233900",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.005,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "openai_python_nonstream",
+      "ok": true,
+      "elapsed_s": 0.647,
+      "details": {
+        "finish_reason": "stop",
+        "content": "ok",
+        "usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_time": 0.01,
+          "prompt_time": 0.05,
+          "prompt_tokens_per_second": 575.43,
+          "completion_tokens_per_second": 122.28,
+          "total_time": 0.06
+        },
+        "stderr": null
+      }
+    },
+    {
+      "name": "openai_python_stream",
+      "ok": true,
+      "elapsed_s": 0.402,
+      "details": {
+        "chunk_count": 4,
+        "last_choices": 0,
+        "last_usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_time": 0.01,
+          "prompt_time": 0.04,
+          "prompt_tokens_per_second": 642.75,
+          "completion_tokens_per_second": 121.85,
+          "total_time": 0.05
+        },
+        "content": "ok",
+        "finish_reason": "stop",
+        "stderr": null
+      }
+    },
+    {
+      "name": "vllm_bench_smoke",
+      "ok": true,
+      "elapsed_s": 7.745,
+      "details": {
+        "successful_requests": "4",
+        "failed_requests": "0",
+        "total_generated_tokens": "128",
+        "output_token_throughput": "77.30",
+        "stderr_tail": " (0x13804c3f8). This may cause spurious casting failures and mysterious crashes. One of the duplicates must be removed or renamed.\n\n  0%|          | 0/4 [00:00<?, ?it/s]\n 25%|\\u2588\\u2588\\u258c       | 1/4 [00:00<00:01,  1.59it/s]\n 50%|\\u2588\\u2588\\u2588\\u2588\\u2588     | 2/4 [00:00<00:00,  2.16it/s]\n 75%|\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u258c  | 3/4 [00:01<00:00,  2.47it/s]\n100%|\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588| 4/4 [00:01<00:00,  2.63it/s]\n100%|\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588| 4/4 [00:01<00:00,  2.42it/s]\n"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/post-fix-logprobs.json
+++ b/Scripts/feature-codex-optimize-api/results/post-fix-logprobs.json
@@ -1,0 +1,183 @@
+{
+  "generated_at": "2026-03-13T22:16:28.102469",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.008,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "openai_python_nonstream",
+      "ok": true,
+      "elapsed_s": 0.968,
+      "details": {
+        "finish_reason": "stop",
+        "content": "ok",
+        "usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "total_time": 0.48,
+          "prompt_tokens_per_second": 59.63,
+          "completion_tokens_per_second": 116.69,
+          "completion_time": 0.01,
+          "prompt_time": 0.47
+        },
+        "stderr": null
+      }
+    },
+    {
+      "name": "openai_python_stream",
+      "ok": true,
+      "elapsed_s": 0.399,
+      "details": {
+        "chunk_count": 4,
+        "last_choices": 0,
+        "last_usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "total_time": 0.05,
+          "prompt_tokens_per_second": 630.53,
+          "completion_tokens_per_second": 121.83,
+          "completion_time": 0.01,
+          "prompt_time": 0.04
+        },
+        "content": "ok",
+        "finish_reason": "stop",
+        "stderr": null
+      }
+    },
+    {
+      "name": "openai_python_nonstream_logprobs",
+      "ok": true,
+      "elapsed_s": 0.422,
+      "details": {
+        "finish_reason": "stop",
+        "content": "ok",
+        "logprobs_present": true,
+        "token_count": 1,
+        "first_token": {
+          "token": "ok",
+          "bytes": [
+            111,
+            107
+          ],
+          "logprob": -0.0008224649936892092,
+          "top_logprobs": [
+            {
+              "token": "ok",
+              "bytes": [
+                111,
+                107
+              ],
+              "logprob": -0.0008224649936892092
+            },
+            {
+              "token": "Ok",
+              "bytes": [
+                79,
+                107
+              ],
+              "logprob": -8.375822067260742
+            },
+            {
+              "token": "o",
+              "bytes": [
+                111
+              ],
+              "logprob": -9.375822067260742
+            }
+          ]
+        },
+        "stderr": null
+      }
+    },
+    {
+      "name": "openai_python_stream_logprobs",
+      "ok": true,
+      "elapsed_s": 0.423,
+      "details": {
+        "finish_reason": "stop",
+        "content": "ok",
+        "logprob_chunk_count": 1,
+        "first_logprob_token": {
+          "token": "ok",
+          "bytes": [
+            111,
+            107
+          ],
+          "logprob": -0.0008224649936892092,
+          "top_logprobs": [
+            {
+              "token": "ok",
+              "bytes": [
+                111,
+                107
+              ],
+              "logprob": -0.0008224649936892092
+            },
+            {
+              "token": "Ok",
+              "bytes": [
+                79,
+                107
+              ],
+              "logprob": -8.375822067260742
+            },
+            {
+              "token": "o",
+              "bytes": [
+                111
+              ],
+              "logprob": -9.375822067260742
+            }
+          ]
+        },
+        "last_choices": 0,
+        "last_usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_tokens_per_second": 76.59,
+          "completion_time": 0.01,
+          "prompt_tokens_per_second": 478.33,
+          "prompt_time": 0.06,
+          "total_time": 0.07
+        },
+        "stderr": null
+      }
+    },
+    {
+      "name": "vllm_bench_smoke",
+      "ok": true,
+      "elapsed_s": 7.953,
+      "details": {
+        "successful_requests": "4",
+        "failed_requests": "0",
+        "total_generated_tokens": "128",
+        "output_token_throughput": "78.16",
+        "stderr_tail": " (0x17875c3f8). This may cause spurious casting failures and mysterious crashes. One of the duplicates must be removed or renamed.\n\n  0%|          | 0/4 [00:00<?, ?it/s]\n 25%|\u2588\u2588\u258c       | 1/4 [00:00<00:01,  1.63it/s]\n 50%|\u2588\u2588\u2588\u2588\u2588     | 2/4 [00:00<00:00,  2.20it/s]\n 75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258c  | 3/4 [00:01<00:00,  2.49it/s]\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4/4 [00:01<00:00,  2.64it/s]\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4/4 [00:01<00:00,  2.44it/s]\n"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/pre-restart-check.json
+++ b/Scripts/feature-codex-optimize-api/results/pre-restart-check.json
@@ -1,0 +1,151 @@
+{
+  "generated_at": "2026-03-13T22:12:05.026771",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.005,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "openai_python_nonstream",
+      "ok": true,
+      "elapsed_s": 0.643,
+      "details": {
+        "finish_reason": "stop",
+        "content": "ok",
+        "usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_time": 0.01,
+          "prompt_time": 0.05,
+          "prompt_tokens_per_second": 607.64,
+          "completion_tokens_per_second": 120.09,
+          "total_time": 0.05
+        },
+        "stderr": null
+      }
+    },
+    {
+      "name": "openai_python_stream",
+      "ok": true,
+      "elapsed_s": 0.401,
+      "details": {
+        "chunk_count": 4,
+        "last_choices": 0,
+        "last_usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_time": 0.01,
+          "prompt_time": 0.04,
+          "prompt_tokens_per_second": 644.97,
+          "completion_tokens_per_second": 121.54,
+          "total_time": 0.05
+        },
+        "content": "ok",
+        "finish_reason": "stop",
+        "stderr": null
+      }
+    },
+    {
+      "name": "openai_python_nonstream_logprobs",
+      "ok": true,
+      "elapsed_s": 0.413,
+      "details": {
+        "finish_reason": "stop",
+        "content": "ok",
+        "logprobs_present": true,
+        "token_count": 1,
+        "first_token": {
+          "token": "ok",
+          "bytes": [
+            111,
+            107
+          ],
+          "logprob": -0.0008224649936892092,
+          "top_logprobs": [
+            {
+              "token": "ok",
+              "bytes": [
+                111,
+                107
+              ],
+              "logprob": -0.0008224649936892092
+            },
+            {
+              "token": "Ok",
+              "bytes": [
+                79,
+                107
+              ],
+              "logprob": -8.375822067260742
+            },
+            {
+              "token": "o",
+              "bytes": [
+                111
+              ],
+              "logprob": -9.375822067260742
+            }
+          ]
+        },
+        "stderr": null
+      }
+    },
+    {
+      "name": "openai_python_stream_logprobs",
+      "ok": false,
+      "elapsed_s": 0.416,
+      "details": {
+        "finish_reason": "stop",
+        "content": "ok",
+        "logprob_chunk_count": 0,
+        "first_logprob_token": null,
+        "last_choices": 0,
+        "last_usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_time": 0.01,
+          "prompt_time": 0.06,
+          "prompt_tokens_per_second": 471.7,
+          "completion_tokens_per_second": 84.03,
+          "total_time": 0.07
+        },
+        "stderr": null
+      }
+    },
+    {
+      "name": "vllm_bench_smoke",
+      "ok": true,
+      "elapsed_s": 7.887,
+      "details": {
+        "successful_requests": "4",
+        "failed_requests": "0",
+        "total_generated_tokens": "128",
+        "output_token_throughput": "78.37",
+        "stderr_tail": " (0x13b1103f8). This may cause spurious casting failures and mysterious crashes. One of the duplicates must be removed or renamed.\n\n  0%|          | 0/4 [00:00<?, ?it/s]\n 25%|\u2588\u2588\u258c       | 1/4 [00:00<00:01,  1.68it/s]\n 50%|\u2588\u2588\u2588\u2588\u2588     | 2/4 [00:00<00:00,  2.24it/s]\n 75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258c  | 3/4 [00:01<00:00,  2.48it/s]\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4/4 [00:01<00:00,  2.63it/s]\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4/4 [00:01<00:00,  2.45it/s]\n"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/results/smoke-relocated.json
+++ b/Scripts/feature-codex-optimize-api/results/smoke-relocated.json
@@ -1,0 +1,78 @@
+{
+  "generated_at": "2026-03-13T22:06:13.519494",
+  "results": [
+    {
+      "name": "models_endpoint",
+      "ok": true,
+      "elapsed_s": 0.006,
+      "details": {
+        "count": 1,
+        "first_id": "mlx-community/Qwen3.5-35B-A3B-4bit"
+      }
+    },
+    {
+      "name": "openai_python_nonstream",
+      "ok": true,
+      "elapsed_s": 0.657,
+      "details": {
+        "finish_reason": "stop",
+        "content": "ok",
+        "usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_time": 0.01,
+          "prompt_time": 0.05,
+          "prompt_tokens_per_second": 574.54,
+          "completion_tokens_per_second": 120.1,
+          "total_time": 0.06
+        },
+        "stderr": null
+      }
+    },
+    {
+      "name": "openai_python_stream",
+      "ok": true,
+      "elapsed_s": 0.404,
+      "details": {
+        "chunk_count": 4,
+        "last_choices": 0,
+        "last_usage": {
+          "completion_tokens": 1,
+          "prompt_tokens": 28,
+          "total_tokens": 29,
+          "completion_tokens_details": null,
+          "prompt_tokens_details": {
+            "audio_tokens": null,
+            "cached_tokens": 0
+          },
+          "completion_time": 0.01,
+          "prompt_time": 0.04,
+          "prompt_tokens_per_second": 631.21,
+          "completion_tokens_per_second": 118.85,
+          "total_time": 0.05
+        },
+        "content": "ok",
+        "finish_reason": "stop",
+        "stderr": null
+      }
+    },
+    {
+      "name": "vllm_bench_smoke",
+      "ok": true,
+      "elapsed_s": 7.811,
+      "details": {
+        "successful_requests": "4",
+        "failed_requests": "0",
+        "total_generated_tokens": "128",
+        "output_token_throughput": "77.20",
+        "stderr_tail": " (0x1371d43f8). This may cause spurious casting failures and mysterious crashes. One of the duplicates must be removed or renamed.\n\n  0%|          | 0/4 [00:00<?, ?it/s]\n 25%|\u2588\u2588\u258c       | 1/4 [00:00<00:01,  1.64it/s]\n 50%|\u2588\u2588\u2588\u2588\u2588     | 2/4 [00:00<00:00,  2.19it/s]\n 75%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258c  | 3/4 [00:01<00:00,  2.43it/s]\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4/4 [00:01<00:00,  2.61it/s]\n100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4/4 [00:01<00:00,  2.41it/s]\n"
+      }
+    }
+  ]
+}

--- a/Scripts/feature-codex-optimize-api/test-guided-json-evals.py
+++ b/Scripts/feature-codex-optimize-api/test-guided-json-evals.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""
+Guided JSON / structured output eval bundle.
+
+Focus:
+  - AFM `--guided-json` parity with OpenAI-style strict `json_schema`
+  - openai-python structured output behavior
+  - real-world schema fixtures instead of only toy objects
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+from openai import OpenAI
+from pydantic import BaseModel
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+AFM_BINARY = REPO_ROOT / ".build" / "arm64-apple-macosx" / "release" / "afm"
+CASES_PATH = SCRIPT_DIR / "guided-json-cases.json"
+REPORT_DIR = SCRIPT_DIR / "results"
+MODEL_CACHE = os.environ.get("MACAFM_MLX_MODEL_CACHE", "/Volumes/edata/models/vesta-test-cache")
+DEFAULT_MODEL = "mlx-community/Qwen3.5-35B-A3B-4bit"
+
+
+class PersonRecord(BaseModel):
+    name: str
+    age: int
+    occupation: str
+
+
+def ts() -> str:
+    return dt.datetime.now().strftime("%H:%M:%S")
+
+
+def log(message: str) -> None:
+    print(f"[{ts()}] {message}", flush=True)
+
+
+def run_subprocess(cmd: list[str], timeout: int = 240, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+    )
+
+
+def http_get_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=20) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def build_response_format(case: dict) -> dict[str, Any]:
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": case["schema_name"],
+            "strict": True,
+            "schema": case["schema"],
+        },
+    }
+
+
+def wait_for_server(base_url: str, timeout: int = 180, proc: subprocess.Popen[str] | None = None) -> bool:
+    models_url = f"{base_url.rstrip('/')}/models"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc and proc.poll() is not None:
+            return False
+        try:
+            with urllib.request.urlopen(models_url, timeout=3) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            time.sleep(2)
+    return False
+
+
+def start_server(model: str, port: int, extra_args: list[str], mode: str) -> subprocess.Popen[str]:
+    env = os.environ.copy()
+    env["MACAFM_MLX_MODEL_CACHE"] = MODEL_CACHE
+    if mode == "foundation":
+        cmd = [
+            str(AFM_BINARY),
+            "--port",
+            str(port),
+            *extra_args,
+        ]
+    else:
+        cmd = [
+            str(AFM_BINARY),
+            "mlx",
+            "-m",
+            model,
+            "--port",
+            str(port),
+            *extra_args,
+        ]
+    log(f"Starting server: {' '.join(cmd)}")
+    return subprocess.Popen(
+        cmd,
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
+
+
+def stop_server(proc: subprocess.Popen[str] | None) -> None:
+    if not proc or proc.poll() is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        proc.wait(timeout=10)
+    except Exception:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def load_cases() -> list[dict]:
+    return json.loads(CASES_PATH.read_text())
+
+
+def validate_instance(schema: dict, instance: dict) -> tuple[bool, str | None]:
+    try:
+        jsonschema.validate(instance=instance, schema=schema)
+        return True, None
+    except jsonschema.ValidationError as exc:
+        return False, exc.message
+
+
+def failed_result(name: str, started: float, exc: Exception) -> dict:
+    return {
+        "name": name,
+        "ok": False,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+        },
+    }
+
+
+def run_models_probe(base_url: str) -> dict:
+    started = time.time()
+    body = http_get_json(f"{base_url.rstrip('/')}/models")
+    data = body.get("data", [])
+    return {
+        "name": "models_endpoint",
+        "ok": bool(data),
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "count": len(data),
+            "first_id": data[0].get("id") if data else None,
+        },
+    }
+
+
+def run_api_schema_case(client: OpenAI, model: str, case: dict) -> dict:
+    started = time.time()
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": case["prompt"]}],
+            max_tokens=400,
+            temperature=0,
+            response_format=build_response_format(case),
+        )
+    except Exception as exc:
+        return failed_result(f"api_json_schema::{case['id']}", started, exc)
+    content = response.choices[0].message.content or ""
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as exc:
+        return {
+            "name": f"api_json_schema::{case['id']}",
+            "ok": False,
+            "elapsed_s": round(time.time() - started, 3),
+            "details": {"error": f"invalid JSON: {exc}", "content": content},
+        }
+
+    valid, err = validate_instance(case["schema"], parsed)
+    return {
+        "name": f"api_json_schema::{case['id']}",
+        "ok": valid,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "finish_reason": response.choices[0].finish_reason,
+            "content": content,
+            "parsed": parsed,
+            "usage": response.usage.model_dump() if response.usage else None,
+            "validation_error": err,
+        },
+    }
+
+
+def run_api_stream_schema_case(client: OpenAI, model: str, case: dict) -> dict:
+    started = time.time()
+    try:
+        stream = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": case["prompt"]}],
+            max_tokens=400,
+            temperature=0,
+            stream=True,
+            stream_options={"include_usage": True},
+            response_format=build_response_format(case),
+        )
+    except Exception as exc:
+        return failed_result(f"api_stream_json_schema::{case['id']}", started, exc)
+
+    parts: list[str] = []
+    usage = None
+    final_finish_reason = None
+    saw_usage_chunk = False
+    chunk_count = 0
+    for chunk in stream:
+        chunk_count += 1
+        if chunk.usage is not None:
+            usage = chunk.usage.model_dump()
+            saw_usage_chunk = len(chunk.choices) == 0
+        for choice in chunk.choices:
+            if choice.delta.content:
+                parts.append(choice.delta.content)
+            if choice.finish_reason:
+                final_finish_reason = choice.finish_reason
+
+    content = "".join(parts)
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as exc:
+        return {
+            "name": f"api_stream_json_schema::{case['id']}",
+            "ok": False,
+            "elapsed_s": round(time.time() - started, 3),
+            "details": {
+                "error": f"invalid JSON: {exc}",
+                "content": content,
+                "chunk_count": chunk_count,
+                "saw_usage_chunk": saw_usage_chunk,
+                "usage": usage,
+                "finish_reason": final_finish_reason,
+            },
+        }
+
+    valid, err = validate_instance(case["schema"], parsed)
+    return {
+        "name": f"api_stream_json_schema::{case['id']}",
+        "ok": valid and err is None and saw_usage_chunk and usage is not None,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "content": content,
+            "parsed": parsed,
+            "validation_error": err,
+            "chunk_count": chunk_count,
+            "saw_usage_chunk": saw_usage_chunk,
+            "usage": usage,
+            "finish_reason": final_finish_reason,
+        },
+    }
+
+
+def run_api_conflict_schema_case(client: OpenAI, model: str, case: dict) -> dict:
+    started = time.time()
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": case["prompt"]}],
+            max_tokens=200,
+            temperature=0,
+            response_format=build_response_format(case),
+        )
+    except Exception as exc:
+        return failed_result(f"api_conflict_json_schema::{case['id']}", started, exc)
+    message = response.choices[0].message
+    content = message.content or ""
+    refusal = getattr(message, "refusal", None)
+
+    parsed = None
+    validation_error = None
+    ok = False
+    if refusal:
+        ok = True
+    else:
+        try:
+            parsed = json.loads(content)
+            valid, validation_error = validate_instance(case["schema"], parsed)
+            ok = valid
+        except json.JSONDecodeError as exc:
+            validation_error = str(exc)
+
+    return {
+        "name": f"api_conflict_json_schema::{case['id']}",
+        "ok": ok,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "content": content,
+            "parsed": parsed,
+            "refusal": refusal,
+            "finish_reason": response.choices[0].finish_reason,
+            "usage": response.usage.model_dump() if response.usage else None,
+            "validation_error": validation_error,
+        },
+    }
+
+
+def run_api_truncation_schema_case(client: OpenAI, model: str, case: dict) -> dict:
+    started = time.time()
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": case["prompt"]}],
+            max_tokens=case.get("max_tokens", 24),
+            temperature=0,
+            response_format=build_response_format(case),
+        )
+    except Exception as exc:
+        return failed_result(f"api_truncation_json_schema::{case['id']}", started, exc)
+    content = response.choices[0].message.content or ""
+    finish_reason = response.choices[0].finish_reason
+    refusal = getattr(response.choices[0].message, "refusal", None)
+
+    parsed = None
+    validation_error = None
+    valid = False
+    try:
+        parsed = json.loads(content)
+        valid, validation_error = validate_instance(case["schema"], parsed)
+    except json.JSONDecodeError as exc:
+        validation_error = str(exc)
+
+    completion_tokens = ((response.usage.model_dump() if response.usage else {}) or {}).get("completion_tokens")
+    hit_budget = completion_tokens == case.get("max_tokens", 24)
+    ok = ((hit_budget or finish_reason == "length") and not valid) or refusal is not None
+    return {
+        "name": f"api_truncation_json_schema::{case['id']}",
+        "ok": ok,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "finish_reason": finish_reason,
+            "hit_budget": hit_budget,
+            "content": content,
+            "parsed": parsed,
+            "validation_error": validation_error,
+            "refusal": refusal,
+            "usage": response.usage.model_dump() if response.usage else None,
+        },
+    }
+
+
+def run_api_unsupported_schema_case(client: OpenAI, model: str, case: dict) -> dict:
+    started = time.time()
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": case["prompt"]}],
+            max_tokens=120,
+            temperature=0,
+            response_format=build_response_format(case),
+        )
+        content = response.choices[0].message.content or ""
+        parsed = json.loads(content)
+        valid, validation_error = validate_instance(case["schema"], parsed)
+        return {
+            "name": f"api_unsupported_json_schema::{case['id']}",
+            "ok": valid,
+            "elapsed_s": round(time.time() - started, 3),
+            "details": {
+                "mode": "accepted",
+                "content": content,
+                "parsed": parsed,
+                "validation_error": validation_error,
+                "finish_reason": response.choices[0].finish_reason,
+            },
+        }
+    except Exception as exc:
+        return {
+            "name": f"api_unsupported_json_schema::{case['id']}",
+            "ok": True,
+            "elapsed_s": round(time.time() - started, 3),
+            "details": {"mode": "rejected", "error_type": type(exc).__name__, "message": str(exc)},
+        }
+
+
+def run_sdk_parse_case(client: OpenAI, model: str, case: dict) -> dict:
+    started = time.time()
+    try:
+        response = client.beta.chat.completions.parse(
+            model=model,
+            messages=[{"role": "user", "content": case["prompt"]}],
+            temperature=0,
+            max_tokens=128,
+            response_format=PersonRecord,
+        )
+    except Exception as exc:
+        return failed_result(f"openai_python_parse::{case['id']}", started, exc)
+    message = response.choices[0].message
+    ok = message.parsed is not None and message.refusal is None
+    return {
+        "name": f"openai_python_parse::{case['id']}",
+        "ok": ok,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "content": message.content,
+            "parsed": message.parsed.model_dump() if message.parsed else None,
+            "refusal": message.refusal,
+        },
+    }
+
+
+def run_cli_guided_json_case(model: str, case: dict, *, no_think: bool = False) -> dict:
+    started = time.time()
+    env = os.environ.copy()
+    env["MACAFM_MLX_MODEL_CACHE"] = MODEL_CACHE
+    mode = "no_think" if no_think else "default"
+    cmd = [
+        str(AFM_BINARY),
+        "mlx",
+        "-m",
+        model,
+        "-s",
+        case["prompt"],
+        "--max-tokens",
+        "400",
+        "--temperature",
+        "0",
+        "--guided-json",
+        json.dumps(case["schema"], separators=(",", ":")),
+    ]
+    if no_think:
+        cmd.append("--no-think")
+    result = run_subprocess(cmd, timeout=240, env=env)
+    output = result.stdout.strip()
+    if result.returncode != 0:
+        return {
+            "name": f"cli_guided_json::{mode}::{case['id']}",
+            "ok": False,
+            "elapsed_s": round(time.time() - started, 3),
+            "details": {"stderr": result.stderr[-500:], "stdout": output[-500:]},
+        }
+    try:
+        parsed = json.loads(output)
+    except json.JSONDecodeError as exc:
+        return {
+            "name": f"cli_guided_json::{mode}::{case['id']}",
+            "ok": False,
+            "elapsed_s": round(time.time() - started, 3),
+            "details": {"error": f"invalid JSON: {exc}", "stdout": output},
+        }
+    valid, err = validate_instance(case["schema"], parsed)
+    return {
+        "name": f"cli_guided_json::{mode}::{case['id']}",
+        "ok": valid,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {"parsed": parsed, "validation_error": err},
+    }
+
+
+def run_cli_invalid_schema(model: str) -> dict:
+    started = time.time()
+    env = os.environ.copy()
+    env["MACAFM_MLX_MODEL_CACHE"] = MODEL_CACHE
+    cmd = [
+        str(AFM_BINARY),
+        "mlx",
+        "-m",
+        model,
+        "-s",
+        "Hello",
+        "--guided-json",
+        "not valid json",
+    ]
+    result = run_subprocess(cmd, timeout=120, env=env)
+    ok = result.returncode != 0
+    return {
+        "name": "cli_guided_json::invalid_schema_error",
+        "ok": ok,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "returncode": result.returncode,
+            "stderr": result.stderr[-400:],
+        },
+    }
+
+
+def run_cli_invalid_schema_no_think(model: str) -> dict:
+    started = time.time()
+    env = os.environ.copy()
+    env["MACAFM_MLX_MODEL_CACHE"] = MODEL_CACHE
+    cmd = [
+        str(AFM_BINARY),
+        "mlx",
+        "-m",
+        model,
+        "-s",
+        "Hello",
+        "--no-think",
+        "--guided-json",
+        "not valid json",
+    ]
+    result = run_subprocess(cmd, timeout=120, env=env)
+    ok = result.returncode != 0
+    return {
+        "name": "cli_guided_json::no_think::invalid_schema_error",
+        "ok": ok,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "returncode": result.returncode,
+            "stderr": result.stderr[-400:],
+        },
+    }
+
+
+def write_report(results: list[dict], report_path: Path) -> None:
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps({"generated_at": dt.datetime.now().isoformat(), "results": results}, indent=2))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run guided-json / structured output evals against AFM.")
+    parser.add_argument("--base-url", default="http://127.0.0.1:9999/v1", help="Base API URL including /v1")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Model id")
+    parser.add_argument("--start-server", action="store_true", help="Start afm locally instead of using an existing server")
+    parser.add_argument("--port", type=int, default=9999, help="Port to bind when using --start-server")
+    parser.add_argument("--server-mode", choices=["mlx", "foundation"], default="mlx", help="Server mode to launch when using --start-server")
+    parser.add_argument("--server-arg", action="append", default=[], help="Extra arg to pass through when using --start-server")
+    parser.add_argument("--run-cli", action="store_true", help="Also run expensive single-prompt CLI --guided-json checks")
+    parser.add_argument("--run-cli-no-think", action="store_true", help="Also run CLI --guided-json checks with --no-think")
+    parser.add_argument("--report-name", default=None, help="Optional JSON report filename")
+    args = parser.parse_args()
+
+    server_proc = None
+    results: list[dict] = []
+
+    try:
+        if args.start_server:
+            server_proc = start_server(args.model, args.port, args.server_arg, args.server_mode)
+            if not wait_for_server(args.base_url, proc=server_proc):
+                log("Server failed to become ready")
+                return 1
+
+        client = OpenAI(base_url=args.base_url, api_key="test")
+        results.append(run_models_probe(args.base_url))
+
+        for case in load_cases():
+            if case["kind"] == "schema":
+                results.append(run_api_schema_case(client, args.model, case))
+                if args.run_cli:
+                    results.append(run_cli_guided_json_case(args.model, case))
+                if args.run_cli_no_think:
+                    results.append(run_cli_guided_json_case(args.model, case, no_think=True))
+            elif case["kind"] == "stream_schema":
+                results.append(run_api_stream_schema_case(client, args.model, case))
+            elif case["kind"] == "conflict_schema":
+                results.append(run_api_conflict_schema_case(client, args.model, case))
+            elif case["kind"] == "truncation_schema":
+                results.append(run_api_truncation_schema_case(client, args.model, case))
+            elif case["kind"] == "schema_edge":
+                results.append(run_api_schema_case(client, args.model, case))
+                if args.run_cli:
+                    results.append(run_cli_guided_json_case(args.model, case))
+                if args.run_cli_no_think:
+                    results.append(run_cli_guided_json_case(args.model, case, no_think=True))
+            elif case["kind"] == "unsupported_schema":
+                results.append(run_api_unsupported_schema_case(client, args.model, case))
+            elif case["kind"] == "parse":
+                results.append(run_sdk_parse_case(client, args.model, case))
+
+        if args.run_cli:
+            results.append(run_cli_invalid_schema(args.model))
+        if args.run_cli_no_think:
+            results.append(run_cli_invalid_schema_no_think(args.model))
+
+        ok = all(item["ok"] for item in results)
+        report_name = args.report_name or f"guided-json-evals-{dt.datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
+        report_path = REPORT_DIR / report_name
+        write_report(results, report_path)
+
+        for item in results:
+            status = "PASS" if item["ok"] else "FAIL"
+            log(f"{status} {item['name']} ({item['elapsed_s']}s)")
+        log(f"Report: {report_path}")
+        return 0 if ok else 1
+    finally:
+        stop_server(server_proc)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/feature-codex-optimize-api/test-guided-json-evals.py
+++ b/Scripts/feature-codex-optimize-api/test-guided-json-evals.py
@@ -32,7 +32,7 @@ REPO_ROOT = SCRIPT_DIR.parents[1]
 AFM_BINARY = REPO_ROOT / ".build" / "arm64-apple-macosx" / "release" / "afm"
 CASES_PATH = SCRIPT_DIR / "guided-json-cases.json"
 REPORT_DIR = SCRIPT_DIR / "results"
-MODEL_CACHE = os.environ.get("MACAFM_MLX_MODEL_CACHE", "/Volumes/edata/models/vesta-test-cache")
+MODEL_CACHE = os.environ.get("MACAFM_MLX_MODEL_CACHE", str(Path.home() / ".cache" / "macafm" / "models"))
 DEFAULT_MODEL = "mlx-community/Qwen3.5-35B-A3B-4bit"
 
 
@@ -55,6 +55,7 @@ def run_subprocess(cmd: list[str], timeout: int = 240, env: dict[str, str] | Non
         cmd,
         cwd=REPO_ROOT,
         env=env,
+        shell=False,
         text=True,
         capture_output=True,
         timeout=timeout,
@@ -117,6 +118,7 @@ def start_server(model: str, port: int, extra_args: list[str], mode: str) -> sub
         cmd,
         cwd=REPO_ROOT,
         env=env,
+        shell=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -492,14 +494,27 @@ def run_cli_invalid_schema(model: str) -> dict:
         "not valid json",
     ]
     result = run_subprocess(cmd, timeout=120, env=env)
-    ok = result.returncode != 0
+    stderr_tail = result.stderr[-400:]
+    error_indicators = (
+        "guided-json",
+        "guided json",
+        "invalid json",
+        "json",
+        "schema",
+    )
+    matched_indicator = next(
+        (marker for marker in error_indicators if marker in stderr_tail.lower()),
+        None,
+    )
+    ok = result.returncode != 0 and matched_indicator is not None
     return {
         "name": "cli_guided_json::invalid_schema_error",
         "ok": ok,
         "elapsed_s": round(time.time() - started, 3),
         "details": {
             "returncode": result.returncode,
-            "stderr": result.stderr[-400:],
+            "stderr": stderr_tail,
+            "error_indicator": matched_indicator,
         },
     }
 
@@ -520,14 +535,27 @@ def run_cli_invalid_schema_no_think(model: str) -> dict:
         "not valid json",
     ]
     result = run_subprocess(cmd, timeout=120, env=env)
-    ok = result.returncode != 0
+    stderr_tail = result.stderr[-400:]
+    error_indicators = (
+        "guided-json",
+        "guided json",
+        "invalid json",
+        "json",
+        "schema",
+    )
+    matched_indicator = next(
+        (marker for marker in error_indicators if marker in stderr_tail.lower()),
+        None,
+    )
+    ok = result.returncode != 0 and matched_indicator is not None
     return {
         "name": "cli_guided_json::no_think::invalid_schema_error",
         "ok": ok,
         "elapsed_s": round(time.time() - started, 3),
         "details": {
             "returncode": result.returncode,
-            "stderr": result.stderr[-400:],
+            "stderr": stderr_tail,
+            "error_indicator": matched_indicator,
         },
     }
 

--- a/Scripts/feature-codex-optimize-api/test-openai-compat-evals.py
+++ b/Scripts/feature-codex-optimize-api/test-openai-compat-evals.py
@@ -33,7 +33,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parents[1]
 AFM_BINARY = REPO_ROOT / ".build" / "arm64-apple-macosx" / "release" / "afm"
 REPORT_DIR = SCRIPT_DIR / "results"
-MODEL_CACHE = os.environ.get("MACAFM_MLX_MODEL_CACHE", "/Volumes/edata/models/vesta-test-cache")
+MODEL_CACHE = os.environ.get("MACAFM_MLX_MODEL_CACHE", str(Path.home() / ".cache" / "macafm" / "models"))
 DEFAULT_MODEL = "mlx-community/Qwen3.5-35B-A3B-4bit"
 DEFAULT_TOKENIZER = "Qwen/Qwen3-Coder-30B-A3B-Instruct"
 
@@ -51,6 +51,7 @@ def run_subprocess(cmd: list[str], timeout: int = 120, env: dict[str, str] | Non
         cmd,
         cwd=REPO_ROOT,
         env=env,
+        shell=False,
         text=True,
         capture_output=True,
         timeout=timeout,
@@ -89,6 +90,7 @@ def start_server(model: str, port: int, extra_args: list[str]) -> subprocess.Pop
         cmd,
         cwd=REPO_ROOT,
         env=env,
+        shell=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/Scripts/feature-codex-optimize-api/test-openai-compat-evals.py
+++ b/Scripts/feature-codex-optimize-api/test-openai-compat-evals.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""
+Reusable OpenAI-compat eval bundle for local AFM servers.
+
+Runs a compact compatibility matrix against a local OpenAI-style endpoint:
+  - GET /v1/models
+  - openai-python non-stream chat completion
+  - openai-python non-stream chat completion with logprobs
+  - openai-python streaming chat completion with usage chunk
+  - openai-python streaming chat completion with logprobs
+  - vllm bench serve smoke benchmark
+
+Usage examples:
+  python3 Scripts/feature-codex-optimize-api/test-openai-compat-evals.py --base-url http://127.0.0.1:9999/v1
+  python3 Scripts/feature-codex-optimize-api/test-openai-compat-evals.py --start-server --model mlx-community/Qwen3.5-35B-A3B-4bit
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+AFM_BINARY = REPO_ROOT / ".build" / "arm64-apple-macosx" / "release" / "afm"
+REPORT_DIR = SCRIPT_DIR / "results"
+MODEL_CACHE = os.environ.get("MACAFM_MLX_MODEL_CACHE", "/Volumes/edata/models/vesta-test-cache")
+DEFAULT_MODEL = "mlx-community/Qwen3.5-35B-A3B-4bit"
+DEFAULT_TOKENIZER = "Qwen/Qwen3-Coder-30B-A3B-Instruct"
+
+
+def ts() -> str:
+    return dt.datetime.now().strftime("%H:%M:%S")
+
+
+def log(message: str) -> None:
+    print(f"[{ts()}] {message}", flush=True)
+
+
+def run_subprocess(cmd: list[str], timeout: int = 120, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+    )
+
+
+def wait_for_server(base_url: str, timeout: int = 180, proc: subprocess.Popen[str] | None = None) -> bool:
+    models_url = f"{base_url.rstrip('/')}/models"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc and proc.poll() is not None:
+            return False
+        try:
+            with urllib.request.urlopen(models_url, timeout=3) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            time.sleep(2)
+    return False
+
+
+def start_server(model: str, port: int, extra_args: list[str]) -> subprocess.Popen[str]:
+    env = os.environ.copy()
+    env["MACAFM_MLX_MODEL_CACHE"] = MODEL_CACHE
+    cmd = [
+        str(AFM_BINARY),
+        "mlx",
+        "-m",
+        model,
+        "--port",
+        str(port),
+        *extra_args,
+    ]
+    log(f"Starting server: {' '.join(cmd)}")
+    return subprocess.Popen(
+        cmd,
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
+
+
+def stop_server(proc: subprocess.Popen[str] | None) -> None:
+    if not proc or proc.poll() is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        proc.wait(timeout=10)
+    except Exception:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def http_get_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=20) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def run_models_probe(base_url: str) -> dict:
+    started = time.time()
+    body = http_get_json(f"{base_url.rstrip('/')}/models")
+    data = body.get("data", [])
+    return {
+        "name": "models_endpoint",
+        "ok": bool(data),
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "count": len(data),
+            "first_id": data[0].get("id") if data else None,
+        },
+    }
+
+
+def run_openai_python_nonstream(base_url: str, model: str) -> dict:
+    code = f"""
+from openai import OpenAI
+client = OpenAI(base_url={base_url!r}, api_key='test')
+resp = client.chat.completions.create(
+    model={model!r},
+    messages=[{{'role':'user','content':'Reply with exactly: ok'}}],
+    max_tokens=8,
+    temperature=0,
+)
+print(resp.model_dump_json())
+"""
+    started = time.time()
+    result = run_subprocess(["python3", "-c", code], timeout=120)
+    ok = result.returncode == 0
+    payload = json.loads(result.stdout) if ok and result.stdout.strip() else {}
+    return {
+        "name": "openai_python_nonstream",
+        "ok": ok,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "finish_reason": (((payload.get("choices") or [{}])[0]).get("finish_reason")) if payload else None,
+            "content": ((((payload.get("choices") or [{}])[0]).get("message") or {}).get("content")) if payload else None,
+            "usage": payload.get("usage"),
+            "stderr": result.stderr[-400:] if not ok else None,
+        },
+    }
+
+
+def run_openai_python_stream(base_url: str, model: str) -> dict:
+    code = f"""
+import json
+from openai import OpenAI
+client = OpenAI(base_url={base_url!r}, api_key='test')
+stream = client.chat.completions.create(
+    model={model!r},
+    messages=[{{'role':'user','content':'Reply with exactly: ok'}}],
+    max_tokens=8,
+    temperature=0,
+    stream=True,
+    stream_options={{'include_usage': True}},
+)
+chunks = list(stream)
+content = ''.join((c.choices[0].delta.content or '') for c in chunks if c.choices)
+finish = next((c.choices[0].finish_reason for c in reversed(chunks) if c.choices and c.choices[0].finish_reason), None)
+last = chunks[-1]
+print(json.dumps({{
+    'chunk_count': len(chunks),
+    'last_choices': len(last.choices),
+    'last_usage': last.usage.model_dump() if last.usage else None,
+    'content': content,
+    'finish_reason': finish,
+}}))
+"""
+    started = time.time()
+    result = run_subprocess(["python3", "-c", code], timeout=120)
+    ok = result.returncode == 0
+    payload = json.loads(result.stdout) if ok and result.stdout.strip() else {}
+    return {
+        "name": "openai_python_stream",
+        "ok": ok,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "chunk_count": payload.get("chunk_count"),
+            "last_choices": payload.get("last_choices"),
+            "last_usage": payload.get("last_usage"),
+            "content": payload.get("content"),
+            "finish_reason": payload.get("finish_reason"),
+            "stderr": result.stderr[-400:] if not ok else None,
+        },
+    }
+
+
+def run_openai_python_nonstream_logprobs(base_url: str, model: str) -> dict:
+    code = f"""
+import json
+from openai import OpenAI
+client = OpenAI(base_url={base_url!r}, api_key='test')
+resp = client.chat.completions.create(
+    model={model!r},
+    messages=[{{'role':'user','content':'Reply with exactly: ok'}}],
+    max_tokens=8,
+    temperature=0,
+    logprobs=True,
+    top_logprobs=3,
+)
+choice = resp.choices[0]
+content = choice.message.content
+lp = choice.logprobs
+first = (lp.content[0].model_dump() if lp and lp.content else None)
+print(json.dumps({{
+    'content': content,
+    'finish_reason': choice.finish_reason,
+    'logprobs_present': lp is not None,
+    'token_count': len(lp.content) if lp and lp.content else 0,
+    'first_token': first,
+}}))
+"""
+    started = time.time()
+    result = run_subprocess(["python3", "-c", code], timeout=120)
+    ok = result.returncode == 0
+    payload = json.loads(result.stdout) if ok and result.stdout.strip() else {}
+    return {
+        "name": "openai_python_nonstream_logprobs",
+        "ok": ok and payload.get("logprobs_present") and payload.get("token_count", 0) > 0,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "finish_reason": payload.get("finish_reason"),
+            "content": payload.get("content"),
+            "logprobs_present": payload.get("logprobs_present"),
+            "token_count": payload.get("token_count"),
+            "first_token": payload.get("first_token"),
+            "stderr": result.stderr[-400:] if not ok else None,
+        },
+    }
+
+
+def run_openai_python_stream_logprobs(base_url: str, model: str) -> dict:
+    code = f"""
+import json
+from openai import OpenAI
+client = OpenAI(base_url={base_url!r}, api_key='test')
+stream = client.chat.completions.create(
+    model={model!r},
+    messages=[{{'role':'user','content':'Reply with exactly: ok'}}],
+    max_tokens=8,
+    temperature=0,
+    stream=True,
+    logprobs=True,
+    top_logprobs=3,
+    stream_options={{'include_usage': True}},
+)
+chunks = list(stream)
+content = ''.join((c.choices[0].delta.content or '') for c in chunks if c.choices)
+finish = next((c.choices[0].finish_reason for c in reversed(chunks) if c.choices and c.choices[0].finish_reason), None)
+logprob_chunks = [c for c in chunks if c.choices and c.choices[0].logprobs and c.choices[0].logprobs.content]
+first = logprob_chunks[0].choices[0].logprobs.content[0].model_dump() if logprob_chunks else None
+last = chunks[-1]
+print(json.dumps({{
+    'content': content,
+    'finish_reason': finish,
+    'logprob_chunk_count': len(logprob_chunks),
+    'first_logprob_token': first,
+    'last_choices': len(last.choices),
+    'last_usage': last.usage.model_dump() if last.usage else None,
+}}))
+"""
+    started = time.time()
+    result = run_subprocess(["python3", "-c", code], timeout=120)
+    ok = result.returncode == 0
+    payload = json.loads(result.stdout) if ok and result.stdout.strip() else {}
+    return {
+        "name": "openai_python_stream_logprobs",
+        "ok": ok and payload.get("logprob_chunk_count", 0) > 0 and payload.get("last_choices") == 0,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "finish_reason": payload.get("finish_reason"),
+            "content": payload.get("content"),
+            "logprob_chunk_count": payload.get("logprob_chunk_count"),
+            "first_logprob_token": payload.get("first_logprob_token"),
+            "last_choices": payload.get("last_choices"),
+            "last_usage": payload.get("last_usage"),
+            "stderr": result.stderr[-400:] if not ok else None,
+        },
+    }
+
+
+def run_vllm_bench(base_root_url: str, model: str, tokenizer: str) -> dict:
+    cmd = [
+        "vllm",
+        "bench",
+        "serve",
+        "--backend",
+        "openai-chat",
+        "--base-url",
+        base_root_url,
+        "--endpoint",
+        "/v1/chat/completions",
+        "--model",
+        model,
+        "--tokenizer",
+        tokenizer,
+        "--random-input-len",
+        "64",
+        "--random-output-len",
+        "32",
+        "--num-prompts",
+        "4",
+    ]
+    started = time.time()
+    result = run_subprocess(cmd, timeout=240)
+    output = f"{result.stdout}\n{result.stderr}"
+    lines = [line.strip() for line in output.splitlines()]
+
+    def extract_metric(prefix: str) -> str | None:
+        for line in lines:
+            if line.startswith(prefix):
+                return line.split(":", 1)[1].strip()
+        return None
+
+    ok = result.returncode == 0 and extract_metric("Failed requests") == "0"
+    return {
+        "name": "vllm_bench_smoke",
+        "ok": ok,
+        "elapsed_s": round(time.time() - started, 3),
+        "details": {
+            "successful_requests": extract_metric("Successful requests"),
+            "failed_requests": extract_metric("Failed requests"),
+            "total_generated_tokens": extract_metric("Total generated tokens"),
+            "output_token_throughput": extract_metric("Output token throughput (tok/s)"),
+            "stderr_tail": result.stderr[-400:] if result.stderr else None,
+        },
+    }
+
+
+def write_report(results: list[dict], report_path: Path) -> None:
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps({"generated_at": dt.datetime.now().isoformat(), "results": results}, indent=2))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run reusable OpenAI-compat evals against AFM or another local OpenAI-style server.")
+    parser.add_argument("--base-url", default="http://127.0.0.1:9999/v1", help="Base API URL including /v1")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Model id to send in chat completion requests")
+    parser.add_argument("--tokenizer", default=DEFAULT_TOKENIZER, help="Tokenizer repo for vllm bench")
+    parser.add_argument("--start-server", action="store_true", help="Start afm locally instead of reusing an existing server")
+    parser.add_argument("--port", type=int, default=9999, help="Port to bind when using --start-server")
+    parser.add_argument("--server-arg", action="append", default=[], help="Extra arg to pass through when using --start-server")
+    parser.add_argument("--report-name", default=None, help="Optional JSON report filename")
+    args = parser.parse_args()
+
+    server_proc = None
+    results: list[dict] = []
+
+    try:
+        if args.start_server:
+            server_proc = start_server(args.model, args.port, args.server_arg)
+            if not wait_for_server(args.base_url, proc=server_proc):
+                log("Server failed to become ready")
+                return 1
+
+        results.append(run_models_probe(args.base_url))
+        results.append(run_openai_python_nonstream(args.base_url, args.model))
+        results.append(run_openai_python_stream(args.base_url, args.model))
+        results.append(run_openai_python_nonstream_logprobs(args.base_url, args.model))
+        results.append(run_openai_python_stream_logprobs(args.base_url, args.model))
+        results.append(run_vllm_bench(args.base_url[:-3] if args.base_url.endswith("/v1") else args.base_url, args.model, args.tokenizer))
+
+        ok = all(item["ok"] for item in results)
+        report_name = args.report_name or f"openai-compat-evals-{dt.datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
+        report_path = REPORT_DIR / report_name
+        write_report(results, report_path)
+
+        for item in results:
+            status = "PASS" if item["ok"] else "FAIL"
+            log(f"{status} {item['name']} ({item['elapsed_s']}s)")
+        log(f"Report: {report_path}")
+        return 0 if ok else 1
+    finally:
+        stop_server(server_proc)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/patches/NemotronH.swift
+++ b/Scripts/patches/NemotronH.swift
@@ -330,10 +330,11 @@ private class NemotronHMLP: Module, UnaryLayer, NemotronHMixer {
     @ModuleInfo(key: "up_proj") var upProj: Linear
     @ModuleInfo(key: "down_proj") var downProj: Linear
 
-    init(_ args: NemotronHConfiguration, intermediateSize: Int? = nil) {
+    init(_ args: NemotronHConfiguration, intermediateSize: Int? = nil, inputSize: Int? = nil) {
         let intermediate = intermediateSize ?? args.intermediateSize
-        self._upProj.wrappedValue = Linear(args.hiddenSize, intermediate, bias: args.mlpBias)
-        self._downProj.wrappedValue = Linear(intermediate, args.hiddenSize, bias: args.mlpBias)
+        let dims = inputSize ?? args.hiddenSize
+        self._upProj.wrappedValue = Linear(dims, intermediate, bias: args.mlpBias)
+        self._downProj.wrappedValue = Linear(intermediate, dims, bias: args.mlpBias)
         super.init()
     }
 
@@ -502,14 +503,17 @@ private class NemotronHMoE: Module, UnaryLayer, NemotronHMixer {
     @ModuleInfo(key: "gate") var gate: NemotronHMoEGate
     @ModuleInfo(key: "switch_mlp") var switchMLP: NemotronHSwitchMLP
     @ModuleInfo(key: "shared_experts") var sharedExperts: NemotronHMLP?
+    @ModuleInfo(key: "fc1_latent_proj") var fc1LatentProj: Linear?
+    @ModuleInfo(key: "fc2_latent_proj") var fc2LatentProj: Linear?
 
     init(_ args: NemotronHConfiguration) {
         self.numExpertsPerTok = args.numExpertsPerTok
         self.hasSharedExperts = args.nSharedExperts != nil && args.nSharedExperts! > 0
+        let expertInputDims = args.moeLatentSize ?? args.hiddenSize
 
         self._gate.wrappedValue = NemotronHMoEGate(args)
         self._switchMLP.wrappedValue = NemotronHSwitchMLP(
-            inputDims: args.hiddenSize,
+            inputDims: expertInputDims,
             hiddenDims: args.moeIntermediateSize,
             numExperts: args.nRoutedExperts
         )
@@ -521,13 +525,24 @@ private class NemotronHMoE: Module, UnaryLayer, NemotronHMixer {
             )
         }
 
+        if let moeLatentSize = args.moeLatentSize {
+            self._fc1LatentProj.wrappedValue = Linear(
+                args.hiddenSize, moeLatentSize, bias: args.mlpBias)
+            self._fc2LatentProj.wrappedValue = Linear(
+                moeLatentSize, args.hiddenSize, bias: args.mlpBias)
+        }
+
         super.init()
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         let (inds, scores) = gate(x)
-        var y = switchMLP(x, inds)
+        let routedInput = if let fc1LatentProj { fc1LatentProj(x) } else { x }
+        var y = switchMLP(routedInput, inds)
         y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
+        if let fc2LatentProj {
+            y = fc2LatentProj(y)
+        }
 
         if let sharedExperts {
             y = y + sharedExperts(x)
@@ -812,6 +827,7 @@ public struct NemotronHConfiguration: Codable, Sendable {
     public var intermediateSize: Int
     public var moeIntermediateSize: Int
     public var moeSharedExpertIntermediateSize: Int
+    public var moeLatentSize: Int?
     public var nRoutedExperts: Int
     public var nSharedExperts: Int?
     public var numExpertsPerTok: Int
@@ -847,6 +863,7 @@ public struct NemotronHConfiguration: Codable, Sendable {
         case intermediateSize = "intermediate_size"
         case moeIntermediateSize = "moe_intermediate_size"
         case moeSharedExpertIntermediateSize = "moe_shared_expert_intermediate_size"
+        case moeLatentSize = "moe_latent_size"
         case nRoutedExperts = "n_routed_experts"
         case nSharedExperts = "n_shared_experts"
         case numExpertsPerTok = "num_experts_per_tok"
@@ -889,6 +906,7 @@ public struct NemotronHConfiguration: Codable, Sendable {
         nGroups = try container.decode(Int.self, forKey: .nGroups)
         intermediateSize = try container.decode(Int.self, forKey: .intermediateSize)
         moeIntermediateSize = try container.decode(Int.self, forKey: .moeIntermediateSize)
+        moeLatentSize = try container.decodeIfPresent(Int.self, forKey: .moeLatentSize)
         moeSharedExpertIntermediateSize = try container.decode(
             Int.self, forKey: .moeSharedExpertIntermediateSize)
         nRoutedExperts = try container.decode(Int.self, forKey: .nRoutedExperts)
@@ -951,6 +969,7 @@ public struct NemotronHConfiguration: Codable, Sendable {
         intermediateSize: Int,
         moeIntermediateSize: Int,
         moeSharedExpertIntermediateSize: Int,
+        moeLatentSize: Int? = nil,
         nRoutedExperts: Int,
         numExpertsPerTok: Int,
         hybridOverridePattern: String,
@@ -986,6 +1005,7 @@ public struct NemotronHConfiguration: Codable, Sendable {
         self.nGroups = nGroups
         self.intermediateSize = intermediateSize
         self.moeIntermediateSize = moeIntermediateSize
+        self.moeLatentSize = moeLatentSize
         self.moeSharedExpertIntermediateSize = moeSharedExpertIntermediateSize
         self.nRoutedExperts = nRoutedExperts
         self.nSharedExperts = nSharedExperts

--- a/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
@@ -46,8 +46,14 @@ struct ChatCompletionsController: RouteCollection {
     }
     
     func chatCompletions(req: Request) async throws -> Response {
+        var fallbackModel = "foundation"
+        var fallbackMessages: [Message] = []
+        var fallbackMaxTokens = 2000
         do {
             let chatRequest = try req.content.decode(ChatCompletionRequest.self)
+            fallbackModel = chatRequest.model ?? "foundation"
+            fallbackMessages = chatRequest.messages
+            fallbackMaxTokens = chatRequest.effectiveMaxTokens ?? 2000
             if veryVerbose {
                 req.logger.info("Foundation full request: \(encodeJSON(chatRequest))")
             }
@@ -124,10 +130,13 @@ struct ChatCompletionsController: RouteCollection {
 
             let promptTokens = estimateTokens(for: processedMessages)
             let completionTokens = estimateTokens(for: content)
+            let effectiveMaxTokens = chatRequest.effectiveMaxTokens ?? 2000
+            let stopReason = completionTokens >= effectiveMaxTokens ? "length" : "stop"
 
             let response = ChatCompletionResponse(
                 model: chatRequest.model ?? "foundation",
                 content: content,
+                finishReason: stopReason,
                 promptTokens: promptTokens,
                 completionTokens: completionTokens
             )
@@ -138,6 +147,29 @@ struct ChatCompletionsController: RouteCollection {
             return try await createSuccessResponse(req: req, response: response)
 
         } catch let foundationError as FoundationModelError {
+            if case .responseTruncated(let maxTokens) = foundationError {
+                let promptTokens = estimateTokens(for: fallbackMessages)
+                let response = ChatCompletionResponse(
+                    model: fallbackModel,
+                    content: "",
+                    finishReason: "length",
+                    promptTokens: promptTokens,
+                    completionTokens: maxTokens
+                )
+                return try await createSuccessResponse(req: req, response: response)
+            }
+            if case .responseGenerationFailed(let message) = foundationError,
+               message.contains("Failed to deserialize a Generable type from model output") {
+                let promptTokens = estimateTokens(for: fallbackMessages)
+                let response = ChatCompletionResponse(
+                    model: fallbackModel,
+                    content: "",
+                    finishReason: "length",
+                    promptTokens: promptTokens,
+                    completionTokens: fallbackMaxTokens
+                )
+                return try await createSuccessResponse(req: req, response: response)
+            }
             // Handle specific error types
             let errorType: String
             let status: HTTPStatus
@@ -306,6 +338,8 @@ struct ChatCompletionsController: RouteCollection {
                     completionTime: completionTime,
                     promptTime: promptTime
                 )
+                let effectiveMaxTokens = chatRequest.effectiveMaxTokens ?? 2000
+                let finishReason = completionTokens >= effectiveMaxTokens ? "length" : "stop"
 
                 // Build timings for webui tokens/sec display
                 let timings = StreamTimings(
@@ -321,17 +355,29 @@ struct ChatCompletionsController: RouteCollection {
                     model: chatRequest.model ?? "foundation",
                     content: "",
                     isFinished: true,
-                    usage: usage,
-                    timings: timings
+                    finishReason: finishReason,
+                    usage: nil,
+                    timings: nil
                 )
                 let finalData = try encoder.encode(finalChunk)
                 if let jsonString = String(data: finalData, encoding: .utf8) {
+                    try await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
+                }
+                let usageChunk = ChatCompletionStreamResponse(
+                    id: streamId,
+                    model: chatRequest.model ?? "foundation",
+                    usage: usage,
+                    timings: timings
+                )
+                let usageData = try encoder.encode(usageChunk)
+                if let jsonString = String(data: usageData, encoding: .utf8) {
                     try await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
                 }
                 if self.veryVerbose {
                     req.logger.info("Foundation full streamed response content: \(fullStreamedContent)")
                     req.logger.info("Foundation stream final usage: \(encodeJSON(usage))")
                     req.logger.info("Foundation stream final chunk: \(encodeJSON(finalChunk))")
+                    req.logger.info("Foundation stream usage chunk: \(encodeJSON(usageChunk))")
                 }
 
                 // Send done marker

--- a/Sources/MacLocalAPI/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/MLXChatCompletionsController.swift
@@ -264,6 +264,7 @@ struct MLXChatCompletionsController: RouteCollection {
                 content: finalContent,
                 reasoningContent: reasoningContent,
                 logprobs: choiceLogprobs,
+                finishReason: stopReason,
                 promptTokens: result.promptTokens,
                 completionTokens: completionTok,
                 cachedTokens: result.cachedTokens,
@@ -779,10 +780,14 @@ struct MLXChatCompletionsController: RouteCollection {
                         let emitContent = extracted.content
                         let emitReasoning = extracted.reasoning
 
-                        // Only emit a chunk if we have something to send
+                        let flushLogprobs = logprobBuffer.isEmpty ? nil : self.buildChoiceLogprobs(logprobBuffer)
+
+                        // Emit a chunk whenever we have visible content, extracted reasoning,
+                        // or buffered logprobs. Without this, per-token logprobs can be lost
+                        // when detokenized content is still buffered for think-tag extraction.
                         let hasReasoning = emitReasoning != nil
                         let hasContent = emitContent != nil
-                        if hasReasoning || hasContent {
+                        if hasReasoning || hasContent || flushLogprobs != nil {
                             if self.veryVerbose {
                                 if let r = emitReasoning { verboseReasoningBuf += r }
                                 if let c = emitContent { verboseContentBuf += c }
@@ -796,8 +801,6 @@ struct MLXChatCompletionsController: RouteCollection {
                                     verboseContentBuf = ""
                                 }
                             }
-                            // Flush accumulated logprobs with this chunk
-                            let flushLogprobs = logprobBuffer.isEmpty ? nil : self.buildChoiceLogprobs(logprobBuffer)
                             logprobBuffer = []
                             let contentChunk = ChatCompletionStreamResponse(
                                 id: streamId,
@@ -1054,13 +1057,29 @@ struct MLXChatCompletionsController: RouteCollection {
                         remainingReasoning = nil
                     }
                     if remaining != nil || remainingReasoning != nil {
+                        let flushLogprobs = logprobBuffer.isEmpty ? nil : self.buildChoiceLogprobs(logprobBuffer)
+                        logprobBuffer = []
                         let flushChunk = ChatCompletionStreamResponse(
                             id: streamId,
                             model: res.modelID,
                             content: remaining ?? "",
                             reasoningContent: remainingReasoning,
+                            logprobs: flushLogprobs,
                             isFirst: false
                         )
+                        if let flushData = try? encoder.encode(flushChunk),
+                           let jsonString = String(data: flushData, encoding: .utf8) {
+                            try? await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
+                        }
+                    } else if !logprobBuffer.isEmpty {
+                        let flushChunk = ChatCompletionStreamResponse(
+                            id: streamId,
+                            model: res.modelID,
+                            content: "",
+                            logprobs: self.buildChoiceLogprobs(logprobBuffer),
+                            isFirst: false
+                        )
+                        logprobBuffer = []
                         if let flushData = try? encoder.encode(flushChunk),
                            let jsonString = String(data: flushData, encoding: .utf8) {
                             try? await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
@@ -1082,12 +1101,20 @@ struct MLXChatCompletionsController: RouteCollection {
                     model: res.modelID,
                     content: "",
                     isFinished: true,
-                    finishReason: finishReason,
-                    usage: usage,
-                    timings: StreamTimings(prompt_n: promptTokens, prompt_ms: promptTime * 1000, predicted_n: completionTokens, predicted_ms: generateTime * 1000)
+                    finishReason: finishReason
                 )
                 let finalData = try encoder.encode(finalChunk)
                 if let jsonString = String(data: finalData, encoding: .utf8) {
+                    try? await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
+                }
+                let usageChunk = ChatCompletionStreamResponse(
+                    id: streamId,
+                    model: res.modelID,
+                    usage: usage,
+                    timings: StreamTimings(prompt_n: promptTokens, prompt_ms: promptTime * 1000, predicted_n: completionTokens, predicted_ms: generateTime * 1000)
+                )
+                let usageData = try encoder.encode(usageChunk)
+                if let jsonString = String(data: usageData, encoding: .utf8) {
                     try? await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
                 }
                 try? await writer.write(.buffer(.init(string: "data: [DONE]\n\n")))

--- a/Sources/MacLocalAPI/Models/FoundationModelService.swift
+++ b/Sources/MacLocalAPI/Models/FoundationModelService.swift
@@ -101,6 +101,8 @@ struct RandomnessConfig {
 }
 
 enum FoundationModelError: Error, LocalizedError {
+    private static let structuredTruncationMarker = "Failed to deserialize a Generable type from model output"
+
     case notAvailable
     case sessionCreationFailed
     case responseGenerationFailed(String)
@@ -184,7 +186,7 @@ enum FoundationModelError: Error, LocalizedError {
     static func parseStructuredTruncationError(_ error: Error, maxTokens: Int?) -> FoundationModelError? {
         guard let maxTokens, maxTokens > 0 else { return nil }
         let errorString = String(describing: error)
-        if errorString.contains("Failed to deserialize a Generable type from model output") {
+        if errorString.contains(Self.structuredTruncationMarker) {
             return .responseTruncated(maxTokens: maxTokens)
         }
         return nil

--- a/Sources/MacLocalAPI/Models/FoundationModelService.swift
+++ b/Sources/MacLocalAPI/Models/FoundationModelService.swift
@@ -104,6 +104,7 @@ enum FoundationModelError: Error, LocalizedError {
     case notAvailable
     case sessionCreationFailed
     case responseGenerationFailed(String)
+    case responseTruncated(maxTokens: Int)
     case invalidInput
     case invalidRandomnessParameter(String)
     case contextWindowExceeded(provided: Int, maximum: Int)
@@ -118,6 +119,8 @@ enum FoundationModelError: Error, LocalizedError {
             return "Failed to create Foundation Models session. Ensure Apple Intelligence is enabled in System Settings."
         case .responseGenerationFailed(let message):
             return "Failed to generate response: \(message)"
+        case .responseTruncated:
+            return "Response generation reached the maximum token budget before a complete structured value was produced."
         case .invalidInput:
             return "Invalid input provided to Foundation Models"
         case .invalidRandomnessParameter(let message):
@@ -176,6 +179,15 @@ enum FoundationModelError: Error, LocalizedError {
         }
 
         return .contextWindowExceeded(provided: provided, maximum: maximum)
+    }
+
+    static func parseStructuredTruncationError(_ error: Error, maxTokens: Int?) -> FoundationModelError? {
+        guard let maxTokens, maxTokens > 0 else { return nil }
+        let errorString = String(describing: error)
+        if errorString.contains("Failed to deserialize a Generable type from model output") {
+            return .responseTruncated(maxTokens: maxTokens)
+        }
+        return nil
     }
 }
 
@@ -446,6 +458,9 @@ class FoundationModelService {
             if let guardrailError = FoundationModelError.parseGuardrailError(error) {
                 throw guardrailError
             }
+            if let truncationError = FoundationModelError.parseStructuredTruncationError(error, maxTokens: maxTokens) {
+                throw truncationError
+            }
             throw FoundationModelError.responseGenerationFailed(error.localizedDescription)
         }
         #else
@@ -489,21 +504,23 @@ class FoundationModelService {
                     let options = try self.createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
                     let stream = session.streamResponse(to: prompt, schema: schema, options: options)
                     var previousJson = ""
+                    var emittedPrefixCount = 0
                     var stopped = false
                     for try await partialResponse in stream {
                         if stopped { break }
                         let currentJson = partialResponse.content.jsonString
-                        // Emit only the new suffix (delta) when the snapshot extends
-                        if currentJson.count > previousJson.count && currentJson.hasPrefix(previousJson) {
-                            var delta = String(currentJson.dropFirst(previousJson.count))
+                        let stablePrefixCount = Self.commonPrefixLength(previousJson, currentJson)
+                        if stablePrefixCount > emittedPrefixCount {
+                            let stablePrefix = String(currentJson.prefix(stablePrefixCount))
+                            var delta = String(stablePrefix.dropFirst(emittedPrefixCount))
                             if let stopSeqs = stop, !stopSeqs.isEmpty {
-                                let accumulated = previousJson + delta
+                                let accumulated = stablePrefix
                                 for seq in stopSeqs {
                                     if let range = accumulated.range(of: seq) {
                                         let keepUpTo = range.lowerBound
-                                        let alreadyEmitted = accumulated.index(accumulated.startIndex, offsetBy: previousJson.count)
-                                        if keepUpTo > alreadyEmitted {
-                                            delta = String(accumulated[alreadyEmitted..<keepUpTo])
+                                        let keepCount = accumulated.distance(from: accumulated.startIndex, to: keepUpTo)
+                                        if keepCount > emittedPrefixCount {
+                                            delta = String(accumulated.dropFirst(emittedPrefixCount).prefix(keepCount - emittedPrefixCount))
                                             continuation.yield(delta)
                                         }
                                         stopped = true
@@ -512,16 +529,18 @@ class FoundationModelService {
                                 }
                                 if stopped { break }
                             }
-                            continuation.yield(delta)
-                        } else if currentJson != previousJson {
-                            // Structure mutated (not a simple append) — emit full snapshot
-                            // This is rare but possible with guided generation
-                            let truncated = self.applyStopSequences(to: currentJson, stopSequences: stop)
-                            if truncated.count < currentJson.count { stopped = true }
-                            continuation.yield(truncated)
-                            if stopped { break }
+                            if !delta.isEmpty {
+                                continuation.yield(delta)
+                            }
+                            emittedPrefixCount = stablePrefixCount
                         }
                         previousJson = currentJson
+                    }
+                    if !stopped, previousJson.count > emittedPrefixCount {
+                        let finalSnapshot = self.applyStopSequences(to: previousJson, stopSequences: stop)
+                        if finalSnapshot.count > emittedPrefixCount {
+                            continuation.yield(String(finalSnapshot.dropFirst(emittedPrefixCount)))
+                        }
                     }
                     continuation.finish()
                 } catch {
@@ -529,6 +548,8 @@ class FoundationModelService {
                         continuation.finish(throwing: contextError)
                     } else if let guardrailError = FoundationModelError.parseGuardrailError(error) {
                         continuation.finish(throwing: guardrailError)
+                    } else if let truncationError = FoundationModelError.parseStructuredTruncationError(error, maxTokens: maxTokens) {
+                        continuation.finish(throwing: truncationError)
                     } else {
                         continuation.finish(throwing: FoundationModelError.responseGenerationFailed(error.localizedDescription))
                     }
@@ -624,6 +645,15 @@ class FoundationModelService {
             return String(content[..<idx])
         }
         return content
+    }
+
+    static func commonPrefixLength(_ lhs: String, _ rhs: String) -> Int {
+        var count = 0
+        for (left, right) in zip(lhs, rhs) {
+            guard left == right else { break }
+            count += 1
+        }
+        return count
     }
 
     static func isAvailable() -> Bool {

--- a/Sources/MacLocalAPI/Models/MLXModelService.swift
+++ b/Sources/MacLocalAPI/Models/MLXModelService.swift
@@ -2359,6 +2359,12 @@ final class MLXModelService: @unchecked Sendable {
                 resolvedKwargs[key] = value.value.toAny()
             }
         }
+        if responseFormat?.type == "json_schema",
+           thinkStartTag != nil, thinkEndTag != nil,
+           (resolvedKwargs["enable_thinking"] as? Bool) != false {
+            resolvedKwargs["enable_thinking"] = false
+            print("[\(ts())] [StructuredOutput] Disabling thinking for guided JSON on reasoning-capable model")
+        }
         if !resolvedKwargs.isEmpty {
             if input.additionalContext == nil { input.additionalContext = [:] }
             for (key, value) in resolvedKwargs {

--- a/Sources/MacLocalAPI/Models/MLXModelService.swift
+++ b/Sources/MacLocalAPI/Models/MLXModelService.swift
@@ -91,6 +91,11 @@ private var traceLogging = false
 private var grammarConstraintsActive = false
 
 final class MLXModelService: @unchecked Sendable {
+    private static let registerModelFactoriesOnce: Void = {
+        ModelFactoryRegistry.shared.addTrampoline { LLMModelFactory.shared }
+        ModelFactoryRegistry.shared.addTrampoline { VLMModelFactory.shared }
+    }()
+
     private let resolver: MLXCacheResolver
     private let registry = MLXModelRegistry()
     private let stateLock = NSLock()
@@ -117,6 +122,7 @@ final class MLXModelService: @unchecked Sendable {
     private(set) var thinkEndTag: String?
     private var xgrammarService: XGrammarService?
     init(resolver: MLXCacheResolver) {
+        _ = Self.registerModelFactoriesOnce
         self.resolver = resolver
         self.resolver.applyEnvironment()
     }
@@ -255,6 +261,9 @@ final class MLXModelService: @unchecked Sendable {
                 do {
                     loaded = try await LLMModelFactory.shared.loadContainer(configuration: config)
                 } catch {
+                    if debugLogging {
+                        print("[\(ts())] [MLX] LLM factory load failed for \(modelID): \(error)")
+                    }
                     // LLM factory failed — try VLM factory as fallback
                     loaded = try await VLMModelFactory.shared.loadContainer(configuration: config)
                 }
@@ -2994,4 +3003,3 @@ final class MLXModelService: @unchecked Sendable {
     """
 
 }
-

--- a/Sources/MacLocalAPI/Models/OpenAIResponse.swift
+++ b/Sources/MacLocalAPI/Models/OpenAIResponse.swift
@@ -31,7 +31,7 @@ struct ChatCompletionResponse: Content {
         }
     }
 
-    init(id: String = UUID().uuidString, model: String, content: String, reasoningContent: String? = nil, logprobs: ChoiceLogprobs? = nil, promptTokens: Int = 0, completionTokens: Int = 0, cachedTokens: Int? = nil, completionTime: Double? = nil, promptTime: Double? = nil, timings: StreamTimings? = nil) {
+    init(id: String = UUID().uuidString, model: String, content: String, reasoningContent: String? = nil, logprobs: ChoiceLogprobs? = nil, finishReason: String = "stop", promptTokens: Int = 0, completionTokens: Int = 0, cachedTokens: Int? = nil, completionTime: Double? = nil, promptTime: Double? = nil, timings: StreamTimings? = nil) {
         self.id = "chatcmpl-\(id.prefix(8))"
         self.object = "chat.completion"
         self.created = Int(Date().timeIntervalSince1970)
@@ -41,7 +41,7 @@ struct ChatCompletionResponse: Content {
                 index: 0,
                 message: ResponseMessage(role: "assistant", content: content, reasoningContent: reasoningContent),
                 logprobs: logprobs,
-                finishReason: "stop"
+                finishReason: finishReason
             )
         ]
         self.usage = Usage(
@@ -291,6 +291,21 @@ struct ChatCompletionStreamResponse: Content {
                 )
             ]
         }
+    }
+
+    /// Init for the final stream usage summary chunk.
+    /// OpenAI-compatible usage chunks carry top-level usage with an empty
+    /// choices array so downstream parsers can distinguish them from content
+    /// deltas and terminal finish_reason chunks.
+    init(id: String, model: String, usage: StreamUsage, timings: StreamTimings? = nil) {
+        self.id = "chatcmpl-\(id.prefix(8))"
+        self.object = "chat.completion.chunk"
+        self.created = Int(Date().timeIntervalSince1970)
+        self.model = model
+        self.usage = usage
+        self.timings = timings
+        self.systemFingerprint = Self.fingerprint(for: model)
+        self.choices = []
     }
 
     /// Init for streaming tool call deltas

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -818,10 +818,12 @@ class Server {
 
         // Open browser if webui is enabled
         if webuiEnabled && webuiPath != nil {
-            let url = "http://\(hostname):\(port)"
+            let url = "http://\(browserLaunchHost(for: hostname)):\(port)"
             print("  🌐 Opening WebUI in browser: \(url)")
             print("")
-            openBrowser(url: url)
+            Task { @MainActor in
+                self.openBrowser(url: url)
+            }
         }
 
         // Wait indefinitely (until shutdown is called)
@@ -892,6 +894,8 @@ class Server {
             "/opt/homebrew/share/afm/webui/index.html.gz",
             // Development: Resources folder in current working directory
             "\(cwd)/Resources/webui/index.html.gz",
+            // Development: vendored llama.cpp webui relative to executable
+            "\(executableDir)/../../../vendor/llama.cpp/tools/server/public/index.html.gz",
             // Development: llama.cpp submodule public folder
             "\(cwd)/vendor/llama.cpp/tools/server/public/index.html.gz"
         ]
@@ -906,7 +910,17 @@ class Server {
         return nil
     }
 
+    private func browserLaunchHost(for hostname: String) -> String {
+        switch hostname {
+        case "0.0.0.0", "::", "[::]":
+            return "127.0.0.1"
+        default:
+            return hostname
+        }
+    }
+
     /// Open URL in default browser
+    @MainActor
     private func openBrowser(url: String) {
         guard let targetURL = URL(string: url) else { return }
 
@@ -916,12 +930,31 @@ class Server {
         }
         #endif
 
+        if runBrowserOpenProcess(executable: "/usr/bin/open", arguments: [targetURL.absoluteString]) {
+            return
+        }
+
+        if runBrowserOpenProcess(executable: "/usr/bin/osascript", arguments: ["-e", "open location \"\(targetURL.absoluteString)\""]) {
+            return
+        }
+
+        print("  ⚠️  Failed to open WebUI automatically. Open this URL manually: \(targetURL.absoluteString)")
+    }
+
+    @MainActor
+    private func runBrowserOpenProcess(executable: String, arguments: [String]) -> Bool {
         let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        task.arguments = [targetURL.absoluteString]
+        task.executableURL = URL(fileURLWithPath: executable)
+        task.arguments = arguments
         task.standardOutput = nil
         task.standardError = nil
-        try? task.run()
+        do {
+            try task.run()
+            task.waitUntilExit()
+            return task.terminationReason == .exit && task.terminationStatus == 0
+        } catch {
+            return false
+        }
     }
 
     /// Decompress gzip data

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -1,6 +1,9 @@
 import Vapor
 import Foundation
 import Compression
+#if canImport(AppKit)
+import AppKit
+#endif
 import Logging
 
 // Storage key for the continuation
@@ -905,9 +908,19 @@ class Server {
 
     /// Open URL in default browser
     private func openBrowser(url: String) {
+        guard let targetURL = URL(string: url) else { return }
+
+        #if canImport(AppKit)
+        if NSWorkspace.shared.open(targetURL) {
+            return
+        }
+        #endif
+
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        task.arguments = [url]
+        task.arguments = [targetURL.absoluteString]
+        task.standardOutput = nil
+        task.standardError = nil
         try? task.run()
     }
 

--- a/Sources/MacLocalAPI/Services/BackendProxyService.swift
+++ b/Sources/MacLocalAPI/Services/BackendProxyService.swift
@@ -296,8 +296,8 @@ actor BackendProxyService {
             "model": "error",
             "choices": [[
                 "index": 0,
-                "delta": ["content": ""],
-                "finish_reason": "stop"
+                "delta": [:],
+                "finish_reason": NSNull()
             ]]
         ]
         if let data = try? JSONSerialization.data(withJSONObject: finish),

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -153,7 +153,7 @@ struct MlxCommand: ParsableCommand {
           --seed: Random seed for reproducible output
           --max-logprobs: Max top logprobs per token (default: 20)
           --stop: Stop sequences, comma-separated (e.g. "###,END")
-          --guided-json: Constrain output to JSON schema (vLLM-compatible)
+          --guided-json: Constrain output to JSON schema (vLLM-compatible; auto-disables thinking on reasoning models)
           --no-streaming: Disable streaming (streaming enabled by default)
           --raw: Output raw model text without extracting <think> tags
           --vlm: Force load as vision model (VLM) instead of text-only LLM
@@ -327,7 +327,7 @@ struct MlxCommand: ParsableCommand {
     @Option(name: .long, help: "Stop sequences - comma-separated strings where generation should stop (e.g., '###,END')")
     var stop: String?
 
-    @Option(name: .long, help: "Constrain output to match a JSON schema (vLLM-compatible)")
+    @Option(name: .long, help: "Constrain output to match a JSON schema (vLLM-compatible). Auto-disables thinking on reasoning models for deterministic output.")
     var guidedJson: String?
 
     @Option(name: .long, help: "Tool call parser override: afm_adaptive_xml, hermes, llama3_json, gemma, mistral, qwen3_xml. afm_adaptive_xml adds JSON-in-XML fallback, type coercion, and optional xgrammar EBNF constrained decoding for models that switch between XML and JSON formats. Recommended for Qwen3+ models.")
@@ -988,7 +988,7 @@ struct MacLocalAPI: ParsableCommand {
           -P, --permissive-guardrails: Disable safety guardrails
           -a, --adapter: Path to .fmadapter LoRA adapter file
           --stop: Stop sequences, comma-separated
-          --guided-json: Constrain output to JSON schema
+          --guided-json: Constrain output to JSON schema (auto-disables thinking on reasoning models)
           --no-streaming: Disable streaming
           --prewarm: Pre-warm model on startup (y/n, default: y)
           --help-json: Print machine-readable JSON capability card for AI agents and exit
@@ -1062,7 +1062,7 @@ struct RootCommand: ParsableCommand {
           -P, --permissive-guardrails: Disable safety guardrails
           -a, --adapter: Path to .fmadapter LoRA adapter file
           --stop: Stop sequences, comma-separated
-          --guided-json: Constrain output to JSON schema
+          --guided-json: Constrain output to JSON schema (auto-disables thinking on reasoning models)
           --no-streaming: Disable streaming
           --prewarm: Pre-warm model on startup (y/n, default: y)
           --help-json: Print machine-readable JSON capability card for AI agents and exit
@@ -1137,7 +1137,7 @@ struct RootCommand: ParsableCommand {
     @Flag(name: [.customShort("g"), .long], help: "Enable API gateway mode: discover and proxy to local LLM backends (Ollama, LM Studio, Jan, etc.)")
     var gateway: Bool = false
 
-    @Option(name: .long, help: "Constrain output to match a JSON schema (vLLM-compatible)")
+    @Option(name: .long, help: "Constrain output to match a JSON schema (vLLM-compatible). Auto-disables thinking on reasoning models for deterministic output.")
     var guidedJson: String?
 
     @Option(name: .long, help: "Stop sequences - comma-separated strings where generation should stop (e.g., '###,END')")

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -409,6 +409,11 @@ struct MlxCommand: ParsableCommand {
         if !parsedKwargs.isEmpty {
             service.defaultChatTemplateKwargs = parsedKwargs
         }
+
+        if let guidedJson {
+            _ = try parseGuidedJsonSchema(guidedJson)
+        }
+
         _ = try service.revalidateRegistry()
 
         let rawModel: String

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -582,6 +582,11 @@ struct MlxCommand: ParsableCommand {
 
         let group = DispatchGroup()
         var output: Result<String, Error>?
+        let stdoutFD = dup(STDOUT_FILENO)
+        if stdoutFD == -1 || dup2(STDERR_FILENO, STDOUT_FILENO) == -1 {
+            if stdoutFD != -1 { close(stdoutFD) }
+            throw ValidationError("Failed to redirect single-prompt operational logs to stderr")
+        }
         group.enter()
         Task {
             do {
@@ -633,16 +638,49 @@ struct MlxCommand: ParsableCommand {
             group.leave()
         }
         group.wait()
+        fflush(stdout)
+        _ = dup2(stdoutFD, STDOUT_FILENO)
+        close(stdoutFD)
 
         switch output {
         case .success(let text):
-            print(text)
+            let rendered: String
+            if raw {
+                rendered = text
+            } else {
+                rendered = Self.stripThinkContent(
+                    from: text,
+                    startTag: service.thinkStartTag ?? "<think>",
+                    endTag: service.thinkEndTag ?? "</think>"
+                )
+            }
+            print(rendered)
         case .failure(let error):
             print("Error: \(error.localizedDescription)")
             throw ExitCode.failure
         case .none:
             throw ExitCode.failure
         }
+    }
+
+    private static func stripThinkContent(from text: String, startTag: String, endTag: String) -> String {
+        var output = text
+        while let start = output.range(of: startTag) {
+            if let end = output.range(of: endTag, range: start.upperBound..<output.endIndex) {
+                output.removeSubrange(start.lowerBound..<end.upperBound)
+            } else {
+                // Some guided/grammar-constrained generations can emit a stray
+                // opening think tag before the actual payload without ever
+                // closing it. In that case keep the payload and drop only the tag.
+                if start.lowerBound == output.startIndex {
+                    output.removeSubrange(start)
+                } else {
+                    output.removeSubrange(start.lowerBound..<output.endIndex)
+                }
+                break
+            }
+        }
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func readFromStdin() throws -> String? {

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -639,7 +639,10 @@ struct MlxCommand: ParsableCommand {
         }
         group.wait()
         fflush(stdout)
-        _ = dup2(stdoutFD, STDOUT_FILENO)
+        if dup2(stdoutFD, STDOUT_FILENO) == -1 {
+            close(stdoutFD)
+            throw ValidationError("Failed to restore stdout after single-prompt execution")
+        }
         close(stdoutFD)
 
         switch output {
@@ -670,14 +673,9 @@ struct MlxCommand: ParsableCommand {
                 output.removeSubrange(start.lowerBound..<end.upperBound)
             } else {
                 // Some guided/grammar-constrained generations can emit a stray
-                // opening think tag before the actual payload without ever
-                // closing it. In that case keep the payload and drop only the tag.
-                if start.lowerBound == output.startIndex {
-                    output.removeSubrange(start)
-                } else {
-                    output.removeSubrange(start.lowerBound..<output.endIndex)
-                }
-                break
+                // opening think tag without ever closing it. In that case keep
+                // the payload and drop only the unmatched tag.
+                output.removeSubrange(start)
             }
         }
         return output.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Tests/MacLocalAPITests/StreamingUsageChunkTests.swift
+++ b/Tests/MacLocalAPITests/StreamingUsageChunkTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import MacLocalAPI
+
+final class StreamingUsageChunkTests: XCTestCase {
+    func testNonStreamingResponsePreservesExplicitFinishReason() throws {
+        let response = ChatCompletionResponse(
+            id: "chat-1234",
+            model: "test-model",
+            content: "{\"ok\":true}",
+            finishReason: "length",
+            promptTokens: 12,
+            completionTokens: 24
+        )
+
+        let data = try JSONEncoder().encode(response)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let choices = try XCTUnwrap(json["choices"] as? [[String: Any]])
+        let firstChoice = try XCTUnwrap(choices.first)
+
+        XCTAssertEqual(firstChoice["finish_reason"] as? String, "length")
+    }
+
+    func testUsageSummaryChunkEncodesEmptyChoices() throws {
+        let usage = StreamUsage(promptTokens: 10, completionTokens: 4, completionTime: 0.5, promptTime: 0.1)
+        let chunk = ChatCompletionStreamResponse(
+            id: "stream-1234",
+            model: "test-model",
+            usage: usage,
+            timings: StreamTimings(prompt_n: 10, prompt_ms: 100, predicted_n: 4, predicted_ms: 500)
+        )
+
+        let data = try JSONEncoder().encode(chunk)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(json["object"] as? String, "chat.completion.chunk")
+        XCTAssertEqual((json["choices"] as? [Any])?.count, 0)
+
+        let usageJSON = try XCTUnwrap(json["usage"] as? [String: Any])
+        XCTAssertEqual(usageJSON["prompt_tokens"] as? Int, 10)
+        XCTAssertEqual(usageJSON["completion_tokens"] as? Int, 4)
+    }
+
+    func testFoundationCommonPrefixLengthHandlesMutableSnapshots() {
+        let first = #"{"age": 50, "name": ""}"#
+        let second = #"{"age": 50, "name": "Katherine Johnson", "occupation": "mathematician"}"#
+
+        let prefixLength = FoundationModelService.commonPrefixLength(first, second)
+        XCTAssertEqual(String(second.prefix(prefixLength)), #"{"age": 50, "name": ""#)
+    }
+
+    func testTerminalFinishChunkOmitsUsageSummaryShape() throws {
+        let chunk = ChatCompletionStreamResponse(
+            id: "stream-1234",
+            model: "test-model",
+            content: "",
+            isFinished: true,
+            finishReason: "stop"
+        )
+
+        let data = try JSONEncoder().encode(chunk)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual((json["choices"] as? [Any])?.count, 1)
+        XCTAssertNil(json["usage"])
+    }
+}


### PR DESCRIPTION
## Summary
- improve OpenAI API compatibility evals, finish reasons, and guided JSON coverage
- add Nemotron H latent MoE support via vendor patch path
- fix WebUI path resolution for external binary launches and pin llama.cpp to a newer revision

## Testing
- swift test --filter StreamingUsageChunkTests
- guided JSON eval bundle against MLX and Foundation servers
- local WebUI smoke test with updated llama.cpp webui
- Nemotron H model load smoke test

## Summary by Sourcery

Improve OpenAI-compatible chat completion behavior, structured JSON handling, and WebUI/browser integration while adding Nemotron H latent MoE support and new eval tooling.

New Features:
- Add reusable OpenAI compatibility eval scripts and guided JSON structured-output eval bundle with real-world schema fixtures.
- Support Nemotron H models with optional latent MoE projection dimensions via new configuration field and projections.

Bug Fixes:
- Correct WebUI URL and browser launch behavior when binding to wildcard hosts or running without AppKit, and add additional search path for vendored llama.cpp WebUI assets.
- Fix streaming JSON delta emission for Foundation structured outputs to respect mutable snapshots and stop sequences while emitting a final prefix-complete chunk.
- Ensure chat completion responses and streams emit accurate OpenAI-style finish reasons, including truncation as length, and avoid sending pseudo-finish chunks on backend proxy errors.
- Prevent loss of buffered per-token logprobs in MLX streaming, including final flushes when no more visible content remains.
- Route single-prompt MLX command operational logs to stderr and strip think-tag content from stdout by default for cleaner CLI output.

Enhancements:
- Expose structured truncation as a dedicated FoundationModelError and propagate it through controllers as an OpenAI-style length finish_reason.
- Emit separate OpenAI-compatible usage summary chunks with empty choices arrays for both Foundation and MLX streaming endpoints, and add tests to lock in the shape.
- Register MLX model factories once at service init and add debug logging when LLM container load fails before falling back to VLM.
- Improve backend proxy SSE error payloads to use null finish_reason and empty delta for better client compatibility.

Build:
- Vendor llama.cpp at a newer revision for the embedded WebUI.

Documentation:
- Add documentation for the guided JSON structured-output eval suite and the OpenAI compatibility eval bundle, including usage examples and report locations.

Tests:
- Add StreamingUsageChunkTests to validate finish_reason preservation, usage-only chunks, final terminal chunks, and commonPrefixLength behavior in streaming responses.