### PR TITLE
Feature: Add on-device audio transcription via Apple Speech framework

### DIFF
--- a/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
@@ -100,37 +100,55 @@ struct ChatCompletionsController: RouteCollection {
             let processedMessages: [Message]
             if #available(macOS 26.0, *) {
                 foundationService = try await FoundationModelService.createWithSharedAdapter(instructions: instructions, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails)
-                let shouldApplyVisionOCR = chatRequest.messages.contains { message in
+                // Detect media content that should bypass the Foundation Model
+                let hasImages = chatRequest.messages.contains { message in
                     guard let content = message.content, case .parts(let parts) = content else { return false }
                     return parts.contains(where: { $0.type == "image_url" })
                 }
-                if shouldApplyVisionOCR {
-                    // Run OCR and return results directly — Foundation Models has a
-                    // 4096 token context limit that OCR text easily exceeds.  Bypass
-                    // the LLM entirely, matching `afm vision -f` behaviour.
-                    let visionOptions = VisionRequestOptions()
-                    let visionProcessed = try await VisionAPIController.extractOCRTextFromMessages(chatRequest.messages, options: visionOptions)
-                    visionCleanupURLs = visionProcessed.cleanupURLs
+                let hasAudio = chatRequest.messages.contains { message in
+                    guard let content = message.content, case .parts(let parts) = content else { return false }
+                    return parts.contains(where: { $0.type == "input_audio" })
+                }
+
+                if hasImages || hasAudio {
+                    // Run on-device extraction and return results directly —
+                    // Foundation Models has a 4096 token context limit that
+                    // extracted text easily exceeds.  Bypass the LLM entirely.
+                    var extractedTexts: [String] = []
+                    var allCleanupURLs: [URL] = []
+
+                    if hasImages {
+                        let visionProcessed = try await VisionAPIController.extractOCRTextFromMessages(chatRequest.messages, options: VisionRequestOptions())
+                        extractedTexts.append(contentsOf: visionProcessed.ocrTexts)
+                        allCleanupURLs.append(contentsOf: visionProcessed.cleanupURLs)
+                    }
+                    if hasAudio {
+                        let speechProcessed = try await SpeechAPIController.extractTranscriptionFromMessages(chatRequest.messages, options: SpeechRequestOptions())
+                        extractedTexts.append(contentsOf: speechProcessed.transcriptionTexts)
+                        allCleanupURLs.append(contentsOf: speechProcessed.cleanupURLs)
+                    }
+
+                    visionCleanupURLs = allCleanupURLs
                     defer {
-                        for url in visionCleanupURLs {
+                        for url in allCleanupURLs {
                             try? FileManager.default.removeItem(at: url)
                         }
                     }
 
-                    let ocrContent = visionProcessed.ocrTexts.joined(separator: "\n\n")
+                    let extractedContent = extractedTexts.joined(separator: "\n\n")
 
                     if chatRequest.stream == true && streamingEnabled {
-                        return try await createVisionStreamingResponse(
+                        return try await createBypassStreamingResponse(
                             req: req,
                             chatRequest: chatRequest,
-                            ocrContent: ocrContent
+                            content: extractedContent
                         )
                     } else {
                         let promptTokens = estimateTokens(for: chatRequest.messages)
-                        let completionTokens = estimateTokens(for: ocrContent)
+                        let completionTokens = estimateTokens(for: extractedContent)
                         let response = ChatCompletionResponse(
                             model: chatRequest.model ?? "foundation",
-                            content: ocrContent,
+                            content: extractedContent,
                             finishReason: "stop",
                             promptTokens: promptTokens,
                             completionTokens: completionTokens
@@ -490,9 +508,9 @@ struct ChatCompletionsController: RouteCollection {
         return httpResponse
     }
 
-    /// Stream OCR results directly to the client, bypassing the Foundation Model.
-    /// Mirrors what `afm vision -f` does: run Vision OCR and return extracted text.
-    private func createVisionStreamingResponse(req: Request, chatRequest: ChatCompletionRequest, ocrContent: String) async throws -> Response {
+    /// Stream extracted content directly to the client, bypassing the Foundation Model.
+    /// Used for Vision OCR and Speech transcription results.
+    private func createBypassStreamingResponse(req: Request, chatRequest: ChatCompletionRequest, content: String) async throws -> Response {
         let httpResponse = Response(status: .ok)
         httpResponse.headers.add(name: .contentType, value: "text/event-stream")
         httpResponse.headers.add(name: .cacheControl, value: "no-cache")
@@ -504,17 +522,17 @@ struct ChatCompletionsController: RouteCollection {
         let streamId = UUID().uuidString
         let model = chatRequest.model ?? "foundation"
         let promptTokens = estimateTokens(for: chatRequest.messages)
-        let completionTokens = estimateTokens(for: ocrContent)
+        let completionTokens = estimateTokens(for: content)
 
         httpResponse.body = .init(asyncStream: { writer in
             let encoder = JSONEncoder()
 
             do {
-                // Send content in a single chunk (OCR is already complete)
+                // Send content in a single chunk (extraction is already complete)
                 let contentChunk = ChatCompletionStreamResponse(
                     id: streamId,
                     model: model,
-                    content: ocrContent,
+                    content: content,
                     isFirst: true
                 )
                 let contentData = try encoder.encode(contentChunk)

--- a/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
@@ -105,18 +105,45 @@ struct ChatCompletionsController: RouteCollection {
                     return parts.contains(where: { $0.type == "image_url" })
                 }
                 if shouldApplyVisionOCR {
+                    // Run OCR and return results directly — Foundation Models has a
+                    // 4096 token context limit that OCR text easily exceeds.  Bypass
+                    // the LLM entirely, matching `afm vision -f` behaviour.
                     let visionOptions = VisionRequestOptions()
                     let visionProcessed = try await VisionAPIController.extractOCRTextFromMessages(chatRequest.messages, options: visionOptions)
                     visionCleanupURLs = visionProcessed.cleanupURLs
-                    var messagesWithOCR = visionProcessed.messages
-                    if VisionAPIController.shouldAutoRunVisionTool(chatRequest) {
-                        let toolPrelude = Message(
-                            role: "system",
-                            content: "Built-in tool apple_vision_ocr has already been executed for the attached images. Use the injected OCR text when answering."
-                        )
-                        messagesWithOCR.insert(toolPrelude, at: 0)
+                    defer {
+                        for url in visionCleanupURLs {
+                            try? FileManager.default.removeItem(at: url)
+                        }
                     }
-                    processedMessages = messagesWithOCR
+
+                    // Extract only the OCR portions — the processed messages
+                    // mix original user text with "[Apple Vision OCR image N]\n..."
+                    // blocks.  Return just the OCR blocks, like `afm vision -f`.
+                    let ocrContent = visionProcessed.messages
+                        .filter { $0.role == "user" }
+                        .flatMap { $0.textContent.components(separatedBy: "\n\n") }
+                        .filter { $0.hasPrefix("[Apple Vision OCR image") }
+                        .joined(separator: "\n\n")
+
+                    if chatRequest.stream == true && streamingEnabled {
+                        return try await createVisionStreamingResponse(
+                            req: req,
+                            chatRequest: chatRequest,
+                            ocrContent: ocrContent
+                        )
+                    } else {
+                        let promptTokens = estimateTokens(for: chatRequest.messages)
+                        let completionTokens = estimateTokens(for: ocrContent)
+                        let response = ChatCompletionResponse(
+                            model: chatRequest.model ?? "foundation",
+                            content: ocrContent,
+                            finishReason: "stop",
+                            promptTokens: promptTokens,
+                            completionTokens: completionTokens
+                        )
+                        return try await createSuccessResponse(req: req, response: response)
+                    }
                 } else {
                     processedMessages = chatRequest.messages
                 }
@@ -462,6 +489,81 @@ struct ChatCompletionsController: RouteCollection {
                 }
 
                 // Send [DONE] marker to properly terminate the stream
+                try? await writer.write(.buffer(.init(string: "data: [DONE]\n\n")))
+                try? await writer.write(.end)
+            }
+        })
+
+        return httpResponse
+    }
+
+    /// Stream OCR results directly to the client, bypassing the Foundation Model.
+    /// Mirrors what `afm vision -f` does: run Vision OCR and return extracted text.
+    private func createVisionStreamingResponse(req: Request, chatRequest: ChatCompletionRequest, ocrContent: String) async throws -> Response {
+        let httpResponse = Response(status: .ok)
+        httpResponse.headers.add(name: .contentType, value: "text/event-stream")
+        httpResponse.headers.add(name: .cacheControl, value: "no-cache")
+        httpResponse.headers.add(name: .connection, value: "keep-alive")
+        httpResponse.headers.add(name: "Access-Control-Allow-Origin", value: "*")
+        httpResponse.headers.add(name: "Access-Control-Allow-Headers", value: "Content-Type")
+        httpResponse.headers.add(name: "X-Accel-Buffering", value: "no")
+
+        let streamId = UUID().uuidString
+        let model = chatRequest.model ?? "foundation"
+        let promptTokens = estimateTokens(for: chatRequest.messages)
+        let completionTokens = estimateTokens(for: ocrContent)
+
+        httpResponse.body = .init(asyncStream: { writer in
+            let encoder = JSONEncoder()
+
+            do {
+                // Send content in a single chunk (OCR is already complete)
+                let contentChunk = ChatCompletionStreamResponse(
+                    id: streamId,
+                    model: model,
+                    content: ocrContent,
+                    isFirst: true
+                )
+                let contentData = try encoder.encode(contentChunk)
+                if let jsonString = String(data: contentData, encoding: .utf8) {
+                    try await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
+                }
+
+                // Send final chunk with finish_reason
+                let finalChunk = ChatCompletionStreamResponse(
+                    id: streamId,
+                    model: model,
+                    content: "",
+                    isFinished: true,
+                    finishReason: "stop"
+                )
+                let finalData = try encoder.encode(finalChunk)
+                if let jsonString = String(data: finalData, encoding: .utf8) {
+                    try await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
+                }
+
+                // Send usage chunk
+                let usage = StreamUsage(
+                    promptTokens: promptTokens,
+                    completionTokens: completionTokens,
+                    completionTime: 0,
+                    promptTime: 0
+                )
+                let usageChunk = ChatCompletionStreamResponse(
+                    id: streamId,
+                    model: model,
+                    usage: usage,
+                    timings: nil
+                )
+                let usageData = try encoder.encode(usageChunk)
+                if let jsonString = String(data: usageData, encoding: .utf8) {
+                    try await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
+                }
+
+                try await writer.write(.buffer(.init(string: "data: [DONE]\n\n")))
+                try await writer.write(.end)
+            } catch {
+                req.logger.error("Vision streaming error: \(error)")
                 try? await writer.write(.buffer(.init(string: "data: [DONE]\n\n")))
                 try? await writer.write(.end)
             }

--- a/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
@@ -117,14 +117,7 @@ struct ChatCompletionsController: RouteCollection {
                         }
                     }
 
-                    // Extract only the OCR portions — the processed messages
-                    // mix original user text with "[Apple Vision OCR image N]\n..."
-                    // blocks.  Return just the OCR blocks, like `afm vision -f`.
-                    let ocrContent = visionProcessed.messages
-                        .filter { $0.role == "user" }
-                        .flatMap { $0.textContent.components(separatedBy: "\n\n") }
-                        .filter { $0.hasPrefix("[Apple Vision OCR image") }
-                        .joined(separator: "\n\n")
+                    let ocrContent = visionProcessed.ocrTexts.joined(separator: "\n\n")
 
                     if chatRequest.stream == true && streamingEnabled {
                         return try await createVisionStreamingResponse(

--- a/Sources/MacLocalAPI/Controllers/MLXChatServing.swift
+++ b/Sources/MacLocalAPI/Controllers/MLXChatServing.swift
@@ -98,26 +98,27 @@ extension MLXChatServing {
     }
 
     func waitForSlot(timeout: TimeInterval) async -> Bool {
+        if Task.isCancelled { return false }
         if timeout <= 0 {
             return tryReserveSlot()
         }
 
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if tryReserveSlot() {
-                return true
-            }
+        if tryReserveSlot() { return true }
 
-            let remaining = deadline.timeIntervalSinceNow
-            if remaining <= 0 {
-                break
-            }
+        // Exponential backoff matching BatchScheduler pattern
+        let initialPollNs: UInt64 = 10_000_000   // 10ms
+        let maxPollNs: UInt64     = 500_000_000   // 500ms
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        var delay = initialPollNs
 
-            let sleepDuration = min(remaining, 0.05)
-            try? await Task.sleep(nanoseconds: UInt64(sleepDuration * 1_000_000_000))
+        while ContinuousClock.now < deadline {
+            if Task.isCancelled { return false }
+            try? await Task.sleep(nanoseconds: delay)
+            if Task.isCancelled { return false }
+            if tryReserveSlot() { return true }
+            delay = min(delay * 2, maxPollNs)
         }
-
-        return tryReserveSlot()
+        return false
     }
 
     /// Convenience overload without requestId for batch/internal callers.

--- a/Sources/MacLocalAPI/Controllers/SpeechAPIController.swift
+++ b/Sources/MacLocalAPI/Controllers/SpeechAPIController.swift
@@ -8,17 +8,6 @@ struct SpeechTranscriptionResponse: Content {
 }
 
 struct SpeechAPIController: RouteCollection {
-    private static let supportedMediaTypes: [String: String] = [
-        "audio/wav": "wav",
-        "audio/x-wav": "wav",
-        "audio/mpeg": "mp3",
-        "audio/mp3": "mp3",
-        "audio/mp4": "m4a",
-        "audio/x-m4a": "m4a",
-        "audio/x-caf": "caf",
-        "audio/aiff": "aiff",
-        "audio/x-aiff": "aiff"
-    ]
 
     func boot(routes: RoutesBuilder) throws {
         let v1 = routes.grouped("v1")
@@ -61,9 +50,9 @@ struct SpeechAPIController: RouteCollection {
 
         let filePath: String
         if let file = body.file, !file.isEmpty {
-            filePath = URL(fileURLWithPath: NSString(string: file).expandingTildeInPath).standardized.path
+            filePath = try Self.sanitizeAudioPath(file)
         } else if let data = body.data, !data.isEmpty {
-            let ext = body.format ?? "wav"
+            let ext = try Self.validatedExtension(body.format ?? "wav")
             let tempURL = try Self.writeTempAudio(base64: data, ext: ext)
             cleanupURLs.append(tempURL)
             filePath = tempURL.path
@@ -96,6 +85,7 @@ struct SpeechAPIController: RouteCollection {
         var updatedMessages: [Message] = []
         var transcriptionTexts: [String] = []
         var cleanupURLs: [URL] = []
+        var audioIndex = 0
 
         for message in messages {
             guard let content = message.content, case .parts(let parts) = content else {
@@ -104,10 +94,9 @@ struct SpeechAPIController: RouteCollection {
             }
 
             var textChunks = parts.compactMap(\.text)
-            var audioIndex = 0
             for part in parts where part.type == "input_audio" {
                 guard let inputAudio = part.input_audio else { continue }
-                let ext = inputAudio.format.isEmpty ? "wav" : inputAudio.format
+                let ext = try validatedExtension(inputAudio.format.isEmpty ? "wav" : inputAudio.format)
                 let tempURL = try writeTempAudio(base64: inputAudio.data, ext: ext)
                 cleanupURLs.append(tempURL)
                 let transcription = try await service.transcribe(from: tempURL.path, options: options)
@@ -121,6 +110,38 @@ struct SpeechAPIController: RouteCollection {
         }
 
         return (updatedMessages, transcriptionTexts, cleanupURLs)
+    }
+
+    // MARK: - Helpers
+
+    /// Validate and resolve a file path for the API endpoint.
+    /// Resolves symlinks, rejects directories, and enforces audio extension allowlist.
+    private static func sanitizeAudioPath(_ raw: String) throws -> String {
+        let expanded = NSString(string: raw).expandingTildeInPath
+        let resolved = URL(fileURLWithPath: expanded).resolvingSymlinksInPath().path
+        let fm = FileManager.default
+
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: resolved, isDirectory: &isDir) else {
+            throw SpeechError.fileNotFound
+        }
+        guard !isDir.boolValue else {
+            throw SpeechError.unsupportedFormat
+        }
+        let ext = URL(fileURLWithPath: resolved).pathExtension.lowercased()
+        guard SpeechRequestOptions.supportedExtensions.contains(ext) else {
+            throw SpeechError.unsupportedFormat
+        }
+        return resolved
+    }
+
+    /// Validate that ext is a supported audio extension before using it in a filename.
+    private static func validatedExtension(_ ext: String) throws -> String {
+        let clean = ext.lowercased()
+        guard SpeechRequestOptions.supportedExtensions.contains(clean) else {
+            throw SpeechError.unsupportedFormat
+        }
+        return clean
     }
 
     private static func writeTempAudio(base64: String, ext: String) throws -> URL {

--- a/Sources/MacLocalAPI/Controllers/SpeechAPIController.swift
+++ b/Sources/MacLocalAPI/Controllers/SpeechAPIController.swift
@@ -1,0 +1,138 @@
+import Vapor
+import Foundation
+
+struct SpeechTranscriptionResponse: Content {
+    let object: String
+    let text: String
+    let locale: String
+}
+
+struct SpeechAPIController: RouteCollection {
+    private static let supportedMediaTypes: [String: String] = [
+        "audio/wav": "wav",
+        "audio/x-wav": "wav",
+        "audio/mpeg": "mp3",
+        "audio/mp3": "mp3",
+        "audio/mp4": "m4a",
+        "audio/x-m4a": "m4a",
+        "audio/x-caf": "caf",
+        "audio/aiff": "aiff",
+        "audio/x-aiff": "aiff"
+    ]
+
+    func boot(routes: RoutesBuilder) throws {
+        let v1 = routes.grouped("v1")
+        let speech = v1.grouped("audio")
+        speech.on(.POST, "transcriptions", body: .collect(maxSize: "50mb"), use: transcribe)
+        speech.on(.OPTIONS, "transcriptions", use: handleOptions)
+    }
+
+    private func handleOptions(req: Request) async throws -> Response {
+        let response = Response(status: .ok)
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        response.headers.add(name: .accessControlAllowMethods, value: "POST, OPTIONS")
+        response.headers.add(name: .accessControlAllowHeaders, value: "Content-Type, Authorization")
+        return response
+    }
+
+    private func transcribe(req: Request) async throws -> Response {
+        guard #available(macOS 13.0, *) else {
+            throw Abort(.serviceUnavailable, reason: "Speech recognition requires macOS 13.0 or later")
+        }
+
+        struct TranscriptionRequest: Content {
+            let file: String?
+            let data: String?
+            let format: String?
+            let locale: String?
+        }
+
+        let body = try req.content.decode(TranscriptionRequest.self)
+        let locale = body.locale ?? "en-US"
+        let options = SpeechRequestOptions(locale: locale)
+        let service = SpeechService()
+        var cleanupURLs: [URL] = []
+
+        defer {
+            for url in cleanupURLs {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+
+        let filePath: String
+        if let file = body.file, !file.isEmpty {
+            filePath = URL(fileURLWithPath: NSString(string: file).expandingTildeInPath).standardized.path
+        } else if let data = body.data, !data.isEmpty {
+            let ext = body.format ?? "wav"
+            let tempURL = try Self.writeTempAudio(base64: data, ext: ext)
+            cleanupURLs.append(tempURL)
+            filePath = tempURL.path
+        } else {
+            throw Abort(.badRequest, reason: "Either 'file' path or 'data' (base64) is required")
+        }
+
+        let text = try await service.transcribe(from: filePath, options: options)
+
+        let response = SpeechTranscriptionResponse(
+            object: "speech.transcription",
+            text: text,
+            locale: locale
+        )
+        let httpResponse = Response(status: .ok)
+        httpResponse.headers.add(name: .contentType, value: "application/json")
+        httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
+        try httpResponse.content.encode(response)
+        return httpResponse
+    }
+
+    // MARK: - Chat completions integration
+
+    static func extractTranscriptionFromMessages(_ messages: [Message], options: SpeechRequestOptions) async throws -> (messages: [Message], transcriptionTexts: [String], cleanupURLs: [URL]) {
+        guard #available(macOS 13.0, *) else {
+            return (messages, [], [])
+        }
+
+        let service = SpeechService()
+        var updatedMessages: [Message] = []
+        var transcriptionTexts: [String] = []
+        var cleanupURLs: [URL] = []
+
+        for message in messages {
+            guard let content = message.content, case .parts(let parts) = content else {
+                updatedMessages.append(message)
+                continue
+            }
+
+            var textChunks = parts.compactMap(\.text)
+            var audioIndex = 0
+            for part in parts where part.type == "input_audio" {
+                guard let inputAudio = part.input_audio else { continue }
+                let ext = inputAudio.format.isEmpty ? "wav" : inputAudio.format
+                let tempURL = try writeTempAudio(base64: inputAudio.data, ext: ext)
+                cleanupURLs.append(tempURL)
+                let transcription = try await service.transcribe(from: tempURL.path, options: options)
+                audioIndex += 1
+                let labeled = "[Apple Speech transcription \(audioIndex)]\n\(transcription)"
+                textChunks.append(labeled)
+                transcriptionTexts.append(labeled)
+            }
+
+            updatedMessages.append(Message(role: message.role, content: textChunks.joined(separator: "\n\n")))
+        }
+
+        return (updatedMessages, transcriptionTexts, cleanupURLs)
+    }
+
+    private static func writeTempAudio(base64: String, ext: String) throws -> URL {
+        guard let data = Data(base64Encoded: base64, options: .ignoreUnknownCharacters) else {
+            throw Abort(.badRequest, reason: "Invalid base64 audio data")
+        }
+        if data.count > SpeechRequestOptions.defaultMaxFileBytes {
+            throw SpeechError.requestTooLarge(actualBytes: data.count, maxBytes: SpeechRequestOptions.defaultMaxFileBytes)
+        }
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("afm_speech_\(UUID().uuidString).\(ext)")
+        try data.write(to: tempURL)
+        return tempURL
+    }
+}

--- a/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
+++ b/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
@@ -430,7 +430,8 @@ struct VisionAPIController: RouteCollection {
         if let url = URL(string: raw), let scheme = url.scheme?.lowercased() {
             switch scheme {
             case "file":
-                return VisionResolvedInput(path: url.path, sourceType: "file_url", cleanupURLs: [])
+                let sanitized = try sanitizeFilePath(url.path)
+                return VisionResolvedInput(path: sanitized, sourceType: "file_url", cleanupURLs: [])
             case "http", "https":
                 throw VisionError.remoteURLNotSupported
             default:
@@ -438,7 +439,33 @@ struct VisionAPIController: RouteCollection {
             }
         }
 
-        return VisionResolvedInput(path: resolvePath(raw), sourceType: "file", cleanupURLs: [])
+        let sanitized = try sanitizeFilePath(resolvePath(raw))
+        return VisionResolvedInput(path: sanitized, sourceType: "file", cleanupURLs: [])
+    }
+
+    /// Validate that a file path points to an existing regular file with a
+    /// supported image/document extension.  Rejects directory traversal,
+    /// symlinks to unexpected locations, device nodes, etc.
+    private static func sanitizeFilePath(_ path: String) throws -> String {
+        let resolved = URL(fileURLWithPath: path).standardizedFileURL.path
+        let fm = FileManager.default
+
+        // Must exist
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: resolved, isDirectory: &isDir) else {
+            throw VisionError.fileNotFound
+        }
+        // Must be a regular file, not a directory
+        guard !isDir.boolValue else {
+            throw VisionError.unsupportedFormat
+        }
+        // Extension must be a supported image/document type
+        let ext = URL(fileURLWithPath: resolved).pathExtension.lowercased()
+        let allowed: Set<String> = ["png", "jpg", "jpeg", "heic", "pdf"]
+        guard allowed.contains(ext) else {
+            throw VisionError.unsupportedFormat
+        }
+        return resolved
     }
 
     static func writeTempDataPayload(_ payload: String, filename: String, mediaType: String?) throws -> URL {

--- a/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
+++ b/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
@@ -444,10 +444,10 @@ struct VisionAPIController: RouteCollection {
     }
 
     /// Validate that a file path points to an existing regular file with a
-    /// supported image/document extension.  Rejects directory traversal,
-    /// symlinks to unexpected locations, device nodes, etc.
+    /// supported image/document extension.  Resolves symlinks and rejects
+    /// directories, non-image files, and path traversal.
     private static func sanitizeFilePath(_ path: String) throws -> String {
-        let resolved = URL(fileURLWithPath: path).standardizedFileURL.path
+        let resolved = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
         let fm = FileManager.default
 
         // Must exist
@@ -461,7 +461,7 @@ struct VisionAPIController: RouteCollection {
         }
         // Extension must be a supported image/document type
         let ext = URL(fileURLWithPath: resolved).pathExtension.lowercased()
-        let allowed: Set<String> = ["png", "jpg", "jpeg", "heic", "pdf"]
+        let allowed: Set<String> = ["png", "jpg", "jpeg", "heic", "pdf", "tif", "tiff", "gif", "bmp", "webp"]
         guard allowed.contains(ext) else {
             throw VisionError.unsupportedFormat
         }
@@ -518,13 +518,14 @@ struct VisionAPIController: RouteCollection {
         return "png"
     }
 
-    static func extractOCRTextFromMessages(_ messages: [Message], options: VisionRequestOptions) async throws -> (messages: [Message], cleanupURLs: [URL]) {
+    static func extractOCRTextFromMessages(_ messages: [Message], options: VisionRequestOptions) async throws -> (messages: [Message], ocrTexts: [String], cleanupURLs: [URL]) {
         guard #available(macOS 26.0, *) else {
-            return (messages, [])
+            return (messages, [], [])
         }
 
         let service = VisionService()
         var updatedMessages: [Message] = []
+        var ocrTexts: [String] = []
         var cleanupURLs: [URL] = []
 
         for message in messages {
@@ -541,13 +542,15 @@ struct VisionAPIController: RouteCollection {
                 cleanupURLs.append(contentsOf: resolved.cleanupURLs)
                 let ocrText = try await service.extractText(from: resolved.path, options: options)
                 imageIndex += 1
-                textChunks.append("[Apple Vision OCR image \(imageIndex)]\n\(ocrText)")
+                let labeled = "[Apple Vision OCR image \(imageIndex)]\n\(ocrText)"
+                textChunks.append(labeled)
+                ocrTexts.append(labeled)
             }
 
             updatedMessages.append(Message(role: message.role, content: textChunks.joined(separator: "\n\n")))
         }
 
-        return (updatedMessages, cleanupURLs)
+        return (updatedMessages, ocrTexts, cleanupURLs)
     }
 
     static func shouldAutoRunVisionTool(_ request: ChatCompletionRequest) -> Bool {

--- a/Sources/MacLocalAPI/Models/OpenAIRequest.swift
+++ b/Sources/MacLocalAPI/Models/OpenAIRequest.swift
@@ -163,14 +163,27 @@ enum MessageContent: Codable {
 }
 
 struct ContentPart: Codable {
-    let type: String        // "text" or "image_url"
+    let type: String        // "text", "image_url", or "input_audio"
     let text: String?       // For type="text"
     let image_url: ImageURL? // For type="image_url"
+    let input_audio: InputAudio? // For type="input_audio"
+
+    init(type: String, text: String? = nil, image_url: ImageURL? = nil, input_audio: InputAudio? = nil) {
+        self.type = type
+        self.text = text
+        self.image_url = image_url
+        self.input_audio = input_audio
+    }
 }
 
 struct ImageURL: Codable {
     let url: String  // "data:image/png;base64,..." or URL
     let detail: String?  // "auto", "low", "high" (optional)
+}
+
+struct InputAudio: Codable {
+    let data: String   // base64-encoded audio
+    let format: String // "wav", "mp3", etc.
 }
 
 struct Message: Content {

--- a/Sources/MacLocalAPI/Models/SpeechService.swift
+++ b/Sources/MacLocalAPI/Models/SpeechService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import Speech
 
 enum SpeechError: Error, LocalizedError {
@@ -35,6 +36,7 @@ enum SpeechError: Error, LocalizedError {
 
 struct SpeechRequestOptions: Sendable {
     static let defaultMaxFileBytes = 50 * 1024 * 1024  // 50 MB
+    static let recognitionTimeoutNs: UInt64 = 120_000_000_000  // 120 seconds
     static let supportedExtensions: Set<String> = ["wav", "mp3", "m4a", "caf", "aiff", "aif"]
 
     let locale: String
@@ -103,25 +105,34 @@ final class SpeechService {
         request.requiresOnDeviceRecognition = true
         request.shouldReportPartialResults = false
 
-        // Run recognition with a timeout to prevent hung requests
-        let recognitionTimeout: UInt64 = 120_000_000_000 // 120 seconds
+        // Run recognition with a timeout to prevent hung requests.
+        // OSAllocatedUnfairLock guards the one-shot continuation resume.
+        let resumed = OSAllocatedUnfairLock(initialState: false)
+
         let text: String = try await withThrowingTaskGroup(of: String.self) { group in
             group.addTask {
                 try await withCheckedThrowingContinuation { continuation in
-                    var resumed = false
                     let queue = OperationQueue()
                     queue.qualityOfService = .userInitiated
 
                     recognizer.queue = queue
-                    recognizer.recognitionTask(with: request) { result, error in
-                        guard !resumed else { return }
+                    let task = recognizer.recognitionTask(with: request) { result, error in
+                        let alreadyResumed = resumed.withLock { done in
+                            if done { return true }
+                            done = true
+                            return false
+                        }
+                        guard !alreadyResumed else { return }
+
                         if let error {
-                            resumed = true
                             continuation.resume(throwing: SpeechError.recognitionFailed(error.localizedDescription))
                             return
                         }
-                        guard let result, result.isFinal else { return }
-                        resumed = true
+                        guard let result, result.isFinal else {
+                            // Not final yet — un-mark so next callback can proceed
+                            resumed.withLock { $0 = false }
+                            return
+                        }
                         let formatted = result.bestTranscription.formattedString
                         if formatted.isEmpty {
                             continuation.resume(throwing: SpeechError.noSpeechFound)
@@ -129,11 +140,21 @@ final class SpeechService {
                             continuation.resume(returning: formatted)
                         }
                     }
+
+                    // Cancel the recognition task if the parent task is cancelled
+                    // (e.g., timeout fires first), ensuring the callback fires
+                    // promptly with an error.
+                    Task {
+                        while !Task.isCancelled {
+                            try? await Task.sleep(nanoseconds: 500_000_000)
+                        }
+                        task.cancel()
+                    }
                 }
             }
             group.addTask {
-                try await Task.sleep(nanoseconds: recognitionTimeout)
-                throw SpeechError.recognitionFailed("Recognition timed out after 120 seconds")
+                try await Task.sleep(nanoseconds: SpeechRequestOptions.recognitionTimeoutNs)
+                throw SpeechError.recognitionFailed("Recognition timed out")
             }
             let result = try await group.next()!
             group.cancelAll()

--- a/Sources/MacLocalAPI/Models/SpeechService.swift
+++ b/Sources/MacLocalAPI/Models/SpeechService.swift
@@ -108,48 +108,46 @@ final class SpeechService {
         // Run recognition with a timeout to prevent hung requests.
         // OSAllocatedUnfairLock guards the one-shot continuation resume.
         let resumed = OSAllocatedUnfairLock(initialState: false)
+        // Holds the SFSpeechRecognitionTask so onCancel can reach it.
+        let taskRef = OSAllocatedUnfairLock<SFSpeechRecognitionTask?>(initialState: nil)
 
         let text: String = try await withThrowingTaskGroup(of: String.self) { group in
             group.addTask {
-                try await withCheckedThrowingContinuation { continuation in
-                    let queue = OperationQueue()
-                    queue.qualityOfService = .userInitiated
+                try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { continuation in
+                        let queue = OperationQueue()
+                        queue.qualityOfService = .userInitiated
 
-                    recognizer.queue = queue
-                    let task = recognizer.recognitionTask(with: request) { result, error in
-                        let alreadyResumed = resumed.withLock { done in
-                            if done { return true }
-                            done = true
-                            return false
+                        recognizer.queue = queue
+                        let task = recognizer.recognitionTask(with: request) { result, error in
+                            if let error {
+                                let shouldResume = resumed.withLock { done in
+                                    if done { return false }
+                                    done = true
+                                    return true
+                                }
+                                guard shouldResume else { return }
+                                continuation.resume(throwing: SpeechError.recognitionFailed(error.localizedDescription))
+                                return
+                            }
+                            guard let result, result.isFinal else { return }
+                            let shouldResume = resumed.withLock { done in
+                                if done { return false }
+                                done = true
+                                return true
+                            }
+                            guard shouldResume else { return }
+                            let formatted = result.bestTranscription.formattedString
+                            if formatted.isEmpty {
+                                continuation.resume(throwing: SpeechError.noSpeechFound)
+                            } else {
+                                continuation.resume(returning: formatted)
+                            }
                         }
-                        guard !alreadyResumed else { return }
-
-                        if let error {
-                            continuation.resume(throwing: SpeechError.recognitionFailed(error.localizedDescription))
-                            return
-                        }
-                        guard let result, result.isFinal else {
-                            // Not final yet — un-mark so next callback can proceed
-                            resumed.withLock { $0 = false }
-                            return
-                        }
-                        let formatted = result.bestTranscription.formattedString
-                        if formatted.isEmpty {
-                            continuation.resume(throwing: SpeechError.noSpeechFound)
-                        } else {
-                            continuation.resume(returning: formatted)
-                        }
+                        taskRef.withLock { $0 = task }
                     }
-
-                    // Cancel the recognition task if the parent task is cancelled
-                    // (e.g., timeout fires first), ensuring the callback fires
-                    // promptly with an error.
-                    Task {
-                        while !Task.isCancelled {
-                            try? await Task.sleep(nanoseconds: 500_000_000)
-                        }
-                        task.cancel()
-                    }
+                } onCancel: {
+                    taskRef.withLock { $0?.cancel() }
                 }
             }
             group.addTask {

--- a/Sources/MacLocalAPI/Models/SpeechService.swift
+++ b/Sources/MacLocalAPI/Models/SpeechService.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Speech
+
+enum SpeechError: Error, LocalizedError {
+    case platformUnavailable
+    case fileNotFound
+    case unsupportedFormat
+    case requestTooLarge(actualBytes: Int, maxBytes: Int)
+    case recognitionFailed(String)
+    case noSpeechFound
+    case onDeviceNotAvailable
+    case authorizationDenied
+
+    var errorDescription: String? {
+        switch self {
+        case .platformUnavailable:
+            return "Apple Speech framework requires macOS 10.15 or later"
+        case .fileNotFound:
+            return "The specified audio file was not found"
+        case .unsupportedFormat:
+            return "Unsupported audio format. Supported formats: WAV, MP3, M4A, CAF, AIFF"
+        case .requestTooLarge(let actualBytes, let maxBytes):
+            return "Audio file size \(actualBytes) bytes exceeds the limit of \(maxBytes) bytes"
+        case .recognitionFailed(let message):
+            return "Speech recognition failed: \(message)"
+        case .noSpeechFound:
+            return "No speech was detected in the audio file"
+        case .onDeviceNotAvailable:
+            return "On-device speech recognition is not available for the requested locale"
+        case .authorizationDenied:
+            return "Speech recognition authorization was denied. Grant access in System Settings > Privacy & Security > Speech Recognition"
+        }
+    }
+}
+
+struct SpeechRequestOptions: Sendable {
+    static let defaultMaxFileBytes = 50 * 1024 * 1024  // 50 MB
+    static let supportedExtensions: Set<String> = ["wav", "mp3", "m4a", "caf", "aiff", "aif"]
+
+    let locale: String
+    let maxFileBytes: Int
+
+    init(
+        locale: String = "en-US",
+        maxFileBytes: Int = SpeechRequestOptions.defaultMaxFileBytes
+    ) {
+        self.locale = locale
+        self.maxFileBytes = maxFileBytes
+    }
+}
+
+@available(macOS 13.0, *)
+final class SpeechService {
+
+    func transcribe(from filePath: String) async throws -> String {
+        try await transcribe(from: filePath, options: SpeechRequestOptions())
+    }
+
+    func transcribe(from filePath: String, options: SpeechRequestOptions) async throws -> String {
+        let fileURL = URL(fileURLWithPath: filePath)
+
+        // Validate file exists
+        guard FileManager.default.fileExists(atPath: filePath) else {
+            throw SpeechError.fileNotFound
+        }
+
+        // Validate extension
+        let ext = fileURL.pathExtension.lowercased()
+        guard SpeechRequestOptions.supportedExtensions.contains(ext) else {
+            throw SpeechError.unsupportedFormat
+        }
+
+        // Validate size
+        let attrs = try FileManager.default.attributesOfItem(atPath: filePath)
+        if let size = attrs[.size] as? Int, size > options.maxFileBytes {
+            throw SpeechError.requestTooLarge(actualBytes: size, maxBytes: options.maxFileBytes)
+        }
+
+        // Check authorization
+        let status = SFSpeechRecognizer.authorizationStatus()
+        if status == .denied || status == .restricted {
+            throw SpeechError.authorizationDenied
+        }
+        if status == .notDetermined {
+            let granted = await withCheckedContinuation { continuation in
+                SFSpeechRecognizer.requestAuthorization { newStatus in
+                    continuation.resume(returning: newStatus == .authorized)
+                }
+            }
+            guard granted else { throw SpeechError.authorizationDenied }
+        }
+
+        // Create recognizer
+        guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: options.locale)) else {
+            throw SpeechError.onDeviceNotAvailable
+        }
+        recognizer.supportsOnDeviceRecognition = true
+
+        // Create request
+        let request = SFSpeechURLRecognitionRequest(url: fileURL)
+        request.requiresOnDeviceRecognition = true
+        request.shouldReportPartialResults = false
+
+        // Use SFSpeechRecognitionTaskDelegate approach via a dedicated queue
+        let text: String = try await withCheckedThrowingContinuation { continuation in
+            var resumed = false
+            let queue = OperationQueue()
+            queue.qualityOfService = .userInitiated
+
+            recognizer.queue = queue
+            recognizer.recognitionTask(with: request) { result, error in
+                guard !resumed else { return }
+                if let error {
+                    resumed = true
+                    continuation.resume(throwing: SpeechError.recognitionFailed(error.localizedDescription))
+                    return
+                }
+                guard let result, result.isFinal else { return }
+                resumed = true
+                let formatted = result.bestTranscription.formattedString
+                if formatted.isEmpty {
+                    continuation.resume(throwing: SpeechError.noSpeechFound)
+                } else {
+                    continuation.resume(returning: formatted)
+                }
+            }
+        }
+
+        return text
+    }
+}

--- a/Sources/MacLocalAPI/Models/SpeechService.swift
+++ b/Sources/MacLocalAPI/Models/SpeechService.swift
@@ -90,40 +90,54 @@ final class SpeechService {
             guard granted else { throw SpeechError.authorizationDenied }
         }
 
-        // Create recognizer
+        // Create recognizer and verify on-device support
         guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: options.locale)) else {
             throw SpeechError.onDeviceNotAvailable
         }
-        recognizer.supportsOnDeviceRecognition = true
+        guard recognizer.supportsOnDeviceRecognition else {
+            throw SpeechError.onDeviceNotAvailable
+        }
 
         // Create request
         let request = SFSpeechURLRecognitionRequest(url: fileURL)
         request.requiresOnDeviceRecognition = true
         request.shouldReportPartialResults = false
 
-        // Use SFSpeechRecognitionTaskDelegate approach via a dedicated queue
-        let text: String = try await withCheckedThrowingContinuation { continuation in
-            var resumed = false
-            let queue = OperationQueue()
-            queue.qualityOfService = .userInitiated
+        // Run recognition with a timeout to prevent hung requests
+        let recognitionTimeout: UInt64 = 120_000_000_000 // 120 seconds
+        let text: String = try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                try await withCheckedThrowingContinuation { continuation in
+                    var resumed = false
+                    let queue = OperationQueue()
+                    queue.qualityOfService = .userInitiated
 
-            recognizer.queue = queue
-            recognizer.recognitionTask(with: request) { result, error in
-                guard !resumed else { return }
-                if let error {
-                    resumed = true
-                    continuation.resume(throwing: SpeechError.recognitionFailed(error.localizedDescription))
-                    return
-                }
-                guard let result, result.isFinal else { return }
-                resumed = true
-                let formatted = result.bestTranscription.formattedString
-                if formatted.isEmpty {
-                    continuation.resume(throwing: SpeechError.noSpeechFound)
-                } else {
-                    continuation.resume(returning: formatted)
+                    recognizer.queue = queue
+                    recognizer.recognitionTask(with: request) { result, error in
+                        guard !resumed else { return }
+                        if let error {
+                            resumed = true
+                            continuation.resume(throwing: SpeechError.recognitionFailed(error.localizedDescription))
+                            return
+                        }
+                        guard let result, result.isFinal else { return }
+                        resumed = true
+                        let formatted = result.bestTranscription.formattedString
+                        if formatted.isEmpty {
+                            continuation.resume(throwing: SpeechError.noSpeechFound)
+                        } else {
+                            continuation.resume(returning: formatted)
+                        }
+                    }
                 }
             }
+            group.addTask {
+                try await Task.sleep(nanoseconds: recognitionTimeout)
+                throw SpeechError.recognitionFailed("Recognition timed out after 120 seconds")
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
         }
 
         return text

--- a/Sources/MacLocalAPI/Models/SpeechService.swift
+++ b/Sources/MacLocalAPI/Models/SpeechService.swift
@@ -145,6 +145,7 @@ final class SpeechService {
                             }
                         }
                         taskRef.withLock { $0 = task }
+                        if Task.isCancelled { task.cancel() }
                     }
                 } onCancel: {
                     taskRef.withLock { $0?.cancel() }

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -241,6 +241,7 @@ class Server {
         }
 
         try app.register(collection: VisionAPIController())
+        try app.register(collection: SpeechAPIController())
 
         if let mlxModelID = mlxModelID, let mlxModelService = mlxModelService {
             let mlxController = MLXChatCompletionsController(
@@ -329,7 +330,7 @@ class Server {
                     total_slots: 1,
                     model_path: mlxModelID,
                     role: "mlx",
-                    modalities: Modalities(vision: true, audio: false),
+                    modalities: Modalities(vision: true, audio: true),
                     chat_template: "",
                     bos_token: "",
                     eos_token: "",
@@ -372,7 +373,7 @@ class Server {
                 total_slots: 1,
                 model_path: modelPath,
                 role: self.gatewayEnabled ? "router" : "model",
-                modalities: Modalities(vision: hasVision, audio: false),
+                modalities: Modalities(vision: hasVision, audio: true),
                 chat_template: "",
                 bos_token: "",
                 eos_token: "",

--- a/Sources/MacLocalAPI/SpeechCommand.swift
+++ b/Sources/MacLocalAPI/SpeechCommand.swift
@@ -1,0 +1,61 @@
+import ArgumentParser
+import Foundation
+
+struct SpeechCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "speech",
+        abstract: "Transcribe audio files using Apple's Speech framework",
+        discussion: """
+        Use Apple's Speech framework to perform on-device speech-to-text transcription.
+
+        Supported formats: WAV, MP3, M4A, CAF, AIFF
+
+        Examples:
+          afm speech -f recording.wav
+          afm speech --file /path/to/audio.m4a
+          afm speech -f meeting.mp3 --locale ja-JP
+        """
+    )
+
+    @Option(name: [.short, .long], help: "Path to the audio file")
+    var file: String
+
+    @Option(name: .long, help: "Locale for speech recognition (default: en-US)")
+    var locale: String = "en-US"
+
+    @Flag(name: .long, help: "Print machine-readable JSON capability card for AI agents and exit")
+    var helpJson: Bool = false
+
+    func run() async throws {
+        if helpJson {
+            printHelpJson(command: "afm speech")
+            return
+        }
+
+        guard !file.isEmpty else {
+            print("Error: File path is required. Use -f or --file to specify the input file.")
+            throw ExitCode.failure
+        }
+
+        let expandedPath = NSString(string: file).expandingTildeInPath
+        let resolvedPath = URL(fileURLWithPath: expandedPath).standardized.path
+
+        do {
+            if #available(macOS 13.0, *) {
+                let service = SpeechService()
+                let options = SpeechRequestOptions(locale: locale)
+                let text = try await service.transcribe(from: resolvedPath, options: options)
+                print(text)
+            } else {
+                throw SpeechError.platformUnavailable
+            }
+        } catch {
+            if let speechError = error as? SpeechError {
+                print("Error: \(speechError.localizedDescription)")
+            } else {
+                print("Error: \(error.localizedDescription)")
+            }
+            throw ExitCode.failure
+        }
+    }
+}

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -1235,7 +1235,7 @@ struct RootCommand: ParsableCommand {
         GitHub: https://github.com/scouzi1966/maclocal-api
         """,
         version: MacLocalAPI.buildVersion,
-        subcommands: [MlxCommand.self, VisionCommand.self]
+        subcommands: [MlxCommand.self, VisionCommand.self, SpeechCommand.self]
     )
 
     @Option(name: [.customShort("s"), .long], help: "Run a single prompt without starting the server")
@@ -1371,6 +1371,28 @@ if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "mlx" {
         try cmd.run()
     } catch {
         MlxCommand.exit(withError: error)
+    }
+} else if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "speech" {
+    let args = Array(CommandLine.arguments.dropFirst(2))
+    do {
+        let cmd = try SpeechCommand.parse(args)
+        let group = DispatchGroup()
+        var caughtError: Error?
+        group.enter()
+        Task {
+            do {
+                try await cmd.run()
+            } catch {
+                caughtError = error
+            }
+            group.leave()
+        }
+        group.wait()
+        if let error = caughtError {
+            throw error
+        }
+    } catch {
+        SpeechCommand.exit(withError: error)
     }
 } else if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "vision" {
     let args = Array(CommandLine.arguments.dropFirst(2))


### PR DESCRIPTION
Closes #106

> **Note:** This PR depends on #105 (Vision OCR webui fix) being merged first. The speech feature builds on the `createBypassStreamingResponse` refactor and `ocrTexts` structured return introduced there. Once #105 lands, this diff will only contain the speech-specific changes.

## Summary

Adds on-device audio transcription using Apple's Speech framework, mirroring the Vision OCR architecture. No network, no API keys — `SFSpeechRecognizer` with `requiresOnDeviceRecognition = true`.

I realized after improving the vision pipeline that it would actually be pretty straightforward to add a very fast audio path using the same built-in Apple libraries.

### New files
- **`SpeechService.swift`** — wraps `SFSpeechRecognizer` with on-device recognition, 120s timeout via `withThrowingTaskGroup`, thread-safe continuation using `OSAllocatedUnfairLock`, cancellation propagation via `withTaskCancellationHandler`
- **`SpeechCommand.swift`** — CLI `afm speech -f <file>` with `--locale` support
- **`SpeechAPIController.swift`** — `POST /v1/audio/transcriptions` endpoint with path sanitization (symlink resolution, extension allowlist) + `extractTranscriptionFromMessages()` for chat integration

### Modified files
- **`OpenAIRequest.swift`** — `InputAudio` struct, `input_audio` field on `ContentPart`
- **`ChatCompletionsController.swift`** — detects `input_audio` alongside `image_url`, runs transcription, bypasses Foundation Model. Handles combined image+audio messages. Renamed `createVisionStreamingResponse` → `createBypassStreamingResponse` for shared use.
- **`Server.swift`** — registers `SpeechAPIController`, sets `audio: true` modality
- **`main.swift`** — registers `afm speech` subcommand

### What's free
The llama.cpp webui already supports audio uploads and shows a microphone button when `audio: true` — no webui changes needed.

## Test plan

- [x] CLI: `afm speech -f <file>` with AIFF, M4A — correct transcription
- [x] CLI: nonexistent file, wrong format — appropriate errors
- [x] API: `POST /v1/audio/transcriptions` with base64 data — correct transcription
- [x] API: path traversal via `file` param — rejected
- [x] API: malicious `format` extension — rejected
- [x] Chat: non-streaming `input_audio` content part — transcription returned, no prompt echo
- [x] Chat: streaming `input_audio` — SSE with transcription, stop, DONE
- [x] Chat: multiple audio files in one message — globally unique labels
- [x] Chat: combined `image_url` + `input_audio` — both OCR and transcription returned
- [x] Chat: text-only — still routes to Foundation Model
- [x] Modalities: `/props` returns `audio: true`
- [x] Regression: Vision OCR still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)