### PR TITLE
Feature: Add Apple Vision OCR HTTP API and Foundation chat OCR integration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -98,7 +98,8 @@ let package = Package(
             dependencies: [
                 "MacLocalAPI",
                 .product(name: "Jinja", package: "swift-jinja"),
-                .product(name: "XCTVapor", package: "vapor")
+                .product(name: "XCTVapor", package: "vapor"),
+                .product(name: "VaporTesting", package: "vapor")
             ]
         )
     ],

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ afm mlx -m mlx-community/Qwen3-Coder-Next-4bit -t 1.0 --top-p 0.95 --max-tokens 
 - **🌐 API Gateway** - Auto-discovers and proxies Ollama, LM Studio, Jan, and other local backends into a single API
 - **⚡ LoRA adapter support** - Supports fine-tuning with LoRA adapters using Apple's tuning Toolkit
 - **📱 Apple Foundation Models** - Uses Apple's on-device 3B parameter language model
-- **👁️ Vision OCR** - Extract text from images and PDFs using Apple Vision (`afm vision`)
+- **👁️ Vision OCR** - Extract text from images and PDFs using Apple Vision via CLI and HTTP (`afm vision`, `/v1/vision/ocr`)
 - **🖥️ Built-in WebUI** - Chat interface with model selection (`afm -w`)
 - **🔒 Privacy-First** - All processing happens locally on your device
 - **⚡ Fast & Lightweight** - No network calls, no API keys required
@@ -276,6 +276,24 @@ Returns available Foundation Models.
 curl http://localhost:9999/v1/models
 ```
 
+### Vision OCR
+**POST** `/v1/vision/ocr`
+
+Runs Apple Vision OCR against local files, uploads, base64 payloads, `data:` URLs, and OpenAI-style image inputs.
+
+```bash
+curl -X POST http://localhost:9999/v1/vision/ocr \
+  -H "Content-Type: application/json" \
+  -d '{
+    "file": "/tmp/invoice.pdf",
+    "recognition_level": "accurate",
+    "languages": ["en-US"],
+    "max_pages": 10
+  }'
+```
+
+The endpoint returns structured JSON with per-document text, per-page text, text blocks, detected tables, document hints, and a top-level `combined_text` field. See [docs/vision-ocr-api.md](docs/vision-ocr-api.md) for request formats, options, and response details.
+
 ### Health Check
 **GET** `/health`
 
@@ -307,6 +325,36 @@ response = client.chat.completions.create(
 
 print(response.choices[0].message.content)
 ```
+
+### Vision OCR from OpenAI-Compatible Clients
+
+The OCR endpoint also accepts OpenAI-style multimodal payloads. This is useful when your client already sends `messages[].content[]` parts with `image_url`.
+
+```bash
+curl -X POST http://localhost:9999/v1/vision/ocr \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Extract the invoice text"},
+        {
+          "type": "image_url",
+          "image_url": {
+            "url": "data:application/pdf;base64,..."
+          }
+        }
+      ]
+    }],
+    "recognition_level": "accurate",
+    "languages": ["en-US"]
+  }'
+```
+
+Foundation chat requests can also auto-run Apple Vision OCR before prompting the model when:
+- the request includes image content
+- the request includes the built-in `apple_vision_ocr` tool
+- `tool_choice` is `auto`, `required`, omitted, or explicitly selects that tool
 
 ### JavaScript/Node.js
 

--- a/Scripts/apply-mlx-patches.sh
+++ b/Scripts/apply-mlx-patches.sh
@@ -32,6 +32,21 @@ PACKAGE_PINS=(
   '.upToNextMinor(from: "1.1.6")|from: "1.3.0"'
 )
 
