### PR TITLE
Fix macOS 26 Speech SIGABRT (embed Info.plist) + bump baseline to v0.9.11

### DIFF
--- a/.claude/skills/afm-build-promote-nightly/skill.md
+++ b/.claude/skills/afm-build-promote-nightly/skill.md
@@ -324,6 +324,35 @@ echo "PASS: Relocated binary runs without crash"
 
 **If either check fails, STOP IMMEDIATELY. Do NOT package, publish, or release.** Every pip and Homebrew user will get a crash on first run.
 
+**Step 5h: Info.plist embedding check (MANDATORY — blocks Speech Recognition SIGABRT):**
+
+macOS 26 SIGABRTs any process that requests privacy-sensitive APIs (Speech Recognition, microphone, camera, etc.) without the matching `*UsageDescription` key in its embedded Info.plist. Required for `afm speech`, `POST /v1/audio/transcriptions`, and chat `input_audio` content parts. Any future privacy-API integration needs its `*UsageDescription` key added here too.
+
+```bash
+# 1. Verify __TEXT,__info_plist section is present in the binary
+if ! otool -l "$BIN" | grep -q '__info_plist'; then
+  echo "FATAL: Missing __TEXT,__info_plist section in binary"
+  echo "Check Package.swift linker flags (-Xlinker -sectcreate ...) and Sources/MacLocalAPI/Info.plist"
+  exit 1
+fi
+
+# 2. Verify NSSpeechRecognitionUsageDescription key is embedded
+if ! strings "$BIN" | grep -q 'NSSpeechRecognitionUsageDescription'; then
+  echo "FATAL: NSSpeechRecognitionUsageDescription missing from embedded plist"
+  echo "afm speech / /v1/audio/transcriptions will SIGABRT on macOS 26"
+  exit 1
+fi
+
+# 3. Verify Info.plist source file is well-formed
+plutil -lint Sources/MacLocalAPI/Info.plist || { echo "FATAL: Info.plist is malformed"; exit 1; }
+
+echo "PASS: Info.plist embedded with NSSpeechRecognitionUsageDescription"
+```
+
+**If this fails, STOP.** Shipping a stable release with broken Speech Recognition is worse than shipping a nightly — stable users have higher expectations.
+
+**Note on CFBundleIdentifier in Info.plist:** The `CFBundleIdentifier` (`com.scouzi1966.afm`) establishes the TCC identity. Changing it later forces every user to re-grant Speech Recognition / microphone / camera permission. Treat it as a stable contract across releases.
+
 ### Step 6: Package Stable Tarball
 
 ```bash

--- a/.claude/skills/afm-release-wheel/skill.md
+++ b/.claude/skills/afm-release-wheel/skill.md
@@ -70,10 +70,21 @@ test -f "$METALLIB" && echo "Metallib: OK ($(ls -lh "$METALLIB" | awk '{print $5
 
 # WebUI (MANDATORY)
 test -f Resources/webui/index.html.gz && echo "WebUI: OK" || echo "FATAL: WebUI MISSING — run /build-afm first"
+
+# Info.plist embedded with NSSpeechRecognitionUsageDescription (MANDATORY for macOS 26)
+# Wheel users get a crash on `afm speech` / POST /v1/audio/transcriptions / chat input_audio
+# if the binary doesn't have this key embedded. See Sources/MacLocalAPI/Info.plist +
+# Package.swift -Xlinker -sectcreate flags.
+if otool -l "$BIN" | grep -q '__info_plist' && strings "$BIN" | grep -q 'NSSpeechRecognitionUsageDescription'; then
+  echo "Info.plist: OK (NSSpeechRecognitionUsageDescription embedded)"
+else
+  echo "FATAL: Info.plist missing or NSSpeechRecognitionUsageDescription not embedded — run /build-afm to rebuild"
+fi
 ```
 
 If binary is missing, **STOP** and tell user to run `/build-afm` first.
 If WebUI is missing, **STOP** — the `-w` flag won't work without it. Run `/build-afm` to rebuild with webui.
