### PR TITLE
fix: resolve relative model paths against original shell CWD

### DIFF
--- a/Sources/MacLocalAPI/Models/MLXCacheResolver.swift
+++ b/Sources/MacLocalAPI/Models/MLXCacheResolver.swift
@@ -16,19 +16,33 @@ struct MLXCacheResolver {
         // Downloads always go to HF hub (~/.cache/huggingface/hub).
     }
 
+    /// Original shell CWD, captured before MLXMetalLibrary.ensureAvailable() changes the process CWD.
+    /// Used to resolve relative model paths against the directory the user invoked afm from.
+    private static let shellCWD: String = ProcessInfo.processInfo.environment["PWD"]
+        ?? FileManager.default.currentDirectoryPath
+
+    /// Resolve a relative path against the original shell CWD (not the process CWD,
+    /// which may have been changed by MLXMetalLibrary for metallib discovery).
+    private func resolveRelativePath(_ path: String) -> URL {
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path).standardized
+        }
+        return URL(fileURLWithPath: Self.shellCWD).appendingPathComponent(path).standardized
+    }
+
     func normalizedModelID(_ input: String) -> String {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return trimmed }
         // Absolute or relative filesystem path: resolve to absolute if it exists on disk
         if trimmed.hasPrefix("/") || trimmed.hasPrefix("./") || trimmed.hasPrefix("..") {
-            let url = URL(fileURLWithPath: trimmed).standardized
+            let url = resolveRelativePath(trimmed)
             if FileManager.default.fileExists(atPath: url.path) {
                 return url.path
             }
         }
         // Check if it's a relative path that exists on disk (e.g. "models/foo")
         if trimmed.contains("/") {
-            let url = URL(fileURLWithPath: trimmed).standardized
+            let url = resolveRelativePath(trimmed)
             if FileManager.default.fileExists(atPath: url.path) {
                 return url.path
             }


### PR DESCRIPTION
## Summary
`MLXMetalLibrary.ensureAvailable()` changes the process CWD to the metallib directory at startup. After that, relative model paths (`../model`, `./model`) resolve against the wrong directory.

Fix: capture `$PWD` (original shell CWD) at static init time in `MLXCacheResolver` and resolve all relative paths against it via `resolveRelativePath()`.

## Tested
- `afm mlx -m ../Qwen3.5-35B-A3B-4bit` from sibling dir — works
- `afm mlx -m ./Qwen3.5-35B-A3B-4bit` from parent dir — works
- `afm mlx -m /absolute/path` — still works
- `afm mlx -m mlx-community/model` with `MACAFM_MLX_MODEL_CACHE` — still works

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure relative model paths (e.g., ./model, ../model, nested paths) are resolved using the shell’s original working directory so they continue to work after MLXMetalLibrary changes the process CWD.