### PR TITLE
fix: clean single-prompt output for piping (-s)

### DIFF
--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -547,7 +547,10 @@ struct MlxCommand: ParsableCommand {
             return
         }
 
-        print("MLX model: \(selectedModel)")
+        let isSinglePromptMode = (singlePrompt != nil || isatty(STDIN_FILENO) == 0)
+        if !isSinglePromptMode {
+            print("MLX model: \(selectedModel)")
+        }
 
         // Read context window from model config
         var contextWindow: Int? = nil
@@ -762,19 +765,20 @@ struct MlxCommand: ParsableCommand {
 
         switch output {
         case .success(let text):
-            let rendered: String
             if raw {
-                rendered = text
+                print(text)
             } else {
-                rendered = Self.stripThinkContent(
-                    from: text,
-                    startTag: service.thinkStartTag ?? "<think>",
-                    endTag: service.thinkEndTag ?? "</think>"
-                )
+                let startTag = service.thinkStartTag ?? "<think>"
+                let endTag = service.thinkEndTag ?? "</think>"
+                let rendered = Self.stripThinkContent(from: text, startTag: startTag, endTag: endTag)
+                if rendered.isEmpty && text.contains(startTag) {
+                    print("(no visible response — model used all tokens for reasoning. Try increasing --max-tokens)")
+                    return
+                }
+                print(rendered)
             }
-            print(rendered)
         case .failure(let error):
-            print("Error: \(error.localizedDescription)")
+            FileHandle.standardError.write(Data("Error: \(error.localizedDescription)\n".utf8))
             throw ExitCode.failure
         case .none:
             throw ExitCode.failure
@@ -787,10 +791,10 @@ struct MlxCommand: ParsableCommand {
             if let end = output.range(of: endTag, range: start.upperBound..<output.endIndex) {
                 output.removeSubrange(start.lowerBound..<end.upperBound)
             } else {
-                // Some guided/grammar-constrained generations can emit a stray
-                // opening think tag without ever closing it. In that case keep
-                // the payload and drop only the unmatched tag.
-                output.removeSubrange(start)
+                // Unclosed think tag — truncated output or grammar-constrained
+                // generation. Strip everything from the opening tag onwards
+                // since it's all thinking content without a visible response.
+                output.removeSubrange(start.lowerBound..<output.endIndex)
             }
         }
         return output.trimmingCharacters(in: .whitespacesAndNewlines)


### PR DESCRIPTION
## Summary
- Suppress `MLX model:` line from stdout in single-prompt mode (was printing before fd redirect)
- Strip unclosed `<think>` tags — when output truncates mid-thinking, remove everything from `<think>` onwards instead of leaking thinking content
- When thinking consumes all tokens with no visible response, print a helpful message: `(no visible response — model used all tokens for reasoning. Try increasing --max-tokens)`

## Before
```
$ afm mlx -m model -s "hello" --max-tokens 10 2>/dev/null
Thinking Process:

1.  **Analyze
```

## After
```
$ afm mlx -m model -s "hello" --max-tokens 500 2>/dev/null
hello

$ afm mlx -m model -s "hello" --max-tokens 10 2>/dev/null
(no visible response — model used all tokens for reasoning. Try increasing --max-tokens)
```

Stdout is now clean for piping: `afm mlx -s "prompt" 2>/dev/null | next_process`

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust single-prompt output handling to keep stdout clean for piping and improve user feedback when thinking consumes all tokens.

Bug Fixes:
- Suppress the model header line in single-prompt or non-interactive mode so it no longer pollutes stdout when piping.
- Ensure unclosed thinking tags are fully stripped from the visible output to avoid leaking intermediate reasoning content.
- Print a clear message when the model uses all tokens for thinking and produces no visible response instead of returning an empty output.
- Send error messages to stderr rather than stdout to keep successful command output clean.