### PR TITLE
fix: skip radix save for wrapped RotatingKVCache to prevent SIGTRAP (#94)

### DIFF
--- a/Sources/MacLocalAPI/Models/MLXModelService.swift
+++ b/Sources/MacLocalAPI/Models/MLXModelService.swift
@@ -1690,8 +1690,16 @@ final class MLXModelService: @unchecked Sendable {
                 print("[\(ts())] [KVCache] Timing: TTFT=\(String(format: "%.3f", ttft))s total=\(String(format: "%.3f", total))s prompt_tokens=\(promptTok) gen_tokens=\(genTok)")
             }
 
-            // Save prompt cache state into radix tree
-            if useCache, let radix = self.radixCache, !inputTokens.isEmpty {
+            // Save prompt cache state into radix tree.
+            // Skip save when RotatingKVCache has wrapped past maxCacheSize — the
+            // trim/truncate/state-read cycle on wrapped rotating caches corrupts
+            // internal MLX state, causing the next request's prefill to SIGTRAP.
+            // (#94). Non-rotating models and pre-wrap rotating caches save normally.
+            let hasWrappedRotating = generationCache.contains { cache in
+                guard let rc = cache as? RotatingKVCache else { return false }
+                return rc.offset > rc.cacheSize
+            }
+            if useCache, let radix = self.radixCache, !inputTokens.isEmpty, !hasWrappedRotating {
                 let promptLen = inputTokens.count
                 let tSave0 = Date.timeIntervalSinceReferenceDate
                 if debugLogging {
@@ -2340,8 +2348,13 @@ final class MLXModelService: @unchecked Sendable {
                         var saveTruncateTime: Double? = nil
                         var saveInsertTime: Double? = nil
 
-                        // Save prompt cache state into radix tree
-                        if useCache, let radix = self.radixCache, !inputTokens.isEmpty, !Task.isCancelled {
+                        // Save prompt cache state into radix tree.
+                        // Skip when RotatingKVCache has wrapped (#94).
+                        let hasWrappedRotating = generationCache.contains { cache in
+                            guard let rc = cache as? RotatingKVCache else { return false }
+                            return rc.offset > rc.cacheSize
+                        }
+                        if useCache, let radix = self.radixCache, !inputTokens.isEmpty, !Task.isCancelled, !hasWrappedRotating {
                             let promptLen = inputTokens.count
                             let tSave0 = Date.timeIntervalSinceReferenceDate
                             for layer in generationCache {

--- a/Sources/MacLocalAPI/Models/RadixTreeCache.swift
+++ b/Sources/MacLocalAPI/Models/RadixTreeCache.swift
@@ -14,7 +14,14 @@ final class KVCacheEntry: @unchecked Sendable {
 
     init(tokens: [Int], layerStates: [[MLXArray]], layerMetaStates: [[String]] = []) {
         self.tokens = tokens
-        self.layerStates = layerStates
+        // Snapshot into standalone contiguous buffers before storing in the radix tree.
+        // Raw MLX slices keep the full backing Metal allocation alive and can also
+        // retain lazy graph links to the live cache buffers from the completed request.
+        let snapshottedStates = layerStates.map { state in
+            state.map { MLX.contiguous($0) }
+        }
+        MLX.eval(snapshottedStates.flatMap { $0 })
+        self.layerStates = snapshottedStates
         self.layerMetaStates = layerMetaStates
         self.lastAccessTime = mach_absolute_time()
     }

--- a/Tests/MacLocalAPITests/RadixTreeCacheTests.swift
+++ b/Tests/MacLocalAPITests/RadixTreeCacheTests.swift
@@ -184,6 +184,28 @@ struct RadixTreeCacheTests {
         #expect(len == 3)
     }
 
+    @Test("insert snapshots MLXArray views into independent storage")
+    func insertSnapshotsMLXArrayViews() {
+        let cache = RadixTreeCache(modelID: "test", maxEntries: 64)
+        let backing = MLXArray([Int32(10), Int32(20), Int32(30), Int32(40)])
+        let view = backing[..<3]
+
+        cache.insert(tokens: [1, 2, 3], layerStates: [[view]])
+
+        backing[..<3] = MLXArray([Int32(90), Int32(91), Int32(92)])
+        MLX.eval([backing])
+
+        let (prefixLen, states, _) = cache.findPrefix([1, 2, 3])
+        #expect(prefixLen == 3)
+        guard let storedStates = states else {
+            Issue.record("Expected stored radix state")
+            return
+        }
+        #expect(storedStates.count == 1)
+        #expect(storedStates[0].count == 1)
+        #expect(storedStates[0][0].asArray(Int32.self) == [10, 20, 30])
+    }
+
     @Test("insert: partial edge split with remaining tokens")
     func insertSplitWithRemaining() {
         let cache = RadixTreeCache(modelID: "test", maxEntries: 64)


### PR DESCRIPTION
## Summary

Fixes a server crash (SIGTRAP) on the second large prompt (>3K tokens) when prefix caching is enabled with Gemma 4 models. Pre-existing bug on main — affects all Gemma 4 variants (31B-4bit, 31B-8bit, 31B-mxfp4).

## Root Cause

The serial `MLXModelService.generate()` path saves post-generation RotatingKVCache state to the radix tree. When the cache has wrapped past `maxCacheSize` (offset > 1024 for Gemma 4), the trim/truncate/state-read cycle corrupts internal MLX state. The next request's prefill then SIGTRAPs with no error message.

The BatchScheduler path was unaffected because it snapshots cache state at prefill time (pre-wrap) using `MLX.contiguous()`.

## Fix

- Skip radix tree save when any RotatingKVCache has wrapped (`offset > maxCacheSize`). Short prompts (pre-wrap) still get cached normally.
- Defense in depth: `MLX.contiguous()` + `eval()` in `KVCacheEntry.init` to break view aliasing on all stored arrays.
- Regression test for radix array aliasing.

## Test Results

5 sequential 3600+ token prompts with `--enable-prefix-caching`:
- gemma-4-31b-it-4bit: 5/5 survived (was crashing on request 2)
- gemma-4-31b-it-8bit: 5/5 survived (was crashing on request 2)

Closes #94

## Summary by Sourcery

Guard radix tree prefix caching against corrupted MLX KV cache state when rotating caches wrap, and ensure stored cache arrays are fully materialized snapshots rather than live views.

Bug Fixes:
- Skip saving prefix cache entries to the radix tree when any RotatingKVCache has wrapped past its configured cache size to avoid crashing subsequent requests.
- Prevent radix tree entries from retaining aliased MLXArray views that can be mutated or tied to live computation graphs.

Tests:
- Add a regression test confirming that radix cache insertion snapshots MLXArray views so later mutations to the backing array do not affect stored prefix states.