+If Info.plist check fails, **STOP** — shipping a wheel without the embedded Info.plist means every pip user that calls Speech Recognition gets a SIGABRT on macOS 26. Run `/build-afm` (which now enforces this).
 
 ### Step 4: Stage Assets and Build Wheel
 

--- a/.claude/skills/build-afm-nightly-publish/skill.md
+++ b/.claude/skills/build-afm-nightly-publish/skill.md
@@ -308,7 +308,44 @@ fi
 
 **Why this matters:** Even a single `Bundle.module` call anywhere in the code path triggers the auto-generated `fatalError`. This is a regression guard — any future code that adds `Bundle.module` will be caught here before it ships.
 
-#### Check 11: Report all vendor/submodule pin levels
+#### Check 11: Info.plist embedded with privacy usage descriptions
+
+macOS 26 SIGABRTs any process that requests privacy-sensitive APIs (Speech Recognition, microphone, camera, contacts, etc.) without a matching `*UsageDescription` key in its Info.plist. Currently required for PR #107's Apple Speech feature (`afm speech`, `POST /v1/audio/transcriptions`, chat `input_audio` content parts). Any future privacy-API integration needs its key added here too.
+
+```bash
+BIN=.build/arm64-apple-macosx/release/afm
+
+# Verify __TEXT,__info_plist section exists (embedded via Package.swift linker flags)
+if otool -l "$BIN" | grep -q '__info_plist'; then
+  PLIST_SIZE=$(otool -l "$BIN" | grep -A4 __info_plist | grep 'size' | awk '{print $2}')
+  echo "PASS: __info_plist section present ($PLIST_SIZE bytes)"
+else
+  echo "FAIL: Missing __TEXT,__info_plist section"
+  echo "Check Package.swift linker flags (-Xlinker -sectcreate ...) and Sources/MacLocalAPI/Info.plist"
+fi
+
+# Verify NSSpeechRecognitionUsageDescription key is present
+if strings "$BIN" | grep -q 'NSSpeechRecognitionUsageDescription'; then
+  echo "PASS: NSSpeechRecognitionUsageDescription key embedded"
+else
+  echo "FAIL: NSSpeechRecognitionUsageDescription missing from embedded plist"
+  echo "afm speech / /v1/audio/transcriptions will SIGABRT on macOS 26"
+fi
+
+# Verify plist structure is parseable (not corrupted during build)
+plutil -lint Sources/MacLocalAPI/Info.plist
+```
+
+**Why this matters:** Without the embedded plist, running `afm speech -f foo.wav` (or any endpoint that calls SFSpeechRecognizer) crashes before returning any output. The build script `Scripts/build-from-scratch.sh` already enforces this — but also check here so the publish flow fails loudly if someone bypasses the build script or if Package.swift's linker flags get reverted in a merge.
+
+**Root cause if it fails:**
+1. `Sources/MacLocalAPI/Info.plist` was deleted or renamed
+2. Package.swift's `linkerSettings` lost the `-Xlinker -sectcreate -Xlinker __TEXT -Xlinker __info_plist -Xlinker …` flags
+3. Someone added a new privacy-API usage (microphone, camera) without adding the corresponding `*UsageDescription` key to Info.plist
+
+Full plist must also include `CFBundleIdentifier`, `CFBundleName`, `CFBundleExecutable` — these establish TCC identity. Changing `CFBundleIdentifier` later would force existing users to re-grant Speech Recognition permission.
+
+#### Check 12: Report all vendor/submodule pin levels
 
 Present the exact version of every submodule and SPM dependency so the user can verify the build reproduces the expected dependency tree. Also fetch the latest release tag from each upstream repo to show if we're behind.
 