+PACKAGE_EXCLUDE_PATTERNS=(
+  'MLXLLM|Models/DeepseekV3.swift.original'
+  'MLXLLM|Models/SSM.swift.original'
+  'MLXLLM|LLMModelFactory.swift.original'
+  'MLXVLM|Models/Qwen3VL.swift.original'
+  'MLXVLM|VLMModelFactory.swift.original'
+  'MLXLMCommon|Evaluate.swift.original'
+  'MLXLMCommon|Tool/ToolCallFormat.swift.original'
+  'MLXLMCommon|SwitchLayers.swift.original'
+  'MLXLMCommon|Chat.swift.original'
+  'MLXLMCommon|KVCache.swift.original'
+  'MLXLMCommon|Load.swift.original'
+  'MLXLMCommon|Tokenizer.swift.original'
+)
+
 is_new_file() {
   local filename="$1"
   for nf in "${NEW_FILES[@]}"; do
@@ -58,6 +73,33 @@ add_mlxfast_dep() {
   log_info "Added MLXFast dependency to MLXLMCommon"
 }
 
+ensure_target_exclude() {
+  local pkg_file="$1"
+  local target_name="$2"
+  local exclude_entry="$3"
+
+  [ -f "$pkg_file" ] || return 1
+
+  if grep -qF "\"$exclude_entry\"" "$pkg_file"; then
+    return 0
+  fi
+
+  TARGET_NAME="$target_name" EXCLUDE_ENTRY="$exclude_entry" perl -0pi -e '
+    my $target_name = $ENV{TARGET_NAME};
+    my $exclude_entry = $ENV{EXCLUDE_ENTRY};
+    s{
+      (\.target\(\s*
+       \s*name:\s*"$target_name",.*?
+       \s*exclude:\s*\[
+       .*?
+       "README\.md")
+    }{$1,\n                "$exclude_entry"}sx
+      or die "Failed to add exclude $exclude_entry to $target_name\n";
+  ' "$pkg_file"
+
+  log_info "Added Package.swift exclude for $target_name: $exclude_entry"
+}
+
 apply_package_pins() {
   local pkg_file="$1"
   [ -f "$pkg_file" ] || { log_error "Package.swift not found: $pkg_file"; return 1; }
@@ -80,6 +122,12 @@ apply_package_pins() {
       log_warn "Pattern not found in Package.swift: $search"
     fi
   done
+
+  for entry in "${PACKAGE_EXCLUDE_PATTERNS[@]}"; do
+    local target_name="${entry%%|*}"
+    local exclude_entry="${entry##*|}"
+    ensure_target_exclude "$pkg_file" "$target_name" "$exclude_entry"
+  done
 }
 
 check_package_pins() {
@@ -97,6 +145,17 @@ check_package_pins() {
       log_info "Pinned: $replace"
     else
       log_warn "Not pinned: $replace"
+      all_ok=false
+    fi
+  done
+
+  for entry in "${PACKAGE_EXCLUDE_PATTERNS[@]}"; do
+    local target_name="${entry%%|*}"
+    local exclude_entry="${entry##*|}"
+    if grep -qF "\"$exclude_entry\"" "$pkg_file"; then
+      log_info "Exclude present for $target_name: $exclude_entry"
+    else
+      log_warn "Missing exclude for $target_name: $exclude_entry"
       all_ok=false
     fi
   done

--- a/Sources/MacLocalAPI/Controllers/BatchAPIController.swift
+++ b/Sources/MacLocalAPI/Controllers/BatchAPIController.swift
@@ -303,7 +303,7 @@ struct BatchAPIController: RouteCollection {
                 maxTokens: effectiveMaxTokens
             )
 
-            let choiceLogprobs = MLXChatCompletionsController.buildChoiceLogprobs(collected.logprobs)
+            let choiceLogprobs = StreamCollector.buildChoiceLogprobs(collected.logprobs)
 
             // Build response with full post-processing
             let response: ChatCompletionResponse

--- a/Sources/MacLocalAPI/Controllers/BatchCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/BatchCompletionsController.swift
@@ -4,7 +4,7 @@ import os
 
 struct BatchCompletionsController: RouteCollection {
     /// Maximum requests allowed in a single SSE multiplex batch.
-    private static let maxBatchSize = 200
+    private static let maxBatchSize = 64
 
     private let service: any MLXChatServing
     private let modelID: String

--- a/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
@@ -49,6 +49,7 @@ struct ChatCompletionsController: RouteCollection {
         var fallbackModel = "foundation"
         var fallbackMessages: [Message] = []
         var fallbackMaxTokens = 2000
+        var visionCleanupURLs: [URL] = []
         do {
             let chatRequest = try req.content.decode(ChatCompletionRequest.self)
             fallbackModel = chatRequest.model ?? "foundation"
@@ -96,11 +97,36 @@ struct ChatCompletionsController: RouteCollection {
             }
 
             let foundationService: FoundationModelService
-            let processedMessages: [Message] = chatRequest.messages
+            let processedMessages: [Message]
             if #available(macOS 26.0, *) {
                 foundationService = try await FoundationModelService.createWithSharedAdapter(instructions: instructions, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails)
+                let shouldApplyVisionOCR = chatRequest.messages.contains { message in
+                    guard let content = message.content, case .parts(let parts) = content else { return false }
+                    return parts.contains(where: { $0.type == "image_url" })
+                }
+                if shouldApplyVisionOCR {
+                    let visionOptions = VisionRequestOptions()
+                    let visionProcessed = try await VisionAPIController.extractOCRTextFromMessages(chatRequest.messages, options: visionOptions)
+                    visionCleanupURLs = visionProcessed.cleanupURLs
+                    var messagesWithOCR = visionProcessed.messages
+                    if VisionAPIController.shouldAutoRunVisionTool(chatRequest) {
+                        let toolPrelude = Message(
+                            role: "system",
+                            content: "Built-in tool apple_vision_ocr has already been executed for the attached images. Use the injected OCR text when answering."
+                        )
+                        messagesWithOCR.insert(toolPrelude, at: 0)
+                    }
+                    processedMessages = messagesWithOCR
+                } else {
+                    processedMessages = chatRequest.messages
+                }
             } else {
                 throw FoundationModelError.notAvailable
+            }
+            defer {
+                for url in visionCleanupURLs {
+                    try? FileManager.default.removeItem(at: url)
+                }
             }
 
             // Check if streaming is requested and enabled

--- a/Sources/MacLocalAPI/Controllers/MLXChatServing.swift
+++ b/Sources/MacLocalAPI/Controllers/MLXChatServing.swift
@@ -91,6 +91,16 @@ protocol MLXChatServing {
 }
 
 extension MLXChatServing {
+    var defaultGuidedJsonSchema: ResponseFormat? { nil }
+
+    func effectiveResponseFormat(requestFormat: ResponseFormat?) -> ResponseFormat? {
+        requestFormat ?? defaultGuidedJsonSchema
+    }
+
+    func waitForSlot(timeout: TimeInterval) async -> Bool {
+        tryReserveSlot()
+    }
+
     /// Convenience overload without requestId for batch/internal callers.
     func generateStreaming(
         model: String, messages: [Message], temperature: Double?, maxTokens: Int?,

--- a/Sources/MacLocalAPI/Controllers/MLXChatServing.swift
+++ b/Sources/MacLocalAPI/Controllers/MLXChatServing.swift
@@ -98,7 +98,26 @@ extension MLXChatServing {
     }
 
     func waitForSlot(timeout: TimeInterval) async -> Bool {
-        tryReserveSlot()
+        if timeout <= 0 {
+            return tryReserveSlot()
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if tryReserveSlot() {
+                return true
+            }
+
+            let remaining = deadline.timeIntervalSinceNow
+            if remaining <= 0 {
+                break
+            }
+
+            let sleepDuration = min(remaining, 0.05)
+            try? await Task.sleep(nanoseconds: UInt64(sleepDuration * 1_000_000_000))
+        }
+
+        return tryReserveSlot()
     }
 
     /// Convenience overload without requestId for batch/internal callers.

--- a/Sources/MacLocalAPI/Controllers/StreamCollector.swift
+++ b/Sources/MacLocalAPI/Controllers/StreamCollector.swift
@@ -21,6 +21,109 @@ struct CollectedResult: Sendable {
 /// Used by BatchAPIController and BatchCompletionsController to avoid
 /// duplicating the post-processing logic from MLXChatCompletionsController.
 enum StreamCollector {
+    static func buildChoiceLogprobs(_ resolved: [ResolvedLogprob]) -> ChoiceLogprobs? {
+        guard !resolved.isEmpty else { return nil }
+        let content = resolved.map { entry in
+            let topEntries = entry.topTokens.map { top in
+                TopLogprobEntry(
+                    token: top.token,
+                    logprob: Double(top.logprob),
+                    bytes: Array(top.token.utf8).map { Int($0) }
+                )
+            }
+            return TokenLogprobContent(
+                token: entry.token,
+                logprob: Double(entry.logprob),
+                bytes: Array(entry.token.utf8).map { Int($0) },
+                topLogprobs: topEntries
+            )
+        }
+        return ChoiceLogprobs(content: content)
+    }
+
+    private static func extractThinkTags(
+        buffer: inout String,
+        insideThinkBlock: inout Bool,
+        startTag: String = "<think>",
+        endTag: String = "</think>"
+    ) -> (reasoning: String?, content: String?) {
+        var reasoning = ""
+        var content = ""
+        let startTagLen = startTag.count
+        let endTagLen = endTag.count
+
+        while !buffer.isEmpty {
+            if insideThinkBlock {
+                if let endRange = buffer.range(of: endTag) {
+                    reasoning += String(buffer[buffer.startIndex..<endRange.lowerBound])
+                    buffer = String(buffer[endRange.upperBound...])
+                    insideThinkBlock = false
+                } else if buffer.count > endTagLen {
+                    let safeEnd = buffer.index(buffer.endIndex, offsetBy: -endTagLen)
+                    reasoning += String(buffer[buffer.startIndex..<safeEnd])
+                    buffer = String(buffer[safeEnd...])
+                    break
+                } else {
+                    break
+                }
+            } else {
+                if let startRange = buffer.range(of: startTag) {
+                    content += String(buffer[buffer.startIndex..<startRange.lowerBound])
+                    buffer = String(buffer[startRange.upperBound...])
+                    insideThinkBlock = true
+                } else if buffer.count > startTagLen {
+                    let safeEnd = buffer.index(buffer.endIndex, offsetBy: -startTagLen)
+                    content += String(buffer[buffer.startIndex..<safeEnd])
+                    buffer = String(buffer[safeEnd...])
+                    break
+                } else {
+                    break
+                }
+            }
+        }
+
+        return (
+            reasoning: reasoning.isEmpty ? nil : reasoning,
+            content: content.isEmpty ? nil : content
+        )
+    }
+
+    static func extractThinkContent(
+        from text: String,
+        startTag: String = "<think>",
+        endTag: String = "</think>"
+    ) -> (content: String, reasoning: String?) {
+        guard text.contains(startTag) else { return (text, nil) }
+        var buffer = text
+        var inside = false
+        var allReasoning = ""
+        var allContent = ""
+
+        while !buffer.isEmpty {
+            let extracted = extractThinkTags(
+                buffer: &buffer,
+                insideThinkBlock: &inside,
+                startTag: startTag,
+                endTag: endTag
+            )
+            if let reasoning = extracted.reasoning { allReasoning += reasoning }
+            if let content = extracted.content { allContent += content }
+            if extracted.reasoning == nil && extracted.content == nil { break }
+        }
+
+        if !buffer.isEmpty {
+            if inside {
+                allReasoning += buffer
+            } else {
+                allContent += buffer
+            }
+        }
+
+        let reasoning = allReasoning.isEmpty ? nil : allReasoning.trimmingCharacters(in: .whitespacesAndNewlines)
+        let content = allContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (content, reasoning)
+    }
+
 
     /// Collect all chunks from a streaming result into a single finalized result.
     ///
@@ -81,7 +184,7 @@ enum StreamCollector {
             content = nil
             reasoningContent = nil
         } else if extractThinking {
-            let (extracted, reasoning) = MLXChatCompletionsController.extractThinkContent(
+            let (extracted, reasoning) = extractThinkContent(
                 from: fullText,
                 startTag: thinkStartTag,
                 endTag: thinkEndTag

--- a/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
+++ b/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
@@ -1,0 +1,629 @@
+import Vapor
+import Foundation
+
+protocol VisionServing {
+    func extractText(from filePath: String) async throws -> String
+    func extractText(from filePath: String, options: VisionRequestOptions) async throws -> String
+    func extractTextWithDetails(from filePath: String) async throws -> VisionResult
+    func extractTextWithDetails(from filePath: String, options: VisionRequestOptions) async throws -> VisionResult
+    func extractTables(from filePath: String) async throws -> [TableResult]
+    func extractTables(from filePath: String, options: VisionRequestOptions) async throws -> [TableResult]
+    func debugRawDetection(from filePath: String) async throws -> String
+    func debugRawDetection(from filePath: String, options: VisionRequestOptions) async throws -> String
+}
+
+@available(macOS 26.0, *)
+extension VisionService: VisionServing {}
+
+struct VisionOCRRequest: Content {
+    let file: String?
+    let data: String?
+    let filename: String?
+    let mediaType: String?
+    let imageURL: ImageURL?
+    let messages: [Message]?
+    let verbose: Bool?
+    let table: Bool?
+    let debug: Bool?
+    let recognitionLevel: String?
+    let usesLanguageCorrection: Bool?
+    let languages: [String]?
+    let maxPages: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case file
+        case data
+        case filename
+        case mediaType = "media_type"
+        case imageURL = "image_url"
+        case messages
+        case verbose
+        case table
+        case debug
+        case recognitionLevel = "recognition_level"
+        case usesLanguageCorrection = "uses_language_correction"
+        case languages
+        case maxPages = "max_pages"
+    }
+}
+
+struct VisionOCRResponse: Content {
+    let object: String
+    let mode: String
+    let documents: [VisionOCRDocument]
+    let combinedText: String
+    let documentHints: [String]
+    let debugOutput: String?
+
+    enum CodingKeys: String, CodingKey {
+        case object
+        case mode
+        case documents
+        case combinedText = "combined_text"
+        case documentHints = "document_hints"
+        case debugOutput = "debug_output"
+    }
+}
+
+struct VisionOCRDocument: Content {
+    let file: String
+    let sourceType: String
+    let text: String
+    let fullText: String
+    let pageCount: Int
+    let documentHints: [String]
+    let pages: [VisionOCRPage]
+    let textBlocks: [VisionOCRTextBlock]
+    let tables: [VisionOCRTable]
+
+    enum CodingKeys: String, CodingKey {
+        case file
+        case sourceType = "source_type"
+        case text
+        case fullText = "full_text"
+        case pageCount = "page_count"
+        case documentHints = "document_hints"
+        case pages
+        case textBlocks = "text_blocks"
+        case tables
+    }
+}
+
+struct VisionOCRPage: Content {
+    let pageNumber: Int
+    let text: String
+    let width: Double
+    let height: Double
+    let textBlocks: [VisionOCRTextBlock]
+    let tables: [VisionOCRTable]
+
+    enum CodingKeys: String, CodingKey {
+        case pageNumber = "page_number"
+        case text
+        case width
+        case height
+        case textBlocks = "text_blocks"
+        case tables
+    }
+}
+
+struct VisionOCRTextBlock: Content {
+    let text: String
+    let confidence: Float
+    let pageNumber: Int
+    let boundingBox: VisionOCRBoundingBox
+
+    enum CodingKeys: String, CodingKey {
+        case text
+        case confidence
+        case pageNumber = "page_number"
+        case boundingBox = "bounding_box"
+    }
+}
+
+struct VisionOCRTable: Content {
+    let pageNumber: Int
+    let rows: [[String]]
+    let headers: [String]
+    let rowObjects: [[String: String]]
+    let columnCount: Int
+    let averageConfidence: Float
+    let mergedCellHints: [String]
+    let boundingBox: VisionOCRBoundingBox
+    let csvData: String
+
+    enum CodingKeys: String, CodingKey {
+        case pageNumber = "page_number"
+        case rows
+        case headers
+        case rowObjects = "row_objects"
+        case columnCount = "column_count"
+        case averageConfidence = "average_confidence"
+        case mergedCellHints = "merged_cell_hints"
+        case boundingBox = "bounding_box"
+        case csvData = "csv_data"
+    }
+}
+
+struct VisionOCRBoundingBox: Content {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    init(_ rect: CGRect) {
+        self.x = rect.origin.x
+        self.y = rect.origin.y
+        self.width = rect.size.width
+        self.height = rect.size.height
+    }
+}
+
+struct VisionResolvedInput {
+    let path: String
+    let sourceType: String
+    let cleanupURLs: [URL]
+}
+
+struct VisionAPIController: RouteCollection {
+    private static let maxRequestBodySize: ByteCount = "30mb"
+    private static let supportedMediaTypes: [String: String] = [
+        "image/png": "png",
+        "image/jpeg": "jpg",
+        "image/jpg": "jpg",
+        "image/heic": "heic",
+        "application/pdf": "pdf"
+    ]
+    private static let builtInToolName = "apple_vision_ocr"
+
+    private let makeVisionService: () -> (any VisionServing)?
+
+    init(makeVisionService: @escaping () -> (any VisionServing)? = VisionAPIController.defaultVisionServiceFactory) {
+        self.makeVisionService = makeVisionService
+    }
+
+    func boot(routes: RoutesBuilder) throws {
+        let v1 = routes.grouped("v1", "vision")
+        v1.on(.POST, "ocr", body: .collect(maxSize: Self.maxRequestBodySize), use: ocr)
+        v1.on(.OPTIONS, "ocr", use: handleOptions)
+    }
+
+    func handleOptions(req: Request) async throws -> Response {
+        let response = Response(status: .ok)
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        response.headers.add(name: .accessControlAllowMethods, value: "POST, OPTIONS")
+        response.headers.add(name: .accessControlAllowHeaders, value: "Content-Type, Authorization")
+        return response
+    }
+
+    func ocr(req: Request) async throws -> Response {
+        guard let visionService = makeVisionService() else {
+            return try await createErrorResponse(
+                message: VisionError.platformUnavailable.localizedDescription,
+                status: .serviceUnavailable,
+                type: "vision_unavailable"
+            )
+        }
+
+        let parsed = try parseRequest(req)
+        let options = try buildOptions(from: parsed.request)
+        guard !parsed.inputs.isEmpty else {
+            return try await createErrorResponse(
+                message: VisionError.missingInput.localizedDescription,
+                status: .badRequest
+            )
+        }
+
+        defer { cleanup(parsed.cleanupURLs) }
+
+        let wantsDebug = parsed.request.debug ?? false
+        let wantsTable = parsed.request.table ?? false
+        let mode = wantsDebug ? "debug" : (wantsTable ? "table" : "text")
+
+        do {
+            if wantsDebug {
+                let outputs = try await parsed.inputs.asyncMap { input in
+                    try await visionService.debugRawDetection(from: input.path, options: options)
+                }
+                return try await createSuccessResponse(
+                    VisionOCRResponse(
+                        object: "vision.ocr",
+                        mode: mode,
+                        documents: [],
+                        combinedText: "",
+                        documentHints: [],
+                        debugOutput: outputs.joined(separator: "\n\n")
+                    )
+                )
+            }
+
+            let documents = try await parsed.inputs.asyncMap { input in
+                let result = try await visionService.extractTextWithDetails(from: input.path, options: options)
+                return Self.mapDocument(result, sourceType: input.sourceType)
+            }
+
+            let combinedText = documents.map(\.fullText).joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
+            let hints = Array(Set(documents.flatMap(\.documentHints))).sorted()
+            return try await createSuccessResponse(
+                VisionOCRResponse(
+                    object: "vision.ocr",
+                    mode: mode,
+                    documents: documents,
+                    combinedText: combinedText,
+                    documentHints: hints,
+                    debugOutput: nil
+                )
+            )
+        } catch let visionError as VisionError {
+            return try await createErrorResponse(
+                message: visionError.localizedDescription,
+                status: Self.httpStatus(for: visionError)
+            )
+        } catch {
+            return try await createErrorResponse(
+                message: error.localizedDescription,
+                status: .internalServerError,
+                type: "internal_error"
+            )
+        }
+    }
+
+    private func parseRequest(_ req: Request) throws -> (request: VisionOCRRequest, inputs: [VisionResolvedInput], cleanupURLs: [URL]) {
+        let multipartFile = try? req.content.get(Vapor.File.self, at: "file")
+        let multipartFilename = multipartFile?.filename
+        let multipartMediaType = multipartFile?.contentType?.description
+
+        let request: VisionOCRRequest
+        if multipartFile != nil {
+            request = VisionOCRRequest(
+                file: nil,
+                data: nil,
+                filename: multipartFilename,
+                mediaType: multipartMediaType,
+                imageURL: nil,
+                messages: nil,
+                verbose: boolField(req, "verbose"),
+                table: boolField(req, "table"),
+                debug: boolField(req, "debug"),
+                recognitionLevel: stringField(req, "recognition_level"),
+                usesLanguageCorrection: boolField(req, "uses_language_correction"),
+                languages: arrayField(req, "languages"),
+                maxPages: intField(req, "max_pages")
+            )
+        } else {
+            request = try req.content.decode(VisionOCRRequest.self)
+        }
+
+        var inputs: [VisionResolvedInput] = []
+        var cleanupURLs: [URL] = []
+
+        if let multipartFile {
+            let fileURL = try Self.writeTempFile(
+                data: Data(buffer: multipartFile.data),
+                filename: multipartFilename ?? "upload.bin",
+                mediaType: multipartMediaType
+            )
+            inputs.append(VisionResolvedInput(path: fileURL.path, sourceType: "upload", cleanupURLs: [fileURL]))
+            cleanupURLs.append(fileURL)
+        }
+
+        if let file = request.file?.trimmingCharacters(in: .whitespacesAndNewlines), !file.isEmpty {
+            inputs.append(VisionResolvedInput(path: Self.resolvePath(file), sourceType: "file", cleanupURLs: []))
+        }
+
+        if let data = request.data?.trimmingCharacters(in: .whitespacesAndNewlines), !data.isEmpty {
+            let fileURL = try Self.writeTempDataPayload(
+                data,
+                filename: request.filename ?? "upload",
+                mediaType: request.mediaType
+            )
+            inputs.append(VisionResolvedInput(path: fileURL.path, sourceType: "data", cleanupURLs: [fileURL]))
+            cleanupURLs.append(fileURL)
+        }
+
+        if let imageURL = request.imageURL {
+            let resolved = try Self.resolveImageURL(imageURL)
+            inputs.append(VisionResolvedInput(path: resolved.path, sourceType: "image_url", cleanupURLs: resolved.cleanupURLs))
+            cleanupURLs.append(contentsOf: resolved.cleanupURLs)
+        }
+
+        if let messages = request.messages {
+            for message in messages {
+                guard let content = message.content, case .parts(let parts) = content else { continue }
+                for part in parts where part.type == "image_url" {
+                    guard let imageURL = part.image_url else { continue }
+                    let resolved = try Self.resolveImageURL(imageURL)
+                    inputs.append(VisionResolvedInput(path: resolved.path, sourceType: "message_image", cleanupURLs: resolved.cleanupURLs))
+                    cleanupURLs.append(contentsOf: resolved.cleanupURLs)
+                }
+            }
+        }
+
+        return (request, inputs, cleanupURLs)
+    }
+
+    private func buildOptions(from request: VisionOCRRequest) throws -> VisionRequestOptions {
+        let level: VisionRecognitionLevel
+        if let requested = request.recognitionLevel?.lowercased(), !requested.isEmpty {
+            guard let parsed = VisionRecognitionLevel(rawValue: requested) else {
+                throw Abort(.badRequest, reason: "recognition_level must be 'accurate' or 'fast'")
+            }
+            level = parsed
+        } else {
+            level = .accurate
+        }
+
+        return VisionRequestOptions(
+            recognitionLevel: level,
+            usesLanguageCorrection: request.usesLanguageCorrection ?? true,
+            recognitionLanguages: request.languages ?? [],
+            maxPages: request.maxPages ?? VisionRequestOptions.defaultMaxPages
+        )
+    }
+
+    private func createSuccessResponse(_ payload: VisionOCRResponse) async throws -> Response {
+        let response = Response(status: .ok)
+        response.headers.add(name: .contentType, value: "application/json")
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        try response.content.encode(payload)
+        return response
+    }
+
+    private func createErrorResponse(message: String, status: HTTPStatus, type: String = "invalid_request_error") async throws -> Response {
+        let response = Response(status: status)
+        response.headers.add(name: .contentType, value: "application/json")
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        try response.content.encode(OpenAIError(message: message, type: type))
+        return response
+    }
+
+    private func boolField(_ req: Request, _ field: String) -> Bool? {
+        guard let value = try? req.content.get(String.self, at: field) else { return nil }
+        switch value.lowercased() {
+        case "true", "1", "yes", "y", "on":
+            return true
+        case "false", "0", "no", "n", "off":
+            return false
+        default:
+            return nil
+        }
+    }
+
+    private func intField(_ req: Request, _ field: String) -> Int? {
+        guard let value = try? req.content.get(String.self, at: field) else { return nil }
+        return Int(value)
+    }
+
+    private func stringField(_ req: Request, _ field: String) -> String? {
+        try? req.content.get(String.self, at: field)
+    }
+
+    private func arrayField(_ req: Request, _ field: String) -> [String]? {
+        if let items = try? req.content.get([String].self, at: field) {
+            return items
+        }
+        guard let raw = try? req.content.get(String.self, at: field) else { return nil }
+        return raw
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private func cleanup(_ urls: [URL]) {
+        for url in urls {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    private static func resolvePath(_ file: String) -> String {
+        let expandedPath = NSString(string: file).expandingTildeInPath
+        return URL(fileURLWithPath: expandedPath).standardized.path
+    }
+
+    static func resolveImageURL(_ imageURL: ImageURL) throws -> VisionResolvedInput {
+        let raw = imageURL.url
+        if raw.hasPrefix("data:") {
+            let fileURL = try writeTempDataPayload(raw, filename: "image", mediaType: nil)
+            return VisionResolvedInput(path: fileURL.path, sourceType: "data_url", cleanupURLs: [fileURL])
+        }
+
+        if let url = URL(string: raw), let scheme = url.scheme?.lowercased() {
+            switch scheme {
+            case "file":
+                return VisionResolvedInput(path: url.path, sourceType: "file_url", cleanupURLs: [])
+            case "http", "https":
+                let data = try Data(contentsOf: url)
+                let fileURL = try writeTempFile(data: data, filename: url.lastPathComponent.isEmpty ? "remote" : url.lastPathComponent, mediaType: nil)
+                return VisionResolvedInput(path: fileURL.path, sourceType: "remote_url", cleanupURLs: [fileURL])
+            default:
+                break
+            }
+        }
+
+        return VisionResolvedInput(path: resolvePath(raw), sourceType: "file", cleanupURLs: [])
+    }
+
+    static func writeTempDataPayload(_ payload: String, filename: String, mediaType: String?) throws -> URL {
+        if payload.hasPrefix("data:") {
+            guard let commaIndex = payload.firstIndex(of: ",") else {
+                throw VisionError.invalidDataURL
+            }
+            let header = String(payload[..<commaIndex])
+            let base64 = String(payload[payload.index(after: commaIndex)...])
+            guard let decoded = Data(base64Encoded: base64, options: .ignoreUnknownCharacters) else {
+                throw VisionError.invalidDataURL
+            }
+            let media = header
+                .replacingOccurrences(of: "data:", with: "")
+                .split(separator: ";")
+                .first
+                .map(String.init)
+            return try writeTempFile(data: decoded, filename: filename, mediaType: media)
+        }
+
+        guard let decoded = Data(base64Encoded: payload, options: .ignoreUnknownCharacters) else {
+            throw VisionError.invalidDataURL
+        }
+        return try writeTempFile(data: decoded, filename: filename, mediaType: mediaType)
+    }
+
+    static func writeTempFile(data: Data, filename: String, mediaType: String?) throws -> URL {
+        if data.count > VisionRequestOptions.defaultMaxFileBytes {
+            throw VisionError.requestTooLarge(
+                actualBytes: data.count,
+                maxBytes: VisionRequestOptions.defaultMaxFileBytes
+            )
+        }
+
+        let ext = inferExtension(filename: filename, mediaType: mediaType)
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("afm_vision_\(UUID().uuidString).\(ext)")
+        try data.write(to: tempURL)
+        return tempURL
+    }
+
+    private static func inferExtension(filename: String, mediaType: String?) -> String {
+        let filenameExt = URL(fileURLWithPath: filename).pathExtension.lowercased()
+        if !filenameExt.isEmpty {
+            return filenameExt
+        }
+        if let mediaType, let mapped = supportedMediaTypes[mediaType.lowercased()] {
+            return mapped
+        }
+        return "png"
+    }
+
+    static func extractOCRTextFromMessages(_ messages: [Message], options: VisionRequestOptions) async throws -> (messages: [Message], cleanupURLs: [URL]) {
+        guard #available(macOS 26.0, *) else {
+            return (messages, [])
+        }
+
+        let service = VisionService()
+        var updatedMessages: [Message] = []
+        var cleanupURLs: [URL] = []
+
+        for message in messages {
+            guard let content = message.content, case .parts(let parts) = content else {
+                updatedMessages.append(message)
+                continue
+            }
+
+            var textChunks = parts.compactMap(\.text)
+            var imageIndex = 0
+            for part in parts where part.type == "image_url" {
+                guard let imageURL = part.image_url else { continue }
+                let resolved = try resolveImageURL(imageURL)
+                cleanupURLs.append(contentsOf: resolved.cleanupURLs)
+                let ocrText = try await service.extractText(from: resolved.path, options: options)
+                imageIndex += 1
+                textChunks.append("[Apple Vision OCR image \(imageIndex)]\n\(ocrText)")
+            }
+
+            updatedMessages.append(Message(role: message.role, content: textChunks.joined(separator: "\n\n")))
+        }
+
+        return (updatedMessages, cleanupURLs)
+    }
+
+    static func shouldAutoRunVisionTool(_ request: ChatCompletionRequest) -> Bool {
+        guard let tools = request.tools, tools.contains(where: { $0.function.name == builtInToolName }) else {
+            return false
+        }
+
+        let hasImageContent = request.messages.contains { message in
+            guard let content = message.content, case .parts(let parts) = content else { return false }
+            return parts.contains(where: { $0.type == "image_url" })
+        }
+        guard hasImageContent else { return false }
+
+        switch request.toolChoice {
+        case .mode(let mode):
+            return mode == "required" || mode == "auto"
+        case .function(let functionChoice):
+            return functionChoice.function.name == builtInToolName
+        case nil:
+            return true
+        }
+    }
+
+    private static func mapDocument(_ result: VisionResult, sourceType: String) -> VisionOCRDocument {
+        let pages = result.pages.map { page in
+            VisionOCRPage(
+                pageNumber: page.pageNumber,
+                text: page.fullText,
+                width: page.width,
+                height: page.height,
+                textBlocks: page.textBlocks.map(mapTextBlock),
+                tables: page.tables.map(mapTable)
+            )
+        }
+        return VisionOCRDocument(
+            file: result.filePath,
+            sourceType: sourceType,
+            text: result.fullText,
+            fullText: result.fullText,
+            pageCount: max(result.pages.count, 1),
+            documentHints: result.documentHints,
+            pages: pages,
+            textBlocks: result.textBlocks.map(mapTextBlock),
+            tables: result.pages.flatMap(\.tables).map(mapTable)
+        )
+    }
+
+    private static func mapTextBlock(_ block: TextBlock) -> VisionOCRTextBlock {
+        VisionOCRTextBlock(
+            text: block.text,
+            confidence: block.confidence,
+            pageNumber: block.pageNumber,
+            boundingBox: VisionOCRBoundingBox(block.boundingBox)
+        )
+    }
+
+    private static func mapTable(_ table: TableResult) -> VisionOCRTable {
+        VisionOCRTable(
+            pageNumber: table.pageNumber,
+            rows: table.rows,
+            headers: table.headers,
+            rowObjects: table.rowObjects,
+            columnCount: table.columnCount,
+            averageConfidence: table.averageConfidence,
+            mergedCellHints: table.mergedCellHints,
+            boundingBox: VisionOCRBoundingBox(table.boundingBox),
+            csvData: table.csvData
+        )
+    }
+
+    private static func httpStatus(for error: VisionError) -> HTTPStatus {
+        switch error {
+        case .missingInput, .unsupportedFormat, .invalidDataURL:
+            return .badRequest
+        case .fileNotFound:
+            return .notFound
+        case .requestTooLarge:
+            return .payloadTooLarge
+        case .pageLimitExceeded, .imageDimensionsExceeded, .imageLoadingFailed, .textRecognitionFailed, .noTextFound, .noTablesFound, .documentSegmentationFailed:
+            return .unprocessableEntity
+        case .platformUnavailable:
+            return .serviceUnavailable
+        }
+    }
+
+    private static func defaultVisionServiceFactory() -> (any VisionServing)? {
+        if #available(macOS 26.0, *) {
+            return VisionService()
+        }
+        return nil
+    }
+}
+
+private extension Array {
+    func asyncMap<T>(_ transform: (Element) async throws -> T) async throws -> [T] {
+        var result: [T] = []
+        result.reserveCapacity(count)
+        for value in self {
+            let transformed = try await transform(value)
+            result.append(transformed)
+        }
+        return result
+    }
+}

--- a/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
+++ b/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
@@ -432,11 +432,9 @@ struct VisionAPIController: RouteCollection {
             case "file":
                 return VisionResolvedInput(path: url.path, sourceType: "file_url", cleanupURLs: [])
             case "http", "https":
-                let data = try Data(contentsOf: url)
-                let fileURL = try writeTempFile(data: data, filename: url.lastPathComponent.isEmpty ? "remote" : url.lastPathComponent, mediaType: nil)
-                return VisionResolvedInput(path: fileURL.path, sourceType: "remote_url", cleanupURLs: [fileURL])
+                throw VisionError.remoteURLNotSupported
             default:
-                break
+                throw VisionError.unsupportedURLScheme(scheme)
             }
         }
 
@@ -595,7 +593,7 @@ struct VisionAPIController: RouteCollection {
 
     private static func httpStatus(for error: VisionError) -> HTTPStatus {
         switch error {
-        case .missingInput, .unsupportedFormat, .invalidDataURL:
+        case .missingInput, .unsupportedFormat, .remoteURLNotSupported, .unsupportedURLScheme, .invalidDataURL:
             return .badRequest
         case .fileNotFound:
             return .notFound

--- a/Sources/MacLocalAPI/Models/BackendConfiguration.swift
+++ b/Sources/MacLocalAPI/Models/BackendConfiguration.swift
@@ -94,7 +94,7 @@ struct ModelCapabilities: Sendable {
     static let `default` = ModelCapabilities()
 
     /// Foundation model capabilities
-    static let foundation = ModelCapabilities(vision: false, contextLength: 4096)
+    static let foundation = ModelCapabilities(vision: true, tools: true, contextLength: 4096)
 }
 
 /// Response from Ollama's POST /api/show endpoint

--- a/Sources/MacLocalAPI/Models/OpenAIResponse.swift
+++ b/Sources/MacLocalAPI/Models/OpenAIResponse.swift
@@ -308,9 +308,18 @@ struct Usage: Content {
             self.promptTokensPerSecond = nil
         }
 
-        // Lightweight peak memory from MLX allocator counter — no GPU profiling overhead
+        self.peakMemoryGib = Self.safePeakMemoryGib()
+    }
+
+    private static func safePeakMemoryGib() -> Double? {
+        do {
+            try MLXMetalLibrary.ensureAvailable(verbose: false)
+        } catch {
+            return nil
+        }
+
         let gib = 1024.0 * 1024.0 * 1024.0
-        self.peakMemoryGib = (Double(Memory.snapshot().peakMemory) / gib * 10).rounded() / 10
+        return (Double(Memory.snapshot().peakMemory) / gib * 10).rounded() / 10
     }
 }
 

--- a/Sources/MacLocalAPI/Models/VisionService.swift
+++ b/Sources/MacLocalAPI/Models/VisionService.swift
@@ -10,6 +10,8 @@ enum VisionError: Error, LocalizedError {
     case missingInput
     case fileNotFound
     case unsupportedFormat
+    case remoteURLNotSupported
+    case unsupportedURLScheme(String)
     case invalidDataURL
     case requestTooLarge(actualBytes: Int, maxBytes: Int)
     case pageLimitExceeded(actualPages: Int, maxPages: Int)
@@ -30,6 +32,10 @@ enum VisionError: Error, LocalizedError {
             return "The specified file was not found"
         case .unsupportedFormat:
             return "Unsupported file format. Supported formats: PNG, JPG, JPEG, HEIC, PDF"
+        case .remoteURLNotSupported:
+            return "Remote HTTP(S) image URLs are not supported for Apple Vision OCR"
+        case .unsupportedURLScheme(let scheme):
+            return "Unsupported image URL scheme: \(scheme)"
         case .invalidDataURL:
             return "Invalid data URL or base64 payload"
         case .requestTooLarge(let actualBytes, let maxBytes):

--- a/Sources/MacLocalAPI/Models/VisionService.swift
+++ b/Sources/MacLocalAPI/Models/VisionService.swift
@@ -1,25 +1,43 @@
 import Foundation
 import Vision
-import CoreImage
+import CoreGraphics
+import ImageIO
 import PDFKit
 import Quartz
-import AppKit
 
 enum VisionError: Error, LocalizedError {
+    case platformUnavailable
+    case missingInput
     case fileNotFound
     case unsupportedFormat
+    case invalidDataURL
+    case requestTooLarge(actualBytes: Int, maxBytes: Int)
+    case pageLimitExceeded(actualPages: Int, maxPages: Int)
+    case imageDimensionsExceeded(width: Int, height: Int, maxDimension: Int)
     case imageLoadingFailed
     case textRecognitionFailed(String)
     case noTextFound
     case noTablesFound
     case documentSegmentationFailed(String)
-    
+
     var errorDescription: String? {
         switch self {
+        case .platformUnavailable:
+            return "Apple Vision OCR requires macOS 26.0 or later"
+        case .missingInput:
+            return "No OCR input was provided"
         case .fileNotFound:
             return "The specified file was not found"
         case .unsupportedFormat:
             return "Unsupported file format. Supported formats: PNG, JPG, JPEG, HEIC, PDF"
+        case .invalidDataURL:
+            return "Invalid data URL or base64 payload"
+        case .requestTooLarge(let actualBytes, let maxBytes):
+            return "Input size \(actualBytes) bytes exceeds the limit of \(maxBytes) bytes"
+        case .pageLimitExceeded(let actualPages, let maxPages):
+            return "Document has \(actualPages) pages which exceeds the limit of \(maxPages)"
+        case .imageDimensionsExceeded(let width, let height, let maxDimension):
+            return "Image dimensions \(width)x\(height) exceed the limit of \(maxDimension) pixels"
         case .imageLoadingFailed:
             return "Failed to load the image from the specified file"
         case .textRecognitionFailed(let message):
@@ -34,280 +52,431 @@ enum VisionError: Error, LocalizedError {
     }
 }
 
-@available(macOS 26.0, *)
-class VisionService {
-    
-    private let supportedExtensions = ["png", "jpg", "jpeg", "heic", "pdf"]
-    
-    func extractText(from filePath: String) async throws -> String {
-        let (url, fileExtension) = try validateFile(at: filePath)
-        let requestHandler = try createRequestHandler(from: url, fileExtension: fileExtension)
-        
-        // Create vision request
-        let request = VNRecognizeTextRequest()
-        request.recognitionLevel = .accurate
-        request.usesLanguageCorrection = true
-        
-        // Perform text recognition
-        do {
-            try requestHandler.perform([request])
-        } catch {
-            throw VisionError.textRecognitionFailed(error.localizedDescription)
+enum VisionRecognitionLevel: String, Sendable {
+    case accurate
+    case fast
+
+    var requestLevel: VNRequestTextRecognitionLevel {
+        switch self {
+        case .accurate:
+            return .accurate
+        case .fast:
+            return .fast
         }
-        
-        // Extract recognized text
-        guard let observations = request.results else {
-            throw VisionError.noTextFound
-        }
-        
-        let recognizedStrings = observations.compactMap { observation in
-            observation.topCandidates(1).first?.string
-        }
-        
-        guard !recognizedStrings.isEmpty else {
-            throw VisionError.noTextFound
-        }
-        
-        return recognizedStrings.joined(separator: "\n")
     }
-    
+}
+
+struct VisionRequestOptions: Sendable {
+    static let defaultMaxFileBytes = 25 * 1024 * 1024
+    static let defaultMaxPages = 50
+    static let defaultMaxImageDimension = 4096
+
+    let recognitionLevel: VisionRecognitionLevel
+    let usesLanguageCorrection: Bool
+    let recognitionLanguages: [String]
+    let maxPages: Int
+    let maxFileBytes: Int
+    let maxImageDimension: Int
+
+    init(
+        recognitionLevel: VisionRecognitionLevel = .accurate,
+        usesLanguageCorrection: Bool = true,
+        recognitionLanguages: [String] = [],
+        maxPages: Int = VisionRequestOptions.defaultMaxPages,
+        maxFileBytes: Int = VisionRequestOptions.defaultMaxFileBytes,
+        maxImageDimension: Int = VisionRequestOptions.defaultMaxImageDimension
+    ) {
+        self.recognitionLevel = recognitionLevel
+        self.usesLanguageCorrection = usesLanguageCorrection
+        self.recognitionLanguages = recognitionLanguages
+        self.maxPages = maxPages
+        self.maxFileBytes = maxFileBytes
+        self.maxImageDimension = maxImageDimension
+    }
+}
+
+@available(macOS 26.0, *)
+final class VisionService {
+    private static let supportedExtensions: Set<String> = ["png", "jpg", "jpeg", "heic", "pdf"]
+    private static let pdfRenderScale: CGFloat = 2.0
+
+    func extractText(from filePath: String) async throws -> String {
+        try await extractText(from: filePath, options: VisionRequestOptions())
+    }
+
+    func extractText(from filePath: String, options: VisionRequestOptions) async throws -> String {
+        let result = try await extractTextWithDetails(from: filePath, options: options)
+        return result.fullText
+    }
+
     func extractTextWithDetails(from filePath: String) async throws -> VisionResult {
-        let (url, fileExtension) = try validateFile(at: filePath)
-        let requestHandler = try createRequestHandler(from: url, fileExtension: fileExtension)
-        
-        // Create vision request
-        let request = VNRecognizeTextRequest()
-        request.recognitionLevel = .accurate
-        request.usesLanguageCorrection = true
-        
-        // Perform text recognition
-        do {
-            try requestHandler.perform([request])
-        } catch {
-            throw VisionError.textRecognitionFailed(error.localizedDescription)
-        }
-        
-        // Extract recognized text with details
-        guard let observations = request.results else {
-            throw VisionError.noTextFound
-        }
-        
-        let textBlocks = observations.compactMap { observation -> TextBlock? in
-            guard let candidate = observation.topCandidates(1).first else { return nil }
-            
-            return TextBlock(
-                text: candidate.string,
-                confidence: candidate.confidence,
-                boundingBox: observation.boundingBox
-            )
-        }
-        
+        try await extractTextWithDetails(from: filePath, options: VisionRequestOptions())
+    }
+
+    func extractTextWithDetails(from filePath: String, options: VisionRequestOptions) async throws -> VisionResult {
+        let document = try analyzeDocument(at: filePath, options: options)
+        let textBlocks = document.pages.flatMap(\.textBlocks)
         guard !textBlocks.isEmpty else {
             throw VisionError.noTextFound
         }
-        
-        let fullText = textBlocks.map { $0.text }.joined(separator: "\n")
-        
         return VisionResult(
-            fullText: fullText,
+            fullText: document.fullText,
             textBlocks: textBlocks,
-            filePath: filePath
+            filePath: filePath,
+            pages: document.pages,
+            documentHints: document.documentHints
         )
     }
-    
+
     func extractTables(from filePath: String) async throws -> [TableResult] {
-        let (url, fileExtension) = try validateFile(at: filePath)
-        let requestHandler = try createRequestHandler(from: url, fileExtension: fileExtension)
-        
-        // First, try document segmentation to identify potential table regions
-        let segmentationRequest = VNDetectDocumentSegmentationRequest()
-        
-        do {
-            try requestHandler.perform([segmentationRequest])
-        } catch {
-            throw VisionError.documentSegmentationFailed(error.localizedDescription)
-        }
-        
-        // Get text recognition for the entire document
-        let textRequest = VNRecognizeTextRequest()
-        textRequest.recognitionLevel = .accurate
-        textRequest.usesLanguageCorrection = true
-        
-        do {
-            try requestHandler.perform([textRequest])
-        } catch {
-            throw VisionError.textRecognitionFailed(error.localizedDescription)
-        }
-        
-        guard let textObservations = textRequest.results else {
-            throw VisionError.noTextFound
-        }
-        
-        // Convert observations to text blocks with positions
-        let textBlocks = textObservations.compactMap { observation -> PositionedTextBlock? in
-            guard let candidate = observation.topCandidates(1).first else { return nil }
-            
-            return PositionedTextBlock(
-                text: candidate.string,
-                confidence: candidate.confidence,
-                boundingBox: observation.boundingBox
-            )
-        }
-        
-        // Analyze spatial relationships to detect tables
-        let tableAnalyzer = TableAnalyzer()
-        let detectedTables = tableAnalyzer.detectTables(from: textBlocks)
-        
-        guard !detectedTables.isEmpty else {
+        try await extractTables(from: filePath, options: VisionRequestOptions())
+    }
+
+    func extractTables(from filePath: String, options: VisionRequestOptions) async throws -> [TableResult] {
+        let document = try analyzeDocument(at: filePath, options: options)
+        let tables = document.pages.flatMap(\.tables)
+        guard !tables.isEmpty else {
             throw VisionError.noTablesFound
         }
-        
-        return detectedTables
+        return tables
     }
-    
+
     func debugRawDetection(from filePath: String) async throws -> String {
-        let (url, fileExtension) = try validateFile(at: filePath)
-        let requestHandler = try createRequestHandler(from: url, fileExtension: fileExtension)
-        
-        // Get text recognition for the entire document
-        let textRequest = VNRecognizeTextRequest()
-        textRequest.recognitionLevel = .accurate
-        textRequest.usesLanguageCorrection = true
-        
-        do {
-            try requestHandler.perform([textRequest])
-        } catch {
-            throw VisionError.textRecognitionFailed(error.localizedDescription)
+        try await debugRawDetection(from: filePath, options: VisionRequestOptions())
+    }
+
+    func debugRawDetection(from filePath: String, options: VisionRequestOptions) async throws -> String {
+        let (url, fileExtension) = try validateFile(at: filePath, maxBytes: options.maxFileBytes)
+        let pageSources = try createPageSources(from: url, fileExtension: fileExtension, options: options)
+        var sections: [String] = []
+
+        for page in pageSources {
+            let textRequest = makeTextRequest(options: options)
+            do {
+                try page.requestHandler.perform([textRequest])
+            } catch {
+                throw VisionError.textRecognitionFailed(error.localizedDescription)
+            }
+
+            guard let observations = textRequest.results else { continue }
+            var debugOutput = "=== PAGE \(page.pageNumber) RAW VISION DETECTION ===\n"
+            debugOutput += "Total text blocks detected: \(observations.count)\n\n"
+            let sortedObservations = observations.sorted { first, second in
+                if abs(first.boundingBox.origin.y - second.boundingBox.origin.y) < 0.01 {
+                    return first.boundingBox.origin.x < second.boundingBox.origin.x
+                }
+                return first.boundingBox.origin.y > second.boundingBox.origin.y
+            }
+
+            for (index, observation) in sortedObservations.enumerated() {
+                guard let candidate = observation.topCandidates(1).first else { continue }
+                let box = observation.boundingBox
+                debugOutput += "Block \(index + 1):\n"
+                debugOutput += "  Text: \"\(candidate.string)\"\n"
+                debugOutput += "  Confidence: \(String(format: "%.3f", candidate.confidence))\n"
+                debugOutput += "  Position: x=\(String(format: "%.3f", box.origin.x)), y=\(String(format: "%.3f", box.origin.y))\n"
+                debugOutput += "  Size: width=\(String(format: "%.3f", box.width)), height=\(String(format: "%.3f", box.height))\n\n"
+            }
+            sections.append(debugOutput)
         }
-        
-        guard let textObservations = textRequest.results else {
+
+        let output = sections.joined(separator: "\n")
+        guard !output.isEmpty else { throw VisionError.noTextFound }
+        return output
+    }
+
+    private func analyzeDocument(at filePath: String, options: VisionRequestOptions) throws -> VisionDocumentResult {
+        let (url, fileExtension) = try validateFile(at: filePath, maxBytes: options.maxFileBytes)
+        let pageSources = try createPageSources(from: url, fileExtension: fileExtension, options: options)
+        var pageResults: [VisionPageResult] = []
+        let analyzer = TableAnalyzer()
+
+        for page in pageSources {
+            let textRequest = makeTextRequest(options: options)
+            do {
+                try page.requestHandler.perform([textRequest])
+            } catch {
+                throw VisionError.textRecognitionFailed(error.localizedDescription)
+            }
+
+            let observations = textRequest.results ?? []
+            let textBlocks = observations.compactMap { observation -> TextBlock? in
+                guard let candidate = observation.topCandidates(1).first else { return nil }
+                return TextBlock(
+                    text: candidate.string,
+                    confidence: candidate.confidence,
+                    boundingBox: observation.boundingBox,
+                    pageNumber: page.pageNumber
+                )
+            }
+
+            let positionedBlocks = observations.compactMap { observation -> PositionedTextBlock? in
+                guard let candidate = observation.topCandidates(1).first else { return nil }
+                return PositionedTextBlock(
+                    text: candidate.string,
+                    confidence: candidate.confidence,
+                    boundingBox: observation.boundingBox,
+                    pageNumber: page.pageNumber
+                )
+            }
+
+            let tables = analyzer.detectTables(from: positionedBlocks, pageNumber: page.pageNumber)
+            let fullText = textBlocks.map(\.text).joined(separator: "\n")
+            pageResults.append(
+                VisionPageResult(
+                    pageNumber: page.pageNumber,
+                    fullText: fullText,
+                    textBlocks: textBlocks,
+                    tables: tables,
+                    width: page.size.width,
+                    height: page.size.height
+                )
+            )
+        }
+
+        let allTextBlocks = pageResults.flatMap(\.textBlocks)
+        guard !allTextBlocks.isEmpty else {
             throw VisionError.noTextFound
         }
-        
-        // Create debug output with all detected text blocks and their positions
-        var debugOutput = "=== RAW VISION FRAMEWORK DETECTION ===\n"
-        debugOutput += "Total text blocks detected: \(textObservations.count)\n\n"
-        
-        // Sort by Y position (top to bottom) for better readability
-        let sortedObservations = textObservations.sorted { first, second in
-            if abs(first.boundingBox.origin.y - second.boundingBox.origin.y) < 0.01 {
-                return first.boundingBox.origin.x < second.boundingBox.origin.x
-            }
-            return first.boundingBox.origin.y > second.boundingBox.origin.y
-        }
-        
-        for (index, observation) in sortedObservations.enumerated() {
-            guard let candidate = observation.topCandidates(1).first else { continue }
-            
-            let text = candidate.string
-            let confidence = candidate.confidence
-            let boundingBox = observation.boundingBox
-            
-            debugOutput += "Block \(index + 1):\n"
-            debugOutput += "  Text: \"\(text)\"\n"
-            debugOutput += "  Confidence: \(String(format: "%.3f", confidence))\n"
-            debugOutput += "  Position: x=\(String(format: "%.3f", boundingBox.origin.x)), y=\(String(format: "%.3f", boundingBox.origin.y))\n"
-            debugOutput += "  Size: width=\(String(format: "%.3f", boundingBox.width)), height=\(String(format: "%.3f", boundingBox.height))\n"
-            debugOutput += "\n"
-        }
-        
-        return debugOutput
+
+        let fullText = pageResults
+            .map { "Page \($0.pageNumber)\n\($0.fullText)" }
+            .joined(separator: "\n\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return VisionDocumentResult(
+            filePath: filePath,
+            fullText: fullText,
+            pages: pageResults,
+            documentHints: deriveDocumentHints(from: pageResults)
+        )
     }
-    
-    private func createPDFRequestHandler(from url: URL) throws -> VNImageRequestHandler {
-        guard let pdfDocument = PDFDocument(url: url) else {
-            throw VisionError.imageLoadingFailed
-        }
-        
-        guard pdfDocument.pageCount > 0 else {
-            throw VisionError.imageLoadingFailed
-        }
-        
-        // Use the first page of the PDF
-        guard let pdfPage = pdfDocument.page(at: 0) else {
-            throw VisionError.imageLoadingFailed
-        }
-        
-        // Convert PDF page to image using macOS APIs
-        let pageRect = pdfPage.bounds(for: .mediaBox)
-        let scale: CGFloat = 2.0 // Use 2x scale for better quality
-        let scaledSize = CGSize(width: pageRect.width * scale, height: pageRect.height * scale)
-        
-        guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
-              let context = CGContext(data: nil,
-                                    width: Int(scaledSize.width),
-                                    height: Int(scaledSize.height),
-                                    bitsPerComponent: 8,
-                                    bytesPerRow: 0,
-                                    space: colorSpace,
-                                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else {
-            throw VisionError.imageLoadingFailed
-        }
-        
-        // Set white background
-        context.setFillColor(CGColor.white)
-        context.fill(CGRect(origin: .zero, size: scaledSize))
-        
-        // Scale and render PDF page
-        context.scaleBy(x: scale, y: scale)
-        context.translateBy(x: 0, y: pageRect.height)
-        context.scaleBy(x: 1.0, y: -1.0)
-        pdfPage.draw(with: .mediaBox, to: context)
-        
-        guard let cgImage = context.makeImage() else {
-            throw VisionError.imageLoadingFailed
-        }
-        
-        return VNImageRequestHandler(cgImage: cgImage)
-    }
-    
-    private func validateFile(at filePath: String) throws -> (URL, String) {
+
+    private func validateFile(at filePath: String, maxBytes: Int) throws -> (URL, String) {
         let url = URL(fileURLWithPath: filePath)
         guard FileManager.default.fileExists(atPath: filePath) else {
             throw VisionError.fileNotFound
         }
-        
+
+        let values = try url.resourceValues(forKeys: [.fileSizeKey])
+        let fileSize = values.fileSize ?? 0
+        if fileSize > maxBytes {
+            throw VisionError.requestTooLarge(actualBytes: fileSize, maxBytes: maxBytes)
+        }
+
         let fileExtension = url.pathExtension.lowercased()
-        guard supportedExtensions.contains(fileExtension) else {
+        guard Self.supportedExtensions.contains(fileExtension) else {
             throw VisionError.unsupportedFormat
         }
-        
+
         return (url, fileExtension)
     }
-    
-    private func createRequestHandler(from url: URL, fileExtension: String) throws -> VNImageRequestHandler {
+
+    private func createPageSources(from url: URL, fileExtension: String, options: VisionRequestOptions) throws -> [VisionPageSource] {
         if fileExtension == "pdf" {
-            // Handle PDF files
-            return try createPDFRequestHandler(from: url)
-        } else {
-            // Handle image files
-            let imageData: Data
-            do {
-                imageData = try Data(contentsOf: url)
-            } catch {
+            return try createPDFPageSources(from: url, options: options)
+        }
+        return [try createImagePageSource(from: url, pageNumber: 1, options: options)]
+    }
+
+    private func createImagePageSource(from url: URL, pageNumber: Int, options: VisionRequestOptions) throws -> VisionPageSource {
+        let imageData: Data
+        do {
+            imageData = try Data(contentsOf: url)
+        } catch {
+            throw VisionError.imageLoadingFailed
+        }
+        return try createImagePageSource(from: imageData, pageNumber: pageNumber, options: options)
+    }
+
+    private func createImagePageSource(from data: Data, pageNumber: Int, options: VisionRequestOptions) throws -> VisionPageSource {
+        let metadata = try validateImageDimensions(data: data, maxDimension: options.maxImageDimension)
+        return VisionPageSource(
+            pageNumber: pageNumber,
+            requestHandler: VNImageRequestHandler(data: data),
+            size: metadata
+        )
+    }
+
+    private func createPDFPageSources(from url: URL, options: VisionRequestOptions) throws -> [VisionPageSource] {
+        guard let pdfDocument = PDFDocument(url: url), pdfDocument.pageCount > 0 else {
+            throw VisionError.imageLoadingFailed
+        }
+        if pdfDocument.pageCount > options.maxPages {
+            throw VisionError.pageLimitExceeded(actualPages: pdfDocument.pageCount, maxPages: options.maxPages)
+        }
+
+        var pageSources: [VisionPageSource] = []
+        for index in 0..<pdfDocument.pageCount {
+            guard let page = pdfDocument.page(at: index) else { continue }
+            let pageRect = page.bounds(for: .mediaBox)
+            let scaledSize = CGSize(
+                width: pageRect.width * Self.pdfRenderScale,
+                height: pageRect.height * Self.pdfRenderScale
+            )
+            guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+                  let context = CGContext(
+                    data: nil,
+                    width: Int(scaledSize.width),
+                    height: Int(scaledSize.height),
+                    bitsPerComponent: 8,
+                    bytesPerRow: 0,
+                    space: colorSpace,
+                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                  ) else {
                 throw VisionError.imageLoadingFailed
             }
-            return VNImageRequestHandler(data: imageData)
+
+            context.setFillColor(CGColor.white)
+            context.fill(CGRect(origin: .zero, size: scaledSize))
+            context.scaleBy(x: Self.pdfRenderScale, y: Self.pdfRenderScale)
+            context.translateBy(x: 0, y: pageRect.height)
+            context.scaleBy(x: 1.0, y: -1.0)
+            page.draw(with: .mediaBox, to: context)
+
+            guard let cgImage = context.makeImage() else {
+                throw VisionError.imageLoadingFailed
+            }
+
+            if Int(max(cgImage.width, cgImage.height)) > options.maxImageDimension {
+                throw VisionError.imageDimensionsExceeded(
+                    width: cgImage.width,
+                    height: cgImage.height,
+                    maxDimension: options.maxImageDimension
+                )
+            }
+
+            pageSources.append(
+                VisionPageSource(
+                    pageNumber: index + 1,
+                    requestHandler: VNImageRequestHandler(cgImage: cgImage),
+                    size: CGSize(width: cgImage.width, height: cgImage.height)
+                )
+            )
         }
+
+        return pageSources
     }
+
+    private func validateImageDimensions(data: Data, maxDimension: Int) throws -> CGSize {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let width = properties[kCGImagePropertyPixelWidth] as? Int,
+              let height = properties[kCGImagePropertyPixelHeight] as? Int else {
+            throw VisionError.imageLoadingFailed
+        }
+
+        if max(width, height) > maxDimension {
+            throw VisionError.imageDimensionsExceeded(width: width, height: height, maxDimension: maxDimension)
+        }
+        return CGSize(width: width, height: height)
+    }
+
+    private func makeTextRequest(options: VisionRequestOptions) -> VNRecognizeTextRequest {
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = options.recognitionLevel.requestLevel
+        request.usesLanguageCorrection = options.usesLanguageCorrection
+        if !options.recognitionLanguages.isEmpty {
+            request.recognitionLanguages = options.recognitionLanguages
+        }
+        return request
+    }
+
+    private func deriveDocumentHints(from pages: [VisionPageResult]) -> [String] {
+        let fullText = pages.map(\.fullText).joined(separator: "\n").lowercased()
+        var hints: [String] = []
+        if pages.count > 1 {
+            hints.append("multi_page")
+        }
+        if pages.contains(where: { !$0.tables.isEmpty }) {
+            hints.append("table_like")
+        }
+        if fullText.contains("invoice") || fullText.contains("bill to") || fullText.contains("payment due") {
+            hints.append("invoice")
+        }
+        if fullText.contains("receipt") || fullText.contains("subtotal") || fullText.contains("tax") {
+            hints.append("receipt")
+        }
+        if fullText.contains("application") || fullText.contains("signature") || fullText.contains("date:") {
+            hints.append("form")
+        }
+        if hints.isEmpty {
+            hints.append("document")
+        }
+        return hints
+    }
+}
+
+private struct VisionPageSource {
+    let pageNumber: Int
+    let requestHandler: VNImageRequestHandler
+    let size: CGSize
+}
+
+struct VisionDocumentResult {
+    let filePath: String
+    let fullText: String
+    let pages: [VisionPageResult]
+    let documentHints: [String]
+}
+
+struct VisionPageResult {
+    let pageNumber: Int
+    let fullText: String
+    let textBlocks: [TextBlock]
+    let tables: [TableResult]
+    let width: Double
+    let height: Double
 }
 
 struct TextBlock {
     let text: String
     let confidence: Float
     let boundingBox: CGRect
+    let pageNumber: Int
+
+    init(text: String, confidence: Float, boundingBox: CGRect, pageNumber: Int = 1) {
+        self.text = text
+        self.confidence = confidence
+        self.boundingBox = boundingBox
+        self.pageNumber = pageNumber
+    }
 }
 
 struct VisionResult {
     let fullText: String
     let textBlocks: [TextBlock]
     let filePath: String
+    let pages: [VisionPageResult]
+    let documentHints: [String]
+
+    init(
+        fullText: String,
+        textBlocks: [TextBlock],
+        filePath: String,
+        pages: [VisionPageResult] = [],
+        documentHints: [String] = []
+    ) {
+        self.fullText = fullText
+        self.textBlocks = textBlocks
+        self.filePath = filePath
+        self.pages = pages
+        self.documentHints = documentHints
+    }
 }
 
 struct PositionedTextBlock {
     let text: String
     let confidence: Float
     let boundingBox: CGRect
+    let pageNumber: Int
+
+    init(text: String, confidence: Float, boundingBox: CGRect, pageNumber: Int = 1) {
+        self.text = text
+        self.confidence = confidence
+        self.boundingBox = boundingBox
+        self.pageNumber = pageNumber
+    }
 }
 
 struct TableResult {
@@ -315,265 +484,258 @@ struct TableResult {
     let columnCount: Int
     let averageConfidence: Float
     let boundingBox: CGRect
-    
+    let pageNumber: Int
+    let headers: [String]
+    let rowObjects: [[String: String]]
+    let mergedCellHints: [String]
+
+    init(
+        rows: [[String]],
+        columnCount: Int,
+        averageConfidence: Float,
+        boundingBox: CGRect,
+        pageNumber: Int = 1,
+        headers: [String] = [],
+        rowObjects: [[String: String]] = [],
+        mergedCellHints: [String] = []
+    ) {
+        self.rows = rows
+        self.columnCount = columnCount
+        self.averageConfidence = averageConfidence
+        self.boundingBox = boundingBox
+        self.pageNumber = pageNumber
+        self.headers = headers
+        self.rowObjects = rowObjects
+        self.mergedCellHints = mergedCellHints
+    }
+
     var csvData: String {
         let cleanedRows = rows.compactMap { row -> String? in
-            // Remove trailing empty cells
             var cleanRow = row
             while cleanRow.last?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
                 cleanRow.removeLast()
             }
-            
-            // Skip rows that are completely empty or only contain empty strings
+
             let hasContent = cleanRow.contains { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
             guard hasContent else { return nil }
-            
-            // Format each cell for CSV
-            let csvRow = cleanRow.map { cell in
+
+            return cleanRow.map { cell in
                 let trimmedCell = cell.trimmingCharacters(in: .whitespacesAndNewlines)
-                // Escape quotes and wrap in quotes if contains comma or quote
                 if trimmedCell.contains(",") || trimmedCell.contains("\"") || trimmedCell.contains("\n") {
                     return "\"" + trimmedCell.replacingOccurrences(of: "\"", with: "\"\"") + "\""
                 }
                 return trimmedCell
             }.joined(separator: ",")
-            
-            return csvRow
         }
-        
+
         return cleanedRows.joined(separator: "\n")
     }
 }
 
-class TableAnalyzer {
-    func detectTables(from textBlocks: [PositionedTextBlock]) -> [TableResult] {
-        // Sort text blocks by Y position (top to bottom), then X position (left to right)
+final class TableAnalyzer {
+    func detectTables(from textBlocks: [PositionedTextBlock], pageNumber: Int) -> [TableResult] {
         let sortedBlocks = textBlocks.sorted { first, second in
             if abs(first.boundingBox.origin.y - second.boundingBox.origin.y) < 0.01 {
                 return first.boundingBox.origin.x < second.boundingBox.origin.x
             }
-            return first.boundingBox.origin.y > second.boundingBox.origin.y // Note: Y coordinates are flipped in Vision
+            return first.boundingBox.origin.y > second.boundingBox.origin.y
         }
-        
-        // Group text blocks into potential rows based on Y alignment
+
         let rowGroups = groupIntoRows(sortedBlocks)
-        
-        // Detect table structures from row groups
-        return detectTablesFromRows(rowGroups)
+        return detectTablesFromRows(rowGroups, pageNumber: pageNumber)
     }
-    
+
     private func groupIntoRows(_ blocks: [PositionedTextBlock]) -> [[PositionedTextBlock]] {
         var rowGroups: [[PositionedTextBlock]] = []
-        let yTolerance: Float = 0.02 // 2% tolerance for Y alignment
-        
+        let yTolerance: Float = 0.02
+
         for block in blocks {
             let blockY = Float(block.boundingBox.origin.y)
-            
-            // Try to find an existing row with similar Y coordinate
             if let existingRowIndex = rowGroups.firstIndex(where: { rowGroup in
                 let rowY = Float(rowGroup.first?.boundingBox.origin.y ?? 0)
                 return abs(blockY - rowY) <= yTolerance
             }) {
                 rowGroups[existingRowIndex].append(block)
             } else {
-                // Create a new row
                 rowGroups.append([block])
             }
         }
-        
-        // Sort blocks within each row by X position
-        for i in 0..<rowGroups.count {
-            rowGroups[i].sort { $0.boundingBox.origin.x < $1.boundingBox.origin.x }
+
+        for index in rowGroups.indices {
+            rowGroups[index].sort { $0.boundingBox.origin.x < $1.boundingBox.origin.x }
         }
-        
+
         return rowGroups
     }
-    
-    private func detectTablesFromRows(_ rowGroups: [[PositionedTextBlock]]) -> [TableResult] {
+
+    private func detectTablesFromRows(_ rowGroups: [[PositionedTextBlock]], pageNumber: Int) -> [TableResult] {
         var tables: [TableResult] = []
-        
-        // Look for sequences of rows that could form tables
         var currentTableRows: [[PositionedTextBlock]] = []
         var maxColumnsSeen = 0
-        
+
         for rowGroup in rowGroups {
             let currentColumnCount = rowGroup.count
-            
-            // A table row should have at least 1 column (allowing for sparse rows)
             if currentColumnCount >= 1 {
                 if currentTableRows.isEmpty {
-                    // Start a new table
                     currentTableRows = [rowGroup]
                     maxColumnsSeen = currentColumnCount
                 } else {
-                    // Check if this row could belong to the current table
-                    let shouldContinueTable = isRowPartOfTable(rowGroup, comparedTo: currentTableRows, maxColumns: maxColumnsSeen)
-                    
-                    if shouldContinueTable {
+                    let shouldContinue = isRowPartOfTable(
+                        rowGroup,
+                        comparedTo: currentTableRows,
+                        maxColumns: maxColumnsSeen
+                    )
+                    if shouldContinue {
                         currentTableRows.append(rowGroup)
                         maxColumnsSeen = max(maxColumnsSeen, currentColumnCount)
                     } else {
-                        // Finalize the current table if it has enough rows
-                        if currentTableRows.count >= 2 && maxColumnsSeen >= 2 {
-                            if let table = createTable(from: currentTableRows) {
-                                tables.append(table)
-                            }
+                        if currentTableRows.count >= 2 && maxColumnsSeen >= 2,
+                           let table = createTable(from: currentTableRows, pageNumber: pageNumber) {
+                            tables.append(table)
                         }
-                        
-                        // Start a new potential table
                         currentTableRows = [rowGroup]
                         maxColumnsSeen = currentColumnCount
                     }
                 }
             } else {
-                // Empty row or single column - finalize current table
-                if currentTableRows.count >= 2 && maxColumnsSeen >= 2 {
-                    if let table = createTable(from: currentTableRows) {
-                        tables.append(table)
-                    }
+                if currentTableRows.count >= 2 && maxColumnsSeen >= 2,
+                   let table = createTable(from: currentTableRows, pageNumber: pageNumber) {
+                    tables.append(table)
                 }
                 currentTableRows = []
                 maxColumnsSeen = 0
             }
         }
-        
-        // Don't forget the last table
-        if currentTableRows.count >= 2 && maxColumnsSeen >= 2 {
-            if let table = createTable(from: currentTableRows) {
-                tables.append(table)
-            }
+
+        if currentTableRows.count >= 2 && maxColumnsSeen >= 2,
+           let table = createTable(from: currentTableRows, pageNumber: pageNumber) {
+            tables.append(table)
         }
-        
+
         return tables
     }
-    
-    private func isRowPartOfTable(_ newRow: [PositionedTextBlock], comparedTo existingRows: [[PositionedTextBlock]], maxColumns: Int) -> Bool {
+
+    private func isRowPartOfTable(
+        _ newRow: [PositionedTextBlock],
+        comparedTo existingRows: [[PositionedTextBlock]],
+        maxColumns: Int
+    ) -> Bool {
         guard !existingRows.isEmpty else { return true }
-        
-        // Check if the new row's text blocks align spatially with existing rows
-        let existingXPositions = existingRows.flatMap { row in 
+
+        let existingXPositions = existingRows.flatMap { row in
             row.map { Float($0.boundingBox.origin.x) }
         }.sorted()
-        
         let newRowXPositions = newRow.map { Float($0.boundingBox.origin.x) }.sorted()
-        
-        // If most of the new row's positions align with existing positions, it's likely part of the same table
+
         let alignmentCount = newRowXPositions.filter { newX in
             existingXPositions.contains { existingX in
-                abs(newX - existingX) <= 0.05 // 5% tolerance for alignment
+                abs(newX - existingX) <= 0.05
             }
         }.count
-        
-        // Consider it part of the table if at least 50% of positions align, or if column count is reasonable
-        let alignmentRatio = Float(alignmentCount) / Float(newRowXPositions.count)
-        let columnCountReasonable = newRow.count <= maxColumns * 2 // Allow up to 2x the max columns seen
-        
+
+        let alignmentRatio = Float(alignmentCount) / Float(max(newRowXPositions.count, 1))
+        let columnCountReasonable = newRow.count <= maxColumns * 2
         return alignmentRatio >= 0.3 || columnCountReasonable
     }
-    
-    private func createTable(from rowGroups: [[PositionedTextBlock]]) -> TableResult? {
+
+    private func createTable(from rowGroups: [[PositionedTextBlock]], pageNumber: Int) -> TableResult? {
         guard rowGroups.count >= 2 else { return nil }
-        
-        // Use the first row (usually the header) to establish column structure
         let headerRow = rowGroups.first!
         guard headerRow.count >= 2 else { return nil }
-        
-        // Calculate column positions based on all text blocks, but prioritize the header row structure
+
         let columnPositions = calculateColumnPositions(from: rowGroups, prioritizeRow: headerRow)
         let maxColumns = columnPositions.count
-        
-        // Convert to string matrix, aligning columns based on calculated positions
         var tableData: [[String]] = []
         var allConfidences: [Float] = []
-        
+
         for rowGroup in rowGroups {
-            var row: [String] = Array(repeating: "", count: maxColumns)
-            
+            var row = Array(repeating: "", count: maxColumns)
             for block in rowGroup {
-                // Find the best column for this block based on its X position
-                let blockX = Float(block.boundingBox.origin.x)
-                let columnIndex = findBestColumn(for: blockX, in: columnPositions)
-                
+                let columnIndex = findBestColumn(for: Float(block.boundingBox.origin.x), in: columnPositions)
                 if columnIndex < maxColumns {
                     row[columnIndex] = block.text.trimmingCharacters(in: .whitespacesAndNewlines)
                     allConfidences.append(block.confidence)
                 }
             }
-            
             tableData.append(row)
         }
-        
-        // Calculate bounding box encompassing all table cells
+
         let allBlocks = rowGroups.flatMap { $0 }
         let minX = allBlocks.map { $0.boundingBox.origin.x }.min() ?? 0
         let maxX = allBlocks.map { $0.boundingBox.maxX }.max() ?? 0
         let minY = allBlocks.map { $0.boundingBox.origin.y }.min() ?? 0
         let maxY = allBlocks.map { $0.boundingBox.maxY }.max() ?? 0
-        
         let tableBoundingBox = CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
-        
         let averageConfidence = allConfidences.isEmpty ? 0.0 : allConfidences.reduce(0, +) / Float(allConfidences.count)
-        
+
+        let headers = normalizedHeaders(from: tableData.first ?? [])
+        let rowObjects = tableData.dropFirst().map { row in
+            var object: [String: String] = [:]
+            for index in 0..<min(headers.count, row.count) {
+                object[headers[index]] = row[index]
+            }
+            return object
+        }
+        let mergedCellHints = deriveMergedCellHints(from: tableData)
+
         return TableResult(
             rows: tableData,
             columnCount: maxColumns,
             averageConfidence: averageConfidence,
-            boundingBox: tableBoundingBox
+            boundingBox: tableBoundingBox,
+            pageNumber: pageNumber,
+            headers: headers,
+            rowObjects: rowObjects,
+            mergedCellHints: mergedCellHints
         )
     }
-    
-    private func calculateColumnPositions(from rowGroups: [[PositionedTextBlock]], prioritizeRow: [PositionedTextBlock]) -> [Float] {
-        // Start with positions from the priority row (header)
-        var columnPositions = prioritizeRow.map { Float($0.boundingBox.origin.x) }.sorted()
-        
-        // Collect all other X positions from remaining rows
-        var allXPositions: [Float] = []
+
+    private func calculateColumnPositions(
+        from rowGroups: [[PositionedTextBlock]],
+        prioritizeRow: [PositionedTextBlock]
+    ) -> [Float] {
+        var positions = prioritizeRow.map { Float($0.boundingBox.origin.x) }
+
         for rowGroup in rowGroups {
             for block in rowGroup {
-                allXPositions.append(Float(block.boundingBox.origin.x))
+                let x = Float(block.boundingBox.origin.x)
+                if !positions.contains(where: { abs($0 - x) <= 0.05 }) {
+                    positions.append(x)
+                }
             }
         }
-        allXPositions.sort()
-        
-        // Use a dynamic tolerance based on the average distance between header columns
-        let dynamicTolerance = calculateDynamicTolerance(for: columnPositions)
-        
-        // Add additional column positions if they don't conflict with existing ones
-        for position in allXPositions {
-            let tooClose = columnPositions.contains { abs(position - $0) <= dynamicTolerance }
-            if !tooClose {
-                columnPositions.append(position)
-            }
-        }
-        
-        return columnPositions.sorted()
+        return positions.sorted()
     }
-    
-    private func calculateDynamicTolerance(for positions: [Float]) -> Float {
-        guard positions.count > 1 else { return 0.01 }
-        
-        var distances: [Float] = []
-        for i in 1..<positions.count {
-            distances.append(positions[i] - positions[i-1])
-        }
-        
-        let avgDistance = distances.reduce(0, +) / Float(distances.count)
-        // Use 25% of average distance as tolerance, with min/max bounds
-        return max(0.005, min(0.03, avgDistance * 0.25))
-    }
-    
-    private func findBestColumn(for xPosition: Float, in columnPositions: [Float]) -> Int {
-        var bestColumn = 0
-        var minDistance = Float.greatestFiniteMagnitude
-        
-        for (index, columnX) in columnPositions.enumerated() {
-            let distance = abs(xPosition - columnX)
-            if distance < minDistance {
-                minDistance = distance
-                bestColumn = index
+
+    private func findBestColumn(for blockX: Float, in columnPositions: [Float]) -> Int {
+        guard !columnPositions.isEmpty else { return 0 }
+        var bestIndex = 0
+        var bestDistance = abs(blockX - columnPositions[0])
+        for (index, position) in columnPositions.enumerated().dropFirst() {
+            let distance = abs(blockX - position)
+            if distance < bestDistance {
+                bestDistance = distance
+                bestIndex = index
             }
         }
-        
-        return bestColumn
+        return bestIndex
+    }
+
+    private func normalizedHeaders(from row: [String]) -> [String] {
+        row.enumerated().map { index, value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? "column_\(index + 1)" : trimmed
+        }
+    }
+
+    private func deriveMergedCellHints(from rows: [[String]]) -> [String] {
+        var hints: [String] = []
+        for (rowIndex, row) in rows.enumerated() where row.count >= 3 {
+            let emptyRuns = row.enumerated().filter { $0.element.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            if !emptyRuns.isEmpty {
+                hints.append("row_\(rowIndex + 1)_contains_sparse_cells")
+            }
+        }
+        return hints
     }
 }

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -240,6 +240,8 @@ class Server {
             return response
         }
 
+        try app.register(collection: VisionAPIController())
+
         if let mlxModelID = mlxModelID, let mlxModelService = mlxModelService {
             let mlxController = MLXChatCompletionsController(
                 streamingEnabled: streamingEnabled,
@@ -340,7 +342,7 @@ class Server {
             let isFoundation = modelParam == nil || modelParam == "foundation"
 
             var nCtx = 4096
-            var hasVision = false
+            var hasVision = isFoundation
             var modelPath = "foundation"
 
             if !isFoundation, let modelName = modelParam {

--- a/Sources/MacLocalAPI/Utils/MLXMetalLibrary.swift
+++ b/Sources/MacLocalAPI/Utils/MLXMetalLibrary.swift
@@ -37,6 +37,28 @@ enum MLXMetalLibrary {
             .appendingPathComponent("default.metallib")
         if fileManager.fileExists(atPath: bundled.path) { return bundled }
 
+        // 3a. Walk up a few parent directories from the test runner/executable.
+        //     SwiftPM test layouts often place the test binary deeper than the app bundle.
+        var searchDir = executableDir
+        for _ in 0..<5 {
+            let candidate = searchDir
+                .appendingPathComponent("MacLocalAPI_MacLocalAPI.bundle")
+                .appendingPathComponent("default.metallib")
+            if fileManager.fileExists(atPath: candidate.path) { return candidate }
+            searchDir.deleteLastPathComponent()
+        }
+
+        // 3aa. Current working directory and common SwiftPM build layouts.
+        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let cwdCandidates = [
+            cwd.appendingPathComponent("MacLocalAPI_MacLocalAPI.bundle/default.metallib"),
+            cwd.appendingPathComponent(".build/debug/MacLocalAPI_MacLocalAPI.bundle/default.metallib"),
+            cwd.appendingPathComponent(".build/arm64-apple-macosx/debug/MacLocalAPI_MacLocalAPI.bundle/default.metallib"),
+        ]
+        for candidate in cwdCandidates where fileManager.fileExists(atPath: candidate.path) {
+            return candidate
+        }
+
         // 3b. Homebrew layout: binary in bin/, bundle in ../libexec/
         let homebrew = executableDir
             .deletingLastPathComponent()

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -1100,7 +1100,7 @@ struct MacLocalAPI: ParsableCommand {
             description: Extract text and tables from images/PDFs using Apple Vision OCR
             usage: afm vision -f <file> [--table]
             full_details: afm vision --help-json
-        api_endpoints: [/v1/chat/completions, /v1/models, /health]
+        api_endpoints: [/v1/chat/completions, /v1/models, /v1/vision/ocr, /health]
         env_vars:
           MACAFM_MLX_MODEL_CACHE: Override model cache directory
           MACAFM_MLX_METALLIB: Override metallib path
@@ -1178,7 +1178,7 @@ struct RootCommand: ParsableCommand {
             description: Extract text and tables from images/PDFs using Apple Vision OCR
             usage: afm vision -f <file> [--table]
             full_details: afm vision --help-json
-        api_endpoints: [/v1/chat/completions, /v1/models, /health]
+        api_endpoints: [/v1/chat/completions, /v1/models, /v1/vision/ocr, /health]
         env_vars:
           MACAFM_MLX_MODEL_CACHE: Override model cache directory
           MACAFM_MLX_METALLIB: Override metallib path

--- a/Tests/MacLocalAPITests/BatchDispatchTests.swift
+++ b/Tests/MacLocalAPITests/BatchDispatchTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Vapor
 import XCTVapor
+import VaporTesting
 import Foundation
 import Testing
 
@@ -45,42 +46,42 @@ private final class FakeBatchService: MLXChatServing, @unchecked Sendable {
     func resolvedToolCallParser(logBypass: Bool) -> String? { toolCallParser }
 
     func tryReserveSlot() -> Bool {
-        _lock.lock()
-        reserveSlotCallCount += 1
-        _lock.unlock()
-        return !shouldFailReserveSlot
+        _lock.withLock {
+            reserveSlotCallCount += 1
+            return !shouldFailReserveSlot
+        }
     }
 
     func releaseSlot() {
-        _lock.lock()
-        releaseSlotCallCount += 1
-        _lock.unlock()
+        _lock.withLock {
+            releaseSlotCallCount += 1
+        }
     }
 
     func ensureBatchMode(concurrency: Int) async throws {
-        _lock.lock()
-        ensureBatchModeCallCount += 1
-        let shouldFail = shouldFailEnsureBatchMode
-        _lock.unlock()
+        let shouldFail = _lock.withLock {
+            ensureBatchModeCallCount += 1
+            return shouldFailEnsureBatchMode
+        }
         if shouldFail {
             throw MLXServiceError.noModelLoaded
         }
     }
 
     func releaseBatchReference() {
-        _lock.lock()
-        releaseBatchReferenceCallCount += 1
-        _lock.unlock()
+        _lock.withLock {
+            releaseBatchReferenceCallCount += 1
+        }
     }
 
     private(set) var cancelBatchSlotsCallCount = 0
     private(set) var lastCancelledSlotIds: Set<UUID> = []
 
     func cancelBatchSlots(ids: Set<UUID>) async {
-        _lock.lock()
-        cancelBatchSlotsCallCount += 1
-        lastCancelledSlotIds = ids
-        _lock.unlock()
+        _lock.withLock {
+            cancelBatchSlotsCallCount += 1
+            lastCancelledSlotIds = ids
+        }
     }
 
     func startAPIProfile() {}
@@ -110,10 +111,49 @@ private final class FakeBatchService: MLXChatServing, @unchecked Sendable {
         tools: [RequestTool]?, stop: [String]?, responseFormat: ResponseFormat?,
         chatTemplateKwargs: [String: AnyCodable]?
     ) async throws -> ChatStreamingResult {
-        _lock.lock()
-        generateStreamingCallCount += 1
-        _lock.unlock()
+        _lock.withLock {
+            generateStreamingCallCount += 1
+        }
         return streamingResultFactory?(messages) ?? defaultStreamingResult
+    }
+
+    func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        requestId: String?
+    ) async throws -> ChatStreamingResult {
+        try await generateStreaming(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs
+        )
     }
 
     static func makeStreamingResult(chunks: [StreamChunk]) -> ChatStreamingResult {
@@ -1603,6 +1643,7 @@ struct BatchPostProcessingParityTests {
     func batchAPIThinkExtraction() async throws {
         let app = try await Application.make(.testing)
         defer { Task { try await app.asyncShutdown() } }
+        let tester = try app.testing(method: .running(port: 0))
 
         let svc = FakeBatchService(maxConcurrent: 8)
         svc.streamingResultFactory = { _ in
@@ -1629,13 +1670,13 @@ struct BatchPostProcessingParityTests {
         uploadHeaders.add(name: .contentType, value: "multipart/form-data; boundary=\(boundary)")
         let multipartBody = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"test.jsonl\"\r\nContent-Type: application/octet-stream\r\n\r\n\(jsonl)\r\n--\(boundary)--\r\n"
 
-        try await app.test(.POST, "/v1/files", headers: uploadHeaders, body: .init(string: multipartBody)) { res async in
+        try await tester.test(.POST, "/v1/files", headers: uploadHeaders, body: .init(string: multipartBody)) { res async in
             #expect(res.status == .ok)
             let file = try? res.content.decode(FileObject.self)
             guard let fileId = file?.id else { return }
 
             // Create batch
-            try? await app.test(.POST, "/v1/batches", beforeRequest: { req in
+            _ = try? await tester.test(.POST, "/v1/batches", beforeRequest: { req in
                 try req.content.encode(["input_file_id": fileId, "endpoint": "/v1/chat/completions", "completion_window": "24h"])
             }) { batchRes async in
                 #expect(batchRes.status == .ok)
@@ -1645,11 +1686,11 @@ struct BatchPostProcessingParityTests {
                 // Poll until completed (max 5 tries)
                 for _ in 0..<5 {
                     try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
-                    try? await app.test(.GET, "/v1/batches/\(batchId)") { pollRes async in
+                    _ = try? await tester.test(.GET, "/v1/batches/\(batchId)") { pollRes async in
                         let polled = try? pollRes.content.decode(BatchObject.self)
                         if polled?.status == "completed", let outputId = polled?.outputFileId {
                             // Check output file for reasoning_content
-                            try? await app.test(.GET, "/v1/files/\(outputId)/content") { contentRes async in
+                            _ = try? await tester.test(.GET, "/v1/files/\(outputId)/content") { contentRes async in
                                 let body = contentRes.body.string
                                 // The output should contain reasoning_content
                                 #expect(body.contains("reasoning_content") || body.contains("visible content"))
@@ -1667,6 +1708,7 @@ struct BatchPostProcessingParityTests {
     func batchAPILogprobs() async throws {
         let app = try await Application.make(.testing)
         defer { Task { try await app.asyncShutdown() } }
+        let tester = try app.testing(method: .running(port: 0))
 
         let svc = FakeBatchService(maxConcurrent: 8)
         svc.streamingResultFactory = { _ in
@@ -1696,11 +1738,11 @@ struct BatchPostProcessingParityTests {
         uploadHeaders.add(name: .contentType, value: "multipart/form-data; boundary=\(boundary)")
         let multipartBody = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"test.jsonl\"\r\nContent-Type: application/octet-stream\r\n\r\n\(jsonl)\r\n--\(boundary)--\r\n"
 
-        try await app.test(.POST, "/v1/files", headers: uploadHeaders, body: .init(string: multipartBody)) { res async in
+        try await tester.test(.POST, "/v1/files", headers: uploadHeaders, body: .init(string: multipartBody)) { res async in
             let file = try? res.content.decode(FileObject.self)
             guard let fileId = file?.id else { return }
 
-            try? await app.test(.POST, "/v1/batches", beforeRequest: { req in
+            _ = try? await tester.test(.POST, "/v1/batches", beforeRequest: { req in
                 try req.content.encode(["input_file_id": fileId, "endpoint": "/v1/chat/completions", "completion_window": "24h"])
             }) { batchRes async in
                 let batch = try? batchRes.content.decode(BatchObject.self)
@@ -1708,10 +1750,10 @@ struct BatchPostProcessingParityTests {
 
                 for _ in 0..<5 {
                     try? await Task.sleep(nanoseconds: 100_000_000)
-                    try? await app.test(.GET, "/v1/batches/\(batchId)") { pollRes async in
+                    _ = try? await tester.test(.GET, "/v1/batches/\(batchId)") { pollRes async in
                         let polled = try? pollRes.content.decode(BatchObject.self)
                         if polled?.status == "completed", let outputId = polled?.outputFileId {
-                            try? await app.test(.GET, "/v1/files/\(outputId)/content") { contentRes async in
+                            _ = try? await tester.test(.GET, "/v1/files/\(outputId)/content") { contentRes async in
                                 let body = contentRes.body.string
                                 #expect(body.contains("logprobs") || body.contains("Hi"))
                             }
@@ -1728,6 +1770,7 @@ struct BatchPostProcessingParityTests {
     func batchAPIToolCalls() async throws {
         let app = try await Application.make(.testing)
         defer { Task { try await app.asyncShutdown() } }
+        let tester = try app.testing(method: .running(port: 0))
 
         let tc = ResponseToolCall(
             index: 0, id: "call_abc", type: "function",
@@ -1757,11 +1800,11 @@ struct BatchPostProcessingParityTests {
         uploadHeaders.add(name: .contentType, value: "multipart/form-data; boundary=\(boundary)")
         let multipartBody = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"test.jsonl\"\r\nContent-Type: application/octet-stream\r\n\r\n\(jsonl)\r\n--\(boundary)--\r\n"
 
-        try await app.test(.POST, "/v1/files", headers: uploadHeaders, body: .init(string: multipartBody)) { res async in
+        try await tester.test(.POST, "/v1/files", headers: uploadHeaders, body: .init(string: multipartBody)) { res async in
             let file = try? res.content.decode(FileObject.self)
             guard let fileId = file?.id else { return }
 
-            try? await app.test(.POST, "/v1/batches", beforeRequest: { req in
+            _ = try? await tester.test(.POST, "/v1/batches", beforeRequest: { req in
                 try req.content.encode(["input_file_id": fileId, "endpoint": "/v1/chat/completions", "completion_window": "24h"])
             }) { batchRes async in
                 let batch = try? batchRes.content.decode(BatchObject.self)
@@ -1769,10 +1812,10 @@ struct BatchPostProcessingParityTests {
 
                 for _ in 0..<5 {
                     try? await Task.sleep(nanoseconds: 100_000_000)
-                    try? await app.test(.GET, "/v1/batches/\(batchId)") { pollRes async in
+                    _ = try? await tester.test(.GET, "/v1/batches/\(batchId)") { pollRes async in
                         let polled = try? pollRes.content.decode(BatchObject.self)
                         if polled?.status == "completed", let outputId = polled?.outputFileId {
-                            try? await app.test(.GET, "/v1/files/\(outputId)/content") { contentRes async in
+                            _ = try? await tester.test(.GET, "/v1/files/\(outputId)/content") { contentRes async in
                                 let body = contentRes.body.string
                                 #expect(body.contains("tool_calls"))
                                 #expect(body.contains("get_weather"))
@@ -1790,6 +1833,7 @@ struct BatchPostProcessingParityTests {
     func grammarDowngradeHeader() async throws {
         let app = try await Application.make(.testing)
         defer { Task { try await app.asyncShutdown() } }
+        let tester = try app.testing(method: .running(port: 0))
 
         let svc = FakeBatchService(maxConcurrent: 8)
         svc.supportsStrictToolGrammar = true
@@ -1801,7 +1845,7 @@ struct BatchPostProcessingParityTests {
         {"requests":[{"custom_id":"strict-1","body":{"model":"test-model","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"test","strict":true,"parameters":{"type":"object","properties":{"x":{"type":"string"}}}}}]}}]}
         """
 
-        try await app.test(.POST, "/v1/batch/completions", beforeRequest: { req in
+        try await tester.test(.POST, "/v1/batch/completions", beforeRequest: { req in
             req.headers.contentType = .json
             req.body = .init(string: body)
         }) { res async in
@@ -1815,6 +1859,7 @@ struct BatchPostProcessingParityTests {
     func grammarDowngradeHeaderSkippedForUnsupportedToolGrammar() async throws {
         let app = try await Application.make(.testing)
         defer { Task { try await app.asyncShutdown() } }
+        let tester = try app.testing(method: .running(port: 0))
 
         let svc = FakeBatchService(maxConcurrent: 8)
         svc.supportsStrictToolGrammar = false
@@ -1825,7 +1870,7 @@ struct BatchPostProcessingParityTests {
         {"requests":[{"custom_id":"strict-1","body":{"model":"test-model","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"test","strict":true,"parameters":{"type":"object","properties":{"x":{"type":"string"}}}}}]}}]}
         """
 
-        try await app.test(.POST, "/v1/batch/completions", beforeRequest: { req in
+        try await tester.test(.POST, "/v1/batch/completions", beforeRequest: { req in
             req.headers.contentType = .json
             req.body = .init(string: body)
         }) { res async in
@@ -1838,6 +1883,7 @@ struct BatchPostProcessingParityTests {
     func structuredOutputSanitizedInNonStreamingBatch() async throws {
         let app = try await Application.make(.testing)
         defer { Task { try await app.asyncShutdown() } }
+        let tester = try app.testing(method: .running(port: 0))
 
         let svc = FakeBatchService(maxConcurrent: 8)
         svc.streamingResultFactory = { _ in
@@ -1855,7 +1901,7 @@ struct BatchPostProcessingParityTests {
         {"requests":[{"custom_id":"json-1","body":{"model":"test-model","stream":false,"messages":[{"role":"user","content":"hi"}],"tools":[],"response_format":{"type":"json_object"}}}]}
         """
 
-        try await app.test(.POST, "/v1/batch/completions", beforeRequest: { req in
+        try await tester.test(.POST, "/v1/batch/completions", beforeRequest: { req in
             req.headers.contentType = .json
             req.body = .init(string: body)
         }) { res async in
@@ -1938,6 +1984,7 @@ struct BatchJSONLPerLineValidationTests {
     func rejectsWrongMethod() async throws {
         let app = try await Application.make(.testing)
         defer { Task { try await app.asyncShutdown() } }
+        let tester = try app.testing(method: .running(port: 0))
         let svc = FakeBatchService(maxConcurrent: 8)
         let store = BatchStore()
         let controller = BatchAPIController(service: svc, store: store, modelID: "test-model")
@@ -1948,7 +1995,7 @@ struct BatchJSONLPerLineValidationTests {
         {"custom_id":"bad","method":"GET","url":"/v1/chat/completions","body":{"model":"test","messages":[{"role":"user","content":"hi"}]}}
         """
         var fileId = ""
-        try await app.test(.POST, "/v1/files", beforeRequest: { req in
+        try await tester.test(.POST, "/v1/files", beforeRequest: { req in
             let boundary = "test-boundary"
             req.headers.contentType = .init(type: "multipart", subType: "form-data", parameters: ["boundary": boundary])
             var body = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n"
@@ -1964,7 +2011,7 @@ struct BatchJSONLPerLineValidationTests {
         }
 
         // Create batch — should fail with 400 on method validation
-        try await app.test(.POST, "/v1/batches", beforeRequest: { req in
+        try await tester.test(.POST, "/v1/batches", beforeRequest: { req in
             req.headers.contentType = .json
             req.body = .init(string: "{\"input_file_id\":\"\(fileId)\",\"endpoint\":\"/v1/chat/completions\",\"completion_window\":\"24h\"}")
         }) { res async in
@@ -1978,6 +2025,7 @@ struct BatchJSONLPerLineValidationTests {
     func rejectsWrongUrl() async throws {
         let app = try await Application.make(.testing)
         defer { Task { try await app.asyncShutdown() } }
+        let tester = try app.testing(method: .running(port: 0))
         let svc = FakeBatchService(maxConcurrent: 8)
         let store = BatchStore()
         let controller = BatchAPIController(service: svc, store: store, modelID: "test-model")
@@ -1987,7 +2035,7 @@ struct BatchJSONLPerLineValidationTests {
         {"custom_id":"bad","method":"POST","url":"/v1/embeddings","body":{"model":"test","messages":[{"role":"user","content":"hi"}]}}
         """
         var fileId = ""
-        try await app.test(.POST, "/v1/files", beforeRequest: { req in
+        try await tester.test(.POST, "/v1/files", beforeRequest: { req in
             let boundary = "test-boundary"
             req.headers.contentType = .init(type: "multipart", subType: "form-data", parameters: ["boundary": boundary])
             var body = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n"
@@ -2002,7 +2050,7 @@ struct BatchJSONLPerLineValidationTests {
             }
         }
 
-        try await app.test(.POST, "/v1/batches", beforeRequest: { req in
+        try await tester.test(.POST, "/v1/batches", beforeRequest: { req in
             req.headers.contentType = .json
             req.body = .init(string: "{\"input_file_id\":\"\(fileId)\",\"endpoint\":\"/v1/chat/completions\",\"completion_window\":\"24h\"}")
         }) { res async in
@@ -2016,6 +2064,7 @@ struct BatchJSONLPerLineValidationTests {
     func acceptsValidMethodAndUrl() async throws {
         let app = try await Application.make(.testing)
         defer { Task { try await app.asyncShutdown() } }
+        let tester = try app.testing(method: .running(port: 0))
         let svc = FakeBatchService(maxConcurrent: 8)
         let store = BatchStore()
         let controller = BatchAPIController(service: svc, store: store, modelID: "test-model")
@@ -2025,7 +2074,7 @@ struct BatchJSONLPerLineValidationTests {
         {"custom_id":"ok","method":"POST","url":"/v1/chat/completions","body":{"model":"test","messages":[{"role":"user","content":"hi"}]}}
         """
         var fileId = ""
-        try await app.test(.POST, "/v1/files", beforeRequest: { req in
+        try await tester.test(.POST, "/v1/files", beforeRequest: { req in
             let boundary = "test-boundary"
             req.headers.contentType = .init(type: "multipart", subType: "form-data", parameters: ["boundary": boundary])
             var body = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n"
@@ -2041,7 +2090,7 @@ struct BatchJSONLPerLineValidationTests {
         }
 
         // Should succeed (200, not 400)
-        try await app.test(.POST, "/v1/batches", beforeRequest: { req in
+        try await tester.test(.POST, "/v1/batches", beforeRequest: { req in
             req.headers.contentType = .json
             req.body = .init(string: "{\"input_file_id\":\"\(fileId)\",\"endpoint\":\"/v1/chat/completions\",\"completion_window\":\"24h\"}")
         }) { res async in
@@ -2057,6 +2106,7 @@ struct BatchCancelEndpointTests {
     func cancelNonInProgressReturns400() async throws {
         let app = try await Application.make(.testing)
         defer { Task { try await app.asyncShutdown() } }
+        let tester = try app.testing(method: .running(port: 0))
         let svc = FakeBatchService(maxConcurrent: 8)
         let store = BatchStore()
         let controller = BatchAPIController(service: svc, store: store, modelID: "test-model")
@@ -2065,7 +2115,7 @@ struct BatchCancelEndpointTests {
         let batchId = await store.createBatch(inputFileId: "f1", endpoint: "/v1/chat/completions", totalRequests: 1)
         // Leave in "validating" state (not in_progress)
 
-        try await app.test(.POST, "/v1/batches/\(batchId)/cancel") { res async in
+        try await tester.test(.POST, "/v1/batches/\(batchId)/cancel") { res async in
             #expect(res.status == .badRequest)
         }
     }
@@ -2074,6 +2124,7 @@ struct BatchCancelEndpointTests {
     func cancelTransitionsToCancelled() async throws {
         let app = try await Application.make(.testing)
         defer { Task { try await app.asyncShutdown() } }
+        let tester = try app.testing(method: .running(port: 0))
         let svc = FakeBatchService(maxConcurrent: 8)
         let store = BatchStore()
         let controller = BatchAPIController(service: svc, store: store, modelID: "test-model")
@@ -2082,7 +2133,7 @@ struct BatchCancelEndpointTests {
         let batchId = await store.createBatch(inputFileId: "f1", endpoint: "/v1/chat/completions", totalRequests: 2)
         await store.markBatchInProgress(batchId)
 
-        try await app.test(.POST, "/v1/batches/\(batchId)/cancel") { res async in
+        try await tester.test(.POST, "/v1/batches/\(batchId)/cancel") { res async in
             #expect(res.status == .ok)
             if let data = res.body.string.data(using: .utf8),
                let obj = try? JSONDecoder().decode(BatchObject.self, from: data) {
@@ -2095,12 +2146,13 @@ struct BatchCancelEndpointTests {
     func cancelNonexistentReturns404() async throws {
         let app = try await Application.make(.testing)
         defer { Task { try await app.asyncShutdown() } }
+        let tester = try app.testing(method: .running(port: 0))
         let svc = FakeBatchService(maxConcurrent: 8)
         let store = BatchStore()
         let controller = BatchAPIController(service: svc, store: store, modelID: "test-model")
         try app.register(collection: controller)
 
-        try await app.test(.POST, "/v1/batches/batch_nonexistent/cancel") { res async in
+        try await tester.test(.POST, "/v1/batches/batch_nonexistent/cancel") { res async in
             #expect(res.status == .notFound)
         }
     }

--- a/Tests/MacLocalAPITests/LogitProcessorBatchTests.swift
+++ b/Tests/MacLocalAPITests/LogitProcessorBatchTests.swift
@@ -11,6 +11,10 @@ import MLX
 struct LogitProcessorBatchTests {
 // dimensions: execution=batch, sampling_params=top_k/min_p/presence_penalty/repetition_penalty
 
+    init() throws {
+        try MLXMetalLibrary.ensureAvailable(verbose: false)
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // MARK: - TopKProcessor
     // ═══════════════════════════════════════════════════════════════════

--- a/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
+++ b/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
@@ -809,6 +809,45 @@ private final class FakeMLXChatService: MLXChatServing, @unchecked Sendable {
         return streamingHandler?(messages) ?? streamingResult
     }
 
+    func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        requestId: String?
+    ) async throws -> ChatStreamingResult {
+        try await generateStreaming(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs
+        )
+    }
+
     private func recordGenerateTools(_ tools: [RequestTool]?) {
         stateLock.lock()
         recordedGenerateToolNames.append(tools?.map(\.function.name) ?? [])

--- a/Tests/MacLocalAPITests/NullableToolSchemaTests.swift
+++ b/Tests/MacLocalAPITests/NullableToolSchemaTests.swift
@@ -74,12 +74,13 @@ struct NullableToolSchemaTests {
         let jinjaValue = try Value(any: compatible)
         #expect(!jinjaValue.isNull)
 
-        // Verify "default" key was stripped
+        // Verify "default" key was stripped and nullable anyOf collapsed to a concrete type.
         if let dict = compatible as? [String: Any],
            let props = dict["properties"] as? [String: Any],
            let units = props["units"] as? [String: Any] {
             #expect(units["default"] == nil, "null-valued 'default' key should be stripped")
-            #expect(units["anyOf"] != nil, "non-null 'anyOf' key should be preserved")
+            #expect(units["anyOf"] == nil, "nullable anyOf should be flattened for template compatibility")
+            #expect(units["type"] as? String == "string", "flattened nullable schema should preserve the concrete type")
         } else {
             Issue.record("Expected nested dict structure")
         }

--- a/Tests/MacLocalAPITests/VisionAPIControllerTests.swift
+++ b/Tests/MacLocalAPITests/VisionAPIControllerTests.swift
@@ -1,0 +1,250 @@
+import XCTest
+import Vapor
+import XCTVapor
+
+@testable import MacLocalAPI
+
+final class VisionAPIControllerTests: XCTestCase {
+    private var app: Application!
+
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
+    func testOCRReturnsStructuredDocumentPayload() async throws {
+        let service = FakeVisionService()
+        service.verboseResult = makeVisionResult(filePath: "/tmp/doc.png")
+        try VisionAPIController(makeVisionService: { service }).boot(routes: app)
+
+        let body = ByteBuffer(string: #"{"file":"~/doc.png","recognition_level":"fast","languages":["en-US"]}"#)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/vision/ocr", headers: headers, body: body) { res async in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertContains(res.body.string, #""page_count":2"#)
+            XCTAssertContains(res.body.string, #""document_hints""#)
+            XCTAssertContains(res.body.string, #""invoice""#)
+            XCTAssertContains(res.body.string, #""headers":["Item","Amount"]"#)
+            XCTAssertContains(res.body.string, #""row_objects""#)
+            XCTAssertContains(res.body.string, #""Widget""#)
+            XCTAssertContains(res.body.string, #""10.00""#)
+            XCTAssertContains(res.body.string, #""source_type":"file""#)
+            XCTAssertContains(res.body.string, #""combined_text":"Page 1"#)
+            XCTAssertEqual(service.lastOptions?.recognitionLevel, .fast)
+            XCTAssertEqual(service.lastOptions?.recognitionLanguages, ["en-US"])
+        }
+    }
+
+    func testOCRAcceptsBase64Payload() async throws {
+        let service = FakeVisionService()
+        service.verboseResult = makeVisionResult(filePath: "/tmp/upload.png")
+        try VisionAPIController(makeVisionService: { service }).boot(routes: app)
+
+        let payload = Data("fake image".utf8).base64EncodedString()
+        let body = ByteBuffer(string: #"{"data":"\#(payload)","filename":"scan.png"}"#)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/vision/ocr", headers: headers, body: body) { res async in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertContains(res.body.string, #""source_type":"data""#)
+            XCTAssertEqual(service.lastPath?.hasSuffix(".png"), true)
+        }
+    }
+
+    func testOCRAcceptsOpenAIMessageImageURL() async throws {
+        let service = FakeVisionService()
+        service.verboseResult = makeVisionResult(filePath: "/tmp/upload.png")
+        try VisionAPIController(makeVisionService: { service }).boot(routes: app)
+
+        let payload = Data("fake pdf".utf8).base64EncodedString()
+        let body = ByteBuffer(string: """
+        {
+          "messages": [{
+            "role": "user",
+            "content": [
+              {"type":"text","text":"read this"},
+              {"type":"image_url","image_url":{"url":"data:application/pdf;base64,\(payload)"}}
+            ]
+          }]
+        }
+        """)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/vision/ocr", headers: headers, body: body) { res async in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertContains(res.body.string, #""source_type":"message_image""#)
+            XCTAssertEqual(service.lastPath?.hasSuffix(".pdf"), true)
+        }
+    }
+
+    func testOCRReturnsPayloadTooLargeForOversizeInput() async throws {
+        try VisionAPIController(makeVisionService: { FakeVisionService() }).boot(routes: app)
+
+        let data = Data(count: VisionRequestOptions.defaultMaxFileBytes + 1).base64EncodedString()
+        let body = ByteBuffer(string: #"{"data":"\#(data)","filename":"big.png"}"#)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/vision/ocr", headers: headers, body: body) { res async in
+            XCTAssertEqual(res.status, .payloadTooLarge)
+        }
+    }
+
+    func testVisionOCRAutoToolDetection() {
+        let tool = RequestTool(
+            type: "function",
+            function: RequestToolFunction(
+                name: "apple_vision_ocr",
+                description: nil,
+                parameters: nil,
+                strict: nil
+            )
+        )
+        let request = ChatCompletionRequest(
+            model: "foundation",
+            messages: [
+                Message(
+                    role: "user",
+                    content: .parts([
+                        ContentPart(type: "text", text: "scan this", image_url: nil),
+                        ContentPart(type: "image_url", text: nil, image_url: ImageURL(url: "data:image/png;base64,ZmFrZQ==", detail: nil))
+                    ])
+                )
+            ],
+            temperature: nil,
+            maxTokens: nil,
+            maxCompletionTokens: nil,
+            topP: nil,
+            repetitionPenalty: nil,
+            repeatPenalty: nil,
+            frequencyPenalty: nil,
+            presencePenalty: nil,
+            topK: nil,
+            minP: nil,
+            seed: nil,
+            logprobs: nil,
+            topLogprobs: nil,
+            stop: nil,
+            stream: nil,
+            user: nil,
+            tools: [tool],
+            toolChoice: .mode("auto"),
+            responseFormat: nil,
+            chatTemplateKwargs: nil
+        )
+
+        XCTAssertTrue(VisionAPIController.shouldAutoRunVisionTool(request))
+    }
+}
+
+private final class FakeVisionService: VisionServing {
+    var lastPath: String?
+    var lastOptions: VisionRequestOptions?
+    var textResult = ""
+    var verboseResult = VisionResult(fullText: "", textBlocks: [], filePath: "")
+    var tablesResult: [TableResult] = []
+    var debugResult = ""
+    var textError: Error?
+    var verboseError: Error?
+    var tablesError: Error?
+    var debugError: Error?
+
+    func extractText(from filePath: String) async throws -> String {
+        lastPath = filePath
+        if let textError { throw textError }
+        return textResult
+    }
+
+    func extractText(from filePath: String, options: VisionRequestOptions) async throws -> String {
+        lastPath = filePath
+        lastOptions = options
+        if let textError { throw textError }
+        return textResult
+    }
+
+    func extractTextWithDetails(from filePath: String) async throws -> VisionResult {
+        lastPath = filePath
+        if let verboseError { throw verboseError }
+        return verboseResult
+    }
+
+    func extractTextWithDetails(from filePath: String, options: VisionRequestOptions) async throws -> VisionResult {
+        lastPath = filePath
+        lastOptions = options
+        if let verboseError { throw verboseError }
+        return verboseResult
+    }
+
+    func extractTables(from filePath: String) async throws -> [TableResult] {
+        lastPath = filePath
+        if let tablesError { throw tablesError }
+        return tablesResult
+    }
+
+    func extractTables(from filePath: String, options: VisionRequestOptions) async throws -> [TableResult] {
+        lastPath = filePath
+        lastOptions = options
+        if let tablesError { throw tablesError }
+        return tablesResult
+    }
+
+    func debugRawDetection(from filePath: String) async throws -> String {
+        lastPath = filePath
+        if let debugError { throw debugError }
+        return debugResult
+    }
+
+    func debugRawDetection(from filePath: String, options: VisionRequestOptions) async throws -> String {
+        lastPath = filePath
+        lastOptions = options
+        if let debugError { throw debugError }
+        return debugResult
+    }
+}
+
+private func makeVisionResult(filePath: String) -> VisionResult {
+    let table = TableResult(
+        rows: [["Item", "Amount"], ["Widget", "10.00"]],
+        columnCount: 2,
+        averageConfidence: 0.93,
+        boundingBox: CGRect(x: 0.1, y: 0.2, width: 0.5, height: 0.3),
+        pageNumber: 2,
+        headers: ["Item", "Amount"],
+        rowObjects: [["Item": "Widget", "Amount": "10.00"]],
+        mergedCellHints: ["row_1_contains_sparse_cells"]
+    )
+    let pageOne = VisionPageResult(
+        pageNumber: 1,
+        fullText: "Page 1",
+        textBlocks: [
+            TextBlock(text: "Page 1", confidence: 0.99, boundingBox: CGRect(x: 0, y: 0, width: 1, height: 0.2), pageNumber: 1)
+        ],
+        tables: [],
+        width: 1024,
+        height: 768
+    )
+    let pageTwo = VisionPageResult(
+        pageNumber: 2,
+        fullText: "Page 2",
+        textBlocks: [
+            TextBlock(text: "Widget", confidence: 0.96, boundingBox: CGRect(x: 0.2, y: 0.3, width: 0.2, height: 0.1), pageNumber: 2)
+        ],
+        tables: [table],
+        width: 1024,
+        height: 768
+    )
+    return VisionResult(
+        fullText: "Page 1\n\nPage 2",
+        textBlocks: pageOne.textBlocks + pageTwo.textBlocks,
+        filePath: filePath,
+        pages: [pageOne, pageTwo],
+        documentHints: ["invoice", "multi_page", "table_like"]
+    )
+}

--- a/Tests/MacLocalAPITests/VisionAPIControllerTests.swift
+++ b/Tests/MacLocalAPITests/VisionAPIControllerTests.swift
@@ -97,6 +97,27 @@ final class VisionAPIControllerTests: XCTestCase {
         }
     }
 
+    func testResolveImageURLRejectsRemoteHTTPURLs() throws {
+        XCTAssertThrowsError(
+            try VisionAPIController.resolveImageURL(ImageURL(url: "https://example.com/invoice.png", detail: nil))
+        ) { error in
+            guard case .remoteURLNotSupported = error as? VisionError else {
+                return XCTFail("Expected remoteURLNotSupported, got \(error)")
+            }
+        }
+    }
+
+    func testResolveImageURLRejectsUnknownSchemes() throws {
+        XCTAssertThrowsError(
+            try VisionAPIController.resolveImageURL(ImageURL(url: "ftp://example.com/invoice.png", detail: nil))
+        ) { error in
+            guard case .unsupportedURLScheme(let scheme) = error as? VisionError else {
+                return XCTFail("Expected unsupportedURLScheme, got \(error)")
+            }
+            XCTAssertEqual(scheme, "ftp")
+        }
+    }
+
     func testVisionOCRAutoToolDetection() {
         let tool = RequestTool(
             type: "function",

--- a/docs/vision-ocr-api.md
+++ b/docs/vision-ocr-api.md
@@ -1,0 +1,199 @@
+# Vision OCR API
+
+`POST /v1/vision/ocr` exposes Apple Vision OCR over HTTP in the same local server as the OpenAI-compatible chat endpoints.
+
+It is intended for:
+- direct OCR over HTTP without shelling out to `afm vision`
+- clients that already produce OpenAI-style `image_url` content parts
+- local document extraction workflows that need structured text, table output, and page-level metadata
+
+## Requirements
+
+- macOS 26.0 or later
+- Apple Silicon
+- Apple Vision available on the host machine
+
+## Supported Inputs
+
+The endpoint accepts one or more OCR inputs in a single request.
+
+### Local file path
+
+```json
+{
+  "file": "/tmp/invoice.pdf"
+}
+```
+
+### Base64 payload
+
+```json
+{
+  "data": "iVBORw0KGgoAAAANSUhEUgAA...",
+  "filename": "scan.png",
+  "media_type": "image/png"
+}
+```
+
+### Data URL
+
+```json
+{
+  "data": "data:application/pdf;base64,JVBERi0xLjcK..."
+}
+```
+
+### OpenAI-style image input
+
+```json
+{
+  "image_url": {
+    "url": "data:image/png;base64,..."
+  }
+}
+```
+
+### OpenAI-style chat message parts
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        { "type": "text", "text": "Read this document" },
+        {
+          "type": "image_url",
+          "image_url": {
+            "url": "data:application/pdf;base64,..."
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Multipart upload
+
+Use a multipart `file` field. Optional OCR controls can be supplied as form fields alongside the upload.
+
+```bash
+curl http://localhost:9999/v1/vision/ocr \
+  -F "file=@/tmp/invoice.pdf" \
+  -F "recognition_level=accurate" \
+  -F "languages=en-US"
+```
+
+## OCR Options
+
+```json
+{
+  "recognition_level": "accurate",
+  "uses_language_correction": true,
+  "languages": ["en-US"],
+  "max_pages": 10,
+  "table": false,
+  "debug": false
+}
+```
+
+Supported options:
+- `recognition_level`: `accurate` or `fast`
+- `uses_language_correction`: enables Vision language correction
+- `languages`: preferred OCR language tags
+- `max_pages`: page cap for multi-page PDFs
+- `table`: returns structured table extraction in the document payload
+- `debug`: returns raw Vision detection output instead of OCR documents
+
+Current guardrails:
+- max input size: 25 MB
+- max pages per document: 50 by default
+- max image dimension: 4096 px on either side
+- supported formats: `png`, `jpg`, `jpeg`, `heic`, `pdf`
+
+## Response Shape
+
+Successful responses return a `vision.ocr` object:
+
+```json
+{
+  "object": "vision.ocr",
+  "mode": "text",
+  "documents": [
+    {
+      "file": "/tmp/invoice.pdf",
+      "source_type": "file",
+      "text": "Page 1...\n\nPage 2...",
+      "full_text": "Page 1...\n\nPage 2...",
+      "page_count": 2,
+      "document_hints": ["invoice", "multi_page", "table_like"],
+      "pages": [
+        {
+          "page_number": 1,
+          "text": "Page 1...",
+          "width": 1024,
+          "height": 768,
+          "text_blocks": [],
+          "tables": []
+        }
+      ],
+      "text_blocks": [],
+      "tables": []
+    }
+  ],
+  "combined_text": "Page 1...\n\nPage 2...",
+  "document_hints": ["invoice", "multi_page", "table_like"]
+}
+```
+
+Notable fields:
+- `mode`: `text`, `table`, or `debug`
+- `documents`: one entry per resolved OCR input
+- `pages`: per-page text, dimensions, blocks, and tables
+- `text_blocks`: flattened OCR text blocks with confidence and bounding boxes
+- `tables`: structured tables with headers, rows, row objects, CSV, and bounding boxes
+- `combined_text`: all OCR text joined across all documents
+- `document_hints`: inferred hints such as `invoice`, `multi_page`, or `table_like`
+
+## Error Semantics
+
+The endpoint maps OCR failures to HTTP statuses:
+- `400 Bad Request`: missing input, unsupported format, invalid base64 or data URL
+- `404 Not Found`: local file path does not exist
+- `413 Payload Too Large`: request exceeds the OCR file-size limit
+- `422 Unprocessable Entity`: page-limit exceeded, image too large, unreadable image, no text found, no tables found, segmentation failure
+- `503 Service Unavailable`: Apple Vision OCR is unavailable on the current platform
+
+Errors use the same JSON envelope style as the rest of the OpenAI-compatible API:
+
+```json
+{
+  "error": {
+    "message": "The specified file was not found",
+    "type": "invalid_request_error"
+  }
+}
+```
+
+## Foundation Chat Integration
+
+Foundation chat requests can auto-run Apple Vision OCR before prompting the model.
+
+This only happens when all of the following are true:
+- the request includes image content in `messages[].content[]`
+- the request includes the built-in tool named `apple_vision_ocr`
+- `tool_choice` is omitted, `auto`, `required`, or explicitly selects `apple_vision_ocr`
+
+When that path is taken, OCR text is injected into the message content before the Foundation model sees the prompt.
+
+## Validation
+
+Validated locally with:
+
+```bash
+swift test --disable-sandbox
+```
+
+Result at the time of implementation:
+- `293 tests in 19 suites passed`


### PR DESCRIPTION
Hi there! I was hoping to use the afm client with Apple Vision OCR as a first-class HTTP/API feature instead of limiting it to the afm vision CLI path. I was curious how this worked and ended up building out a whole feature. Hopefully this is useful to you and others.

## Motivation

  The codebase already had two separate image/document paths:

  - MLX/VLM image handling through the OpenAI-compatible API
  - Apple Vision OCR only through afm vision

That made Apple Vision useful from the terminal, but not from applications already speaking the OpenAI-compatible API. This change just adds Apple Vision OCR as an API path.

 ## New capabilities:

  - POST /v1/vision/ocr
  - OCR over local file paths, multipart uploads, base64 payloads, data: URLs, OpenAI-style image_url, and messages[].content[] image
    parts
  - structured OCR responses with per-document, per-page, text-block, and table data
  - multi-page PDF support
  - Foundation chat integration that can auto-run Apple Vision OCR for image inputs when the built-in OCR tool is present

  ## What Changed

  ### New HTTP endpoint

  - Added POST /v1/vision/ocr

  Accepted inputs:

  - file
  - data + optional filename / media_type
  - image_url
  - OpenAI-style messages[].content[] image parts
  - multipart upload via file

  Supported OCR options:

  - recognition_level
  - uses_language_correction
  - languages
  - max_pages
  - table
  - debug

  ### Richer OCR output

  Responses now include:

  - documents
  - combined_text
  - document_hints
  - per-page text and dimensions
  - text blocks with confidence and bounding boxes
  - structured table output with headers, rows, row objects, CSV, confidence, and bounding boxes

  ### Multi-page PDF support

  Apple Vision OCR now processes multiple PDF pages instead of only the first page.

  ### Foundation chat integration

  Foundation chat requests can auto-run Apple Vision OCR before model prompting when:

  - the request includes image content
  - the built-in apple_vision_ocr tool is present
  - tool_choice is omitted, auto, required, or explicitly selects that tool

  In that path, OCR text is injected into message content before the Foundation model sees the prompt.

  ### Error handling and guardrails

  Added more error mapping and input limits for:

  - unsupported formats
  - missing files
  - oversized requests
  - page-limit violations
  - excessive image dimensions
  - unreadable images / empty OCR results

  ### Tests and docs

  Added coverage for:

  - structured OCR responses
  - base64 payload input
  - OpenAI-style message image input
  - oversize request rejection
  - auto-tool detection

  Also documented the new endpoint and request/response format.

  ## Files of Interest

  - Sources/MacLocalAPI/Controllers/VisionAPIController.swift
  - Sources/MacLocalAPI/Models/VisionService.swift
  - Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
  - Tests/MacLocalAPITests/VisionAPIControllerTests.swift
  - README.md
  - docs/vision-ocr-api.md

  ## Validation

  Ran:

  swift test --disable-sandbox

  Result:

  - 293 tests in 19 suites passed

  Also re-ran:

  swift test --disable-sandbox --filter VisionAPIControllerTests

  Result:

  - 5 tests passed, 0 failures

## Summary by Sourcery

Add an HTTP Apple Vision OCR endpoint with structured multi-page output and integrate it with Foundation chat, along with related tooling, server, and test updates.

New Features:
- Introduce POST /v1/vision/ocr for Apple Vision OCR over HTTP, supporting files, uploads, base64/data URLs, and OpenAI-style image inputs.
- Provide structured OCR results including per-page text, text blocks with metadata, tables with headers/rows/CSV, and document-level hints.
- Enable Foundation chat requests to automatically run Apple Vision OCR on image content when the built-in OCR tool is available.

Enhancements:
- Extend VisionService to support configurable OCR options, multi-page PDFs, richer document/table metadata, and stricter input validation and limits.
- Refine table detection and representation to include headers, row objects, merged-cell hints, and page numbers.
- Improve MLX streaming/logprobs collection, memory reporting, and default model capabilities, including guided JSON handling and think-tag extraction reuse.
- Harden MLX Metal library lookup for test/bundle layouts and reduce batch SSE multiplex maximum size to improve stability.
- Enhance patching and package configuration scripts to add target excludes for original model files and include VaporTesting in test dependencies.

Documentation:
- Document the Vision OCR HTTP API, inputs, options, and response format, and update README with endpoint usage and client integration notes.

Tests:
- Add comprehensive tests for the Vision OCR controller, including structured outputs, base64 inputs, OpenAI-style image inputs, oversize rejection, and auto-tool detection.
- Update existing batch, streaming, nullable tool schema, and logit processor tests to cover new helpers, behaviors, and testing utilities.