### PR TITLE
Add on-device speech and expanded vision APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ xcuserdata/
 # IDE
 .vscode/
 .idea/
+.claude/
 
 # Logs
 *.log
@@ -70,6 +71,9 @@ test_lora.fmadapter
 
 # Build-from-scratch test workspace
 build-from-scratch/
+
+# Local test workspace
+afm-test/
 
 # Vendor patch stamp
 vendor/mlx-swift-lm/.patches-applied

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ vendor/llama.cpp/tools/server/public/
 .codex/*secret*
 .codex/*auth*.json
 /default.metallib
+
+# Worktrees
+.worktrees/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "vendor/llama.cpp"]
 	path = vendor/llama.cpp
 	url = https://github.com/ggml-org/llama.cpp.git
+	ignore = dirty
 [submodule "vendor/mlx-swift-lm"]
 	path = vendor/mlx-swift-lm
 	url = https://github.com/ml-explore/mlx-swift-lm.git
+	ignore = dirty
 [submodule "vendor/xgrammar"]
 	path = vendor/xgrammar
 	url = https://github.com/mlc-ai/xgrammar.git
+	ignore = dirty

--- a/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
@@ -49,7 +49,6 @@ struct ChatCompletionsController: RouteCollection {
         var fallbackModel = "foundation"
         var fallbackMessages: [Message] = []
         var fallbackMaxTokens = 2000
-        var visionCleanupURLs: [URL] = []
         do {
             let chatRequest = try req.content.decode(ChatCompletionRequest.self)
             fallbackModel = chatRequest.model ?? "foundation"
@@ -100,37 +99,56 @@ struct ChatCompletionsController: RouteCollection {
             let processedMessages: [Message]
             if #available(macOS 26.0, *) {
                 foundationService = try await FoundationModelService.createWithSharedAdapter(instructions: instructions, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails)
-                let shouldApplyVisionOCR = chatRequest.messages.contains { message in
+                // Detect media content that should bypass the Foundation Model
+                let hasImages = chatRequest.messages.contains { message in
                     guard let content = message.content, case .parts(let parts) = content else { return false }
                     return parts.contains(where: { $0.type == "image_url" })
                 }
-                if shouldApplyVisionOCR {
-                    // Run OCR and return results directly — Foundation Models has a
-                    // 4096 token context limit that OCR text easily exceeds.  Bypass
-                    // the LLM entirely, matching `afm vision -f` behaviour.
-                    let visionOptions = VisionRequestOptions()
-                    let visionProcessed = try await VisionAPIController.extractOCRTextFromMessages(chatRequest.messages, options: visionOptions)
-                    visionCleanupURLs = visionProcessed.cleanupURLs
+                let hasAudio = chatRequest.messages.contains { message in
+                    guard let content = message.content, case .parts(let parts) = content else { return false }
+                    return parts.contains(where: { $0.type == "input_audio" })
+                }
+
+                if hasImages || hasAudio {
+                    // Run on-device extraction and return results directly —
+                    // Foundation Models has a 4096 token context limit that
+                    // extracted text easily exceeds.  Bypass the LLM entirely.
+                    var extractedTexts: [String] = []
+                    var allCleanupURLs: [URL] = []
+
+                    if hasImages {
+                        let visionProcessed = try await VisionAPIController.extractOCRTextFromMessages(chatRequest.messages, options: VisionRequestOptions())
+                        extractedTexts.append(contentsOf: visionProcessed.ocrTexts)
+                        allCleanupURLs.append(contentsOf: visionProcessed.cleanupURLs)
+                    }
+                    if hasAudio {
+                        let speechProcessed = try await SpeechAPIController.extractTranscriptionFromMessages(chatRequest.messages, options: SpeechRequestOptions())
+                        extractedTexts.append(contentsOf: speechProcessed.transcriptionTexts)
+                        allCleanupURLs.append(contentsOf: speechProcessed.cleanupURLs)
+                    }
+
+                    // Safe to clean up temp files here: extractedContent is materialized
+                    // in memory as a String, so the streaming path never reads temp files.
                     defer {
-                        for url in visionCleanupURLs {
+                        for url in allCleanupURLs {
                             try? FileManager.default.removeItem(at: url)
                         }
                     }
 
-                    let ocrContent = visionProcessed.ocrTexts.joined(separator: "\n\n")
+                    let extractedContent = extractedTexts.joined(separator: "\n\n")
 
                     if chatRequest.stream == true && streamingEnabled {
-                        return try await createVisionStreamingResponse(
+                        return try await createBypassStreamingResponse(
                             req: req,
                             chatRequest: chatRequest,
-                            ocrContent: ocrContent
+                            content: extractedContent
                         )
                     } else {
                         let promptTokens = estimateTokens(for: chatRequest.messages)
-                        let completionTokens = estimateTokens(for: ocrContent)
+                        let completionTokens = estimateTokens(for: extractedContent)
                         let response = ChatCompletionResponse(
                             model: chatRequest.model ?? "foundation",
-                            content: ocrContent,
+                            content: extractedContent,
                             finishReason: "stop",
                             promptTokens: promptTokens,
                             completionTokens: completionTokens
@@ -143,12 +161,6 @@ struct ChatCompletionsController: RouteCollection {
             } else {
                 throw FoundationModelError.notAvailable
             }
-            defer {
-                for url in visionCleanupURLs {
-                    try? FileManager.default.removeItem(at: url)
-                }
-            }
-
             // Check if streaming is requested and enabled
             if chatRequest.stream == true && streamingEnabled {
                 return try await createStreamingResponse(req: req, chatRequest: chatRequest, processedMessages: processedMessages, foundationService: foundationService)
@@ -490,9 +502,9 @@ struct ChatCompletionsController: RouteCollection {
         return httpResponse
     }
 
-    /// Stream OCR results directly to the client, bypassing the Foundation Model.
-    /// Mirrors what `afm vision -f` does: run Vision OCR and return extracted text.
-    private func createVisionStreamingResponse(req: Request, chatRequest: ChatCompletionRequest, ocrContent: String) async throws -> Response {
+    /// Stream extracted content directly to the client, bypassing the Foundation Model.
+    /// Used for Vision OCR and Speech transcription results.
+    private func createBypassStreamingResponse(req: Request, chatRequest: ChatCompletionRequest, content: String) async throws -> Response {
         let httpResponse = Response(status: .ok)
         httpResponse.headers.add(name: .contentType, value: "text/event-stream")
         httpResponse.headers.add(name: .cacheControl, value: "no-cache")
@@ -504,17 +516,17 @@ struct ChatCompletionsController: RouteCollection {
         let streamId = UUID().uuidString
         let model = chatRequest.model ?? "foundation"
         let promptTokens = estimateTokens(for: chatRequest.messages)
-        let completionTokens = estimateTokens(for: ocrContent)
+        let completionTokens = estimateTokens(for: content)
 
         httpResponse.body = .init(asyncStream: { writer in
             let encoder = JSONEncoder()
 
             do {
-                // Send content in a single chunk (OCR is already complete)
+                // Send content in a single chunk (extraction is already complete)
                 let contentChunk = ChatCompletionStreamResponse(
                     id: streamId,
                     model: model,
-                    content: ocrContent,
+                    content: content,
                     isFirst: true
                 )
                 let contentData = try encoder.encode(contentChunk)

--- a/Sources/MacLocalAPI/Controllers/SpeechAPIController.swift
+++ b/Sources/MacLocalAPI/Controllers/SpeechAPIController.swift
@@ -1,0 +1,378 @@
+import Vapor
+import Foundation
+
+extension SpeechError: AbortError {
+    var status: HTTPResponseStatus {
+        switch self {
+        case .platformUnavailable: return .serviceUnavailable
+        case .fileNotFound: return .notFound
+        case .unsupportedFormat: return .badRequest
+        case .recognitionFailed: return .internalServerError
+        case .noSpeechFound: return .unprocessableEntity
+        case .onDeviceNotAvailable: return .serviceUnavailable
+        case .authorizationDenied: return .forbidden
+        }
+    }
+
+    var reason: String { errorDescription ?? "Speech error" }
+}
+
+struct SpeechTranscriptionResponse: Content {
+    let object: String
+    let text: String
+    let locale: String
+}
+
+struct TTSSpeechRequest: Content {
+    let model: String?
+    let input: String
+    let voice: String?
+    let responseFormat: String?
+    let speed: Double?
+    let locale: String?
+    let appleVoice: String?
+
+    enum CodingKeys: String, CodingKey {
+        case model, input, voice
+        case responseFormat = "response_format"
+        case speed, locale
+        case appleVoice = "apple_voice"
+    }
+}
+
+struct VerboseTranscriptionResponse: Content {
+    let text: String
+    let language: String
+    let duration: Double
+    let words: [TranscriptionWord]?
+    let segments: [TranscriptionSegment]?
+}
+
+struct SpeechAPIController: RouteCollection {
+
+    func boot(routes: RoutesBuilder) throws {
+        let v1 = routes.grouped("v1")
+        let speech = v1.grouped("audio")
+        speech.on(.POST, "transcriptions", body: .collect(maxSize: "110mb"), use: transcribe)
+        speech.on(.OPTIONS, "transcriptions", use: handleOptions)
+        speech.on(.POST, "speech", body: .collect(maxSize: "1mb"), use: synthesize)
+        speech.on(.OPTIONS, "speech", use: handleOptions)
+        speech.on(.GET, "voices", use: listVoices)
+        speech.on(.OPTIONS, "voices", use: handleOptions)
+    }
+
+    private func handleOptions(req: Request) async throws -> Response {
+        let response = Response(status: .ok)
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        response.headers.add(name: .accessControlAllowMethods, value: "GET, POST, OPTIONS")
+        response.headers.add(name: .accessControlAllowHeaders, value: "Content-Type, Authorization")
+        return response
+    }
+
+    private func createErrorResponse(message: String, status: HTTPStatus, type: String = "invalid_request_error") async throws -> Response {
+        let response = Response(status: status)
+        response.headers.add(name: .contentType, value: "application/json")
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        try response.content.encode(OpenAIError(message: message, type: type))
+        return response
+    }
+
+    private func transcribe(req: Request) async throws -> Response {
+        guard #available(macOS 13.0, *) else {
+            return try await createErrorResponse(message: "Speech recognition requires macOS 13.0 or later", status: .serviceUnavailable, type: "speech_unavailable")
+        }
+
+        struct TranscriptionRequest: Content {
+            let file: String?
+            let data: String?
+            let format: String?
+            let locale: String?
+            let model: String?
+            let language: String?
+            let responseFormat: String?
+            let timestampGranularities: [String]?
+            enum CodingKeys: String, CodingKey {
+                case file, data, format, locale, model, language
+                case responseFormat = "response_format"
+                case timestampGranularities = "timestamp_granularities"
+            }
+        }
+
+        let body = try req.content.decode(TranscriptionRequest.self)
+
+        // language takes precedence over locale
+        let effectiveLocale: String
+        if let language = body.language, !language.isEmpty {
+            effectiveLocale = language
+        } else {
+            effectiveLocale = body.locale ?? "en-US"
+        }
+
+        let options = SpeechRequestOptions(locale: effectiveLocale)
+        let service = SpeechService()
+        var cleanupURLs: [URL] = []
+
+        defer {
+            for url in cleanupURLs {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+
+        let filePath: String
+        if let file = body.file, !file.isEmpty {
+            filePath = try Self.sanitizeAudioPath(file)
+        } else if let data = body.data, !data.isEmpty {
+            let ext = try Self.validatedExtension(body.format ?? "wav")
+            let tempURL = try Self.writeTempAudio(base64: data, ext: ext)
+            cleanupURLs.append(tempURL)
+            filePath = tempURL.path
+        } else {
+            return try await createErrorResponse(message: "Either 'file' path or 'data' (base64) is required", status: .badRequest)
+        }
+
+        let responseFormat = body.responseFormat?.lowercased() ?? "json"
+
+        switch responseFormat {
+        case "text":
+            let text = try await service.transcribe(from: filePath, options: options)
+            let httpResponse = Response(status: .ok)
+            httpResponse.headers.add(name: .contentType, value: "text/plain")
+            httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
+            httpResponse.body = .init(string: text)
+            return httpResponse
+
+        case "json":
+            let text = try await service.transcribe(from: filePath, options: options)
+            let httpResponse = Response(status: .ok)
+            httpResponse.headers.add(name: .contentType, value: "application/json")
+            httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
+            try httpResponse.content.encode(SpeechTranscriptionResponse(
+                object: "speech.transcription",
+                text: text,
+                locale: effectiveLocale
+            ))
+            return httpResponse
+
+        case "verbose_json":
+            let result = try await service.transcribeWithDetails(from: filePath, options: options)
+            let granularities = Set(body.timestampGranularities ?? ["segment"])
+            let verboseResponse = Self.formatAsVerboseJSON(result: result, granularities: granularities)
+            let httpResponse = Response(status: .ok)
+            httpResponse.headers.add(name: .contentType, value: "application/json")
+            httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
+            try httpResponse.content.encode(verboseResponse)
+            return httpResponse
+
+        case "srt":
+            let result = try await service.transcribeWithDetails(from: filePath, options: options)
+            let srtText = result.formatAsSRT()
+            let httpResponse = Response(status: .ok)
+            httpResponse.headers.add(name: .contentType, value: "text/plain")
+            httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
+            httpResponse.body = .init(string: srtText)
+            return httpResponse
+
+        case "vtt":
+            let result = try await service.transcribeWithDetails(from: filePath, options: options)
+            let vttText = result.formatAsVTT()
+            let httpResponse = Response(status: .ok)
+            httpResponse.headers.add(name: .contentType, value: "text/vtt")
+            httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
+            httpResponse.body = .init(string: vttText)
+            return httpResponse
+
+        default:
+            return try await createErrorResponse(message: "Unsupported response_format '\(responseFormat)'. Supported: json, text, verbose_json, srt, vtt", status: .badRequest)
+        }
+    }
+
+    private func synthesize(req: Request) async throws -> Response {
+        guard #available(macOS 13.0, *) else {
+            return try await createErrorResponse(message: "Text-to-speech requires macOS 13.0 or later", status: .serviceUnavailable, type: "speech_unavailable")
+        }
+
+        let body = try req.content.decode(TTSSpeechRequest.self)
+
+        guard !body.input.isEmpty else {
+            return try await createErrorResponse(message: "Input text is required and must not be empty", status: .badRequest)
+        }
+        guard body.input.count <= TTSRequestOptions.maxInputCharacters else {
+            return try await createErrorResponse(message: "Input text exceeds maximum of \(TTSRequestOptions.maxInputCharacters) characters", status: .badRequest)
+        }
+
+        let format: TTSAudioFormat
+        if let fmt = body.responseFormat {
+            guard let parsed = TTSAudioFormat(rawValue: fmt.lowercased()) else {
+                return try await createErrorResponse(message: "Unsupported response_format '\(fmt)'. Supported: aac, wav, caf", status: .badRequest)
+            }
+            format = parsed
+        } else {
+            format = .aac
+        }
+
+        let options = TTSRequestOptions(
+            voice: body.voice ?? "alloy",
+            appleVoice: body.appleVoice,
+            locale: body.locale ?? "en-US",
+            speed: Float(body.speed ?? 1.0),
+            format: format
+        )
+
+        let service = SpeechSynthesisService()
+        let audioData: Data
+        do {
+            audioData = try await service.synthesize(text: body.input, options: options)
+        } catch let error as SpeechSynthesisError {
+            let status: HTTPResponseStatus
+            switch error {
+            case .voiceNotAvailable: status = .notFound
+            case .inputTooLong, .emptyInput, .unsupportedFormat: status = .badRequest
+            case .synthesisTimedOut: status = .gatewayTimeout
+            case .platformUnavailable: status = .serviceUnavailable
+            case .synthesisFailed: status = .internalServerError
+            }
+            return try await createErrorResponse(message: error.errorDescription ?? "TTS synthesis failed", status: status, type: "speech_error")
+        } catch {
+            return try await createErrorResponse(message: "TTS synthesis failed: \(error.localizedDescription)", status: .internalServerError, type: "internal_error")
+        }
+
+        let response = Response(status: .ok)
+        response.headers.add(name: .contentType, value: format.contentType)
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        response.body = .init(data: audioData)
+        return response
+    }
+
+    private func listVoices(req: Request) async throws -> Response {
+        guard #available(macOS 13.0, *) else {
+            return try await createErrorResponse(message: "Text-to-speech requires macOS 13.0 or later", status: .serviceUnavailable, type: "speech_unavailable")
+        }
+
+        let locale = req.query[String.self, at: "locale"]
+        let voices = SpeechSynthesisService.listVoices(locale: locale)
+
+        struct VoiceListResponse: Content {
+            let voices: [VoiceInfo]
+        }
+
+        let response = Response(status: .ok)
+        response.headers.add(name: .contentType, value: "application/json")
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        try response.content.encode(VoiceListResponse(voices: voices))
+        return response
+    }
+
+    // MARK: - Chat completions integration
+
+    static func extractTranscriptionFromMessages(_ messages: [Message], options: SpeechRequestOptions) async throws -> (messages: [Message], transcriptionTexts: [String], cleanupURLs: [URL]) {
+        guard #available(macOS 13.0, *) else {
+            return (messages, [], [])
+        }
+
+        let service = SpeechService()
+        var updatedMessages: [Message] = []
+        var transcriptionTexts: [String] = []
+        var cleanupURLs: [URL] = []
+        var audioIndex = 0
+
+        for message in messages {
+            guard let content = message.content, case .parts(let parts) = content else {
+                updatedMessages.append(message)
+                continue
+            }
+
+            // Prepare audio parts for concurrent transcription
+            struct AudioWork: Sendable {
+                let tempURL: URL
+                let options: SpeechRequestOptions
+                let index: Int
+            }
+            var audioWork: [AudioWork] = []
+            for part in parts where part.type == "input_audio" {
+                guard let inputAudio = part.input_audio else { continue }
+                let ext = try validatedExtension(inputAudio.format.isEmpty ? "wav" : inputAudio.format)
+                let tempURL = try writeTempAudio(base64: inputAudio.data, ext: ext)
+                cleanupURLs.append(tempURL)
+                audioIndex += 1
+                let perAudioOptions = inputAudio.language.map { SpeechRequestOptions(locale: $0) } ?? options
+                audioWork.append(AudioWork(tempURL: tempURL, options: perAudioOptions, index: audioIndex))
+            }
+
+            let results = try await withThrowingTaskGroup(of: (Int, String).self) { group in
+                for work in audioWork {
+                    group.addTask {
+                        let transcription = try await service.transcribe(from: work.tempURL.path, options: work.options)
+                        return (work.index, "[Apple Speech transcription \(work.index)]\n\(transcription)")
+                    }
+                }
+                var collected: [(Int, String)] = []
+                for try await result in group {
+                    collected.append(result)
+                }
+                return collected.sorted { $0.0 < $1.0 }.map(\.1)
+            }
+
+            var textChunks = parts.compactMap(\.text)
+            textChunks.append(contentsOf: results)
+            transcriptionTexts.append(contentsOf: results)
+
+            updatedMessages.append(Message(role: message.role, content: textChunks.joined(separator: "\n\n")))
+        }
+
+        return (updatedMessages, transcriptionTexts, cleanupURLs)
+    }
+
+    // MARK: - Transcription response formatting
+
+    private static func formatAsVerboseJSON(result: TranscriptionResult, granularities: Set<String>) -> VerboseTranscriptionResponse {
+        VerboseTranscriptionResponse(
+            text: result.text,
+            language: result.language,
+            duration: result.duration,
+            words: granularities.contains("word") ? result.words : nil,
+            segments: granularities.contains("segment") ? result.segments : nil
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Validate and resolve a file path for the API endpoint.
+    /// Resolves symlinks, rejects directories, and enforces audio extension allowlist.
+    private static func sanitizeAudioPath(_ raw: String) throws -> String {
+        let expanded = NSString(string: raw).expandingTildeInPath
+        let resolved = URL(fileURLWithPath: expanded).resolvingSymlinksInPath().path
+        let fm = FileManager.default
+
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: resolved, isDirectory: &isDir) else {
+            throw SpeechError.fileNotFound
+        }
+        guard !isDir.boolValue else {
+            throw SpeechError.unsupportedFormat
+        }
+        let ext = URL(fileURLWithPath: resolved).pathExtension.lowercased()
+        guard SpeechRequestOptions.supportedExtensions.contains(ext) else {
+            throw SpeechError.unsupportedFormat
+        }
+        return resolved
+    }
+
+    /// Validate that ext is a supported audio extension before using it in a filename.
+    private static func validatedExtension(_ ext: String) throws -> String {
+        let clean = ext.lowercased()
+        guard SpeechRequestOptions.supportedExtensions.contains(clean) else {
+            throw SpeechError.unsupportedFormat
+        }
+        return clean
+    }
+
+    private static func writeTempAudio(base64: String, ext: String) throws -> URL {
+        guard let data = Data(base64Encoded: base64, options: .ignoreUnknownCharacters) else {
+            throw Abort(.badRequest, reason: "Invalid base64 audio data")
+        }
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("afm_speech_\(UUID().uuidString).\(ext)")
+        try data.write(to: tempURL)
+        return tempURL
+    }
+}

--- a/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
+++ b/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
@@ -2,17 +2,30 @@ import Vapor
 import Foundation
 
 protocol VisionServing {
+    @available(macOS 26.0, *)
     func extractText(from filePath: String) async throws -> String
+    @available(macOS 26.0, *)
     func extractText(from filePath: String, options: VisionRequestOptions) async throws -> String
+    @available(macOS 26.0, *)
     func extractTextWithDetails(from filePath: String) async throws -> VisionResult
+    @available(macOS 26.0, *)
     func extractTextWithDetails(from filePath: String, options: VisionRequestOptions) async throws -> VisionResult
+    @available(macOS 26.0, *)
     func extractTables(from filePath: String) async throws -> [TableResult]
+    @available(macOS 26.0, *)
     func extractTables(from filePath: String, options: VisionRequestOptions) async throws -> [TableResult]
+    @available(macOS 26.0, *)
     func debugRawDetection(from filePath: String) async throws -> String
+    @available(macOS 26.0, *)
     func debugRawDetection(from filePath: String, options: VisionRequestOptions) async throws -> String
+
+    // New modes (macOS 13+)
+    func detectBarcodes(from filePath: String, options: VisionRequestOptions) throws -> [BarcodeResult]
+    func classifyImage(from filePath: String, maxLabels: Int) throws -> ClassifyResult
+    func detectSaliency(from filePath: String, type: String, includeHeatMap: Bool) throws -> SaliencyResult
+    func autoCrop(imageData: Data) throws -> Data
 }
 
-@available(macOS 26.0, *)
 extension VisionService: VisionServing {}
 
 struct VisionOCRRequest: Content {
@@ -29,6 +42,14 @@ struct VisionOCRRequest: Content {
     let usesLanguageCorrection: Bool?
     let languages: [String]?
     let maxPages: Int?
+    // New parameters
+    let mode: String?
+    let detail: String?
+    let autoCrop: Bool?
+    let responseFormat: String?
+    let maxLabels: Int?
+    let saliencyType: String?
+    let includeHeatMap: Bool?
 
     enum CodingKeys: String, CodingKey {
         case file
@@ -44,6 +65,88 @@ struct VisionOCRRequest: Content {
         case usesLanguageCorrection = "uses_language_correction"
         case languages
         case maxPages = "max_pages"
+        case mode
+        case detail
+        case autoCrop = "auto_crop"
+        case responseFormat = "response_format"
+        case maxLabels = "max_labels"
+        case saliencyType = "saliency_type"
+        case includeHeatMap = "include_heat_map"
+    }
+}
+
+// MARK: - New vision mode response types
+
+struct VisionBarcodeResponse: Content {
+    let object: String
+    let mode: String
+    let results: [VisionBarcodeItem]
+}
+
+struct VisionBarcodeItem: Content {
+    let type: String
+    let payload: String
+    let boundingBox: VisionOCRBoundingBox
+    let confidence: Float
+
+    enum CodingKeys: String, CodingKey {
+        case type, payload
+        case boundingBox = "bounding_box"
+        case confidence
+    }
+}
+
+struct VisionClassifyResponse: Content {
+    let object: String
+    let mode: String
+    let labels: [VisionClassifyLabel]
+    let salientRegions: [VisionOCRBoundingBox]
+
+    enum CodingKeys: String, CodingKey {
+        case object, mode, labels
+        case salientRegions = "salient_regions"
+    }
+}
+
+struct VisionClassifyLabel: Content {
+    let label: String
+    let confidence: Float
+}
+
+struct VisionSaliencyResponse: Content {
+    let object: String
+    let mode: String
+    let regions: [VisionSaliencyRegionItem]
+    let heatMap: String?
+
+    enum CodingKeys: String, CodingKey {
+        case object, mode, regions
+        case heatMap = "heat_map"
+    }
+}
+
+struct VisionSaliencyRegionItem: Content {
+    let type: String
+    let boundingBox: VisionOCRBoundingBox
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case boundingBox = "bounding_box"
+    }
+}
+
+struct VisionAutoResponse: Content {
+    let object: String
+    let mode: String
+    let modesRun: [String]
+    let text: VisionOCRResponse?
+    let barcodes: [VisionBarcodeItem]?
+    let labels: [VisionClassifyLabel]?
+
+    enum CodingKeys: String, CodingKey {
+        case object, mode
+        case modesRun = "modes_run"
+        case text, barcodes, labels
     }
 }
 
@@ -216,44 +319,229 @@ struct VisionAPIController: RouteCollection {
 
         defer { cleanup(parsed.cleanupURLs) }
 
+        // Resolve mode: explicit mode > legacy flags > default "text"
         let wantsDebug = parsed.request.debug ?? false
         let wantsTable = parsed.request.table ?? false
-        let mode = wantsDebug ? "debug" : (wantsTable ? "table" : "text")
+        let resolvedMode: String
+        if wantsDebug {
+            resolvedMode = "debug"
+        } else if let explicitMode = parsed.request.mode?.lowercased(), !explicitMode.isEmpty {
+            resolvedMode = explicitMode
+        } else if wantsTable {
+            resolvedMode = "table"
+        } else {
+            resolvedMode = "text"
+        }
+
+        // Apply auto_crop preprocessing if requested
+        var effectiveInputs = parsed.inputs
+        var cropCleanupURLs: [URL] = []
+        if parsed.request.autoCrop ?? false {
+            effectiveInputs = try effectiveInputs.map { input in
+                let fileURL = URL(fileURLWithPath: input.path)
+                let attrs = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+                if let fileSize = attrs[.size] as? Int, fileSize > VisionRequestOptions.defaultMaxFileBytes {
+                    throw VisionError.fileTooLarge(bytes: fileSize, maxBytes: VisionRequestOptions.defaultMaxFileBytes)
+                }
+                let imageData: Data
+                do {
+                    imageData = try Data(contentsOf: fileURL)
+                } catch {
+                    throw VisionError.imageLoadingFailed
+                }
+                let croppedData = try visionService.autoCrop(imageData: imageData)
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("afm_vision_crop_\(UUID().uuidString).png")
+                try croppedData.write(to: tempURL)
+                cropCleanupURLs.append(tempURL)
+                return VisionResolvedInput(path: tempURL.path, sourceType: input.sourceType, cleanupURLs: input.cleanupURLs)
+            }
+        }
+        defer { cleanup(cropCleanupURLs) }
 
         do {
-            if wantsDebug {
-                let outputs = try await parsed.inputs.asyncMap { input in
-                    try await visionService.debugRawDetection(from: input.path, options: options)
-                }
-                return try await createSuccessResponse(
-                    VisionOCRResponse(
-                        object: "vision.ocr",
-                        mode: mode,
-                        documents: [],
-                        combinedText: "",
-                        documentHints: [],
-                        debugOutput: outputs.joined(separator: "\n\n")
+            switch resolvedMode {
+            case "debug":
+                if #available(macOS 26.0, *) {
+                    let outputs = try await effectiveInputs.asyncMap { input in
+                        try await visionService.debugRawDetection(from: input.path, options: options)
+                    }
+                    return try await createSuccessResponse(
+                        VisionOCRResponse(
+                            object: "vision.ocr",
+                            mode: resolvedMode,
+                            documents: [],
+                            combinedText: "",
+                            documentHints: [],
+                            debugOutput: outputs.joined(separator: "\n\n")
+                        )
                     )
-                )
-            }
+                } else {
+                    return try await createErrorResponse(
+                        message: VisionError.modeRequiresMacOS26("debug").localizedDescription,
+                        status: .notImplemented
+                    )
+                }
 
-            let documents = try await parsed.inputs.asyncMap { input in
-                let result = try await visionService.extractTextWithDetails(from: input.path, options: options)
-                return Self.mapDocument(result, sourceType: input.sourceType)
-            }
+            case "text", "table":
+                if #available(macOS 26.0, *) {
+                    let documents = try await effectiveInputs.asyncMap { input in
+                        let result = try await visionService.extractTextWithDetails(from: input.path, options: options)
+                        return Self.mapDocument(result, sourceType: input.sourceType)
+                    }
+                    let combinedText = documents.map(\.fullText).joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
+                    let hints = Array(Set(documents.flatMap(\.documentHints))).sorted()
 
-            let combinedText = documents.map(\.fullText).joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
-            let hints = Array(Set(documents.flatMap(\.documentHints))).sorted()
-            return try await createSuccessResponse(
-                VisionOCRResponse(
+                    // Handle response_format
+                    let responseFormat = parsed.request.responseFormat?.lowercased() ?? "json"
+                    if responseFormat == "text" {
+                        let response = Response(status: .ok)
+                        response.headers.add(name: .contentType, value: "text/plain")
+                        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+                        response.body = .init(string: combinedText)
+                        return response
+                    }
+
+                    return try await createSuccessResponse(
+                        VisionOCRResponse(
+                            object: "vision.ocr",
+                            mode: resolvedMode,
+                            documents: documents,
+                            combinedText: combinedText,
+                            documentHints: hints,
+                            debugOutput: nil
+                        )
+                    )
+                } else {
+                    return try await createErrorResponse(
+                        message: VisionError.modeRequiresMacOS26(resolvedMode).localizedDescription,
+                        status: .notImplemented
+                    )
+                }
+
+            case "barcode":
+                let allBarcodes = try effectiveInputs.flatMap { input in
+                    try visionService.detectBarcodes(from: input.path, options: options)
+                }
+                let items = allBarcodes.map { b in
+                    VisionBarcodeItem(
+                        type: b.type,
+                        payload: b.payload,
+                        boundingBox: VisionOCRBoundingBox(b.boundingBox),
+                        confidence: b.confidence
+                    )
+                }
+                return try await createJSONResponse(VisionBarcodeResponse(
                     object: "vision.ocr",
-                    mode: mode,
-                    documents: documents,
-                    combinedText: combinedText,
-                    documentHints: hints,
-                    debugOutput: nil
+                    mode: "barcode",
+                    results: items
+                ))
+
+            case "classify":
+                let maxLabels = parsed.request.maxLabels ?? 5
+                let allResults = try effectiveInputs.map { input in
+                    try visionService.classifyImage(from: input.path, maxLabels: maxLabels)
+                }
+                let labels = allResults.flatMap { $0.labels }.map {
+                    VisionClassifyLabel(label: $0.label, confidence: $0.confidence)
+                }
+                let regions = allResults.flatMap { $0.salientRegions }.map {
+                    VisionOCRBoundingBox($0)
+                }
+                return try await createJSONResponse(VisionClassifyResponse(
+                    object: "vision.ocr",
+                    mode: "classify",
+                    labels: labels,
+                    salientRegions: regions
+                ))
+
+            case "saliency":
+                let saliencyType = parsed.request.saliencyType ?? "attention"
+                let includeHeatMap = parsed.request.includeHeatMap ?? false
+                let allResults = try effectiveInputs.map { input in
+                    try visionService.detectSaliency(from: input.path, type: saliencyType, includeHeatMap: includeHeatMap)
+                }
+                let regions = allResults.flatMap { $0.regions }.map {
+                    VisionSaliencyRegionItem(type: $0.type, boundingBox: VisionOCRBoundingBox($0.boundingBox))
+                }
+                let heatMap = allResults.compactMap(\.heatMapPNG).first.map { $0.base64EncodedString() }
+                return try await createJSONResponse(VisionSaliencyResponse(
+                    object: "vision.ocr",
+                    mode: "saliency",
+                    regions: regions,
+                    heatMap: heatMap
+                ))
+
+            case "auto":
+                // Run barcode, classify (sync), then text (async)
+                let maxLabels = parsed.request.maxLabels ?? 5
+
+                // Filter to image-only inputs for barcode/classify (they reject PDFs)
+                let imageInputs = effectiveInputs.filter { input in
+                    let ext = URL(fileURLWithPath: input.path).pathExtension.lowercased()
+                    return VisionService.imageOnlyExtensions.contains(ext)
+                }
+
+                var modesRun: [String] = []
+                var barcodeItems: [VisionBarcodeItem]?
+                var classifyLabels: [VisionClassifyLabel]?
+                var textResponse: VisionOCRResponse?
+
+                // Barcode and classify are synchronous Vision framework calls
+                let barcodes = try imageInputs.flatMap { input in
+                    try visionService.detectBarcodes(from: input.path, options: options)
+                }
+                let classified = try imageInputs.map { input in
+                    try visionService.classifyImage(from: input.path, maxLabels: maxLabels)
+                }
+
+                if #available(macOS 26.0, *) {
+                    let documents = try await effectiveInputs.asyncMap { input in
+                        let result = try await visionService.extractTextWithDetails(from: input.path, options: options)
+                        return Self.mapDocument(result, sourceType: input.sourceType)
+                    }
+
+                    let combinedText = documents.map(\.fullText).joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
+                    let hints = Array(Set(documents.flatMap(\.documentHints))).sorted()
+                    modesRun.append("text")
+                    textResponse = VisionOCRResponse(
+                        object: "vision.ocr",
+                        mode: "text",
+                        documents: documents,
+                        combinedText: combinedText,
+                        documentHints: hints,
+                        debugOutput: nil
+                    )
+                }
+
+                modesRun.append("barcode")
+                if !barcodes.isEmpty {
+                    barcodeItems = barcodes.map {
+                        VisionBarcodeItem(type: $0.type, payload: $0.payload, boundingBox: VisionOCRBoundingBox($0.boundingBox), confidence: $0.confidence)
+                    }
+                }
+
+                let labels = classified.flatMap(\.labels)
+                modesRun.append("classify")
+                if !labels.isEmpty {
+                    classifyLabels = labels.map { VisionClassifyLabel(label: $0.label, confidence: $0.confidence) }
+                }
+
+                return try await createJSONResponse(VisionAutoResponse(
+                    object: "vision.ocr",
+                    mode: "auto",
+                    modesRun: modesRun,
+                    text: textResponse,
+                    barcodes: barcodeItems,
+                    labels: classifyLabels
+                ))
+
+            default:
+                return try await createErrorResponse(
+                    message: "Unknown mode '\(resolvedMode)'. Supported: text, table, barcode, classify, saliency, auto",
+                    status: .badRequest
                 )
-            )
+            }
         } catch let visionError as VisionError {
             return try await createErrorResponse(
                 message: visionError.localizedDescription,
@@ -288,7 +576,14 @@ struct VisionAPIController: RouteCollection {
                 recognitionLevel: stringField(req, "recognition_level"),
                 usesLanguageCorrection: boolField(req, "uses_language_correction"),
                 languages: arrayField(req, "languages"),
-                maxPages: intField(req, "max_pages")
+                maxPages: intField(req, "max_pages"),
+                mode: stringField(req, "mode"),
+                detail: stringField(req, "detail"),
+                autoCrop: boolField(req, "auto_crop"),
+                responseFormat: stringField(req, "response_format"),
+                maxLabels: intField(req, "max_labels"),
+                saliencyType: stringField(req, "saliency_type"),
+                includeHeatMap: boolField(req, "include_heat_map")
             )
         } else {
             request = try req.content.decode(VisionOCRRequest.self)
@@ -349,6 +644,14 @@ struct VisionAPIController: RouteCollection {
                 throw Abort(.badRequest, reason: "recognition_level must be 'accurate' or 'fast'")
             }
             level = parsed
+        } else if let detail = request.detail?.lowercased(), !detail.isEmpty {
+            // detail is an alias: high -> accurate, low -> fast
+            switch detail {
+            case "high": level = .accurate
+            case "low": level = .fast
+            default:
+                throw Abort(.badRequest, reason: "detail must be 'high' or 'low'")
+            }
         } else {
             level = .accurate
         }
@@ -359,6 +662,14 @@ struct VisionAPIController: RouteCollection {
             recognitionLanguages: request.languages ?? [],
             maxPages: request.maxPages ?? VisionRequestOptions.defaultMaxPages
         )
+    }
+
+    private func createJSONResponse<T: Content>(_ payload: T) async throws -> Response {
+        let response = Response(status: .ok)
+        response.headers.add(name: .contentType, value: "application/json")
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        try response.content.encode(payload)
+        return response
     }
 
     private func createSuccessResponse(_ payload: VisionOCRResponse) async throws -> Response {
@@ -493,13 +804,6 @@ struct VisionAPIController: RouteCollection {
     }
 
     static func writeTempFile(data: Data, filename: String, mediaType: String?) throws -> URL {
-        if data.count > VisionRequestOptions.defaultMaxFileBytes {
-            throw VisionError.requestTooLarge(
-                actualBytes: data.count,
-                maxBytes: VisionRequestOptions.defaultMaxFileBytes
-            )
-        }
-
         let ext = inferExtension(filename: filename, mediaType: mediaType)
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("afm_vision_\(UUID().uuidString).\(ext)")
@@ -627,20 +931,19 @@ struct VisionAPIController: RouteCollection {
             return .badRequest
         case .fileNotFound:
             return .notFound
-        case .requestTooLarge:
+        case .fileTooLarge:
             return .payloadTooLarge
         case .pageLimitExceeded, .imageDimensionsExceeded, .imageLoadingFailed, .textRecognitionFailed, .noTextFound, .noTablesFound, .documentSegmentationFailed:
             return .unprocessableEntity
         case .platformUnavailable:
             return .serviceUnavailable
+        case .modeRequiresMacOS26:
+            return .notImplemented
         }
     }
 
     private static func defaultVisionServiceFactory() -> (any VisionServing)? {
-        if #available(macOS 26.0, *) {
-            return VisionService()
-        }
-        return nil
+        return VisionService()
     }
 }
 

--- a/Sources/MacLocalAPI/Models/OpenAIRequest.swift
+++ b/Sources/MacLocalAPI/Models/OpenAIRequest.swift
@@ -163,14 +163,28 @@ enum MessageContent: Codable {
 }
 
 struct ContentPart: Codable {
-    let type: String        // "text" or "image_url"
+    let type: String        // "text", "image_url", or "input_audio"
     let text: String?       // For type="text"
     let image_url: ImageURL? // For type="image_url"
+    let input_audio: InputAudio? // For type="input_audio"
+
+    init(type: String, text: String? = nil, image_url: ImageURL? = nil, input_audio: InputAudio? = nil) {
+        self.type = type
+        self.text = text
+        self.image_url = image_url
+        self.input_audio = input_audio
+    }
 }
 
 struct ImageURL: Codable {
     let url: String  // "data:image/png;base64,..." or URL
     let detail: String?  // "auto", "low", "high" (optional)
+}
+
+struct InputAudio: Codable {
+    let data: String   // base64-encoded audio
+    let format: String // "wav", "mp3", etc.
+    let language: String? // locale for transcription (e.g. "en-US", "ja-JP")
 }
 
 struct Message: Content {

--- a/Sources/MacLocalAPI/Models/SpeechService.swift
+++ b/Sources/MacLocalAPI/Models/SpeechService.swift
@@ -1,0 +1,247 @@
+import Foundation
+import os
+import Speech
+
+enum SpeechError: Error, LocalizedError {
+    case platformUnavailable
+    case fileNotFound
+    case unsupportedFormat
+    case recognitionFailed(String)
+    case noSpeechFound
+    case onDeviceNotAvailable
+    case authorizationDenied
+
+    var errorDescription: String? {
+        switch self {
+        case .platformUnavailable:
+            return "Apple Speech framework requires macOS 10.15 or later"
+        case .fileNotFound:
+            return "The specified audio file was not found"
+        case .unsupportedFormat:
+            return "Unsupported audio format. Supported formats: WAV, MP3, M4A, CAF, AIFF"
+        case .recognitionFailed(let message):
+            return "Speech recognition failed: \(message)"
+        case .noSpeechFound:
+            return "No speech was detected in the audio file"
+        case .onDeviceNotAvailable:
+            return "On-device speech recognition is not available for the requested locale"
+        case .authorizationDenied:
+            return "Speech recognition authorization was denied. Grant access in System Settings > Privacy & Security > Speech Recognition"
+        }
+    }
+}
+
+struct SpeechRequestOptions: Sendable {
+    static let recognitionTimeoutNs: UInt64 = 120_000_000_000  // 120 seconds
+    static let supportedExtensions: Set<String> = ["wav", "mp3", "m4a", "caf", "aiff", "aif"]
+
+    let locale: String
+
+    init(locale: String = "en-US") {
+        self.locale = locale
+    }
+}
+
+struct TranscriptionWord: Sendable, Codable {
+    let word: String
+    let start: Double
+    let end: Double
+}
+
+struct TranscriptionSegment: Sendable, Codable {
+    let id: Int
+    let start: Double
+    let end: Double
+    let text: String
+    let confidence: Float
+}
+
+struct TranscriptionResult: Sendable, Codable {
+    let text: String
+    let language: String
+    let duration: Double
+    let words: [TranscriptionWord]
+    let segments: [TranscriptionSegment]
+
+    func formatAsSRT() -> String {
+        segments.enumerated().map { index, seg in
+            let startTS = Self.srtTimestamp(seg.start)
+            let endTS = Self.srtTimestamp(seg.end)
+            return "\(index + 1)\n\(startTS) --> \(endTS)\n\(seg.text)"
+        }.joined(separator: "\n\n")
+    }
+
+    func formatAsVTT() -> String {
+        var lines = ["WEBVTT", ""]
+        lines += segments.map { seg in
+            let startTS = Self.vttTimestamp(seg.start)
+            let endTS = Self.vttTimestamp(seg.end)
+            return "\(startTS) --> \(endTS)\n\(seg.text)"
+        }
+        return lines.joined(separator: "\n\n")
+    }
+
+    static func srtTimestamp(_ seconds: Double) -> String {
+        let h = Int(seconds) / 3600
+        let m = (Int(seconds) % 3600) / 60
+        let s = Int(seconds) % 60
+        let ms = Int((seconds.truncatingRemainder(dividingBy: 1)) * 1000)
+        return String(format: "%02d:%02d:%02d,%03d", h, m, s, ms)
+    }
+
+    static func vttTimestamp(_ seconds: Double) -> String {
+        let h = Int(seconds) / 3600
+        let m = (Int(seconds) % 3600) / 60
+        let s = Int(seconds) % 60
+        let ms = Int((seconds.truncatingRemainder(dividingBy: 1)) * 1000)
+        return String(format: "%02d:%02d:%02d.%03d", h, m, s, ms)
+    }
+}
+
+@available(macOS 13.0, *)
+final class SpeechService {
+
+    func transcribe(from filePath: String) async throws -> String {
+        try await transcribe(from: filePath, options: SpeechRequestOptions())
+    }
+
+    func transcribe(from filePath: String, options: SpeechRequestOptions) async throws -> String {
+        let result = try await transcribeWithDetails(from: filePath, options: options)
+        return result.text
+    }
+
+    func transcribeWithDetails(from filePath: String) async throws -> TranscriptionResult {
+        try await transcribeWithDetails(from: filePath, options: SpeechRequestOptions())
+    }
+
+    func transcribeWithDetails(from filePath: String, options: SpeechRequestOptions) async throws -> TranscriptionResult {
+        let fileURL = URL(fileURLWithPath: filePath)
+
+        // Validate file exists
+        guard FileManager.default.fileExists(atPath: filePath) else {
+            throw SpeechError.fileNotFound
+        }
+
+        // Validate extension
+        let ext = fileURL.pathExtension.lowercased()
+        guard SpeechRequestOptions.supportedExtensions.contains(ext) else {
+            throw SpeechError.unsupportedFormat
+        }
+
+        // Check authorization
+        let status = SFSpeechRecognizer.authorizationStatus()
+        if status == .denied || status == .restricted {
+            throw SpeechError.authorizationDenied
+        }
+        if status == .notDetermined {
+            let granted = await withCheckedContinuation { continuation in
+                SFSpeechRecognizer.requestAuthorization { newStatus in
+                    continuation.resume(returning: newStatus == .authorized)
+                }
+            }
+            guard granted else { throw SpeechError.authorizationDenied }
+        }
+
+        // Create recognizer and verify on-device support
+        guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: options.locale)) else {
+            throw SpeechError.onDeviceNotAvailable
+        }
+        guard recognizer.supportsOnDeviceRecognition else {
+            throw SpeechError.onDeviceNotAvailable
+        }
+
+        // Create request
+        let request = SFSpeechURLRecognitionRequest(url: fileURL)
+        request.requiresOnDeviceRecognition = true
+        request.shouldReportPartialResults = false
+
+        // Run recognition with a timeout to prevent hung requests.
+        // OSAllocatedUnfairLock guards the one-shot continuation resume.
+        let resumed = OSAllocatedUnfairLock(initialState: false)
+        // Holds the SFSpeechRecognitionTask so onCancel can reach it.
+        let taskRef = OSAllocatedUnfairLock<SFSpeechRecognitionTask?>(initialState: nil)
+
+        let transcriptionResult: TranscriptionResult = try await withThrowingTaskGroup(of: TranscriptionResult.self) { group in
+            group.addTask {
+                try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { continuation in
+                        let queue = OperationQueue()
+                        queue.qualityOfService = .userInitiated
+
+                        recognizer.queue = queue
+                        let task = recognizer.recognitionTask(with: request) { result, error in
+                            if let error {
+                                let shouldResume = resumed.withLock { done in
+                                    if done { return false }
+                                    done = true
+                                    return true
+                                }
+                                guard shouldResume else { return }
+                                continuation.resume(throwing: SpeechError.recognitionFailed(error.localizedDescription))
+                                return
+                            }
+                            guard let result, result.isFinal else { return }
+                            let shouldResume = resumed.withLock { done in
+                                if done { return false }
+                                done = true
+                                return true
+                            }
+                            guard shouldResume else { return }
+                            let transcription = result.bestTranscription
+                            let formatted = transcription.formattedString
+                            if formatted.isEmpty {
+                                continuation.resume(throwing: SpeechError.noSpeechFound)
+                                return
+                            }
+
+                            // Extract word-level timing from segments
+                            let words = transcription.segments.map { seg in
+                                TranscriptionWord(
+                                    word: seg.substring,
+                                    start: seg.timestamp,
+                                    end: seg.timestamp + seg.duration
+                                )
+                            }
+
+                            // Build a single segment from the full transcription
+                            let totalDuration = transcription.segments.last.map { $0.timestamp + $0.duration } ?? 0
+                            let avgConfidence = transcription.segments.isEmpty ? Float(0)
+                                : transcription.segments.map(\.confidence).reduce(0, +) / Float(transcription.segments.count)
+                            let segments = [TranscriptionSegment(
+                                id: 0,
+                                start: 0,
+                                end: totalDuration,
+                                text: formatted,
+                                confidence: avgConfidence
+                            )]
+
+                            // Extract language from locale
+                            let lang = options.locale.split(separator: "-").first.map(String.init) ?? options.locale
+
+                            continuation.resume(returning: TranscriptionResult(
+                                text: formatted,
+                                language: lang,
+                                duration: totalDuration,
+                                words: words,
+                                segments: segments
+                            ))
+                        }
+                        taskRef.withLock { $0 = task }
+                        if Task.isCancelled { task.cancel() }
+                    }
+                } onCancel: {
+                    taskRef.withLock { $0?.cancel() }
+                }
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: SpeechRequestOptions.recognitionTimeoutNs)
+                throw SpeechError.recognitionFailed("Recognition timed out")
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+
+        return transcriptionResult
+    }
+}

--- a/Sources/MacLocalAPI/Models/SpeechSynthesisService.swift
+++ b/Sources/MacLocalAPI/Models/SpeechSynthesisService.swift
@@ -1,0 +1,439 @@
+import Foundation
+import AVFoundation
+import os
+
+enum SpeechSynthesisError: Error, LocalizedError {
+    case platformUnavailable
+    case inputTooLong(actualChars: Int, maxChars: Int)
+    case emptyInput
+    case voiceNotAvailable(String)
+    case synthesisTimedOut
+    case synthesisFailed(String)
+    case unsupportedFormat(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .platformUnavailable:
+            return "Text-to-speech requires macOS 13.0 or later"
+        case .inputTooLong(let actual, let max):
+            return "Input text \(actual) characters exceeds the limit of \(max)"
+        case .emptyInput:
+            return "Input text is empty"
+        case .voiceNotAvailable(let name):
+            return "Voice '\(name)' is not available on this system"
+        case .synthesisTimedOut:
+            return "Speech synthesis timed out"
+        case .synthesisFailed(let message):
+            return "Speech synthesis failed: \(message)"
+        case .unsupportedFormat(let format):
+            return "Unsupported audio format: \(format). Supported: aac, wav, caf"
+        }
+    }
+}
+
+enum TTSAudioFormat: String, Sendable, CaseIterable {
+    case aac
+    case wav
+    case caf
+
+    var contentType: String {
+        switch self {
+        case .aac: return "audio/aac"
+        case .wav: return "audio/wav"
+        case .caf: return "audio/x-caf"
+        }
+    }
+
+    var fileExtension: String { rawValue }
+}
+
+enum OpenAIVoiceName: String, CaseIterable {
+    case alloy, echo, fable, nova, onyx, shimmer
+
+    enum Gender { case female, male }
+
+    var gender: Gender {
+        switch self {
+        case .alloy, .nova, .shimmer: return .female
+        case .echo, .fable, .onyx: return .male
+        }
+    }
+
+    var preferredAppleVoiceNames: [String] {
+        switch self {
+        case .alloy: return ["Samantha"]
+        case .echo: return ["Daniel"]
+        case .fable: return ["Tom"]
+        case .nova: return ["Karen"]
+        case .onyx: return ["Alex"]
+        case .shimmer: return ["Ava"]
+        }
+    }
+}
+
+struct TTSRequestOptions: Sendable {
+    static let maxInputCharacters = 4096
+    static let synthesisTimeoutNs: UInt64 = 120_000_000_000
+    static let encodeTimeoutNs: UInt64 = 30_000_000_000  // 30s for afconvert
+
+    let voice: String?
+    let appleVoice: String?
+    let locale: String
+    let speed: Float
+    let format: TTSAudioFormat
+
+    init(
+        voice: String? = "alloy",
+        appleVoice: String? = nil,
+        locale: String = "en-US",
+        speed: Float = 1.0,
+        format: TTSAudioFormat = .aac
+    ) {
+        self.voice = voice
+        self.appleVoice = appleVoice
+        self.locale = locale
+        self.speed = speed
+        self.format = format
+    }
+}
+
+struct VoiceInfo: Sendable, Codable {
+    let id: String
+    let name: String
+    let locale: String
+    let gender: String
+    let quality: String
+}
+
+@available(macOS 13.0, *)
+final class SpeechSynthesisService: NSObject, @unchecked Sendable {
+
+    static let speedMinimum: Float = 0.25
+    static let speedMaximum: Float = 4.0
+
+    static func listVoices(locale: String? = nil) -> [VoiceInfo] {
+        let voices = AVSpeechSynthesisVoice.speechVoices()
+        let filtered: [AVSpeechSynthesisVoice]
+        if let locale = locale {
+            let prefix = locale.lowercased()
+            filtered = voices.filter { $0.language.lowercased().hasPrefix(prefix) }
+        } else {
+            filtered = voices
+        }
+        return filtered.map { voice in
+            let quality: String
+            switch voice.quality {
+            case .enhanced: quality = "enhanced"
+            case .premium: quality = "premium"
+            default: quality = "compact"
+            }
+            return VoiceInfo(
+                id: voice.identifier,
+                name: voice.name,
+                locale: voice.language,
+                gender: voice.gender == .male ? "male" : "female",
+                quality: quality
+            )
+        }.sorted {
+            if $0.locale != $1.locale { return $0.locale < $1.locale }
+            return $0.name < $1.name
+        }
+    }
+
+    func synthesize(text: String, options: TTSRequestOptions) async throws -> Data {
+        guard !text.isEmpty else {
+            throw SpeechSynthesisError.emptyInput
+        }
+        guard text.count <= TTSRequestOptions.maxInputCharacters else {
+            throw SpeechSynthesisError.inputTooLong(
+                actualChars: text.count,
+                maxChars: TTSRequestOptions.maxInputCharacters
+            )
+        }
+        guard options.speed >= Self.speedMinimum && options.speed <= Self.speedMaximum else {
+            throw SpeechSynthesisError.synthesisFailed(
+                "Speed must be between \(Self.speedMinimum) and \(Self.speedMaximum)"
+            )
+        }
+
+        let voice = try resolveVoice(options: options)
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = voice
+        utterance.rate = clampRate(options.speed)
+
+        let synthesizer = AVSpeechSynthesizer()
+        let allBuffers: [AVAudioPCMBuffer] = try await withThrowingTaskGroup(of: [AVAudioPCMBuffer].self) { group in
+            group.addTask {
+                let state = OSAllocatedUnfairLock(initialState: (resumed: false, buffers: [AVAudioPCMBuffer](), continuation: nil as CheckedContinuation<[AVAudioPCMBuffer], Error>?))
+                return try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { continuation in
+                        state.withLock { $0.continuation = continuation }
+                        synthesizer.write(utterance) { buffer in
+                            if let pcm = buffer as? AVAudioPCMBuffer, pcm.frameLength > 0 {
+                                state.withLock { $0.buffers.append(pcm) }
+                            } else {
+                                state.withLock { s in
+                                    guard !s.resumed else { return }
+                                    s.resumed = true
+                                    s.continuation?.resume(returning: s.buffers)
+                                    s.continuation = nil
+                                }
+                            }
+                        }
+                        // If already cancelled before we got here, resume immediately
+                        state.withLock { s in
+                            if Task.isCancelled && !s.resumed {
+                                s.resumed = true
+                                s.continuation?.resume(throwing: CancellationError())
+                                s.continuation = nil
+                            }
+                        }
+                    }
+                } onCancel: {
+                    synthesizer.stopSpeaking(at: .immediate)
+                    // If stopSpeaking doesn't trigger the empty-buffer callback,
+                    // resume the continuation to prevent a leak
+                    state.withLock { s in
+                        guard !s.resumed else { return }
+                        s.resumed = true
+                        s.continuation?.resume(throwing: CancellationError())
+                        s.continuation = nil
+                    }
+                }
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: TTSRequestOptions.synthesisTimeoutNs)
+                throw SpeechSynthesisError.synthesisTimedOut
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+
+        guard !allBuffers.isEmpty else {
+            throw SpeechSynthesisError.synthesisFailed("No audio data generated")
+        }
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("afm_tts_\(UUID().uuidString).\(options.format.fileExtension)")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        // Encode collected PCM buffers to the requested format
+        try await encodeBuffers(allBuffers, to: tempURL, format: options.format)
+        return try Data(contentsOf: tempURL)
+    }
+
+    /// Encode PCM buffers to a file. For WAV/CAF, write PCM directly via
+    /// AVAudioFile. For AAC, use AVAudioConverter to transcode.
+    private func encodeBuffers(
+        _ buffers: [AVAudioPCMBuffer],
+        to url: URL,
+        format: TTSAudioFormat
+    ) async throws {
+        let inputFormat = buffers[0].format
+
+        switch format {
+        case .wav, .caf:
+            // PCM output -- write directly
+            let settings: [String: Any] = [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: inputFormat.sampleRate,
+                AVNumberOfChannelsKey: inputFormat.channelCount,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsBigEndianKey: false
+            ]
+            let outputFile = try AVAudioFile(
+                forWriting: url,
+                settings: settings,
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
+            for buffer in buffers {
+                try outputFile.write(from: buffer)
+            }
+
+        case .aac:
+            // AAC encoding: write PCM to temp WAV, then use afconvert CLI.
+            // AVSpeechSynthesizer outputs 22050 Hz; AVAudioConverter's AAC
+            // encoder doesn't support non-standard sample rates, so we shell
+            // out to afconvert which handles resampling transparently.
+            let tempWAV = FileManager.default.temporaryDirectory
+                .appendingPathComponent("afm_tts_pcm_\(UUID().uuidString).wav")
+            defer { try? FileManager.default.removeItem(at: tempWAV) }
+
+            let pcmSettings: [String: Any] = [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: inputFormat.sampleRate,
+                AVNumberOfChannelsKey: inputFormat.channelCount,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsBigEndianKey: false
+            ]
+            // Scope the AVAudioFile so it closes before afconvert reads the WAV
+            do {
+                let pcmFile = try AVAudioFile(
+                    forWriting: tempWAV,
+                    settings: pcmSettings,
+                    commonFormat: .pcmFormatFloat32,
+                    interleaved: false
+                )
+                for buffer in buffers {
+                    try pcmFile.write(from: buffer)
+                }
+            } catch {
+                throw SpeechSynthesisError.synthesisFailed("Failed to write PCM temp file: \(error.localizedDescription)")
+            }
+
+            // Convert WAV → AAC (ADTS format) via afconvert (ships with macOS).
+            // Omit bitrate flag — let CoreAudio pick a suitable rate for the
+            // source sample rate (22050 Hz mono can't sustain 128 kbps).
+            // Run via terminationHandler to avoid blocking the cooperative thread pool.
+            let encode = Process()
+            encode.executableURL = URL(fileURLWithPath: "/usr/bin/afconvert")
+            encode.arguments = [
+                tempWAV.path, url.path,
+                "-d", "aac", "-f", "adts"
+            ]
+            let errPipe = Pipe()
+            encode.standardError = errPipe
+            // Collect stderr asynchronously to avoid blocking the termination handler
+            // and prevent potential deadlock if afconvert writes more than the pipe buffer
+            let stderrData = OSAllocatedUnfairLock(initialState: Data())
+            errPipe.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                if !chunk.isEmpty {
+                    stderrData.withLock { $0.append(chunk) }
+                }
+            }
+            let resumed = OSAllocatedUnfairLock(initialState: false)
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                        encode.terminationHandler = { process in
+                            errPipe.fileHandleForReading.readabilityHandler = nil
+                            let alreadyResumed = resumed.withLock { val -> Bool in
+                                if val { return true }
+                                val = true
+                                return false
+                            }
+                            guard !alreadyResumed else { return }
+                            if process.terminationStatus != 0 {
+                                let errMsg = stderrData.withLock { String(data: $0, encoding: .utf8) ?? "unknown" }
+                                continuation.resume(throwing: SpeechSynthesisError.synthesisFailed(
+                                    "AAC encode failed (\(process.terminationStatus)): \(errMsg)"
+                                ))
+                            } else {
+                                continuation.resume()
+                            }
+                        }
+                        do {
+                            try encode.run()
+                        } catch {
+                            let alreadyResumed = resumed.withLock { val -> Bool in
+                                if val { return true }
+                                val = true
+                                return false
+                            }
+                            guard !alreadyResumed else { return }
+                            continuation.resume(throwing: SpeechSynthesisError.synthesisFailed(
+                                "Failed to launch afconvert: \(error.localizedDescription)"
+                            ))
+                        }
+                    }
+                }
+                group.addTask {
+                    try await Task.sleep(nanoseconds: TTSRequestOptions.encodeTimeoutNs)
+                    let alreadyResumed = resumed.withLock { val -> Bool in
+                        if val { return true }
+                        val = true
+                        return false
+                    }
+                    encode.terminate()
+                    guard !alreadyResumed else { return }
+                    throw SpeechSynthesisError.synthesisTimedOut
+                }
+                let _ = try await group.next()!
+                group.cancelAll()
+            }
+        }
+    }
+
+    private func resolveVoice(options: TTSRequestOptions) throws -> AVSpeechSynthesisVoice {
+        // 1. Exact Apple voice identifier
+        if let appleVoice = options.appleVoice, !appleVoice.isEmpty {
+            if let voice = AVSpeechSynthesisVoice(identifier: appleVoice) {
+                return voice
+            }
+            throw SpeechSynthesisError.voiceNotAvailable(appleVoice)
+        }
+
+        // 2. OpenAI voice name mapping
+        if let voiceName = options.voice,
+           let openAIVoice = OpenAIVoiceName(rawValue: voiceName.lowercased()) {
+            let voices = AVSpeechSynthesisVoice.speechVoices()
+                .filter { $0.language.lowercased().hasPrefix(options.locale.lowercased().prefix(2).description) }
+
+            // Try preferred Apple voice names first
+            for preferred in openAIVoice.preferredAppleVoiceNames {
+                // Prefer enhanced > premium > compact
+                let sorted = voices.filter { $0.name == preferred }
+                    .sorted { qualityRank($0) > qualityRank($1) }
+                if let found = sorted.first {
+                    return found
+                }
+            }
+
+            // Fallback: match by gender, prefer higher quality
+            let genderMatched = voices
+                .filter { voiceMatchesGender($0, openAIVoice.gender) }
+                .sorted { qualityRank($0) > qualityRank($1) }
+            if let found = genderMatched.first {
+                return found
+            }
+
+            // Last fallback: any voice for the locale
+            if let anyVoice = voices.sorted(by: { qualityRank($0) > qualityRank($1) }).first {
+                return anyVoice
+            }
+        }
+
+        // 3. System default for locale
+        if let voice = AVSpeechSynthesisVoice(language: options.locale) {
+            return voice
+        }
+
+        // 4. Absolute fallback
+        if let voice = AVSpeechSynthesisVoice(language: "en-US") {
+            return voice
+        }
+
+        throw SpeechSynthesisError.voiceNotAvailable(options.locale)
+    }
+
+    private func qualityRank(_ voice: AVSpeechSynthesisVoice) -> Int {
+        switch voice.quality {
+        case .enhanced: return 3
+        case .premium: return 2
+        default: return 1
+        }
+    }
+
+    private func voiceMatchesGender(_ voice: AVSpeechSynthesisVoice, _ gender: OpenAIVoiceName.Gender) -> Bool {
+        switch gender {
+        case .female: return voice.gender == .female
+        case .male: return voice.gender == .male
+        }
+    }
+
+    private func clampRate(_ speed: Float) -> Float {
+        let minRate = AVSpeechUtteranceMinimumSpeechRate
+        let maxRate = AVSpeechUtteranceMaximumSpeechRate
+        let defaultRate = AVSpeechUtteranceDefaultSpeechRate
+
+        // Map OpenAI's 0.25-4.0 range to Apple's rate range
+        // speed=1.0 maps to defaultRate
+        let normalized = speed * defaultRate
+        return Swift.min(Swift.max(normalized, minRate), maxRate)
+    }
+}

--- a/Sources/MacLocalAPI/Models/VisionService.swift
+++ b/Sources/MacLocalAPI/Models/VisionService.swift
@@ -13,7 +13,6 @@ enum VisionError: Error, LocalizedError {
     case remoteURLNotSupported
     case unsupportedURLScheme(String)
     case invalidDataURL
-    case requestTooLarge(actualBytes: Int, maxBytes: Int)
     case pageLimitExceeded(actualPages: Int, maxPages: Int)
     case imageDimensionsExceeded(width: Int, height: Int, maxDimension: Int)
     case imageLoadingFailed
@@ -21,6 +20,8 @@ enum VisionError: Error, LocalizedError {
     case noTextFound
     case noTablesFound
     case documentSegmentationFailed(String)
+    case fileTooLarge(bytes: Int, maxBytes: Int)
+    case modeRequiresMacOS26(String)
 
     var errorDescription: String? {
         switch self {
@@ -38,8 +39,6 @@ enum VisionError: Error, LocalizedError {
             return "Unsupported image URL scheme: \(scheme)"
         case .invalidDataURL:
             return "Invalid data URL or base64 payload"
-        case .requestTooLarge(let actualBytes, let maxBytes):
-            return "Input size \(actualBytes) bytes exceeds the limit of \(maxBytes) bytes"
         case .pageLimitExceeded(let actualPages, let maxPages):
             return "Document has \(actualPages) pages which exceeds the limit of \(maxPages)"
         case .imageDimensionsExceeded(let width, let height, let maxDimension):
@@ -54,6 +53,10 @@ enum VisionError: Error, LocalizedError {
             return "No tables were found in the document"
         case .documentSegmentationFailed(let message):
             return "Document segmentation failed: \(message)"
+        case .fileTooLarge(let bytes, let maxBytes):
+            return "File size \(bytes / 1024 / 1024) MB exceeds the limit of \(maxBytes / 1024 / 1024) MB"
+        case .modeRequiresMacOS26(let mode):
+            return "Vision mode '\(mode)' requires macOS 26.0 or later"
         }
     }
 }
@@ -73,15 +76,14 @@ enum VisionRecognitionLevel: String, Sendable {
 }
 
 struct VisionRequestOptions: Sendable {
-    static let defaultMaxFileBytes = 25 * 1024 * 1024
     static let defaultMaxPages = 50
     static let defaultMaxImageDimension = 4096
+    static let defaultMaxFileBytes: Int = 25 * 1024 * 1024  // 25 MB
 
     let recognitionLevel: VisionRecognitionLevel
     let usesLanguageCorrection: Bool
     let recognitionLanguages: [String]
     let maxPages: Int
-    let maxFileBytes: Int
     let maxImageDimension: Int
 
     init(
@@ -89,36 +91,71 @@ struct VisionRequestOptions: Sendable {
         usesLanguageCorrection: Bool = true,
         recognitionLanguages: [String] = [],
         maxPages: Int = VisionRequestOptions.defaultMaxPages,
-        maxFileBytes: Int = VisionRequestOptions.defaultMaxFileBytes,
         maxImageDimension: Int = VisionRequestOptions.defaultMaxImageDimension
     ) {
         self.recognitionLevel = recognitionLevel
         self.usesLanguageCorrection = usesLanguageCorrection
         self.recognitionLanguages = recognitionLanguages
         self.maxPages = maxPages
-        self.maxFileBytes = maxFileBytes
         self.maxImageDimension = maxImageDimension
     }
 }
 
-@available(macOS 26.0, *)
+// MARK: - New vision mode result types
+
+struct BarcodeResult: Sendable {
+    let type: String
+    let payload: String
+    let boundingBox: CGRect
+    let confidence: Float
+}
+
+struct ClassificationLabel: Sendable {
+    let label: String
+    let confidence: Float
+}
+
+struct ClassifyResult: Sendable {
+    let labels: [ClassificationLabel]
+    let salientRegions: [CGRect]
+}
+
+struct SaliencyRegion: Sendable {
+    let type: String
+    let boundingBox: CGRect
+}
+
+struct SaliencyResult: Sendable {
+    let regions: [SaliencyRegion]
+    let heatMapPNG: Data?
+}
+
+// MARK: - VisionService (no class-level macOS restriction)
+
 final class VisionService {
-    private static let supportedExtensions: Set<String> = ["png", "jpg", "jpeg", "heic", "pdf"]
+    static let supportedExtensions: Set<String> = ["png", "jpg", "jpeg", "heic", "pdf"]
+    static let imageOnlyExtensions: Set<String> = ["png", "jpg", "jpeg", "heic"]
     private static let pdfRenderScale: CGFloat = 2.0
 
+    // MARK: - Text extraction (macOS 26+)
+
+    @available(macOS 26.0, *)
     func extractText(from filePath: String) async throws -> String {
         try await extractText(from: filePath, options: VisionRequestOptions())
     }
 
+    @available(macOS 26.0, *)
     func extractText(from filePath: String, options: VisionRequestOptions) async throws -> String {
         let result = try await extractTextWithDetails(from: filePath, options: options)
         return result.fullText
     }
 
+    @available(macOS 26.0, *)
     func extractTextWithDetails(from filePath: String) async throws -> VisionResult {
         try await extractTextWithDetails(from: filePath, options: VisionRequestOptions())
     }
 
+    @available(macOS 26.0, *)
     func extractTextWithDetails(from filePath: String, options: VisionRequestOptions) async throws -> VisionResult {
         let document = try analyzeDocument(at: filePath, options: options)
         let textBlocks = document.pages.flatMap(\.textBlocks)
@@ -134,10 +171,12 @@ final class VisionService {
         )
     }
 
+    @available(macOS 26.0, *)
     func extractTables(from filePath: String) async throws -> [TableResult] {
         try await extractTables(from: filePath, options: VisionRequestOptions())
     }
 
+    @available(macOS 26.0, *)
     func extractTables(from filePath: String, options: VisionRequestOptions) async throws -> [TableResult] {
         let document = try analyzeDocument(at: filePath, options: options)
         let tables = document.pages.flatMap(\.tables)
@@ -147,12 +186,14 @@ final class VisionService {
         return tables
     }
 
+    @available(macOS 26.0, *)
     func debugRawDetection(from filePath: String) async throws -> String {
         try await debugRawDetection(from: filePath, options: VisionRequestOptions())
     }
 
+    @available(macOS 26.0, *)
     func debugRawDetection(from filePath: String, options: VisionRequestOptions) async throws -> String {
-        let (url, fileExtension) = try validateFile(at: filePath, maxBytes: options.maxFileBytes)
+        let (url, fileExtension) = try validateFile(at: filePath)
         let pageSources = try createPageSources(from: url, fileExtension: fileExtension, options: options)
         var sections: [String] = []
 
@@ -191,8 +232,173 @@ final class VisionService {
         return output
     }
 
+    // MARK: - Barcode detection (macOS 13+)
+
+    func detectBarcodes(from filePath: String, options: VisionRequestOptions = VisionRequestOptions()) throws -> [BarcodeResult] {
+        let (url, _) = try validateFile(at: filePath, allowedExtensions: Self.imageOnlyExtensions)
+        guard let imageData = try? Data(contentsOf: url) else {
+            throw VisionError.imageLoadingFailed
+        }
+
+        let handler = VNImageRequestHandler(data: imageData)
+        let request = VNDetectBarcodesRequest()
+
+        try handler.perform([request])
+
+        guard let observations = request.results else { return [] }
+        return observations.map { obs in
+            BarcodeResult(
+                type: obs.symbology.rawValue.replacingOccurrences(of: "VNBarcodeSymbology", with: ""),
+                payload: obs.payloadStringValue ?? "",
+                boundingBox: obs.boundingBox,
+                confidence: obs.confidence
+            )
+        }
+    }
+
+    // MARK: - Image classification (macOS 13+)
+
+    func classifyImage(from filePath: String, maxLabels: Int = 5) throws -> ClassifyResult {
+        let (url, _) = try validateFile(at: filePath, allowedExtensions: Self.imageOnlyExtensions)
+        guard let imageData = try? Data(contentsOf: url) else {
+            throw VisionError.imageLoadingFailed
+        }
+
+        let handler = VNImageRequestHandler(data: imageData)
+        let classifyRequest = VNClassifyImageRequest()
+        let saliencyRequest = VNGenerateAttentionBasedSaliencyImageRequest()
+
+        try handler.perform([classifyRequest, saliencyRequest])
+
+        let labels: [ClassificationLabel]
+        if let observations = classifyRequest.results {
+            labels = observations
+                .sorted { $0.confidence > $1.confidence }
+                .prefix(maxLabels)
+                .map { ClassificationLabel(label: $0.identifier, confidence: $0.confidence) }
+        } else {
+            labels = []
+        }
+
+        let salientRegions: [CGRect]
+        if let saliencyObs = saliencyRequest.results?.first,
+           let salientObjects = saliencyObs.salientObjects {
+            salientRegions = salientObjects.map(\.boundingBox)
+        } else {
+            salientRegions = []
+        }
+
+        return ClassifyResult(labels: labels, salientRegions: salientRegions)
+    }
+
+    // MARK: - Saliency detection (macOS 13+)
+
+    func detectSaliency(from filePath: String, type: String = "attention", includeHeatMap: Bool = false) throws -> SaliencyResult {
+        let (url, _) = try validateFile(at: filePath, allowedExtensions: Self.imageOnlyExtensions)
+        guard let imageData = try? Data(contentsOf: url) else {
+            throw VisionError.imageLoadingFailed
+        }
+
+        let handler = VNImageRequestHandler(data: imageData)
+        let request: VNImageBasedRequest
+        if type == "objectness" {
+            request = VNGenerateObjectnessBasedSaliencyImageRequest()
+        } else {
+            request = VNGenerateAttentionBasedSaliencyImageRequest()
+        }
+
+        try handler.perform([request])
+
+        var regions: [SaliencyRegion] = []
+        var heatMapPNG: Data? = nil
+
+        if let saliencyObs = (request.results as? [VNSaliencyImageObservation])?.first {
+            if let salientObjects = saliencyObs.salientObjects {
+                regions = salientObjects.map { obj in
+                    SaliencyRegion(type: type, boundingBox: obj.boundingBox)
+                }
+            }
+
+            if includeHeatMap {
+                let pixelBuffer = saliencyObs.pixelBuffer
+                heatMapPNG = renderHeatMapPNG(from: pixelBuffer)
+            }
+        }
+
+        return SaliencyResult(regions: regions, heatMapPNG: heatMapPNG)
+    }
+
+    // MARK: - Auto-crop via document segmentation (macOS 13+)
+
+    func autoCrop(imageData: Data) throws -> Data {
+        let handler = VNImageRequestHandler(data: imageData)
+        let request = VNDetectDocumentSegmentationRequest()
+
+        try handler.perform([request])
+
+        guard let observation = request.results?.first else {
+            // No document region found — return original
+            return imageData
+        }
+
+        // Crop the image to the detected document region
+        guard let source = CGImageSourceCreateWithData(imageData as CFData, nil),
+              let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            return imageData
+        }
+
+        let box = observation.boundingBox
+        let imageWidth = CGFloat(cgImage.width)
+        let imageHeight = CGFloat(cgImage.height)
+        let cropRect = CGRect(
+            x: box.origin.x * imageWidth,
+            y: (1.0 - box.origin.y - box.height) * imageHeight,
+            width: box.width * imageWidth,
+            height: box.height * imageHeight
+        )
+
+        guard let croppedImage = cgImage.cropping(to: cropRect) else {
+            return imageData
+        }
+
+        let mutableData = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(mutableData, "public.png" as CFString, 1, nil) else {
+            return imageData
+        }
+        CGImageDestinationAddImage(destination, croppedImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            return imageData
+        }
+        return mutableData as Data
+    }
+
+    // MARK: - Internal helpers
+
+    func validateFile(at filePath: String, maxBytes: Int = VisionRequestOptions.defaultMaxFileBytes, allowedExtensions: Set<String>? = nil) throws -> (URL, String) {
+        let url = URL(fileURLWithPath: filePath)
+        guard FileManager.default.fileExists(atPath: filePath) else {
+            throw VisionError.fileNotFound
+        }
+
+        let fileExtension = url.pathExtension.lowercased()
+        let extensions = allowedExtensions ?? Self.supportedExtensions
+        guard extensions.contains(fileExtension) else {
+            throw VisionError.unsupportedFormat
+        }
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: filePath)
+        if let fileSize = attrs[.size] as? Int, fileSize > maxBytes {
+            throw VisionError.fileTooLarge(bytes: fileSize, maxBytes: maxBytes)
+        }
+
+        return (url, fileExtension)
+    }
+
+    // MARK: - Private helpers
+
+    @available(macOS 26.0, *)
     private func analyzeDocument(at filePath: String, options: VisionRequestOptions) throws -> VisionDocumentResult {
-        let (url, fileExtension) = try validateFile(at: filePath, maxBytes: options.maxFileBytes)
+        let (url, fileExtension) = try validateFile(at: filePath)
         let pageSources = try createPageSources(from: url, fileExtension: fileExtension, options: options)
         var pageResults: [VisionPageResult] = []
         let analyzer = TableAnalyzer()
@@ -256,26 +462,6 @@ final class VisionService {
             pages: pageResults,
             documentHints: deriveDocumentHints(from: pageResults)
         )
-    }
-
-    private func validateFile(at filePath: String, maxBytes: Int) throws -> (URL, String) {
-        let url = URL(fileURLWithPath: filePath)
-        guard FileManager.default.fileExists(atPath: filePath) else {
-            throw VisionError.fileNotFound
-        }
-
-        let values = try url.resourceValues(forKeys: [.fileSizeKey])
-        let fileSize = values.fileSize ?? 0
-        if fileSize > maxBytes {
-            throw VisionError.requestTooLarge(actualBytes: fileSize, maxBytes: maxBytes)
-        }
-
-        let fileExtension = url.pathExtension.lowercased()
-        guard Self.supportedExtensions.contains(fileExtension) else {
-            throw VisionError.unsupportedFormat
-        }
-
-        return (url, fileExtension)
     }
 
     private func createPageSources(from url: URL, fileExtension: String, options: VisionRequestOptions) throws -> [VisionPageSource] {
@@ -378,6 +564,7 @@ final class VisionService {
         return CGSize(width: width, height: height)
     }
 
+    @available(macOS 26.0, *)
     private func makeTextRequest(options: VisionRequestOptions) -> VNRecognizeTextRequest {
         let request = VNRecognizeTextRequest()
         request.recognitionLevel = options.recognitionLevel.requestLevel
@@ -410,6 +597,25 @@ final class VisionService {
             hints.append("document")
         }
         return hints
+    }
+
+    private func renderHeatMapPNG(from pixelBuffer: CVPixelBuffer) -> Data? {
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        let context = CIContext()
+        let width = CVPixelBufferGetWidth(pixelBuffer)
+        let height = CVPixelBufferGetHeight(pixelBuffer)
+        guard let cgImage = context.createCGImage(ciImage, from: CGRect(x: 0, y: 0, width: width, height: height)) else {
+            return nil
+        }
+        let mutableData = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(mutableData, "public.png" as CFString, 1, nil) else {
+            return nil
+        }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            return nil
+        }
+        return mutableData as Data
     }
 }
 

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -63,6 +63,11 @@ class Server {
     private let contextWindow: Int?
     private var telegramBridge: TelegramBridge?
 
+    private static let audioAvailable: Bool = {
+        if #available(macOS 13.0, *) { return true }
+        return false
+    }()
+
     init(port: Int, hostname: String, verbose: Bool, veryVerbose: Bool = false, trace: Bool = false, streamingEnabled: Bool, instructions: String, adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil, permissiveGuardrails: Bool = false, stop: String? = nil, webuiEnabled: Bool = false, gatewayEnabled: Bool = false, prewarmEnabled: Bool = true, telegramConfiguration: TelegramConfiguration? = nil, mlxModelID: String? = nil, mlxModelService: MLXModelService? = nil, mlxRepetitionPenalty: Double? = nil, mlxTopP: Double? = nil, mlxMaxTokens: Int? = nil, mlxRawOutput: Bool = false, mlxTopK: Int? = nil, mlxMinP: Double? = nil, mlxPresencePenalty: Double? = nil, mlxSeed: Int? = nil, mlxMaxLogprobs: Int? = nil, contextWindow: Int? = nil) async throws {
         self.port = port
         self.hostname = hostname
@@ -241,6 +246,7 @@ class Server {
         }
 
         try app.register(collection: VisionAPIController())
+        try app.register(collection: SpeechAPIController())
 
         if let mlxModelID = mlxModelID, let mlxModelService = mlxModelService {
             let mlxController = MLXChatCompletionsController(
@@ -329,7 +335,7 @@ class Server {
                     total_slots: 1,
                     model_path: mlxModelID,
                     role: "mlx",
-                    modalities: Modalities(vision: true, audio: false),
+                    modalities: Modalities(vision: true, audio: Self.audioAvailable),
                     chat_template: "",
                     bos_token: "",
                     eos_token: "",
@@ -372,7 +378,7 @@ class Server {
                 total_slots: 1,
                 model_path: modelPath,
                 role: self.gatewayEnabled ? "router" : "model",
-                modalities: Modalities(vision: hasVision, audio: false),
+                modalities: Modalities(vision: hasVision, audio: Self.audioAvailable),
                 chat_template: "",
                 bos_token: "",
                 eos_token: "",

--- a/Sources/MacLocalAPI/SpeechCommand.swift
+++ b/Sources/MacLocalAPI/SpeechCommand.swift
@@ -1,0 +1,234 @@
+import ArgumentParser
+import Foundation
+
+struct SpeechCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "speech",
+        abstract: "Speech synthesis and transcription using Apple frameworks",
+        discussion: """
+        Use Apple's Speech and AVFoundation frameworks for on-device speech-to-text
+        and text-to-speech.
+
+        Subcommands:
+          synthesize  — Convert text to speech audio
+          transcribe  — Transcribe audio files to text
+
+        Legacy shortcut:
+          afm speech -f file.wav  — Equivalent to: afm speech transcribe -f file.wav
+
+        Examples:
+          afm speech synthesize "Hello world" -o output.aac
+          afm speech synthesize "Hello" --voice nova --format wav
+          afm speech --list-voices --locale en
+          afm speech transcribe -f recording.wav
+          afm speech transcribe -f meeting.mp3 --format verbose_json
+          afm speech -f audio.wav                         # legacy transcribe shortcut
+        """,
+        subcommands: [SpeechSynthesizeCommand.self, SpeechTranscribeCommand.self]
+    )
+
+    @Flag(name: .long, help: "List available voices and exit")
+    var listVoices: Bool = false
+
+    @Option(name: .long, help: "Filter voices by locale prefix (e.g. 'en', 'ja-JP')")
+    var locale: String?
+
+    @Flag(name: .long, help: "Print machine-readable JSON capability card for AI agents and exit")
+    var helpJson: Bool = false
+
+    func run() async throws {
+        if helpJson {
+            printHelpJson(command: "afm speech")
+            return
+        }
+
+        if listVoices {
+            if #available(macOS 13.0, *) {
+                let voices = SpeechSynthesisService.listVoices(locale: locale)
+                if voices.isEmpty {
+                    print("No voices found\(locale.map { " for locale '\($0)'" } ?? "").")
+                    return
+                }
+                let maxNameLen = voices.map(\.name.count).max() ?? 10
+                let maxLocaleLen = voices.map(\.locale.count).max() ?? 5
+                for voice in voices {
+                    let name = voice.name.padding(toLength: maxNameLen, withPad: " ", startingAt: 0)
+                    let loc = voice.locale.padding(toLength: maxLocaleLen, withPad: " ", startingAt: 0)
+                    print("\(name)  \(loc)  \(voice.gender)  \(voice.quality)  \(voice.id)")
+                }
+            } else {
+                throw SpeechError.platformUnavailable
+            }
+            return
+        }
+
+        // No subcommand and no flags — show help
+        throw CleanExit.helpRequest(self)
+    }
+}
+
+struct SpeechSynthesizeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "synthesize",
+        abstract: "Convert text to speech audio"
+    )
+
+    @Argument(help: "Text to synthesize")
+    var text: String
+
+    @Option(name: .long, help: "Voice name: alloy, echo, fable, nova, onyx, shimmer (default: alloy)")
+    var voice: String = "alloy"
+
+    @Option(name: .long, help: "Locale for voice selection (default: en-US)")
+    var locale: String = "en-US"
+
+    @Option(name: .long, help: "Audio format: aac, wav, caf (default: aac)")
+    var format: String = "aac"
+
+    @Option(name: .long, help: "Speech speed: 0.25-4.0 (default: 1.0)")
+    var speed: Float = 1.0
+
+    @Option(name: [.short, .long], help: "Output file path (default: stdout)")
+    var output: String?
+
+    func run() async throws {
+        guard #available(macOS 13.0, *) else {
+            throw SpeechSynthesisError.platformUnavailable
+        }
+
+        guard let audioFormat = TTSAudioFormat(rawValue: format.lowercased()) else {
+            print("Error: Unsupported format '\(format)'. Supported: aac, wav, caf")
+            throw ExitCode.failure
+        }
+
+        let options = TTSRequestOptions(
+            voice: voice,
+            locale: locale,
+            speed: speed,
+            format: audioFormat
+        )
+
+        do {
+            let service = SpeechSynthesisService()
+            let audioData = try await service.synthesize(text: text, options: options)
+
+            if let outputPath = output {
+                let expandedPath = NSString(string: outputPath).expandingTildeInPath
+                let url = URL(fileURLWithPath: expandedPath)
+                try audioData.write(to: url)
+                print("Wrote \(audioData.count) bytes to \(expandedPath)")
+            } else {
+                // Write raw audio to stdout
+                FileHandle.standardOutput.write(audioData)
+            }
+        } catch {
+            if let synthError = error as? SpeechSynthesisError {
+                print("Error: \(synthError.localizedDescription)")
+            } else {
+                print("Error: \(error.localizedDescription)")
+            }
+            throw ExitCode.failure
+        }
+    }
+}
+
+struct SpeechTranscribeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "transcribe",
+        abstract: "Transcribe audio files to text"
+    )
+
+    @Option(name: [.short, .long], help: "Path to the audio file")
+    var file: String
+
+    @Option(name: .long, help: "Locale for speech recognition (default: en-US)")
+    var locale: String = "en-US"
+
+    @Option(name: .long, help: "Output format: text, json, verbose_json, srt, vtt (default: text)")
+    var format: String = "text"
+
+    @Option(name: .long, help: "Language code (ISO-639-1, e.g. 'en', 'ja'). Alias for --locale.")
+    var language: String?
+
+    @Option(name: .long, help: "Timestamp granularities: word, segment, or both (comma-separated)")
+    var timestamps: String?
+
+    func run() async throws {
+        let expandedPath = NSString(string: file).expandingTildeInPath
+        let resolvedPath = URL(fileURLWithPath: expandedPath).resolvingSymlinksInPath().path
+
+        // language takes precedence over locale; pass bare codes through —
+        // SFSpeechRecognizer resolves them to the user's preferred regional variant
+        let effectiveLocale = language ?? locale
+
+        do {
+            if #available(macOS 13.0, *) {
+                let service = SpeechService()
+                let options = SpeechRequestOptions(locale: effectiveLocale)
+
+                switch format.lowercased() {
+                case "text":
+                    let text = try await service.transcribe(from: resolvedPath, options: options)
+                    print(text)
+                case "json":
+                    let text = try await service.transcribe(from: resolvedPath, options: options)
+                    let jsonObj: [String: Any] = ["text": text]
+                    let jsonData = try JSONSerialization.data(withJSONObject: jsonObj, options: [.prettyPrinted])
+                    print(String(data: jsonData, encoding: .utf8) ?? "{}")
+                case "verbose_json", "srt", "vtt":
+                    let result = try await service.transcribeWithDetails(from: resolvedPath, options: options)
+                    let granularities = parseGranularities()
+                    switch format.lowercased() {
+                    case "verbose_json":
+                        print(formatAsVerboseJSON(result: result, granularities: granularities))
+                    case "srt":
+                        print(result.formatAsSRT())
+                    case "vtt":
+                        print(result.formatAsVTT())
+                    default:
+                        break
+                    }
+                default:
+                    print("Error: Unsupported format '\(format)'. Supported: text, json, verbose_json, srt, vtt")
+                    throw ExitCode.failure
+                }
+            } else {
+                throw SpeechError.platformUnavailable
+            }
+        } catch {
+            if let speechError = error as? SpeechError {
+                print("Error: \(speechError.localizedDescription)")
+            } else {
+                print("Error: \(error.localizedDescription)")
+            }
+            throw ExitCode.failure
+        }
+    }
+
+    private func parseGranularities() -> Set<String> {
+        guard let raw = timestamps else { return ["segment"] }
+        return Set(raw.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces).lowercased() })
+    }
+
+    private func formatAsVerboseJSON(result: TranscriptionResult, granularities: Set<String>) -> String {
+        var dict: [String: Any] = [
+            "text": result.text,
+            "language": result.language,
+            "duration": result.duration
+        ]
+        if granularities.contains("word") {
+            dict["words"] = result.words.map { w in
+                ["word": w.word, "start": w.start, "end": w.end] as [String: Any]
+            }
+        }
+        if granularities.contains("segment") {
+            dict["segments"] = result.segments.map { s in
+                ["id": s.id, "start": s.start, "end": s.end, "text": s.text, "confidence": s.confidence] as [String: Any]
+            }
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.prettyPrinted, .sortedKeys]),
+              let str = String(data: data, encoding: .utf8) else { return "{}" }
+        return str
+    }
+
+}

--- a/Sources/MacLocalAPI/VisionCommand.swift
+++ b/Sources/MacLocalAPI/VisionCommand.swift
@@ -4,53 +4,97 @@ import Foundation
 struct VisionCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "vision",
-        abstract: "Extract text from images using Apple's Vision framework",
+        abstract: "Extract text, barcodes, and classifications from images using Apple's Vision framework",
         discussion: """
         ---
         name: afm-vision
-        description: Extract text and tables from images and documents using Apple's Vision framework OCR. Outputs plain text or CSV-formatted tables. Runs locally on-device with no network access required.
-        tags: [vision, ocr, text-extraction, table-extraction, pdf, image, csv, apple-vision, on-device]
+        description: Extract text, tables, barcodes, classifications, and saliency from images and documents using Apple's Vision framework. Runs locally on-device with no network access required.
+        tags: [vision, ocr, text-extraction, table-extraction, barcode, classify, saliency, pdf, image, csv, apple-vision, on-device]
         repository: https://github.com/scouzi1966/maclocal-api
         supported_formats: [PNG, JPG, JPEG, HEIC, PDF]
+        modes: [text, table, barcode, classify, saliency, auto]
         triggers:
           - extract text from image
           - OCR document
           - extract table from image
           - convert image to text
           - PDF text extraction
+          - scan barcode
+          - classify image
+          - detect saliency
         examples:
           - afm vision -f image.png
           - afm vision --file /path/to/document.pdf
           - afm vision -f report.png --table
           - afm vision -f invoice.pdf -t --verbose
+          - afm vision -f photo.jpg --mode classify
+          - afm vision -f photo.jpg --mode barcode
+          - afm vision -f photo.jpg --mode saliency --heat-map
+          - afm vision -f photo.jpg --mode auto
+          - afm vision -f doc.png --auto-crop
+          - afm vision -f doc.png --detail low
         ---
 
-        Use Apple's Vision framework to perform OCR (Optical Character Recognition) on images and documents.
+        Use Apple's Vision framework to perform OCR, barcode detection, image classification,
+        and saliency analysis on images and documents.
 
         Supported formats: PNG, JPG, JPEG, HEIC, PDF
 
+        Modes:
+          text       Extract text (default, requires macOS 26)
+          table      Extract tables as CSV (requires macOS 26)
+          barcode    Detect barcodes and QR codes
+          classify   Classify image content with labels
+          saliency   Detect salient regions (attention or objectness)
+          auto       Run text + barcode + classify together
+
         Examples:
-          afm vision -f image.png                    # Extract all text
-          afm vision --file /path/to/document.pdf    # Extract text from PDF
-          afm vision -f report.png --table           # Extract tables as CSV
-          afm vision -f invoice.pdf -t --verbose     # Extract tables with details
+          afm vision -f image.png                              # Extract text
+          afm vision -f image.png --mode barcode               # Detect barcodes
+          afm vision -f photo.jpg --mode classify              # Classify image
+          afm vision -f photo.jpg --mode saliency --heat-map   # Saliency with heat map
+          afm vision -f photo.jpg --mode auto                  # Run all modes
+          afm vision -f doc.png --auto-crop                    # Auto-crop before OCR
+          afm vision -f doc.png --detail low                   # Fast recognition
         """
     )
-    
+
     @Option(name: [.short, .long], help: "Path to the image or document file")
     var file: String
-    
+
     @Flag(name: .long, help: "Show detailed output with confidence scores and bounding boxes")
     var verbose: Bool = false
-    
+
     @Flag(name: [.customShort("t"), .long], help: "Extract tables and output as CSV format")
     var table: Bool = false
-    
+
     @Flag(name: [.customShort("D")], help: .hidden)
     var debug: Bool = false
 
     @Flag(name: .long, help: "Print machine-readable JSON capability card for AI agents and exit")
     var helpJson: Bool = false
+
+    // New flags
+    @Option(name: .long, help: "Vision mode: text, table, barcode, classify, saliency, auto (default: text)")
+    var mode: String?
+
+    @Option(name: .long, help: "Recognition detail: high or low (default: high)")
+    var detail: String = "high"
+
+    @Flag(name: .long, help: "Auto-crop document region before processing")
+    var autoCrop: Bool = false
+
+    @Option(name: .long, help: "Output format: json, text (default: text for CLI)")
+    var format: String = "text"
+
+    @Option(name: .long, help: "Max classification labels to return (default: 5)")
+    var maxLabels: Int = 5
+
+    @Option(name: .long, help: "Saliency type: attention or objectness (default: attention)")
+    var saliencyType: String = "attention"
+
+    @Flag(name: .long, help: "Include saliency heat map as base64 PNG")
+    var heatMap: Bool = false
 
     func run() async throws {
         if helpJson {
@@ -58,76 +102,174 @@ struct VisionCommand: ParsableCommand {
             return
         }
 
-        // Validate that the file path was provided
         guard !file.isEmpty else {
             print("Error: File path is required. Use -f or --file to specify the input file.")
             throw ExitCode.failure
         }
-        
-        // Expand tilde and resolve relative paths
+
         let expandedPath = NSString(string: file).expandingTildeInPath
         let resolvedPath = URL(fileURLWithPath: expandedPath).standardized.path
-        
-        // Run vision processing
+
+        // Resolve effective mode: --mode takes precedence; --table is legacy fallback
+        let effectiveMode: String
+        if let mode = mode {
+            if table {
+                fputs("Warning: --table ignored because --mode \(mode) was specified\n", stderr)
+            }
+            effectiveMode = mode.lowercased()
+        } else if table {
+            effectiveMode = "table"
+        } else {
+            effectiveMode = "text"
+        }
+
         do {
-            if #available(macOS 26.0, *) {
-                let visionService = VisionService()
-                
-                let output: String
-                
-                if debug {
-                    // Debug mode: output raw Vision framework detection
-                    output = try await visionService.debugRawDetection(from: resolvedPath)
-                } else if table {
-                    // Table extraction mode
-                    let tableResults = try await visionService.extractTables(from: resolvedPath)
-                    
+            let visionService = VisionService()
+
+            // Apply auto-crop preprocessing
+            var processPath = resolvedPath
+            var tempCropURL: URL?
+            if autoCrop {
+                let imageData = try Data(contentsOf: URL(fileURLWithPath: resolvedPath))
+                let croppedData = try visionService.autoCrop(imageData: imageData)
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("afm_vision_crop_\(UUID().uuidString).png")
+                try croppedData.write(to: tempURL)
+                processPath = tempURL.path
+                tempCropURL = tempURL
+            }
+            defer { if let url = tempCropURL { try? FileManager.default.removeItem(at: url) } }
+
+            // Map detail to recognition level
+            let recognitionLevel: VisionRecognitionLevel = detail.lowercased() == "low" ? .fast : .accurate
+            let options = VisionRequestOptions(recognitionLevel: recognitionLevel)
+
+            let output: String
+
+            switch effectiveMode {
+            case "barcode":
+                let results = try visionService.detectBarcodes(from: processPath, options: options)
+                if results.isEmpty {
+                    output = "No barcodes found."
+                } else if format == "json" {
+                    let items = results.map { r in
+                        ["type": r.type, "payload": r.payload, "confidence": String(format: "%.2f", r.confidence)]
+                    }
+                    let data = try JSONSerialization.data(withJSONObject: items, options: [.prettyPrinted])
+                    output = String(data: data, encoding: .utf8) ?? "[]"
+                } else {
+                    output = results.map { r in
+                        "\(r.type): \(r.payload) (confidence: \(String(format: "%.2f", r.confidence)))"
+                    }.joined(separator: "\n")
+                }
+
+            case "classify":
+                let result = try visionService.classifyImage(from: processPath, maxLabels: maxLabels)
+                if result.labels.isEmpty {
+                    output = "No classifications found."
+                } else if format == "json" {
+                    let items = result.labels.map { l in
+                        ["label": l.label, "confidence": String(format: "%.4f", l.confidence)]
+                    }
+                    let data = try JSONSerialization.data(withJSONObject: items, options: [.prettyPrinted])
+                    output = String(data: data, encoding: .utf8) ?? "[]"
+                } else {
+                    output = result.labels.map { l in
+                        "\(l.label): \(String(format: "%.4f", l.confidence))"
+                    }.joined(separator: "\n")
+                }
+
+            case "saliency":
+                let result = try visionService.detectSaliency(from: processPath, type: saliencyType, includeHeatMap: heatMap)
+                if result.regions.isEmpty {
+                    output = "No salient regions found."
+                } else {
+                    var lines = result.regions.map { r in
+                        let box = r.boundingBox
+                        return "\(r.type): x=\(String(format: "%.3f", box.origin.x)), y=\(String(format: "%.3f", box.origin.y)), w=\(String(format: "%.3f", box.width)), h=\(String(format: "%.3f", box.height))"
+                    }
+                    if let heatMapData = result.heatMapPNG {
+                        lines.append("heat_map_base64: \(heatMapData.base64EncodedString())")
+                    }
+                    output = lines.joined(separator: "\n")
+                }
+
+            case "auto":
+                var sections: [String] = []
+
+                let barcodes = try visionService.detectBarcodes(from: processPath, options: options)
+                if !barcodes.isEmpty {
+                    sections.append("=== Barcodes ===\n" + barcodes.map { "\($0.type): \($0.payload)" }.joined(separator: "\n"))
+                }
+
+                let classified = try visionService.classifyImage(from: processPath, maxLabels: maxLabels)
+                if !classified.labels.isEmpty {
+                    sections.append("=== Classifications ===\n" + classified.labels.map { "\($0.label): \(String(format: "%.4f", $0.confidence))" }.joined(separator: "\n"))
+                }
+
+                if #available(macOS 26.0, *) {
+                    let text = try await visionService.extractText(from: processPath, options: options)
+                    sections.append("=== Text ===\n" + text)
+                }
+
+                output = sections.isEmpty ? "No results found." : sections.joined(separator: "\n\n")
+
+            case "debug":
+                if #available(macOS 26.0, *) {
+                    output = try await visionService.debugRawDetection(from: processPath, options: options)
+                } else {
+                    throw VisionError.modeRequiresMacOS26("debug")
+                }
+
+            case "table":
+                if #available(macOS 26.0, *) {
+                    let tableResults = try await visionService.extractTables(from: processPath, options: options)
                     if verbose {
-                        var verboseOutput = "📄 File: \(resolvedPath)\n"
-                        verboseOutput += "🗂️  Found \(tableResults.count) table(s)\n\n"
-                        
-                        for (index, table) in tableResults.enumerated() {
-                            verboseOutput += "📊 Table \(index + 1):\n"
-                            verboseOutput += "Rows: \(table.rows.count), Columns: \(table.columnCount)\n"
-                            verboseOutput += "Confidence: \(String(format: "%.2f", table.averageConfidence))\n\n"
-                            verboseOutput += table.csvData
+                        var verboseOutput = "File: \(resolvedPath)\n"
+                        verboseOutput += "Found \(tableResults.count) table(s)\n\n"
+                        for (index, tbl) in tableResults.enumerated() {
+                            verboseOutput += "Table \(index + 1):\n"
+                            verboseOutput += "Rows: \(tbl.rows.count), Columns: \(tbl.columnCount)\n"
+                            verboseOutput += "Confidence: \(String(format: "%.2f", tbl.averageConfidence))\n\n"
+                            verboseOutput += tbl.csvData
                             if index < tableResults.count - 1 {
                                 verboseOutput += "\n" + String(repeating: "-", count: 50) + "\n\n"
                             }
                         }
-                        
                         output = verboseOutput
                     } else {
-                        // Simple CSV output with table headers
-                        let csvSections = tableResults.enumerated().map { (index, table) in
-                            let tableHeader = "Detected Table \(index + 1)"
-                            return tableHeader + "\n" + table.csvData
+                        let csvSections = tableResults.enumerated().map { (index, tbl) in
+                            "Detected Table \(index + 1)\n" + tbl.csvData
                         }
                         let csvOutput = csvSections.joined(separator: "\n")
                         output = csvOutput.isEmpty ? "No tables found in the document." : csvOutput
                     }
-                } else if verbose {
-                    // Get detailed results with confidence scores
-                    let visionResult = try await visionService.extractTextWithDetails(from: resolvedPath)
-                    var verboseOutput = "📄 File: \(visionResult.filePath)\n"
-                    verboseOutput += "📝 Text Content:\n\n"
-                    verboseOutput += visionResult.fullText
-                    verboseOutput += "\n\n📊 Details:\n"
-                    
-                    for (index, block) in visionResult.textBlocks.enumerated() {
-                        verboseOutput += "Block \(index + 1): \"\(block.text)\" (confidence: \(String(format: "%.2f", block.confidence)))\n"
-                    }
-                    
-                    output = verboseOutput
                 } else {
-                    // Simple text extraction
-                    output = try await visionService.extractText(from: resolvedPath)
+                    throw VisionError.modeRequiresMacOS26("table")
                 }
-                
-                print(output)
-            } else {
-                throw VisionError.textRecognitionFailed("Vision framework requires macOS 26.0 or later")
+
+            default:
+                // text mode (default)
+                if #available(macOS 26.0, *) {
+                    if verbose {
+                        let visionResult = try await visionService.extractTextWithDetails(from: processPath, options: options)
+                        var verboseOutput = "File: \(visionResult.filePath)\n"
+                        verboseOutput += "Text Content:\n\n"
+                        verboseOutput += visionResult.fullText
+                        verboseOutput += "\n\nDetails:\n"
+                        for (index, block) in visionResult.textBlocks.enumerated() {
+                            verboseOutput += "Block \(index + 1): \"\(block.text)\" (confidence: \(String(format: "%.2f", block.confidence)))\n"
+                        }
+                        output = verboseOutput
+                    } else {
+                        output = try await visionService.extractText(from: processPath, options: options)
+                    }
+                } else {
+                    throw VisionError.modeRequiresMacOS26("text")
+                }
             }
+
+            print(output)
         } catch {
             if let visionError = error as? VisionError {
                 print("Error: \(visionError.localizedDescription)")

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -939,6 +939,8 @@ func printHelpJson(command: String) {
         config = MlxCommand.configuration
     case "afm vision":
         config = VisionCommand.configuration
+    case "afm speech":
+        config = SpeechCommand.configuration
     default:
         config = RootCommand.configuration
     }
@@ -1235,7 +1237,7 @@ struct RootCommand: ParsableCommand {
         GitHub: https://github.com/scouzi1966/maclocal-api
         """,
         version: MacLocalAPI.buildVersion,
-        subcommands: [MlxCommand.self, VisionCommand.self]
+        subcommands: [MlxCommand.self, VisionCommand.self, SpeechCommand.self]
     )
 
     @Option(name: [.customShort("s"), .long], help: "Run a single prompt without starting the server")
@@ -1371,6 +1373,38 @@ if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "mlx" {
         try cmd.run()
     } catch {
         MlxCommand.exit(withError: error)
+    }
+} else if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "speech" {
+    var args = Array(CommandLine.arguments.dropFirst(2))
+    // Legacy: if the first arg isn't a known subcommand or flag, assume it's a
+    // file path and prepend "transcribe" (e.g. "afm speech file.wav" routes to
+    // transcribe; flag-prefixed args like "-f" fall through to ArgumentParser).
+    let subcommands: Set<String> = ["synthesize", "transcribe", "help"]
+    if let first = args.first, !subcommands.contains(first), !first.hasPrefix("-") {
+        args.insert("transcribe", at: 0)
+    }
+    do {
+        var cmd = try SpeechCommand.parseAsRoot(args)
+        // Use CFRunLoop so AVSpeechSynthesizer callbacks can fire on the main thread
+        var caughtError: Error?
+        Task {
+            do {
+                if var asyncCmd = cmd as? AsyncParsableCommand {
+                    try await asyncCmd.run()
+                } else {
+                    try cmd.run()
+                }
+            } catch {
+                caughtError = error
+            }
+            CFRunLoopStop(CFRunLoopGetMain())
+        }
+        CFRunLoopRun()
+        if let error = caughtError {
+            throw error
+        }
+    } catch {
+        SpeechCommand.exit(withError: error)
     }
 } else if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "vision" {
     let args = Array(CommandLine.arguments.dropFirst(2))

--- a/Tests/MacLocalAPITests/VisionAPIControllerTests.swift
+++ b/Tests/MacLocalAPITests/VisionAPIControllerTests.swift
@@ -228,6 +228,26 @@ private final class FakeVisionService: VisionServing {
         if let debugError { throw debugError }
         return debugResult
     }
+
+    func detectBarcodes(from filePath: String, options: VisionRequestOptions) throws -> [BarcodeResult] {
+        lastPath = filePath
+        lastOptions = options
+        return []
+    }
+
+    func classifyImage(from filePath: String, maxLabels: Int) throws -> ClassifyResult {
+        lastPath = filePath
+        return ClassifyResult(labels: [], salientRegions: [])
+    }
+
+    func detectSaliency(from filePath: String, type: String, includeHeatMap: Bool) throws -> SaliencyResult {
+        lastPath = filePath
+        return SaliencyResult(regions: [], heatMapPNG: nil)
+    }
+
+    func autoCrop(imageData: Data) throws -> Data {
+        return imageData
+    }
 }
 
 private func makeVisionResult(filePath: String) -> VisionResult {

--- a/docs/superpowers/plans/2026-04-20-vision-speech-expansion.md
+++ b/docs/superpowers/plans/2026-04-20-vision-speech-expansion.md
@@ -1,0 +1,969 @@
+# Vision & Speech Feature Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand AFM's vision and speech capabilities with TTS, transcription enhancements (OpenAI parity), and new vision modes (barcode, classify, saliency, auto-crop).
+
+**Architecture:** Three independent feature areas built on existing VisionService/SpeechService patterns. Each adds service methods, controller routes, and CLI flags. Speech transcription branch must be merged first as a prerequisite. TTS is a new service (`SpeechSynthesisService`). Vision modes extend the existing `VisionService` with per-mode `#available` checks instead of class-level gating.
+
+**Tech Stack:** Swift, Vapor, Apple Vision framework, Apple Speech framework, AVSpeechSynthesizer, AudioToolbox, ArgumentParser
+
+**Spec:** `docs/superpowers/specs/2026-04-20-vision-speech-options-design.md`
+
+---
+
+## Prerequisites
+
+### Task 0: Merge speech transcription branch
+
+**Files:**
+- Merge: `feature/speech-transcription` into `main`
+
+The speech transcription feature branch has SpeechService, SpeechAPIController, and SpeechCommand. It must be on main before we can enhance it.
+
+- [ ] **Step 1: Merge the branch**
+
+```bash
+git merge feature/speech-transcription --no-edit
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit if needed**
+
+The merge commit is automatic. Verify with `git log --oneline -3`.
+
+---
+
+## Part 1: TTS (Text-to-Speech)
+
+### Task 1: Create SpeechSynthesisService
+
+**Files:**
+- Create: `Sources/MacLocalAPI/Models/SpeechSynthesisService.swift`
+
+- [ ] **Step 1: Create the service file**
+
+```swift
+import Foundation
+import AVFoundation
+
+enum SpeechSynthesisError: Error, LocalizedError {
+    case platformUnavailable
+    case inputTooLong(actualChars: Int, maxChars: Int)
+    case emptyInput
+    case voiceNotAvailable(String)
+    case synthesisTimedOut
+    case synthesisFailed(String)
+    case unsupportedFormat(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .platformUnavailable:
+            return "Text-to-speech requires macOS 13.0 or later"
+        case .inputTooLong(let actual, let max):
+            return "Input text \(actual) characters exceeds the limit of \(max)"
+        case .emptyInput:
+            return "Input text is empty"
+        case .voiceNotAvailable(let name):
+            return "Voice '\(name)' is not available on this system"
+        case .synthesisTimedOut:
+            return "Speech synthesis timed out"
+        case .synthesisFailed(let message):
+            return "Speech synthesis failed: \(message)"
+        case .unsupportedFormat(let format):
+            return "Unsupported audio format: \(format). Supported: aac, wav, caf"
+        }
+    }
+}
+
+enum TTSAudioFormat: String, Sendable, CaseIterable {
+    case aac
+    case wav
+    case caf
+
+    var contentType: String {
+        switch self {
+        case .aac: return "audio/aac"
+        case .wav: return "audio/wav"
+        case .caf: return "audio/x-caf"
+        }
+    }
+
+    var fileExtension: String { rawValue }
+}
+
+enum OpenAIVoiceName: String, CaseIterable {
+    case alloy, echo, fable, nova, onyx, shimmer
+
+    enum Gender { case female, male }
+
+    var gender: Gender {
+        switch self {
+        case .alloy, .nova, .shimmer: return .female
+        case .echo, .fable, .onyx: return .male
+        }
+    }
+
+    var preferredAppleVoiceNames: [String] {
+        switch self {
+        case .alloy: return ["Samantha"]
+        case .echo: return ["Daniel"]
+        case .fable: return ["Tom"]
+        case .nova: return ["Karen"]
+        case .onyx: return ["Alex"]
+        case .shimmer: return ["Ava"]
+        }
+    }
+}
+
+struct TTSRequestOptions: Sendable {
+    static let maxInputCharacters = 4096
+    static let synthesisTimeoutNs: UInt64 = 120_000_000_000
+
+    let voice: String?
+    let appleVoice: String?
+    let locale: String
+    let speed: Float
+    let format: TTSAudioFormat
+
+    init(
+        voice: String? = "alloy",
+        appleVoice: String? = nil,
+        locale: String = "en-US",
+        speed: Float = 1.0,
+        format: TTSAudioFormat = .aac
+    ) {
+        self.voice = voice
+        self.appleVoice = appleVoice
+        self.locale = locale
+        self.speed = speed
+        self.format = format
+    }
+}
+
+struct VoiceInfo: Sendable, Codable {
+    let id: String
+    let name: String
+    let locale: String
+    let gender: String
+    let quality: String
+}
+
+@available(macOS 13.0, *)
+final class SpeechSynthesisService: NSObject, @unchecked Sendable {
+
+    static func listVoices(locale: String? = nil) -> [VoiceInfo] {
+        let voices = AVSpeechSynthesisVoice.speechVoices()
+        let filtered: [AVSpeechSynthesisVoice]
+        if let locale = locale {
+            let prefix = locale.lowercased()
+            filtered = voices.filter { $0.language.lowercased().hasPrefix(prefix) }
+        } else {
+            filtered = voices
+        }
+        return filtered.map { voice in
+            let quality: String
+            switch voice.quality {
+            case .enhanced: quality = "enhanced"
+            case .premium: quality = "premium"
+            default: quality = "compact"
+            }
+            return VoiceInfo(
+                id: voice.identifier,
+                name: voice.name,
+                locale: voice.language,
+                gender: voice.gender == .male ? "male" : "female",
+                quality: quality
+            )
+        }.sorted {
+            if $0.locale != $1.locale { return $0.locale < $1.locale }
+            return $0.name < $1.name
+        }
+    }
+
+    static let speedMinimum: Float = 0.25
+    static let speedMaximum: Float = 4.0
+
+    func synthesize(text: String, options: TTSRequestOptions) async throws -> Data {
+        guard !text.isEmpty else {
+            throw SpeechSynthesisError.emptyInput
+        }
+        guard text.count <= TTSRequestOptions.maxInputCharacters else {
+            throw SpeechSynthesisError.inputTooLong(
+                actualChars: text.count,
+                maxChars: TTSRequestOptions.maxInputCharacters
+            )
+        }
+        guard options.speed >= Self.speedMinimum && options.speed <= Self.speedMaximum else {
+            throw SpeechSynthesisError.synthesisFailed(
+                "Speed must be between \(Self.speedMinimum) and \(Self.speedMaximum)"
+            )
+        }
+
+        let voice = try resolveVoice(options: options)
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = voice
+        utterance.rate = clampRate(options.speed)
+
+        // Collect PCM buffers from AVSpeechSynthesizer.write, then encode
+        let synthesizer = AVSpeechSynthesizer()
+        let allBuffers: [AVAudioPCMBuffer] = await withCheckedContinuation { continuation in
+            var buffers: [AVAudioPCMBuffer] = []
+            synthesizer.write(utterance) { buffer in
+                if let pcm = buffer as? AVAudioPCMBuffer, pcm.frameLength > 0 {
+                    buffers.append(pcm)
+                } else {
+                    // Empty buffer signals completion
+                    continuation.resume(returning: buffers)
+                }
+            }
+        }
+
+        guard !allBuffers.isEmpty else {
+            throw SpeechSynthesisError.synthesisFailed("No audio data generated")
+        }
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("afm_tts_\(UUID().uuidString).\(options.format.fileExtension)")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        // Encode collected PCM buffers to the requested format
+        try encodeBuffers(allBuffers, to: tempURL, format: options.format)
+        return try Data(contentsOf: tempURL)
+    }
+
+    /// Encode PCM buffers to a file. For WAV/CAF, write PCM directly via
+    /// AVAudioFile. For AAC, use AVAudioConverter to transcode.
+    private func encodeBuffers(
+        _ buffers: [AVAudioPCMBuffer],
+        to url: URL,
+        format: TTSAudioFormat
+    ) throws {
+        let inputFormat = buffers[0].format
+
+        switch format {
+        case .wav, .caf:
+            // PCM output — write directly
+            let settings: [String: Any] = [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: inputFormat.sampleRate,
+                AVNumberOfChannelsKey: inputFormat.channelCount,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsBigEndianKey: false
+            ]
+            let outputFile = try AVAudioFile(
+                forWriting: url,
+                settings: settings,
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
+            for buffer in buffers {
+                try outputFile.write(from: buffer)
+            }
+
+        case .aac:
+            // AAC encoding via AVAudioConverter
+            let outputSettings: [String: Any] = [
+                AVFormatIDKey: kAudioFormatMPEG4AAC,
+                AVSampleRateKey: inputFormat.sampleRate,
+                AVNumberOfChannelsKey: inputFormat.channelCount,
+                AVEncoderBitRateKey: 128_000
+            ]
+            guard let outputFormat = AVAudioFormat(settings: outputSettings) else {
+                throw SpeechSynthesisError.synthesisFailed("Cannot create AAC output format")
+            }
+            guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+                throw SpeechSynthesisError.synthesisFailed("Cannot create AAC converter")
+            }
+
+            let outputFile = try AVAudioFile(
+                forWriting: url,
+                settings: outputSettings
+            )
+
+            // Feed all input buffers through the converter
+            var inputBufferIndex = 0
+            var inputFrameOffset: AVAudioFrameCount = 0
+
+            let outputBufferSize: AVAudioFrameCount = 4096
+            guard let outputBuffer = AVAudioPCMBuffer(
+                pcmFormat: outputFormat,
+                frameCapacity: outputBufferSize
+            ) else {
+                throw SpeechSynthesisError.synthesisFailed("Cannot allocate output buffer")
+            }
+
+            while inputBufferIndex < buffers.count {
+                var error: NSError?
+                let status = converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+                    if inputBufferIndex >= buffers.count {
+                        outStatus.pointee = .endOfStream
+                        return nil
+                    }
+                    let currentBuffer = buffers[inputBufferIndex]
+                    inputBufferIndex += 1
+                    outStatus.pointee = .haveData
+                    return currentBuffer
+                }
+
+                if let error { throw SpeechSynthesisError.synthesisFailed(error.localizedDescription) }
+                if status == .error { throw SpeechSynthesisError.synthesisFailed("AAC conversion error") }
+
+                if outputBuffer.frameLength > 0 {
+                    try outputFile.write(from: outputBuffer)
+                }
+
+                if status == .endOfStream { break }
+            }
+        }
+    }
+
+    private func resolveVoice(options: TTSRequestOptions) throws -> AVSpeechSynthesisVoice {
+        // 1. Exact Apple voice identifier
+        if let appleVoice = options.appleVoice, !appleVoice.isEmpty {
+            if let voice = AVSpeechSynthesisVoice(identifier: appleVoice) {
+                return voice
+            }
+            throw SpeechSynthesisError.voiceNotAvailable(appleVoice)
+        }
+
+        // 2. OpenAI voice name mapping
+        if let voiceName = options.voice,
+           let openAIVoice = OpenAIVoiceName(rawValue: voiceName.lowercased()) {
+            let voices = AVSpeechSynthesisVoice.speechVoices()
+                .filter { $0.language.lowercased().hasPrefix(options.locale.lowercased().prefix(2).description) }
+
+            // Try preferred Apple voice names first
+            for preferred in openAIVoice.preferredAppleVoiceNames {
+                // Prefer enhanced > premium > compact
+                let sorted = voices.filter { $0.name == preferred }
+                    .sorted { qualityRank($0) > qualityRank($1) }
+                if let found = sorted.first {
+                    return found
+                }
+            }
+
+            // Fallback: match by gender, prefer higher quality
+            let genderMatched = voices
+                .filter { voiceMatchesGender($0, openAIVoice.gender) }
+                .sorted { qualityRank($0) > qualityRank($1) }
+            if let found = genderMatched.first {
+                return found
+            }
+
+            // Last fallback: any voice for the locale
+            if let anyVoice = voices.sorted(by: { qualityRank($0) > qualityRank($1) }).first {
+                return anyVoice
+            }
+        }
+
+        // 3. System default for locale
+        if let voice = AVSpeechSynthesisVoice(language: options.locale) {
+            return voice
+        }
+
+        // 4. Absolute fallback
+        if let voice = AVSpeechSynthesisVoice(language: "en-US") {
+            return voice
+        }
+
+        throw SpeechSynthesisError.voiceNotAvailable(options.locale)
+    }
+
+    private func qualityRank(_ voice: AVSpeechSynthesisVoice) -> Int {
+        switch voice.quality {
+        case .enhanced: return 3
+        case .premium: return 2
+        default: return 1
+        }
+    }
+
+    private func voiceMatchesGender(_ voice: AVSpeechSynthesisVoice, _ gender: OpenAIVoiceName.Gender) -> Bool {
+        switch gender {
+        case .female: return voice.gender == .female
+        case .male: return voice.gender == .male
+        }
+    }
+
+    private func clampRate(_ speed: Float) -> Float {
+        let minRate = AVSpeechUtteranceMinimumSpeechRate
+        let maxRate = AVSpeechUtteranceMaximumSpeechRate
+        let defaultRate = AVSpeechUtteranceDefaultSpeechRate
+
+        // Map OpenAI's 0.25-4.0 range to Apple's rate range
+        // speed=1.0 maps to defaultRate
+        let normalized = speed * defaultRate
+        return Swift.min(Swift.max(normalized, minRate), maxRate)
+    }
+}
+```
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MacLocalAPI/Models/SpeechSynthesisService.swift
+git commit -m "feat: add SpeechSynthesisService for on-device TTS"
+```
+
+### Task 2: Add TTS routes to SpeechAPIController
+
+**Files:**
+- Modify: `Sources/MacLocalAPI/Controllers/SpeechAPIController.swift`
+
+- [ ] **Step 1: Add TTS request struct, voice listing route, and speech synthesis route**
+
+Add to `SpeechAPIController`:
+
+1. A `TTSSpeechRequest` struct:
+```swift
+struct TTSSpeechRequest: Content {
+    let model: String?
+    let input: String
+    let voice: String?
+    let responseFormat: String?
+    let speed: Double?
+    let locale: String?
+    let appleVoice: String?
+
+    enum CodingKeys: String, CodingKey {
+        case model, input, voice
+        case responseFormat = "response_format"
+        case speed, locale
+        case appleVoice = "apple_voice"
+    }
+}
+```
+
+2. Register new routes in `boot(routes:)`:
+```swift
+speech.on(.POST, "speech", body: .collect(maxSize: "1mb"), use: synthesize)
+speech.on(.OPTIONS, "speech", use: handleOptions)
+speech.on(.GET, "voices", use: listVoices)
+speech.on(.OPTIONS, "voices", use: handleOptions)
+```
+
+3. A `synthesize(req:)` handler that:
+   - Decodes `TTSSpeechRequest`
+   - Validates `input` is non-empty and under 4096 chars (return 400)
+   - Parses `response_format` into `TTSAudioFormat` (default `.aac`)
+   - Creates `TTSRequestOptions` from the request fields
+   - Calls `SpeechSynthesisService().synthesize(text:options:)`
+   - Returns raw audio bytes with correct `Content-Type` header
+
+4. A `listVoices(req:)` handler that:
+   - Reads optional `locale` query param
+   - Calls `SpeechSynthesisService.listVoices(locale:)`
+   - Returns JSON `{"voices": [...]}`
+
+- [ ] **Step 2: Verify build**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MacLocalAPI/Controllers/SpeechAPIController.swift
+git commit -m "feat: add TTS and voice listing API endpoints"
+```
+
+### Task 3: Add TTS CLI commands to SpeechCommand
+
+**Files:**
+- Modify: `Sources/MacLocalAPI/SpeechCommand.swift`
+- Modify: `Sources/MacLocalAPI/main.swift`
+
+- [ ] **Step 1: Restructure SpeechCommand with subcommands**
+
+Refactor `SpeechCommand` to have two subcommands: `SpeechTranscribeCommand` and `SpeechSynthesizeCommand`, plus a `--list-voices` flag.
+
+The existing `SpeechCommand` fields (`file`, `locale`, `helpJson`) move into `SpeechTranscribeCommand`. Add `SpeechSynthesizeCommand` with `text` (positional), `--voice`, `--locale`, `--format` (aac/wav/caf, default aac), `--speed`, `-o`/`--output`.
+
+Add `--list-voices` and `--locale` to the parent `SpeechCommand`.
+
+Key subcommand structure:
+```
+afm speech --list-voices [--locale en]
+afm speech synthesize "text" [--voice alloy] [--locale en-US] [--format aac] [--speed 1.0] [-o file]
+afm speech transcribe -f file.wav [--locale en-US] [--format json]
+afm speech -f file.wav  (legacy — dispatches to transcribe)
+```
+
+- [ ] **Step 2: Update main.swift dispatch**
+
+The existing `else if CommandLine.arguments[1] == "speech"` block on the feature branch dispatches to `SpeechCommand`. Since we're restructuring SpeechCommand, update the dispatch to handle the new subcommand structure. Keep backward compat: if args contain `-f`, treat as `transcribe`.
+
+Add the speech dispatch block (it's not yet on main — comes from the merge in Task 0):
+```swift
+} else if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "speech" {
+    let args = Array(CommandLine.arguments.dropFirst(2))
+    do {
+        let cmd = try SpeechCommand.parse(args)
+        let group = DispatchGroup()
+        var caughtError: Error?
+        group.enter()
+        Task {
+            do {
+                try await cmd.run()
+            } catch {
+                caughtError = error
+            }
+            group.leave()
+        }
+        group.wait()
+        if let error = caughtError {
+            throw error
+        }
+    } catch {
+        SpeechCommand.exit(withError: error)
+    }
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/MacLocalAPI/SpeechCommand.swift Sources/MacLocalAPI/main.swift
+git commit -m "feat: add TTS CLI (afm speech synthesize) and voice listing"
+```
+
+---
+
+## Part 2: Transcription Enhancements
+
+### Task 4: Enhance SpeechService with rich results
+
+**Files:**
+- Modify: `Sources/MacLocalAPI/Models/SpeechService.swift`
+
+- [ ] **Step 1: Add rich transcription result types and enhance the service**
+
+Add result structs:
+```swift
+struct TranscriptionWord: Sendable, Codable {
+    let word: String
+    let start: Double
+    let end: Double
+}
+
+struct TranscriptionSegment: Sendable, Codable {
+    let id: Int
+    let start: Double
+    let end: Double
+    let text: String
+    let confidence: Float
+}
+
+struct TranscriptionResult: Sendable, Codable {
+    let text: String
+    let language: String
+    let duration: Double
+    let words: [TranscriptionWord]
+    let segments: [TranscriptionSegment]
+}
+```
+
+Add a new method `transcribeWithDetails(from:options:)` that returns `TranscriptionResult`. The existing `transcribe(from:options:)` can call it and return just `.text`.
+
+In the recognition task callback, when `result.isFinal`, extract:
+- `result.bestTranscription.formattedString` for `text`
+- `result.bestTranscription.segments` for word-level timing (each `SFTranscriptionSegment` has `timestamp`, `duration`, `substring`, `confidence`)
+- Build segments by grouping words into sentence-like chunks (or treat the whole transcription as one segment)
+- `duration` = last segment's `timestamp + duration`
+
+- [ ] **Step 2: Verify build**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MacLocalAPI/Models/SpeechService.swift
+git commit -m "feat: add rich transcription results with timestamps"
+```
+
+### Task 5: Add response format support to SpeechAPIController
+
+**Files:**
+- Modify: `Sources/MacLocalAPI/Controllers/SpeechAPIController.swift`
+
+- [ ] **Step 1: Update transcription endpoint**
+
+Update the `TranscriptionRequest` struct to add new fields:
+```swift
+struct TranscriptionRequest: Content {
+    let file: String?
+    let data: String?
+    let format: String?
+    let locale: String?
+    let model: String?           // accepted, ignored
+    let language: String?        // ISO-639-1, alias for locale
+    let responseFormat: String?  // json, text, verbose_json, srt, vtt
+    let timestampGranularities: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case file, data, format, locale, model, language
+        case responseFormat = "response_format"
+        case timestampGranularities = "timestamp_granularities"
+    }
+}
+```
+
+Resolve `language` as alias for `locale` (language takes precedence if both provided).
+
+Add response formatting methods:
+- `formatAsJSON(result:)` — `{"text": "..."}`
+- `formatAsText(result:)` — plain string
+- `formatAsVerboseJSON(result:granularities:)` — full structure with words/segments
+- `formatAsSRT(result:)` — standard SRT subtitle format
+- `formatAsVTT(result:)` — standard WebVTT subtitle format
+
+Route the controller's transcribe handler to call `transcribeWithDetails` and format based on `response_format`.
+
+- [ ] **Step 2: Verify build**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MacLocalAPI/Controllers/SpeechAPIController.swift
+git commit -m "feat: add response_format support to transcription endpoint"
+```
+
+### Task 6: Update SpeechCommand for new transcription options
+
+**Files:**
+- Modify: `Sources/MacLocalAPI/SpeechCommand.swift`
+
+- [ ] **Step 1: Add --format, --language, --timestamps flags to SpeechTranscribeCommand**
+
+```swift
+@Option(name: .long, help: "Output format: json, text, verbose_json, srt, vtt (default: text for CLI)")
+var format: String = "text"
+
+@Option(name: .long, help: "Language code (ISO-639-1, e.g. 'en', 'ja')")
+var language: String?
+
+@Option(name: .long, help: "Timestamp granularities: word, segment, or both (comma-separated)")
+var timestamps: String?
+```
+
+Update `run()` to use `transcribeWithDetails` when format is not `text`, and format output accordingly. For CLI, default to `text` (just print the transcription). For `verbose_json`, print the full JSON. For `srt`/`vtt`, print subtitle text.
+
+- [ ] **Step 2: Verify build**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MacLocalAPI/SpeechCommand.swift
+git commit -m "feat: add format/language/timestamps CLI flags for transcription"
+```
+
+---
+
+## Part 3: Vision Enhancements
+
+### Task 7: Relax VisionService macOS gating and add new modes
+
+**Files:**
+- Modify: `Sources/MacLocalAPI/Models/VisionService.swift`
+
+- [ ] **Step 1: Remove class-level @available and add per-mode checks**
+
+Change `VisionService` from `@available(macOS 26.0, *)` to no class-level restriction (or `@available(macOS 13.0, *)`). Keep `@available(macOS 26.0, *)` on the text/table methods that use `VNRecognizeTextRequest`.
+
+**Access level change:** Change `validateFile(at:maxBytes:)` from `private` to `internal` so the new mode methods can reuse it.
+
+**macOS version gating change:** Remove `@available(macOS 26.0, *)` from `VisionService` class declaration. Add `@available(macOS 26.0, *)` to individual text/table methods (`extractText`, `extractTextWithDetails`, `extractTables`, `debugRawDetection`, `analyzeDocument`, `makeTextRequest`). The new barcode/classify/saliency methods have no macOS 26 restriction (Vision framework barcode/classification/saliency APIs are available since macOS 13).
+
+**Update `VisionServing` protocol** to add new methods. Update `@available(macOS 26.0, *)` conformance extension to only cover the text/table methods. Add a separate protocol or extend `VisionServing` with default-nil implementations for the new methods so they're accessible on macOS 13+.
+
+**Update `VisionAPIController.defaultVisionServiceFactory()`** to create `VisionService()` on macOS 13+ (not just 26+). For modes that require macOS 26, the individual service methods will check `#available` internally.
+
+Add new result types:
+```swift
+struct BarcodeResult: Sendable {
+    let type: String
+    let payload: String
+    let boundingBox: CGRect
+    let confidence: Float
+}
+
+struct ClassificationLabel: Sendable {
+    let label: String
+    let confidence: Float
+}
+
+struct ClassifyResult: Sendable {
+    let labels: [ClassificationLabel]
+    let salientRegions: [CGRect]
+}
+
+struct SaliencyRegion: Sendable {
+    let type: String
+    let boundingBox: CGRect
+}
+
+struct SaliencyResult: Sendable {
+    let regions: [SaliencyRegion]
+    let heatMapPNG: Data?
+}
+```
+
+Note: `CGRect` is fine in service-layer structs — the controller maps them to `VisionOCRBoundingBox` (which is `Codable`) when building API responses, following the existing pattern used for `TextBlock`.
+
+Add new methods:
+- `detectBarcodes(from:options:)` — uses `VNDetectBarcodesRequest`
+- `classifyImage(from:maxLabels:)` — uses `VNClassifyImageRequest` + `VNGenerateAttentionBasedSaliencyImageRequest`
+- `detectSaliency(from:type:includeHeatMap:)` — uses `VNGenerateAttentionBasedSaliencyImageRequest` or `VNGenerateObjectnessBasedSaliencyImageRequest`
+- `autoCrop(imageData:)` — uses `VNDetectDocumentSegmentationRequest`, returns cropped `Data`
+
+Each method reuses the now-`internal` `validateFile`. The barcode/classify/saliency methods do NOT require macOS 26.
+
+- [ ] **Step 2: Verify build**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MacLocalAPI/Models/VisionService.swift
+git commit -m "feat: add barcode, classify, saliency modes to VisionService"
+```
+
+### Task 8: Update VisionAPIController for new modes
+
+**Files:**
+- Modify: `Sources/MacLocalAPI/Controllers/VisionAPIController.swift`
+
+- [ ] **Step 1: Extend request/response types and routing**
+
+Update `VisionOCRRequest` to add new fields:
+```swift
+let mode: String?           // text, table, barcode, classify, saliency, auto
+let detail: String?         // high, low — alias for recognitionLevel
+let autoCrop: Bool?         // run document segmentation first
+let responseFormat: String? // json, text, verbose_json
+let maxLabels: Int?         // for classify mode
+let saliencyType: String?   // attention, objectness
+let includeHeatMap: Bool?   // for saliency mode
+```
+
+Add CodingKeys for `auto_crop`, `response_format`, `max_labels`, `saliency_type`, `include_heat_map`.
+
+Update `VisionServing` protocol to include new methods.
+
+Add response types:
+```swift
+struct VisionBarcodeResponse: Content { ... }
+struct VisionClassifyResponse: Content { ... }
+struct VisionSaliencyResponse: Content { ... }
+struct VisionAutoResponse: Content { ... }  // combined results with modes_run
+```
+
+Update the `ocr` handler to:
+1. Resolve `mode` (default `"text"`, honor `table` bool as alias)
+2. Resolve `detail` as alias for `recognition_level` (`high`→`accurate`, `low`→`fast`)
+3. If `auto_crop` is true, run document segmentation first on the input
+4. Route to the correct service method based on mode
+5. Format response based on `response_format` (default `json`)
+6. For `auto` mode, run text+barcode+classify via `TaskGroup`. On pre-macOS 26, omit text (barcode+classify only). Include `modes_run` array in response indicating which modes executed.
+7. Return 501 with message if a specific mode requires macOS 26 and host is pre-26 (e.g., `mode=text` on pre-26)
+
+Empty results (no barcodes found, etc.) return 200 with empty arrays, not errors.
+
+- [ ] **Step 2: Verify build**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MacLocalAPI/Controllers/VisionAPIController.swift
+git commit -m "feat: add mode/detail/auto_crop/response_format to vision API"
+```
+
+### Task 9: Update VisionCommand for new CLI flags
+
+**Files:**
+- Modify: `Sources/MacLocalAPI/VisionCommand.swift`
+
+- [ ] **Step 1: Add new flags to VisionCommand**
+
+Add:
+```swift
+@Option(name: .long, help: "Vision mode: text, table, barcode, classify, saliency, auto (default: text)")
+var mode: String = "text"
+
+@Option(name: .long, help: "Recognition detail: high or low (default: high)")
+var detail: String = "high"
+
+@Flag(name: .long, help: "Auto-crop document region before processing")
+var autoCrop: Bool = false
+
+@Option(name: .long, help: "Output format: json, text, verbose_json (default: text for CLI)")
+var format: String = "text"
+
+@Option(name: .long, help: "Max classification labels to return (default: 5)")
+var maxLabels: Int = 5
+
+@Option(name: .long, help: "Saliency type: attention or objectness (default: attention)")
+var saliencyType: String = "attention"
+
+@Flag(name: .long, help: "Include saliency heat map as base64 PNG")
+var heatMap: Bool = false
+```
+
+Update `run()` to:
+- When `mode == "table"` or `--table` flag, use table extraction
+- When `mode == "barcode"`, call barcode detection
+- When `mode == "classify"`, call classification
+- When `mode == "saliency"`, call saliency detection
+- When `mode == "auto"`, run text+barcode+classify
+- Apply `--auto-crop` as preprocessing
+- Map `--detail high` → `.accurate`, `--detail low` → `.fast`
+- Format output per `--format` (CLI defaults to `text` for readable output)
+
+Keep existing `--table` and `--verbose` flags as aliases for backward compat.
+
+- [ ] **Step 2: Verify build**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MacLocalAPI/VisionCommand.swift
+git commit -m "feat: add mode/detail/auto-crop/format CLI flags to vision command"
+```
+
+---
+
+## Part 4: Server Registration
+
+### Task 10: Register new routes in Server.swift
+
+**Files:**
+- Modify: `Sources/MacLocalAPI/Server.swift`
+
+- [ ] **Step 1: Ensure SpeechAPIController is registered**
+
+After the merge in Task 0, `SpeechAPIController` should already be registered. Verify it's present. If not, add:
+```swift
+try app.register(collection: SpeechAPIController())
+```
+right after the `VisionAPIController()` registration (line 243).
+
+The TTS and voice listing routes are already part of `SpeechAPIController.boot()` from Task 2, so no additional registration is needed.
+
+- [ ] **Step 2: Verify build**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit (if changes needed)**
+
+```bash
+git add Sources/MacLocalAPI/Server.swift
+git commit -m "feat: register speech API controller in server"
+```
+
+---
+
+## Part 5: Manual Testing
+
+### Task 11: End-to-end smoke test
+
+- [ ] **Step 1: Build release**
+
+```bash
+swift build -c release 2>&1 | tail -5
+```
+
+- [ ] **Step 2: Test TTS endpoint**
+
+```bash
+curl -s http://localhost:9999/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"input": "Hello from AFM", "voice": "alloy"}' \
+  -o /tmp/tts-test.aac
+file /tmp/tts-test.aac
+```
+Expected: Valid audio file
+
+- [ ] **Step 3: Test voice listing**
+
+```bash
+curl -s http://localhost:9999/v1/audio/voices | python3 -m json.tool | head -20
+```
+Expected: JSON with voices array
+
+- [ ] **Step 4: Test transcription verbose_json**
+
+```bash
+curl -s http://localhost:9999/v1/audio/transcriptions \
+  -H "Content-Type: application/json" \
+  -d '{"file": "/path/to/test.wav", "response_format": "verbose_json"}' | python3 -m json.tool
+```
+Expected: JSON with text, duration, words, segments
+
+- [ ] **Step 5: Test vision barcode mode**
+
+```bash
+curl -s http://localhost:9999/v1/vision/ocr \
+  -H "Content-Type: application/json" \
+  -d '{"file": "/path/to/qr-code.png", "mode": "barcode"}' | python3 -m json.tool
+```
+Expected: JSON with barcode results
+
+- [ ] **Step 6: Test vision classify mode**
+
+```bash
+curl -s http://localhost:9999/v1/vision/ocr \
+  -H "Content-Type: application/json" \
+  -d '{"file": "/path/to/photo.jpg", "mode": "classify"}' | python3 -m json.tool
+```
+Expected: JSON with labels and salient_regions
+
+- [ ] **Step 7: Test vision saliency mode**
+
+```bash
+curl -s http://localhost:9999/v1/vision/ocr \
+  -H "Content-Type: application/json" \
+  -d '{"file": "/path/to/photo.jpg", "mode": "saliency"}' | python3 -m json.tool
+```
+Expected: JSON with regions
+
+- [ ] **Step 8: Test CLI commands**
+
+```bash
+afm speech --list-voices --locale en | head -10
+afm speech synthesize "Hello world" -o /tmp/cli-tts.aac
+afm vision -f /path/to/image.jpg --mode classify
+afm vision -f /path/to/image.jpg --mode barcode
+afm vision -f /path/to/image.jpg --mode saliency
+```

--- a/docs/superpowers/specs/2026-04-20-vision-speech-options-design.md
+++ b/docs/superpowers/specs/2026-04-20-vision-speech-options-design.md
@@ -1,0 +1,327 @@
+# Vision & Speech Feature Expansion
+
+**Date:** 2026-04-20
+**Status:** Approved
+**Approach:** Layered — OpenAI-compatible endpoint shapes with Apple-specific extras as optional parameters
+
+## Overview
+
+Expand AFM's vision and speech capabilities across three areas:
+1. **TTS** — new `/v1/audio/speech` endpoint and `afm speech synthesize` CLI
+2. **Transcription enhancements** — OpenAI parameter parity on existing `/v1/audio/transcriptions`
+3. **Vision enhancements** — new modes (barcode, classify, saliency) and parameters on `/v1/vision/ocr`
+
+All additions follow the same pattern: match OpenAI's API shape where one exists, expose Apple-specific capabilities as additional optional parameters.
+
+### CLI Flag Consistency
+
+All three features use `--format` for output format selection:
+- `afm speech synthesize ... --format wav` (audio format)
+- `afm speech -f audio.wav --format verbose_json` (transcription output format)
+- `afm vision -f image.png --format text` (vision output format)
+
+### Parameter Applicability
+
+Mode-specific parameters are silently ignored when used with inapplicable modes:
+- `max_labels` — only applies to `classify` mode
+- `saliency_type`, `include_heat_map` — only apply to `saliency` mode
+- `auto_crop` — applies to `text`, `table`, `barcode`, and `auto` modes
+
+### Error Handling
+
+All endpoints return HTTP 400 for invalid parameters and HTTP 413 for oversized inputs. Mode-specific "not found" cases (no text, no barcodes, no salient regions) return HTTP 200 with empty result arrays, not errors — the request succeeded, there was just nothing to find.
+
+---
+
+## 1. TTS — `/v1/audio/speech`
+
+### API
+
+**Endpoint:** `POST /v1/audio/speech`
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `model` | string | `tts-1` | Accepted but ignored (single on-device engine). Accepts `tts-1`/`tts-1-hd`. |
+| `input` | string | required | Text to synthesize. Max 4096 characters. |
+| `voice` | string | `alloy` | OpenAI voice name (`alloy`, `echo`, `fable`, `nova`, `onyx`, `shimmer`). Mapped to Apple voices by gender/tone. |
+| `response_format` | string | `aac` | `aac` (default), `wav`, `caf`. Apple does not support MP3 encoding natively. |
+| `speed` | float | `1.0` | `0.25` to `4.0`. Mapped to `AVSpeechUtterance.rate`. Clamped to Apple's supported range. |
+| `locale` | string | `en-US` | Determines voice pool if `voice`/`apple_voice` not specified. |
+| `apple_voice` | string | null | Exact Apple voice identifier (e.g., `com.apple.voice.compact.en-US.Samantha`). Overrides `voice`. |
+
+**Response:** Raw audio bytes with `Content-Type` header (`audio/aac`, `audio/wav`, `audio/x-caf`). Streams as it synthesizes.
+
+**Input limit:** Max 4096 characters. Returns HTTP 400 if exceeded.
+
+### Voice Listing
+
+**Endpoint:** `GET /v1/audio/voices`
+
+Returns available on-device voices:
+```json
+{
+  "voices": [
+    {
+      "id": "com.apple.voice.compact.en-US.Samantha",
+      "name": "Samantha",
+      "locale": "en-US",
+      "gender": "female",
+      "quality": "compact"
+    }
+  ]
+}
+```
+
+Optional query parameter: `locale` to filter (e.g., `?locale=en`).
+
+**Note:** This endpoint is AFM-specific (no OpenAI equivalent). Useful for discovering available Apple voice identifiers.
+
+### CLI
+
+```bash
+afm speech synthesize "Hello world"                    # Default voice, stdout
+afm speech synthesize "Hello world" -o output.mp3      # Save to file
+afm speech synthesize "Hello world" --voice nova       # OpenAI voice name
+afm speech synthesize "Hello world" --locale ja-JP     # Japanese voice
+afm speech --list-voices                               # List available voices
+afm speech --list-voices --locale en                   # Filter by locale
+```
+
+### Implementation
+
+- `SpeechSynthesisService` wrapping `AVSpeechSynthesizer`
+- Delegate writes audio buffers to a pipe/stream
+- AAC encoding via `AVAudioConverter` or `AudioToolbox` `AudioConverterFillComplexBuffer`
+- WAV is raw PCM with header (trivial). CAF via `ExtAudioFile`.
+- `SpeechAPIController` extended with new routes
+- `SpeechCommand` gets `synthesize` subcommand and `--list-voices` flag
+
+### Voice Mapping
+
+OpenAI voice names mapped to Apple voices by gender/tone. Fallback: system default voice for locale.
+
+| OpenAI Voice | Gender | Apple Voice (en-US) | Fallback Strategy |
+|-------------|--------|--------------------|--------------------|
+| `alloy` | neutral | Samantha | First available female voice |
+| `echo` | male | Daniel | First available male voice |
+| `fable` | male | Tom | Second available male voice |
+| `nova` | female | Karen | Second available female voice |
+| `onyx` | male | Alex | Third available male voice |
+| `shimmer` | female | Ava | Third available female voice |
+
+For non-en-US locales: filter voices by locale, pick by gender order. Prefer `enhanced` > `premium` > `compact` quality. If the mapped voice is not downloaded, fall back to the next available voice matching gender, then to any voice for the locale.
+
+### CLI Subcommand Structure
+
+```
+afm speech                          # Error: requires subcommand
+afm speech synthesize "text"        # TTS
+afm speech transcribe -f file.wav   # Transcription (new name)
+afm speech -f file.wav              # Transcription (legacy shortcut)
+afm speech --list-voices            # Voice listing
+```
+
+`transcribe` is the new explicit subcommand. Bare `afm speech -f` kept as alias for backwards compat.
+
+### Limitations
+
+- Quality depends on which voices the user has downloaded (compact vs premium vs enhanced)
+- No voice cloning or custom voices
+- `AVSpeechSynthesizer` rate range is narrower than OpenAI's 0.25-4.0 — clamp to `AVSpeechUtteranceMinimumSpeechRate`...`AVSpeechUtteranceMaximumSpeechRate` and document
+- OpenAI voice name mapping is approximate — see voice mapping table above
+- No native MP3 encoding — AAC is the default compressed format
+
+---
+
+## 2. Transcription Enhancements
+
+### New Parameters on `/v1/audio/transcriptions`
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `model` | string | `whisper-1` | Accepted but ignored (single on-device engine). For OpenAI client compat. |
+| `response_format` | string | `json` | `json`, `text`, `verbose_json`, `srt`, `vtt` |
+| `language` | string | null | ISO-639-1 code. Maps to Apple locale. Alias for existing `locale`. |
+| `timestamp_granularities` | array | `["segment"]` | `["word"]`, `["segment"]`, or both. Only honored with `verbose_json`. |
+
+Existing Apple-specific params retained: `recognition_level`, `uses_language_correction`, `locale` (alias for `language`).
+
+### Response Formats
+
+**`json`** (current behavior):
+```json
+{"text": "Hello, how are you?"}
+```
+
+**`text`**: Plain string body.
+
+**`verbose_json`**:
+```json
+{
+  "text": "Hello, how are you?",
+  "language": "en",
+  "duration": 2.34,
+  "words": [
+    {"word": "Hello", "start": 0.0, "end": 0.42},
+    {"word": "how", "start": 0.52, "end": 0.71}
+  ],
+  "segments": [
+    {"id": 0, "start": 0.0, "end": 2.34, "text": "Hello, how are you?", "confidence": 0.94}
+  ]
+}
+```
+
+**`srt`/`vtt`**: Generated from segment timestamps. Standard subtitle formats.
+
+### CLI Additions
+
+```bash
+afm speech -f audio.wav --format verbose_json
+afm speech -f audio.wav --format srt
+afm speech -f audio.wav --language ja
+afm speech -f audio.wav --timestamps word,segment
+```
+
+### Implementation
+
+- `SFSpeechRecognitionResult` already provides `segments` with `timestamp`, `duration`, `substring`, and `confidence`
+- Top-level `duration` in `verbose_json` is computed from the last segment's `timestamp + duration`
+- Format conversion (SRT/VTT) is string templating from segment data
+- `SpeechService` returns richer result struct; controller formats per `response_format`
+
+---
+
+## 3. Vision Enhancements
+
+### New Parameters on `/v1/vision/ocr`
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `mode` | string | `text` | `text`, `table`, `barcode`, `classify`, `saliency`, `auto` |
+| `detail` | string | `high` | `high` (maps to `accurate`), `low` (maps to `fast`). Alias for `recognition_level`. Only applies to `text`/`table` modes. |
+| `auto_crop` | bool | `false` | Run document segmentation before OCR. |
+| `response_format` | string | `json` | `json`, `text`, `verbose_json`. |
+| `max_labels` | int | `5` | For classify mode: number of classification labels to return. |
+| `saliency_type` | string | `attention` | `attention` or `objectness`. For saliency mode. |
+| `include_heat_map` | bool | `false` | For saliency mode: include base64 PNG heat map. |
+
+Existing params retained: `recognition_level` (alias for `detail`), `verbose` (alias for `response_format: verbose_json`), `table` (alias for `mode: table`), `uses_language_correction`, `languages`, `max_pages`.
+
+### Mode: `barcode`
+
+Uses `VNDetectBarcodesRequest`. Supports QR, EAN-13, Code 128, Data Matrix, PDF417, Aztec, and others.
+
+```json
+{
+  "results": [
+    {
+      "type": "QR",
+      "payload": "https://example.com",
+      "bounding_box": {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.3},
+      "confidence": 0.99
+    }
+  ]
+}
+```
+
+### Mode: `classify`
+
+Image classification using `VNClassifyImageRequest` — returns ranked labels from Apple's ~1,000-label taxonomy with confidence scores, plus attention-based salient regions for context. This is classification, not natural-language classifying.
+
+```json
+{
+  "labels": [
+    {"label": "document", "confidence": 0.92},
+    {"label": "text", "confidence": 0.87},
+    {"label": "indoor", "confidence": 0.65}
+  ],
+  "salient_regions": [
+    {"x": 0.2, "y": 0.1, "width": 0.6, "height": 0.8}
+  ]
+}
+```
+
+### Mode: `saliency`
+
+Two Apple saliency modes:
+- `attention` — where a human would look first (typically single region)
+- `objectness` — where "objects" are (can return multiple regions)
+
+```json
+{
+  "regions": [
+    {
+      "type": "attention",
+      "bounding_box": {"x": 0.15, "y": 0.2, "width": 0.5, "height": 0.6}
+    }
+  ],
+  "heat_map": "<base64 PNG if include_heat_map=true>"
+}
+```
+
+### Mode: `auto`
+
+Runs text + barcode + classify concurrently. Returns all three result sets combined. Response includes a `modes_run` array indicating which modes produced results. Saliency excluded from auto (it's a preprocessing/analysis tool, not extraction).
+
+### Auto-Crop
+
+`VNDetectDocumentSegmentationRequest` detects and crops the document region before passing to OCR pipeline. Two-pass, adds ~50ms.
+
+### CLI Additions
+
+```bash
+afm vision -f photo.jpg --mode classify                          # Top 5 labels
+afm vision -f photo.jpg --mode classify --max-labels 10          # More labels
+afm vision -f photo.jpg --mode saliency
+afm vision -f photo.jpg --mode saliency --saliency-type objectness
+afm vision -f photo.jpg --mode saliency --heat-map
+afm vision -f photo.jpg --mode barcode
+afm vision -f photo.jpg --mode auto
+afm vision -f photo.jpg --auto-crop
+afm vision -f doc.png --format text
+afm vision -f doc.png --detail low
+```
+
+### Implementation
+
+- `VisionService` extended with new request types for barcode, classify, saliency
+- Each mode is a separate method returning a typed result
+- `auto` mode runs text + barcode + classify concurrently via `TaskGroup` (text omitted on pre-macOS 26)
+- Auto-crop is a preprocessing step that feeds into text, table, barcode, and auto modes
+- `VisionAPIController` routes to the correct service method based on `mode`
+- `VisionCommand` gets `--mode`, `--detail`, `--auto-crop`, `--max-labels`, `--saliency-type`, `--heat-map` flags
+
+---
+
+## Backwards Compatibility
+
+All new parameters are optional with defaults matching current behavior:
+- `mode` defaults to `text` (current behavior)
+- `detail` defaults to `high` (current `accurate`)
+- `response_format` defaults to `json` (current behavior)
+- Existing params (`table`, `verbose`, `recognition_level`, `locale`) kept as aliases
+
+No breaking changes to existing API or CLI.
+
+---
+
+## macOS Requirements
+
+| Feature | Minimum macOS |
+|---------|---------------|
+| Vision OCR (existing) | 26.0 |
+| Vision barcode/classify/saliency | 13.0+ (Vision framework) |
+| Speech transcription (existing) | 13.0 |
+| Speech TTS | 13.0+ (AVSpeechSynthesizer) |
+
+Note: Barcode, classify, and saliency use older Vision APIs that don't require macOS 26. Only OCR text/table extraction requires macOS 26 (Apple Intelligence).
+
+### macOS Version Gating Architecture
+
+The existing `VisionService` is gated behind `@available(macOS 26.0, *)`. Since barcode/classify/saliency work on macOS 13+, the service needs per-mode availability checks:
+
+- `text`, `table`, `auto_crop` — require macOS 26.0 (`VNRecognizeTextRequest` with Apple Intelligence)
+- `barcode`, `classify`, `saliency` — require macOS 13.0+
+- `auto` mode — runs all available modes for the current macOS version; text is omitted on pre-26
+
+Implementation: `VisionService` methods check `#available(macOS 26.0, *)` internally rather than gating the entire class. The controller returns HTTP 501 with a message if a mode requires a newer macOS than the host.


### PR DESCRIPTION
Closes #110

## Summary

- Add speech transcription (`/v1/audio/transcriptions`) and text-to-speech (`/v1/audio/speech`, `/v1/audio/voices`) via Apple Speech and AVSpeechSynthesizer. CLI commands: `afm speech transcribe`, `afm speech synthesize`, `afm speech voices`.
- Expand vision endpoint with barcode, classify, and saliency modes. Add `mode`, `detail`, `auto_crop`, `response_format` parameters and corresponding CLI flags.
- All capabilities run entirely on-device. No API keys, no network, no data leaving the machine.

## Test plan

- [ ] Build: `swift build` passes clean
- [ ] Speech transcription: `afm speech transcribe --file <audio>` returns text with timestamps
- [ ] TTS: `afm speech synthesize "test" --voice <voice-id>` produces audio output
- [ ] Voice listing: `afm speech voices` and `GET /v1/audio/voices` return available voices
- [ ] Vision barcode: `afm vision --mode barcode <image-with-qr>` extracts payload
- [ ] Vision classify: `afm vision --mode classify <image>` returns classification labels
- [ ] Vision saliency: `afm vision --mode saliency <image>` returns saliency data
- [ ] Existing OCR and describe modes still work unchanged
- [ ] Streaming and non-streaming transcription response formats (json, verbose_json, srt, vtt, text)