@@ -348,6 +385,7 @@ This is informational — no pass/fail. But if a resolved version is unexpected 
 | 8 | Binary stripped, reasonable size | unstripped → bloated download | PASS/FAIL |
 | 9 | Relocated binary works (pip sim) | Bundle.module fatalError → crash on pip install | PASS/FAIL |
 | 10 | No Bundle.module in source | regression guard → future crash on relocated binary | PASS/FAIL |
+| 11 | Info.plist embedded + NSSpeechRecognitionUsageDescription | macOS 26 SIGABRTs Speech Recognition without UsageDescription key | PASS/FAIL |
 
 Then present two separate tables for vendor pins:
 

--- a/.claude/skills/build-afm/SKILL.md
+++ b/.claude/skills/build-afm/SKILL.md
@@ -88,6 +88,7 @@ The script already handles:
    - Version injection: writes the git commit SHA into `BuildInfo.swift` (then restores it after build)
    - Strip symbols for release builds
    - Metallib bundle verification
+   - **Info.plist embedding verification** — fails the build if the `__TEXT,__info_plist` section is missing or doesn't contain `NSSpeechRecognitionUsageDescription`. Required by `Sources/MacLocalAPI/Info.plist` + Package.swift linker flags (`-Xlinker -sectcreate -Xlinker __TEXT -Xlinker __info_plist -Xlinker …`). Without this, macOS 26 SIGABRTs any Speech Recognition / microphone / camera call.
 
 ### Step 3: Report Results
 

--- a/.claude/skills/test-afm-binary/SKILL.md
+++ b/.claude/skills/test-afm-binary/SKILL.md
@@ -100,6 +100,30 @@ else
 fi
 ```
 
+#### Check E: Info.plist embedded with privacy usage descriptions
+
+macOS 26 SIGABRTs any process that requests privacy-sensitive APIs (Speech Recognition, microphone, camera, etc.) without a matching `*UsageDescription` key in the binary's embedded Info.plist. PR #107's Apple Speech feature triggers this on every `afm speech` / `POST /v1/audio/transcriptions` / chat `input_audio` call.
+
+```bash
+# Verify __TEXT,__info_plist section exists
+if otool -l "$BIN_ABS" | grep -q '__info_plist'; then
+  echo "PASS: __info_plist section present"
+else
+  echo "FAIL: Missing __TEXT,__info_plist section"
+  echo "Check Package.swift linker flags and Sources/MacLocalAPI/Info.plist"
+fi
+
+# Verify NSSpeechRecognitionUsageDescription key is in the embedded plist
+if strings "$BIN_ABS" | grep -q 'NSSpeechRecognitionUsageDescription'; then
+  echo "PASS: NSSpeechRecognitionUsageDescription embedded"
+else
+  echo "FAIL: NSSpeechRecognitionUsageDescription missing"
+  echo "afm speech / /v1/audio/transcriptions will SIGABRT on macOS 26"
+fi
+```
+
+**Note on testing Speech from an unattended context:** If this skill is running inside Claude Code / an editor terminal / any parent process that does NOT have NSSpeechRecognitionUsageDescription, macOS 26 attributes the TCC subject to the parent and the child crashes even with a correct embedded plist. This is a test-environment artifact, not a binary bug. To verify Speech end-to-end, run `afm speech -f <file.wav>` from a fresh Terminal.app window (stock /System/Applications/Utilities/Terminal.app).
+
 #### Present pre-flight results
 
 | Check | What it catches | Result |
@@ -108,8 +132,9 @@ fi
 | B: Metallib | Missing Metal shaders → crash on inference | PASS/FAIL |
 | C: Relocated binary | Bundle.module fatalError → crash on pip install | PASS/FAIL |
 | D: No Bundle.module | Source code regression guard | PASS/FAIL |
+| E: Info.plist embedded | macOS 26 SIGABRT on Speech Recognition without UsageDescription | PASS/FAIL |
 
-**If B, C, or D fail, STOP. Do not proceed.**
+**If B, C, D, or E fail, STOP. Do not proceed.**
 
 ### Step 3: Select Model
 

--- a/Package.swift
+++ b/Package.swift
@@ -72,6 +72,11 @@ let package = Package(
                 .product(name: "Hub", package: "swift-transformers"),
                 .product(name: "HuggingFace", package: "swift-huggingface")
             ],
+            exclude: [
+                // Embedded into the binary's __TEXT,__info_plist section via linker flags below.
+                // Excluded from SPM resource processing so it isn't also copied into the bundle.
+                "Info.plist"
+            ],
             resources: [
                 .copy("Resources/default.metallib")
             ],
@@ -83,6 +88,17 @@ let package = Package(
                 .unsafeFlags(["-file-prefix-map", "\(packageDir)/="], .when(configuration: .release))
             ],
             linkerSettings: [
+                // Embed Info.plist with NSSpeechRecognitionUsageDescription into the binary's
+                // __TEXT,__info_plist section. macOS 26 SIGABRTs any process that requests
+                // privacy-sensitive APIs (Speech Recognition, microphone, camera, etc.) without
+                // a matching *UsageDescription key in its Info.plist. Required for PR #107's
+                // Apple Speech feature; harmless for non-Speech code paths.
+                .unsafeFlags([
+                    "-Xlinker", "-sectcreate",
+                    "-Xlinker", "__TEXT",
+                    "-Xlinker", "__info_plist",
+                    "-Xlinker", "\(packageDir)/Sources/MacLocalAPI/Info.plist"
+                ]),
                 // Create a more portable executable
                 .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "@executable_path"], .when(configuration: .release)),
                 .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "/usr/lib/swift"], .when(configuration: .release)),

--- a/Scripts/build-from-scratch.sh
+++ b/Scripts/build-from-scratch.sh
@@ -204,6 +204,28 @@ else
   exit 1
 fi
 
+# Verify Info.plist is embedded in the binary's __TEXT,__info_plist section.
+# Without this, macOS 26 SIGABRTs any process that requests privacy-sensitive APIs
+# (Speech Recognition, microphone, camera, etc.) — the Speech transcription feature
+# and any future privacy-API integration will crash on first use.
+# The linker flags in Package.swift (-Xlinker -sectcreate -Xlinker __TEXT
+# -Xlinker __info_plist -Xlinker Sources/MacLocalAPI/Info.plist) must be preserved.
+INFO_PLIST_SECTION=$(otool -l "$FINAL_BIN" 2>/dev/null | grep -A2 '__info_plist' | head -3)
+if echo "$INFO_PLIST_SECTION" | grep -q '__info_plist'; then
+  if strings "$FINAL_BIN" | grep -q 'NSSpeechRecognitionUsageDescription'; then
+    log_info "Info.plist embedded OK (NSSpeechRecognitionUsageDescription present)"
+  else
+    log_error "Info.plist section present but NSSpeechRecognitionUsageDescription key is missing"
+    log_error "Check Sources/MacLocalAPI/Info.plist — required for Apple Speech Recognition"
+    exit 1
+  fi
+else
+  log_error "Missing __TEXT,__info_plist section in binary"
+  log_error "Check Package.swift linker flags and Sources/MacLocalAPI/Info.plist exists"
+  log_error "macOS 26 SIGABRTs any process that calls privacy-sensitive APIs without Info.plist"
+  exit 1
+fi
+
 # Make metallib discoverable for `swift test` after a clean release build.
 # MLX framework searches CWD for "default.metallib" as its last resort.
 # A symlink at the project root ensures `swift test` (which runs from project root) finds it.

--- a/Sources/MacLocalAPI/BuildInfo.swift
+++ b/Sources/MacLocalAPI/BuildInfo.swift
@@ -2,7 +2,7 @@
 // Auto-generated build information - DO NOT EDIT MANUALLY
 
 struct BuildInfo {
-    static let version: String? = "v0.9.10"
+    static let version: String? = "v0.9.11"
     static let commit: String? = nil
 
     static var fullVersion: String {

--- a/Sources/MacLocalAPI/Info.plist
+++ b/Sources/MacLocalAPI/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.scouzi1966.afm</string>
+    <key>CFBundleName</key>
+    <string>afm</string>
+    <key>CFBundleExecutable</key>
+    <string>afm</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>afm uses on-device Apple Speech Recognition to transcribe audio you provide via the `afm speech` CLI, the `/v1/audio/transcriptions` API, and chat completions that include `input_audio` content parts.</string>
+</dict>
+</plist>

--- a/macafm/__init__.py
+++ b/macafm/__init__.py
@@ -13,7 +13,7 @@ Requirements:
 - Apple Intelligence enabled in System Settings
 """
 
-__version__ = "0.9.10"
+__version__ = "0.9.11"
 __author__ = "Sylvain Cousineau"
 
 from .cli import main, get_binary_path

--- a/macafm_next.egg-info/PKG-INFO
+++ b/macafm_next.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: macafm-next
-Version: 0.9.10.dev20260408
+Version: 0.9.11.dev20260418
 Summary: Nightly build of AFM — local LLM inference on Apple Silicon via OpenAI-compatible API
 Author: Sylvain Cousineau
 License-Expression: MIT

--- a/macafm_next/__init__.py
+++ b/macafm_next/__init__.py
@@ -10,7 +10,7 @@ Requirements:
 - Apple Intelligence enabled in System Settings
 """
 
-__version__ = "0.9.10.dev20260408"
+__version__ = "0.9.11.dev20260418"
 __author__ = "Sylvain Cousineau"
 
 from .cli import main, get_binary_path

--- a/pyproject-next.toml
+++ b/pyproject-next.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macafm-next"
-version = "0.9.10.dev20260408"
+version = "0.9.11.dev20260418"
 description = "Nightly build of AFM — local LLM inference on Apple Silicon via OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macafm"
-version = "0.9.10"
+version = "0.9.11"
 description = "Access Apple's on-device Foundation Models via CLI and OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Two commits for the next nightly release:

1. **[`b39cd60`] Fix macOS 26 Speech Recognition SIGABRT** — embeds `Sources/MacLocalAPI/Info.plist` into the binary's `__TEXT,__info_plist` section via Package.swift linker flags. Without this, every Speech feature from #107 (CLI `afm speech`, `POST /v1/audio/transcriptions`, chat `input_audio` content parts) crashes before returning output on macOS 26. Adds regression guards in `Scripts/build-from-scratch.sh` and 5 Claude Code skills (`build-afm`, `build-afm-nightly-publish`, `test-afm-binary`, `afm-build-promote-nightly`, `afm-release-wheel`) so any publish flow catches the regression independently.

2. **[`9b3f3bf`] Bump version baseline to `v0.9.11`** — commit `332c8c2` promoted the previous nightly to stable v0.9.10 but never bumped back to the next development version. Every commit merged since (including PRs #104 and #107) has silently reported `v0.9.10`. The `332c8c2` commit message itself said #101 "ships in v0.9.11" — making this the intended baseline.

## Root cause (Speech SIGABRT)

TCC on macOS 26 rejects any privacy-API request from a binary without the matching `*UsageDescription` key. Before the fix, `codesign -dv` reported `Info.plist=not bound`. After the fix, it reports `Info.plist entries=4` and the binary generates tokens from real audio input.

## Reproduction

Before the fix, from a stock Terminal.app window:
```
$ afm speech -f hello.wav
(SIGABRT, exit 134)
```

After the fix:
```
$ afm speech -f hello.wav
(macOS prompt: "Terminal would like to access Speech Recognition" → user allows)
The quick brown fox jumps over the lazy dog
```

Verified end-to-end in a fresh Terminal.app session. The permission prompt fires exactly once and is remembered per parent app per TCC's normal flow.

## No Developer ID required

Fix is pure linker work (`-sectcreate __TEXT __info_plist …`). Binary stays adhoc-signed, no notarization, no Team ID. Brew users install the same binary — they see the one-time permission prompt on first `afm speech` call.

## Test plan

- [x] Build succeeds with new `Scripts/build-from-scratch.sh` guard (fails if `__info_plist` missing or `NSSpeechRecognitionUsageDescription` absent)
- [x] `codesign -dv` shows `Info.plist entries=4` and `Identifier=com.scouzi1966.afm`
- [x] `otool -l afm | grep __info_plist` shows the section at ~0x1021a8520 (647 bytes)
- [x] `strings afm | grep NSSpeechRecognitionUsageDescription` returns the key
- [x] `afm speech -f hello.wav` from stock Terminal.app: macOS prompts once, then transcribes "the quick brown fox"
- [x] `plutil -lint Sources/MacLocalAPI/Info.plist`: OK
- [x] Vision OCR XCTest (PR #104 harness) still passes: 7/7 in 0.110s
- [x] Relocated-binary pip simulation (`afm` + loose `default.metallib` in a tmpdir): generates tokens, no fatalError

## Files changed

| File | Purpose |
|------|---------|
| `Sources/MacLocalAPI/Info.plist` (new) | The embedded plist (CFBundleIdentifier + NSSpeechRecognitionUsageDescription) |
| `Package.swift` | Linker flags to embed the plist; `exclude` so SPM doesn't double-bundle it |
| `Scripts/build-from-scratch.sh` | Build-time guard: fails if plist section or key missing |
| `.claude/skills/build-afm/SKILL.md` | Doc-only: mentions the new build check |
| `.claude/skills/build-afm-nightly-publish/skill.md` | New Check 11; vendor-pins renumbered to Check 12 |
| `.claude/skills/test-afm-binary/SKILL.md` | New Check E in pre-flight; note on TCC parent-responsibility artifact |
| `.claude/skills/afm-build-promote-nightly/skill.md` | New Step 5h blocks stable release if plist missing |
| `.claude/skills/afm-release-wheel/skill.md` | Pre-wheel validation also checks embedded plist |
| `Sources/MacLocalAPI/BuildInfo.swift` | v0.9.10 → v0.9.11 |
| `pyproject.toml` · `macafm/__init__.py` | 0.9.10 → 0.9.11 (stable track) |
| `pyproject-next.toml` · `macafm_next/__init__.py` · `PKG-INFO` | 0.9.10.dev20260408 → 0.9.11.dev20260418 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Embed a macOS Info.plist with required privacy usage descriptions into the AFM binary to prevent Speech-related crashes on macOS 26 and bump the project version baseline to v0.9.11 across Swift and Python artifacts.

Bug Fixes:
- Prevent Speech Recognition-related SIGABRTs on macOS 26 by embedding an Info.plist with NSSpeechRecognitionUsageDescription into the AFM binary.

Enhancements:
- Add build and release-time guards that verify the embedded Info.plist section and required privacy keys so regressions are caught before publishing.
- Document the new Info.plist embedding checks in the Claude Code build, test, nightly publish, and wheel release skills.

Build:
- Extend build-from-scratch.sh to enforce presence and correctness of the embedded Info.plist section and NSSpeechRecognitionUsageDescription.

CI:
- Tighten Claude Code skill workflows to fail publishes and releases if the Info.plist embedding or Speech privacy key checks fail.

Deployment:
- Ensure wheel and nightly promotion flows validate the Info.plist embedding so distributed binaries remain compatible with macOS 26 privacy requirements.

Documentation:
- Update internal skill documentation to describe Info.plist embedding requirements and the impact on macOS 26 Speech behavior.

Chores:
- Bump AFM version metadata from v0.9.10 to v0.9.11 in Swift sources and Python packaging files, including nightly dev version tags.