### PR TITLE
Add on-device speech transcription and TTS

### DIFF
--- a/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
@@ -49,7 +49,6 @@ struct ChatCompletionsController: RouteCollection {
         var fallbackModel = "foundation"
         var fallbackMessages: [Message] = []
         var fallbackMaxTokens = 2000
-        var visionCleanupURLs: [URL] = []
         do {
             let chatRequest = try req.content.decode(ChatCompletionRequest.self)
             fallbackModel = chatRequest.model ?? "foundation"
@@ -128,7 +127,6 @@ struct ChatCompletionsController: RouteCollection {
                         allCleanupURLs.append(contentsOf: speechProcessed.cleanupURLs)
                     }
 
-                    visionCleanupURLs = allCleanupURLs
                     defer {
                         for url in allCleanupURLs {
                             try? FileManager.default.removeItem(at: url)
@@ -162,12 +160,6 @@ struct ChatCompletionsController: RouteCollection {
             } else {
                 throw FoundationModelError.notAvailable
             }
-            defer {
-                for url in visionCleanupURLs {
-                    try? FileManager.default.removeItem(at: url)
-                }
-            }
-
             // Check if streaming is requested and enabled
             if chatRequest.stream == true && streamingEnabled {
                 return try await createStreamingResponse(req: req, chatRequest: chatRequest, processedMessages: processedMessages, foundationService: foundationService)

--- a/Sources/MacLocalAPI/Controllers/SpeechAPIController.swift
+++ b/Sources/MacLocalAPI/Controllers/SpeechAPIController.swift
@@ -1,10 +1,50 @@
 import Vapor
 import Foundation
 
+extension SpeechError: AbortError {
+    var status: HTTPResponseStatus {
+        switch self {
+        case .platformUnavailable: return .serviceUnavailable
+        case .fileNotFound: return .notFound
+        case .unsupportedFormat: return .badRequest
+        case .recognitionFailed: return .internalServerError
+        case .noSpeechFound: return .unprocessableEntity
+        case .onDeviceNotAvailable: return .serviceUnavailable
+        case .authorizationDenied: return .forbidden
+        }
+    }
+
+    var reason: String { errorDescription ?? "Speech error" }
+}
+
 struct SpeechTranscriptionResponse: Content {
     let object: String
     let text: String
     let locale: String
+}
+
+struct TTSSpeechRequest: Content {
+    let input: String
+    let voice: String?
+    let responseFormat: String?
+    let speed: Double?
+    let locale: String?
+    let appleVoice: String?
+
+    enum CodingKeys: String, CodingKey {
+        case input, voice
+        case responseFormat = "response_format"
+        case speed, locale
+        case appleVoice = "apple_voice"
+    }
+}
+
+struct VerboseTranscriptionResponse: Content {
+    let text: String
+    let language: String
+    let duration: Double
+    let words: [TranscriptionWord]?
+    let segments: [TranscriptionSegment]?
 }
 
 struct SpeechAPIController: RouteCollection {
@@ -14,19 +54,31 @@ struct SpeechAPIController: RouteCollection {
         let speech = v1.grouped("audio")
         speech.on(.POST, "transcriptions", body: .collect(maxSize: "50mb"), use: transcribe)
         speech.on(.OPTIONS, "transcriptions", use: handleOptions)
+        speech.on(.POST, "speech", body: .collect(maxSize: "1mb"), use: synthesize)
+        speech.on(.OPTIONS, "speech", use: handleOptions)
+        speech.on(.GET, "voices", use: listVoices)
+        speech.on(.OPTIONS, "voices", use: handleOptions)
     }
 
     private func handleOptions(req: Request) async throws -> Response {
         let response = Response(status: .ok)
         response.headers.add(name: .accessControlAllowOrigin, value: "*")
-        response.headers.add(name: .accessControlAllowMethods, value: "POST, OPTIONS")
+        response.headers.add(name: .accessControlAllowMethods, value: "GET, POST, OPTIONS")
         response.headers.add(name: .accessControlAllowHeaders, value: "Content-Type, Authorization")
+        return response
+    }
+
+    private func createErrorResponse(message: String, status: HTTPStatus, type: String = "invalid_request_error") async throws -> Response {
+        let response = Response(status: status)
+        response.headers.add(name: .contentType, value: "application/json")
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        try response.content.encode(OpenAIError(message: message, type: type))
         return response
     }
 
     private func transcribe(req: Request) async throws -> Response {
         guard #available(macOS 13.0, *) else {
-            throw Abort(.serviceUnavailable, reason: "Speech recognition requires macOS 13.0 or later")
+            return try await createErrorResponse(message: "Speech recognition requires macOS 13.0 or later", status: .serviceUnavailable, type: "speech_unavailable")
         }
 
         struct TranscriptionRequest: Content {
@@ -34,11 +86,28 @@ struct SpeechAPIController: RouteCollection {
             let data: String?
             let format: String?
             let locale: String?
+            let model: String?
+            let language: String?
+            let responseFormat: String?
+            let timestampGranularities: [String]?
+            enum CodingKeys: String, CodingKey {
+                case file, data, format, locale, model, language
+                case responseFormat = "response_format"
+                case timestampGranularities = "timestamp_granularities"
+            }
         }
 
         let body = try req.content.decode(TranscriptionRequest.self)
-        let locale = body.locale ?? "en-US"
-        let options = SpeechRequestOptions(locale: locale)
+
+        // language takes precedence over locale
+        let effectiveLocale: String
+        if let language = body.language, !language.isEmpty {
+            effectiveLocale = language
+        } else {
+            effectiveLocale = body.locale ?? "en-US"
+        }
+
+        let options = SpeechRequestOptions(locale: effectiveLocale)
         let service = SpeechService()
         var cleanupURLs: [URL] = []
 
@@ -57,21 +126,139 @@ struct SpeechAPIController: RouteCollection {
             cleanupURLs.append(tempURL)
             filePath = tempURL.path
         } else {
-            throw Abort(.badRequest, reason: "Either 'file' path or 'data' (base64) is required")
+            return try await createErrorResponse(message: "Either 'file' path or 'data' (base64) is required", status: .badRequest)
         }
 
-        let text = try await service.transcribe(from: filePath, options: options)
+        let responseFormat = body.responseFormat?.lowercased() ?? "json"
 
-        let response = SpeechTranscriptionResponse(
-            object: "speech.transcription",
-            text: text,
-            locale: locale
+        switch responseFormat {
+        case "text":
+            let text = try await service.transcribe(from: filePath, options: options)
+            let httpResponse = Response(status: .ok)
+            httpResponse.headers.add(name: .contentType, value: "text/plain")
+            httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
+            httpResponse.body = .init(string: text)
+            return httpResponse
+
+        case "json":
+            let text = try await service.transcribe(from: filePath, options: options)
+            let httpResponse = Response(status: .ok)
+            httpResponse.headers.add(name: .contentType, value: "application/json")
+            httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
+            try httpResponse.content.encode(SpeechTranscriptionResponse(
+                object: "speech.transcription",
+                text: text,
+                locale: effectiveLocale
+            ))
+            return httpResponse
+
+        case "verbose_json":
+            let result = try await service.transcribeWithDetails(from: filePath, options: options)
+            let granularities = Set(body.timestampGranularities ?? ["segment"])
+            let verboseResponse = Self.formatAsVerboseJSON(result: result, granularities: granularities)
+            let httpResponse = Response(status: .ok)
+            httpResponse.headers.add(name: .contentType, value: "application/json")
+            httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
+            try httpResponse.content.encode(verboseResponse)
+            return httpResponse
+
+        case "srt":
+            let result = try await service.transcribeWithDetails(from: filePath, options: options)
+            let srtText = result.formatAsSRT()
+            let httpResponse = Response(status: .ok)
+            httpResponse.headers.add(name: .contentType, value: "text/plain")
+            httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
+            httpResponse.body = .init(string: srtText)
+            return httpResponse
+
+        case "vtt":
+            let result = try await service.transcribeWithDetails(from: filePath, options: options)
+            let vttText = result.formatAsVTT()
+            let httpResponse = Response(status: .ok)
+            httpResponse.headers.add(name: .contentType, value: "text/vtt")
+            httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
+            httpResponse.body = .init(string: vttText)
+            return httpResponse
+
+        default:
+            return try await createErrorResponse(message: "Unsupported response_format '\(responseFormat)'. Supported: json, text, verbose_json, srt, vtt", status: .badRequest)
+        }
+    }
+
+    private func synthesize(req: Request) async throws -> Response {
+        guard #available(macOS 13.0, *) else {
+            return try await createErrorResponse(message: "Text-to-speech requires macOS 13.0 or later", status: .serviceUnavailable, type: "speech_unavailable")
+        }
+
+        let body = try req.content.decode(TTSSpeechRequest.self)
+
+        guard !body.input.isEmpty else {
+            return try await createErrorResponse(message: "Input text is required and must not be empty", status: .badRequest)
+        }
+        guard body.input.count <= TTSRequestOptions.maxInputCharacters else {
+            return try await createErrorResponse(message: "Input text exceeds maximum of \(TTSRequestOptions.maxInputCharacters) characters", status: .badRequest)
+        }
+
+        let format: TTSAudioFormat
+        if let fmt = body.responseFormat {
+            guard let parsed = TTSAudioFormat(rawValue: fmt.lowercased()) else {
+                return try await createErrorResponse(message: "Unsupported response_format '\(fmt)'. Supported: aac, wav, caf", status: .badRequest)
+            }
+            format = parsed
+        } else {
+            format = .aac
+        }
+
+        let options = TTSRequestOptions(
+            voice: body.voice ?? "alloy",
+            appleVoice: body.appleVoice,
+            locale: body.locale ?? "en-US",
+            speed: Float(body.speed ?? 1.0),
+            format: format
         )
-        let httpResponse = Response(status: .ok)
-        httpResponse.headers.add(name: .contentType, value: "application/json")
-        httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
-        try httpResponse.content.encode(response)
-        return httpResponse
+
+        let service = SpeechSynthesisService()
+        let audioData: Data
+        do {
+            audioData = try await service.synthesize(text: body.input, options: options)
+        } catch let error as SpeechSynthesisError {
+            let status: HTTPResponseStatus
+            switch error {
+            case .voiceNotAvailable: status = .notFound
+            case .inputTooLong, .emptyInput, .unsupportedFormat: status = .badRequest
+            case .synthesisTimedOut: status = .gatewayTimeout
+            case .platformUnavailable: status = .serviceUnavailable
+            case .synthesisFailed: status = .internalServerError
+            }
+            return try await createErrorResponse(message: error.errorDescription ?? "TTS synthesis failed", status: status, type: "speech_error")
+        } catch {
+            return try await createErrorResponse(message: "TTS synthesis failed: \(error.localizedDescription)", status: .internalServerError, type: "internal_error")
+        }
+
+        let response = Response(status: .ok)
+        response.headers.add(name: .contentType, value: format.contentType)
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        response.body = .init(data: audioData)
+        return response
+    }
+
+    private func listVoices(req: Request) async throws -> Response {
+        guard #available(macOS 13.0, *) else {
+            return try await createErrorResponse(message: "Text-to-speech requires macOS 13.0 or later", status: .serviceUnavailable, type: "speech_unavailable")
+        }
+
+        let locale = req.query[String.self, at: "locale"]
+        let voices = SpeechSynthesisService.listVoices(locale: locale)
+
+        struct VoiceListResponse: Content {
+            let voices: [VoiceInfo]
+        }
+
+        let response = Response(status: .ok)
+        response.headers.add(name: .contentType, value: "application/json")
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        try response.content.encode(VoiceListResponse(voices: voices))
+        return response
     }
 
     // MARK: - Chat completions integration
@@ -93,23 +280,57 @@ struct SpeechAPIController: RouteCollection {
                 continue
             }
 
-            var textChunks = parts.compactMap(\.text)
+            // Prepare audio parts for concurrent transcription
+            struct AudioWork: Sendable {
+                let tempURL: URL
+                let options: SpeechRequestOptions
+                let index: Int
+            }
+            var audioWork: [AudioWork] = []
             for part in parts where part.type == "input_audio" {
                 guard let inputAudio = part.input_audio else { continue }
                 let ext = try validatedExtension(inputAudio.format.isEmpty ? "wav" : inputAudio.format)
                 let tempURL = try writeTempAudio(base64: inputAudio.data, ext: ext)
                 cleanupURLs.append(tempURL)
-                let transcription = try await service.transcribe(from: tempURL.path, options: options)
                 audioIndex += 1
-                let labeled = "[Apple Speech transcription \(audioIndex)]\n\(transcription)"
-                textChunks.append(labeled)
-                transcriptionTexts.append(labeled)
+                let perAudioOptions = inputAudio.language.map { SpeechRequestOptions(locale: $0) } ?? options
+                audioWork.append(AudioWork(tempURL: tempURL, options: perAudioOptions, index: audioIndex))
             }
+
+            let results = try await withThrowingTaskGroup(of: (Int, String).self) { group in
+                for work in audioWork {
+                    group.addTask {
+                        let transcription = try await service.transcribe(from: work.tempURL.path, options: work.options)
+                        return (work.index, "[Apple Speech transcription \(work.index)]\n\(transcription)")
+                    }
+                }
+                var collected: [(Int, String)] = []
+                for try await result in group {
+                    collected.append(result)
+                }
+                return collected.sorted { $0.0 < $1.0 }.map(\.1)
+            }
+
+            var textChunks = parts.compactMap(\.text)
+            textChunks.append(contentsOf: results)
+            transcriptionTexts.append(contentsOf: results)
 
             updatedMessages.append(Message(role: message.role, content: textChunks.joined(separator: "\n\n")))
         }
 
         return (updatedMessages, transcriptionTexts, cleanupURLs)
+    }
+
+    // MARK: - Transcription response formatting
+
+    private static func formatAsVerboseJSON(result: TranscriptionResult, granularities: Set<String>) -> VerboseTranscriptionResponse {
+        VerboseTranscriptionResponse(
+            text: result.text,
+            language: result.language,
+            duration: result.duration,
+            words: granularities.contains("word") ? result.words : nil,
+            segments: granularities.contains("segment") ? result.segments : nil
+        )
     }
 
     // MARK: - Helpers
@@ -149,7 +370,7 @@ struct SpeechAPIController: RouteCollection {
             throw Abort(.badRequest, reason: "Invalid base64 audio data")
         }
         if data.count > SpeechRequestOptions.defaultMaxFileBytes {
-            throw SpeechError.requestTooLarge(actualBytes: data.count, maxBytes: SpeechRequestOptions.defaultMaxFileBytes)
+            throw Abort(.payloadTooLarge, reason: "Decoded audio exceeds maximum of \(SpeechRequestOptions.defaultMaxFileBytes / (1024 * 1024))MB")
         }
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("afm_speech_\(UUID().uuidString).\(ext)")

--- a/Sources/MacLocalAPI/Models/OpenAIRequest.swift
+++ b/Sources/MacLocalAPI/Models/OpenAIRequest.swift
@@ -184,6 +184,7 @@ struct ImageURL: Codable {
 struct InputAudio: Codable {
     let data: String   // base64-encoded audio
     let format: String // "wav", "mp3", etc.
+    let language: String? // locale for transcription (e.g. "en-US", "ja-JP")
 }
 
 struct Message: Content {

--- a/Sources/MacLocalAPI/Models/SpeechService.swift
+++ b/Sources/MacLocalAPI/Models/SpeechService.swift
@@ -6,7 +6,6 @@ enum SpeechError: Error, LocalizedError {
     case platformUnavailable
     case fileNotFound
     case unsupportedFormat
-    case requestTooLarge(actualBytes: Int, maxBytes: Int)
     case recognitionFailed(String)
     case noSpeechFound
     case onDeviceNotAvailable
@@ -20,8 +19,6 @@ enum SpeechError: Error, LocalizedError {
             return "The specified audio file was not found"
         case .unsupportedFormat:
             return "Unsupported audio format. Supported formats: WAV, MP3, M4A, CAF, AIFF"
-        case .requestTooLarge(let actualBytes, let maxBytes):
-            return "Audio file size \(actualBytes) bytes exceeds the limit of \(maxBytes) bytes"
         case .recognitionFailed(let message):
             return "Speech recognition failed: \(message)"
         case .noSpeechFound:
@@ -35,19 +32,70 @@ enum SpeechError: Error, LocalizedError {
 }
 
 struct SpeechRequestOptions: Sendable {
-    static let defaultMaxFileBytes = 50 * 1024 * 1024  // 50 MB
     static let recognitionTimeoutNs: UInt64 = 120_000_000_000  // 120 seconds
+    static let defaultMaxFileBytes = 50 * 1024 * 1024  // 50MB matches Vapor body limit
     static let supportedExtensions: Set<String> = ["wav", "mp3", "m4a", "caf", "aiff", "aif"]
 
     let locale: String
-    let maxFileBytes: Int
 
-    init(
-        locale: String = "en-US",
-        maxFileBytes: Int = SpeechRequestOptions.defaultMaxFileBytes
-    ) {
+    init(locale: String = "en-US") {
         self.locale = locale
-        self.maxFileBytes = maxFileBytes
+    }
+}
+
+struct TranscriptionWord: Sendable, Codable {
+    let word: String
+    let start: Double
+    let end: Double
+}
+
+struct TranscriptionSegment: Sendable, Codable {
+    let id: Int
+    let start: Double
+    let end: Double
+    let text: String
+    let confidence: Float
+}
+
+struct TranscriptionResult: Sendable, Codable {
+    let text: String
+    let language: String
+    let duration: Double
+    let words: [TranscriptionWord]
+    let segments: [TranscriptionSegment]
+
+    func formatAsSRT() -> String {
+        segments.enumerated().map { index, seg in
+            let startTS = Self.srtTimestamp(seg.start)
+            let endTS = Self.srtTimestamp(seg.end)
+            return "\(index + 1)\n\(startTS) --> \(endTS)\n\(seg.text)"
+        }.joined(separator: "\n\n")
+    }
+
+    func formatAsVTT() -> String {
+        var lines = ["WEBVTT", ""]
+        lines += segments.map { seg in
+            let startTS = Self.vttTimestamp(seg.start)
+            let endTS = Self.vttTimestamp(seg.end)
+            return "\(startTS) --> \(endTS)\n\(seg.text)"
+        }
+        return lines.joined(separator: "\n\n")
+    }
+
+    static func srtTimestamp(_ seconds: Double) -> String {
+        let h = Int(seconds) / 3600
+        let m = (Int(seconds) % 3600) / 60
+        let s = Int(seconds) % 60
+        let ms = Int((seconds.truncatingRemainder(dividingBy: 1)) * 1000)
+        return String(format: "%02d:%02d:%02d,%03d", h, m, s, ms)
+    }
+
+    static func vttTimestamp(_ seconds: Double) -> String {
+        let h = Int(seconds) / 3600
+        let m = (Int(seconds) % 3600) / 60
+        let s = Int(seconds) % 60
+        let ms = Int((seconds.truncatingRemainder(dividingBy: 1)) * 1000)
+        return String(format: "%02d:%02d:%02d.%03d", h, m, s, ms)
     }
 }
 
@@ -59,6 +107,15 @@ final class SpeechService {
     }
 
     func transcribe(from filePath: String, options: SpeechRequestOptions) async throws -> String {
+        let result = try await transcribeWithDetails(from: filePath, options: options)
+        return result.text
+    }
+
+    func transcribeWithDetails(from filePath: String) async throws -> TranscriptionResult {
+        try await transcribeWithDetails(from: filePath, options: SpeechRequestOptions())
+    }
+
+    func transcribeWithDetails(from filePath: String, options: SpeechRequestOptions) async throws -> TranscriptionResult {
         let fileURL = URL(fileURLWithPath: filePath)
 
         // Validate file exists
@@ -70,12 +127,6 @@ final class SpeechService {
         let ext = fileURL.pathExtension.lowercased()
         guard SpeechRequestOptions.supportedExtensions.contains(ext) else {
             throw SpeechError.unsupportedFormat
-        }
-
-        // Validate size
-        let attrs = try FileManager.default.attributesOfItem(atPath: filePath)
-        if let size = attrs[.size] as? Int, size > options.maxFileBytes {
-            throw SpeechError.requestTooLarge(actualBytes: size, maxBytes: options.maxFileBytes)
         }
 
         // Check authorization
@@ -111,7 +162,7 @@ final class SpeechService {
         // Holds the SFSpeechRecognitionTask so onCancel can reach it.
         let taskRef = OSAllocatedUnfairLock<SFSpeechRecognitionTask?>(initialState: nil)
 
-        let text: String = try await withThrowingTaskGroup(of: String.self) { group in
+        let transcriptionResult: TranscriptionResult = try await withThrowingTaskGroup(of: TranscriptionResult.self) { group in
             group.addTask {
                 try await withTaskCancellationHandler {
                     try await withCheckedThrowingContinuation { continuation in
@@ -137,12 +188,44 @@ final class SpeechService {
                                 return true
                             }
                             guard shouldResume else { return }
-                            let formatted = result.bestTranscription.formattedString
+                            let transcription = result.bestTranscription
+                            let formatted = transcription.formattedString
                             if formatted.isEmpty {
                                 continuation.resume(throwing: SpeechError.noSpeechFound)
-                            } else {
-                                continuation.resume(returning: formatted)
+                                return
                             }
+
+                            // Extract word-level timing from segments
+                            let words = transcription.segments.map { seg in
+                                TranscriptionWord(
+                                    word: seg.substring,
+                                    start: seg.timestamp,
+                                    end: seg.timestamp + seg.duration
+                                )
+                            }
+
+                            // Build a single segment from the full transcription
+                            let totalDuration = transcription.segments.last.map { $0.timestamp + $0.duration } ?? 0
+                            let avgConfidence = transcription.segments.isEmpty ? Float(0)
+                                : transcription.segments.map(\.confidence).reduce(0, +) / Float(transcription.segments.count)
+                            let segments = [TranscriptionSegment(
+                                id: 0,
+                                start: 0,
+                                end: totalDuration,
+                                text: formatted,
+                                confidence: avgConfidence
+                            )]
+
+                            // Extract language from locale
+                            let lang = options.locale.split(separator: "-").first.map(String.init) ?? options.locale
+
+                            continuation.resume(returning: TranscriptionResult(
+                                text: formatted,
+                                language: lang,
+                                duration: totalDuration,
+                                words: words,
+                                segments: segments
+                            ))
                         }
                         taskRef.withLock { $0 = task }
                         if Task.isCancelled { task.cancel() }
@@ -160,6 +243,6 @@ final class SpeechService {
             return result
         }
 
-        return text
+        return transcriptionResult
     }
 }

--- a/Sources/MacLocalAPI/Models/SpeechSynthesisService.swift
+++ b/Sources/MacLocalAPI/Models/SpeechSynthesisService.swift
@@ -1,0 +1,439 @@
+import Foundation
+import AVFoundation
+import os
+
+enum SpeechSynthesisError: Error, LocalizedError {
+    case platformUnavailable
+    case inputTooLong(actualChars: Int, maxChars: Int)
+    case emptyInput
+    case voiceNotAvailable(String)
+    case synthesisTimedOut
+    case synthesisFailed(String)
+    case unsupportedFormat(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .platformUnavailable:
+            return "Text-to-speech requires macOS 13.0 or later"
+        case .inputTooLong(let actual, let max):
+            return "Input text \(actual) characters exceeds the limit of \(max)"
+        case .emptyInput:
+            return "Input text is empty"
+        case .voiceNotAvailable(let name):
+            return "Voice '\(name)' is not available on this system"
+        case .synthesisTimedOut:
+            return "Speech synthesis timed out"
+        case .synthesisFailed(let message):
+            return "Speech synthesis failed: \(message)"
+        case .unsupportedFormat(let format):
+            return "Unsupported audio format: \(format). Supported: aac, wav, caf"
+        }
+    }
+}
+
+enum TTSAudioFormat: String, Sendable, CaseIterable {
+    case aac
+    case wav
+    case caf
+
+    var contentType: String {
+        switch self {
+        case .aac: return "audio/aac"
+        case .wav: return "audio/wav"
+        case .caf: return "audio/x-caf"
+        }
+    }
+
+    var fileExtension: String { rawValue }
+}
+
+enum OpenAIVoiceName: String, CaseIterable {
+    case alloy, echo, fable, nova, onyx, shimmer
+
+    enum Gender { case female, male }
+
+    var gender: Gender {
+        switch self {
+        case .alloy, .nova, .shimmer: return .female
+        case .echo, .fable, .onyx: return .male
+        }
+    }
+
+    var preferredAppleVoiceNames: [String] {
+        switch self {
+        case .alloy: return ["Samantha"]
+        case .echo: return ["Daniel"]
+        case .fable: return ["Tom"]
+        case .nova: return ["Karen"]
+        case .onyx: return ["Alex"]
+        case .shimmer: return ["Ava"]
+        }
+    }
+}
+
+struct TTSRequestOptions: Sendable {
+    static let maxInputCharacters = 4096
+    static let synthesisTimeoutNs: UInt64 = 120_000_000_000
+    static let encodeTimeoutNs: UInt64 = 30_000_000_000  // 30s for afconvert
+
+    let voice: String?
+    let appleVoice: String?
+    let locale: String
+    let speed: Float
+    let format: TTSAudioFormat
+
+    init(
+        voice: String? = "alloy",
+        appleVoice: String? = nil,
+        locale: String = "en-US",
+        speed: Float = 1.0,
+        format: TTSAudioFormat = .aac
+    ) {
+        self.voice = voice
+        self.appleVoice = appleVoice
+        self.locale = locale
+        self.speed = speed
+        self.format = format
+    }
+}
+
+struct VoiceInfo: Sendable, Codable {
+    let id: String
+    let name: String
+    let locale: String
+    let gender: String
+    let quality: String
+}
+
+@available(macOS 13.0, *)
+final class SpeechSynthesisService: NSObject, @unchecked Sendable {
+
+    static let speedMinimum: Float = 0.25
+    static let speedMaximum: Float = 4.0
+
+    static func listVoices(locale: String? = nil) -> [VoiceInfo] {
+        let voices = AVSpeechSynthesisVoice.speechVoices()
+        let filtered: [AVSpeechSynthesisVoice]
+        if let locale = locale {
+            let prefix = locale.lowercased()
+            filtered = voices.filter { $0.language.lowercased().hasPrefix(prefix) }
+        } else {
+            filtered = voices
+        }
+        return filtered.map { voice in
+            let quality: String
+            switch voice.quality {
+            case .enhanced: quality = "enhanced"
+            case .premium: quality = "premium"
+            default: quality = "compact"
+            }
+            return VoiceInfo(
+                id: voice.identifier,
+                name: voice.name,
+                locale: voice.language,
+                gender: voice.gender == .male ? "male" : voice.gender == .female ? "female" : "unspecified",
+                quality: quality
+            )
+        }.sorted {
+            if $0.locale != $1.locale { return $0.locale < $1.locale }
+            return $0.name < $1.name
+        }
+    }
+
+    func synthesize(text: String, options: TTSRequestOptions) async throws -> Data {
+        guard !text.isEmpty else {
+            throw SpeechSynthesisError.emptyInput
+        }
+        guard text.count <= TTSRequestOptions.maxInputCharacters else {
+            throw SpeechSynthesisError.inputTooLong(
+                actualChars: text.count,
+                maxChars: TTSRequestOptions.maxInputCharacters
+            )
+        }
+        guard options.speed >= Self.speedMinimum && options.speed <= Self.speedMaximum else {
+            throw SpeechSynthesisError.synthesisFailed(
+                "Speed must be between \(Self.speedMinimum) and \(Self.speedMaximum)"
+            )
+        }
+
+        let voice = try resolveVoice(options: options)
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = voice
+        utterance.rate = clampRate(options.speed)
+
+        let synthesizer = AVSpeechSynthesizer()
+        let allBuffers: [AVAudioPCMBuffer] = try await withThrowingTaskGroup(of: [AVAudioPCMBuffer].self) { group in
+            group.addTask {
+                let state = OSAllocatedUnfairLock(initialState: (resumed: false, buffers: [AVAudioPCMBuffer](), continuation: nil as CheckedContinuation<[AVAudioPCMBuffer], Error>?))
+                return try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { continuation in
+                        state.withLock { $0.continuation = continuation }
+                        synthesizer.write(utterance) { buffer in
+                            if let pcm = buffer as? AVAudioPCMBuffer, pcm.frameLength > 0 {
+                                state.withLock { $0.buffers.append(pcm) }
+                            } else {
+                                state.withLock { s in
+                                    guard !s.resumed else { return }
+                                    s.resumed = true
+                                    s.continuation?.resume(returning: s.buffers)
+                                    s.continuation = nil
+                                }
+                            }
+                        }
+                        // If already cancelled before we got here, resume immediately
+                        state.withLock { s in
+                            if Task.isCancelled && !s.resumed {
+                                s.resumed = true
+                                s.continuation?.resume(throwing: CancellationError())
+                                s.continuation = nil
+                            }
+                        }
+                    }
+                } onCancel: {
+                    synthesizer.stopSpeaking(at: .immediate)
+                    // If stopSpeaking doesn't trigger the empty-buffer callback,
+                    // resume the continuation to prevent a leak
+                    state.withLock { s in
+                        guard !s.resumed else { return }
+                        s.resumed = true
+                        s.continuation?.resume(throwing: CancellationError())
+                        s.continuation = nil
+                    }
+                }
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: TTSRequestOptions.synthesisTimeoutNs)
+                throw SpeechSynthesisError.synthesisTimedOut
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+
+        guard !allBuffers.isEmpty else {
+            throw SpeechSynthesisError.synthesisFailed("No audio data generated")
+        }
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("afm_tts_\(UUID().uuidString).\(options.format.fileExtension)")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        // Encode collected PCM buffers to the requested format
+        try await encodeBuffers(allBuffers, to: tempURL, format: options.format)
+        return try Data(contentsOf: tempURL)
+    }
+
+    /// Encode PCM buffers to a file. For WAV/CAF, write PCM directly via
+    /// AVAudioFile. For AAC, use AVAudioConverter to transcode.
+    private func encodeBuffers(
+        _ buffers: [AVAudioPCMBuffer],
+        to url: URL,
+        format: TTSAudioFormat
+    ) async throws {
+        let inputFormat = buffers[0].format
+
+        switch format {
+        case .wav, .caf:
+            // PCM output -- write directly
+            let settings: [String: Any] = [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: inputFormat.sampleRate,
+                AVNumberOfChannelsKey: inputFormat.channelCount,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsBigEndianKey: false
+            ]
+            let outputFile = try AVAudioFile(
+                forWriting: url,
+                settings: settings,
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
+            for buffer in buffers {
+                try outputFile.write(from: buffer)
+            }
+
+        case .aac:
+            // AAC encoding: write PCM to temp WAV, then use afconvert CLI.
+            // AVSpeechSynthesizer outputs 22050 Hz; AVAudioConverter's AAC
+            // encoder doesn't support non-standard sample rates, so we shell
+            // out to afconvert which handles resampling transparently.
+            let tempWAV = FileManager.default.temporaryDirectory
+                .appendingPathComponent("afm_tts_pcm_\(UUID().uuidString).wav")
+            defer { try? FileManager.default.removeItem(at: tempWAV) }
+
+            let pcmSettings: [String: Any] = [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: inputFormat.sampleRate,
+                AVNumberOfChannelsKey: inputFormat.channelCount,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsBigEndianKey: false
+            ]
+            // Scope the AVAudioFile so it closes before afconvert reads the WAV
+            do {
+                let pcmFile = try AVAudioFile(
+                    forWriting: tempWAV,
+                    settings: pcmSettings,
+                    commonFormat: .pcmFormatFloat32,
+                    interleaved: false
+                )
+                for buffer in buffers {
+                    try pcmFile.write(from: buffer)
+                }
+            } catch {
+                throw SpeechSynthesisError.synthesisFailed("Failed to write PCM temp file: \(error.localizedDescription)")
+            }
+
+            // Convert WAV → AAC (ADTS format) via afconvert (ships with macOS).
+            // Omit bitrate flag — let CoreAudio pick a suitable rate for the
+            // source sample rate (22050 Hz mono can't sustain 128 kbps).
+            // Run via terminationHandler to avoid blocking the cooperative thread pool.
+            let encode = Process()
+            encode.executableURL = URL(fileURLWithPath: "/usr/bin/afconvert")
+            encode.arguments = [
+                tempWAV.path, url.path,
+                "-d", "aac", "-f", "adts"
+            ]
+            let errPipe = Pipe()
+            encode.standardError = errPipe
+            // Collect stderr asynchronously to avoid blocking the termination handler
+            // and prevent potential deadlock if afconvert writes more than the pipe buffer
+            let stderrData = OSAllocatedUnfairLock(initialState: Data())
+            errPipe.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                if !chunk.isEmpty {
+                    stderrData.withLock { $0.append(chunk) }
+                }
+            }
+            let resumed = OSAllocatedUnfairLock(initialState: false)
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                        encode.terminationHandler = { process in
+                            errPipe.fileHandleForReading.readabilityHandler = nil
+                            let alreadyResumed = resumed.withLock { val -> Bool in
+                                if val { return true }
+                                val = true
+                                return false
+                            }
+                            guard !alreadyResumed else { return }
+                            if process.terminationStatus != 0 {
+                                let errMsg = stderrData.withLock { String(data: $0, encoding: .utf8) ?? "unknown" }
+                                continuation.resume(throwing: SpeechSynthesisError.synthesisFailed(
+                                    "AAC encode failed (\(process.terminationStatus)): \(errMsg)"
+                                ))
+                            } else {
+                                continuation.resume()
+                            }
+                        }
+                        do {
+                            try encode.run()
+                        } catch {
+                            let alreadyResumed = resumed.withLock { val -> Bool in
+                                if val { return true }
+                                val = true
+                                return false
+                            }
+                            guard !alreadyResumed else { return }
+                            continuation.resume(throwing: SpeechSynthesisError.synthesisFailed(
+                                "Failed to launch afconvert: \(error.localizedDescription)"
+                            ))
+                        }
+                    }
+                }
+                group.addTask {
+                    try await Task.sleep(nanoseconds: TTSRequestOptions.encodeTimeoutNs)
+                    let alreadyResumed = resumed.withLock { val -> Bool in
+                        if val { return true }
+                        val = true
+                        return false
+                    }
+                    encode.terminate()
+                    guard !alreadyResumed else { return }
+                    throw SpeechSynthesisError.synthesisTimedOut
+                }
+                let _ = try await group.next()!
+                group.cancelAll()
+            }
+        }
+    }
+
+    private func resolveVoice(options: TTSRequestOptions) throws -> AVSpeechSynthesisVoice {
+        // 1. Exact Apple voice identifier
+        if let appleVoice = options.appleVoice, !appleVoice.isEmpty {
+            if let voice = AVSpeechSynthesisVoice(identifier: appleVoice) {
+                return voice
+            }
+            throw SpeechSynthesisError.voiceNotAvailable(appleVoice)
+        }
+
+        // 2. OpenAI voice name mapping
+        if let voiceName = options.voice,
+           let openAIVoice = OpenAIVoiceName(rawValue: voiceName.lowercased()) {
+            let voices = AVSpeechSynthesisVoice.speechVoices()
+                .filter { $0.language.lowercased().hasPrefix(options.locale.lowercased().prefix(2).description) }
+
+            // Try preferred Apple voice names first
+            for preferred in openAIVoice.preferredAppleVoiceNames {
+                // Prefer enhanced > premium > compact
+                let sorted = voices.filter { $0.name == preferred }
+                    .sorted { qualityRank($0) > qualityRank($1) }
+                if let found = sorted.first {
+                    return found
+                }
+            }
+
+            // Fallback: match by gender, prefer higher quality
+            let genderMatched = voices
+                .filter { voiceMatchesGender($0, openAIVoice.gender) }
+                .sorted { qualityRank($0) > qualityRank($1) }
+            if let found = genderMatched.first {
+                return found
+            }
+
+            // Last fallback: any voice for the locale
+            if let anyVoice = voices.sorted(by: { qualityRank($0) > qualityRank($1) }).first {
+                return anyVoice
+            }
+        }
+
+        // 3. System default for locale
+        if let voice = AVSpeechSynthesisVoice(language: options.locale) {
+            return voice
+        }
+
+        // 4. Absolute fallback
+        if let voice = AVSpeechSynthesisVoice(language: "en-US") {
+            return voice
+        }
+
+        throw SpeechSynthesisError.voiceNotAvailable(options.locale)
+    }
+
+    private func qualityRank(_ voice: AVSpeechSynthesisVoice) -> Int {
+        switch voice.quality {
+        case .enhanced: return 3
+        case .premium: return 2
+        default: return 1
+        }
+    }
+
+    private func voiceMatchesGender(_ voice: AVSpeechSynthesisVoice, _ gender: OpenAIVoiceName.Gender) -> Bool {
+        switch gender {
+        case .female: return voice.gender == .female
+        case .male: return voice.gender == .male
+        }
+    }
+
+    private func clampRate(_ speed: Float) -> Float {
+        let minRate = AVSpeechUtteranceMinimumSpeechRate
+        let maxRate = AVSpeechUtteranceMaximumSpeechRate
+        let defaultRate = AVSpeechUtteranceDefaultSpeechRate
+
+        // Map OpenAI's 0.25-4.0 range to Apple's rate range
+        // speed=1.0 maps to defaultRate
+        let normalized = speed * defaultRate
+        return Swift.min(Swift.max(normalized, minRate), maxRate)
+    }
+}

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -63,6 +63,11 @@ class Server {
     private let contextWindow: Int?
     private var telegramBridge: TelegramBridge?
 
+    private static let audioAvailable: Bool = {
+        if #available(macOS 13.0, *) { return true }
+        return false
+    }()
+
     init(port: Int, hostname: String, verbose: Bool, veryVerbose: Bool = false, trace: Bool = false, streamingEnabled: Bool, instructions: String, adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil, permissiveGuardrails: Bool = false, stop: String? = nil, webuiEnabled: Bool = false, gatewayEnabled: Bool = false, prewarmEnabled: Bool = true, telegramConfiguration: TelegramConfiguration? = nil, mlxModelID: String? = nil, mlxModelService: MLXModelService? = nil, mlxRepetitionPenalty: Double? = nil, mlxTopP: Double? = nil, mlxMaxTokens: Int? = nil, mlxRawOutput: Bool = false, mlxTopK: Int? = nil, mlxMinP: Double? = nil, mlxPresencePenalty: Double? = nil, mlxSeed: Int? = nil, mlxMaxLogprobs: Int? = nil, contextWindow: Int? = nil) async throws {
         self.port = port
         self.hostname = hostname
@@ -330,7 +335,7 @@ class Server {
                     total_slots: 1,
                     model_path: mlxModelID,
                     role: "mlx",
-                    modalities: Modalities(vision: true, audio: true),
+                    modalities: Modalities(vision: true, audio: Self.audioAvailable),
                     chat_template: "",
                     bos_token: "",
                     eos_token: "",
@@ -373,7 +378,7 @@ class Server {
                 total_slots: 1,
                 model_path: modelPath,
                 role: self.gatewayEnabled ? "router" : "model",
-                modalities: Modalities(vision: hasVision, audio: true),
+                modalities: Modalities(vision: hasVision, audio: Self.audioAvailable),
                 chat_template: "",
                 bos_token: "",
                 eos_token: "",

--- a/Sources/MacLocalAPI/SpeechCommand.swift
+++ b/Sources/MacLocalAPI/SpeechCommand.swift
@@ -1,27 +1,37 @@
 import ArgumentParser
 import Foundation
 
-struct SpeechCommand: ParsableCommand {
+struct SpeechCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "speech",
-        abstract: "Transcribe audio files using Apple's Speech framework",
+        abstract: "Speech synthesis and transcription using Apple frameworks",
         discussion: """
-        Use Apple's Speech framework to perform on-device speech-to-text transcription.
+        Use Apple's Speech and AVFoundation frameworks for on-device speech-to-text
+        and text-to-speech.
 
-        Supported formats: WAV, MP3, M4A, CAF, AIFF
+        Subcommands:
+          synthesize  — Convert text to speech audio
+          transcribe  — Transcribe audio files to text
+
+        Legacy shortcut:
+          afm speech -f file.wav  — Equivalent to: afm speech transcribe -f file.wav
 
         Examples:
-          afm speech -f recording.wav
-          afm speech --file /path/to/audio.m4a
-          afm speech -f meeting.mp3 --locale ja-JP
-        """
+          afm speech synthesize "Hello world" -o output.aac
+          afm speech synthesize "Hello" --voice nova --format wav
+          afm speech --list-voices --locale en
+          afm speech transcribe -f recording.wav
+          afm speech transcribe -f meeting.mp3 --format verbose_json
+          afm speech -f audio.wav                         # legacy transcribe shortcut
+        """,
+        subcommands: [SpeechSynthesizeCommand.self, SpeechTranscribeCommand.self]
     )
 
-    @Option(name: [.short, .long], help: "Path to the audio file")
-    var file: String
+    @Flag(name: .long, help: "List available voices and exit")
+    var listVoices: Bool = false
 
-    @Option(name: .long, help: "Locale for speech recognition (default: en-US)")
-    var locale: String = "en-US"
+    @Option(name: .long, help: "Filter voices by locale prefix (e.g. 'en', 'ja-JP')")
+    var locale: String?
 
     @Flag(name: .long, help: "Print machine-readable JSON capability card for AI agents and exit")
     var helpJson: Bool = false
@@ -32,20 +42,164 @@ struct SpeechCommand: ParsableCommand {
             return
         }
 
-        guard !file.isEmpty else {
-            print("Error: File path is required. Use -f or --file to specify the input file.")
+        if listVoices {
+            if #available(macOS 13.0, *) {
+                let voices = SpeechSynthesisService.listVoices(locale: locale)
+                if voices.isEmpty {
+                    print("No voices found\(locale.map { " for locale '\($0)'" } ?? "").")
+                    return
+                }
+                let maxNameLen = voices.map(\.name.count).max() ?? 10
+                let maxLocaleLen = voices.map(\.locale.count).max() ?? 5
+                for voice in voices {
+                    let name = voice.name.padding(toLength: maxNameLen, withPad: " ", startingAt: 0)
+                    let loc = voice.locale.padding(toLength: maxLocaleLen, withPad: " ", startingAt: 0)
+                    print("\(name)  \(loc)  \(voice.gender)  \(voice.quality)  \(voice.id)")
+                }
+            } else {
+                throw SpeechError.platformUnavailable
+            }
+            return
+        }
+
+        // No subcommand and no flags — show help
+        throw CleanExit.helpRequest(self)
+    }
+}
+
+struct SpeechSynthesizeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "synthesize",
+        abstract: "Convert text to speech audio"
+    )
+
+    @Argument(help: "Text to synthesize")
+    var text: String
+
+    @Option(name: .long, help: "Voice name: alloy, echo, fable, nova, onyx, shimmer (default: alloy)")
+    var voice: String = "alloy"
+
+    @Option(name: .long, help: "Locale for voice selection (default: en-US)")
+    var locale: String = "en-US"
+
+    @Option(name: .long, help: "Audio format: aac, wav, caf (default: aac)")
+    var format: String = "aac"
+
+    @Option(name: .long, help: "Speech speed: 0.25-4.0 (default: 1.0)")
+    var speed: Float = 1.0
+
+    @Option(name: [.short, .long], help: "Output file path (default: stdout)")
+    var output: String?
+
+    func run() async throws {
+        guard #available(macOS 13.0, *) else {
+            throw SpeechSynthesisError.platformUnavailable
+        }
+
+        guard let audioFormat = TTSAudioFormat(rawValue: format.lowercased()) else {
+            print("Error: Unsupported format '\(format)'. Supported: aac, wav, caf")
             throw ExitCode.failure
         }
 
+        let options = TTSRequestOptions(
+            voice: voice,
+            locale: locale,
+            speed: speed,
+            format: audioFormat
+        )
+
+        do {
+            let service = SpeechSynthesisService()
+            let audioData = try await service.synthesize(text: text, options: options)
+
+            if let outputPath = output {
+                let expandedPath = NSString(string: outputPath).expandingTildeInPath
+                let url = URL(fileURLWithPath: expandedPath)
+                try audioData.write(to: url)
+                print("Wrote \(audioData.count) bytes to \(expandedPath)")
+            } else {
+                // Write raw audio to stdout
+                FileHandle.standardOutput.write(audioData)
+            }
+        } catch {
+            if let synthError = error as? SpeechSynthesisError {
+                print("Error: \(synthError.localizedDescription)")
+            } else {
+                print("Error: \(error.localizedDescription)")
+            }
+            throw ExitCode.failure
+        }
+    }
+}
+
+struct SpeechTranscribeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "transcribe",
+        abstract: "Transcribe audio files to text"
+    )
+
+    @Option(name: [.short, .long], help: "Path to the audio file")
+    var file: String
+
+    @Option(name: .long, help: "Locale for speech recognition (default: en-US)")
+    var locale: String = "en-US"
+
+    @Option(name: .long, help: "Output format: text, json, verbose_json, srt, vtt (default: text)")
+    var format: String = "text"
+
+    @Option(name: .long, help: "Language code (ISO-639-1, e.g. 'en', 'ja'). Alias for --locale.")
+    var language: String?
+
+    @Option(name: .long, help: "Timestamp granularities: word, segment, or both (comma-separated)")
+    var timestamps: String?
+
+    func run() async throws {
         let expandedPath = NSString(string: file).expandingTildeInPath
-        let resolvedPath = URL(fileURLWithPath: expandedPath).standardized.path
+        let resolvedPath = URL(fileURLWithPath: expandedPath).resolvingSymlinksInPath().path
+
+        // language takes precedence over locale; pass bare codes through —
+        // SFSpeechRecognizer resolves them to the user's preferred regional variant
+        let effectiveLocale = language ?? locale
 
         do {
             if #available(macOS 13.0, *) {
                 let service = SpeechService()
-                let options = SpeechRequestOptions(locale: locale)
-                let text = try await service.transcribe(from: resolvedPath, options: options)
-                print(text)
+                let options = SpeechRequestOptions(locale: effectiveLocale)
+
+                switch format.lowercased() {
+                case "text":
+                    let text = try await service.transcribe(from: resolvedPath, options: options)
+                    print(text)
+                case "json":
+                    let text = try await service.transcribe(from: resolvedPath, options: options)
+                    let jsonObj: [String: Any] = ["text": text]
+                    let jsonData = try JSONSerialization.data(withJSONObject: jsonObj, options: [.prettyPrinted])
+                    print(String(data: jsonData, encoding: .utf8) ?? "{}")
+                case "verbose_json", "srt", "vtt":
+                    let result = try await service.transcribeWithDetails(from: resolvedPath, options: options)
+                    let granularities = parseGranularities()
+                    switch format.lowercased() {
+                    case "verbose_json":
+                        let verbose = VerboseTranscriptionResponse(
+                            text: result.text,
+                            language: result.language,
+                            duration: result.duration,
+                            words: granularities.contains("word") ? result.words : nil,
+                            segments: granularities.contains("segment") ? result.segments : nil
+                        )
+                        let data = try JSONEncoder.prettyPrinted.encode(verbose)
+                        print(String(data: data, encoding: .utf8) ?? "{}")
+                    case "srt":
+                        print(result.formatAsSRT())
+                    case "vtt":
+                        print(result.formatAsVTT())
+                    default:
+                        break
+                    }
+                default:
+                    print("Error: Unsupported format '\(format)'. Supported: text, json, verbose_json, srt, vtt")
+                    throw ExitCode.failure
+                }
             } else {
                 throw SpeechError.platformUnavailable
             }
@@ -58,4 +212,17 @@ struct SpeechCommand: ParsableCommand {
             throw ExitCode.failure
         }
     }
+
+    private func parseGranularities() -> Set<String> {
+        guard let raw = timestamps else { return ["segment"] }
+        return Set(raw.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces).lowercased() })
+    }
+}
+
+private extension JSONEncoder {
+    static let prettyPrinted: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
 }

--- a/Sources/MacLocalAPI/SpeechCommand.swift
+++ b/Sources/MacLocalAPI/SpeechCommand.swift
@@ -12,26 +12,22 @@ struct SpeechCommand: AsyncParsableCommand {
         Subcommands:
           synthesize  — Convert text to speech audio
           transcribe  — Transcribe audio files to text
+          voices      — List available synthesis voices
 
-        Legacy shortcut:
+        Legacy shortcuts:
+          afm speech file.wav     — Equivalent to: afm speech transcribe -f file.wav
           afm speech -f file.wav  — Equivalent to: afm speech transcribe -f file.wav
 
         Examples:
           afm speech synthesize "Hello world" -o output.aac
           afm speech synthesize "Hello" --voice nova --format wav
-          afm speech --list-voices --locale en
+          afm speech voices --locale en
           afm speech transcribe -f recording.wav
           afm speech transcribe -f meeting.mp3 --format verbose_json
           afm speech -f audio.wav                         # legacy transcribe shortcut
         """,
-        subcommands: [SpeechSynthesizeCommand.self, SpeechTranscribeCommand.self]
+        subcommands: [SpeechSynthesizeCommand.self, SpeechTranscribeCommand.self, SpeechVoicesCommand.self]
     )
-
-    @Flag(name: .long, help: "List available voices and exit")
-    var listVoices: Bool = false
-
-    @Option(name: .long, help: "Filter voices by locale prefix (e.g. 'en', 'ja-JP')")
-    var locale: String?
 
     @Flag(name: .long, help: "Print machine-readable JSON capability card for AI agents and exit")
     var helpJson: Bool = false
@@ -42,28 +38,37 @@ struct SpeechCommand: AsyncParsableCommand {
             return
         }
 
-        if listVoices {
-            if #available(macOS 13.0, *) {
-                let voices = SpeechSynthesisService.listVoices(locale: locale)
-                if voices.isEmpty {
-                    print("No voices found\(locale.map { " for locale '\($0)'" } ?? "").")
-                    return
-                }
-                let maxNameLen = voices.map(\.name.count).max() ?? 10
-                let maxLocaleLen = voices.map(\.locale.count).max() ?? 5
-                for voice in voices {
-                    let name = voice.name.padding(toLength: maxNameLen, withPad: " ", startingAt: 0)
-                    let loc = voice.locale.padding(toLength: maxLocaleLen, withPad: " ", startingAt: 0)
-                    print("\(name)  \(loc)  \(voice.gender)  \(voice.quality)  \(voice.id)")
-                }
-            } else {
-                throw SpeechError.platformUnavailable
-            }
-            return
-        }
-
         // No subcommand and no flags — show help
         throw CleanExit.helpRequest(self)
+    }
+}
+
+struct SpeechVoicesCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "voices",
+        abstract: "List available speech synthesis voices"
+    )
+
+    @Option(name: .long, help: "Filter voices by locale prefix (e.g. 'en', 'ja-JP')")
+    var locale: String?
+
+    func run() async throws {
+        guard #available(macOS 13.0, *) else {
+            throw SpeechError.platformUnavailable
+        }
+
+        let voices = SpeechSynthesisService.listVoices(locale: locale)
+        if voices.isEmpty {
+            print("No voices found\(locale.map { " for locale '\($0)'" } ?? "").")
+            return
+        }
+        let maxNameLen = voices.map(\.name.count).max() ?? 10
+        let maxLocaleLen = voices.map(\.locale.count).max() ?? 5
+        for voice in voices {
+            let name = voice.name.padding(toLength: maxNameLen, withPad: " ", startingAt: 0)
+            let loc = voice.locale.padding(toLength: maxLocaleLen, withPad: " ", startingAt: 0)
+            print("\(name)  \(loc)  \(voice.gender)  \(voice.quality)  \(voice.id)")
+        }
     }
 }
 

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -939,6 +939,8 @@ func printHelpJson(command: String) {
         config = MlxCommand.configuration
     case "afm vision":
         config = VisionCommand.configuration
+    case "afm speech":
+        config = SpeechCommand.configuration
     default:
         config = RootCommand.configuration
     }
@@ -1373,21 +1375,30 @@ if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "mlx" {
         MlxCommand.exit(withError: error)
     }
 } else if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "speech" {
-    let args = Array(CommandLine.arguments.dropFirst(2))
+    var args = Array(CommandLine.arguments.dropFirst(2))
+    // Legacy: if the first arg isn't a known subcommand, assume it's a file path
+    // or flag for transcribe (e.g. "afm speech file.wav" or "afm speech -f file.wav").
+    let subcommands: Set<String> = ["synthesize", "transcribe", "voices", "help"]
+    if let first = args.first, !subcommands.contains(first), !first.hasPrefix("-") {
+        args.insert("transcribe", at: 0)
+    }
     do {
-        let cmd = try SpeechCommand.parse(args)
-        let group = DispatchGroup()
+        var cmd = try SpeechCommand.parseAsRoot(args)
+        // Use CFRunLoop so AVSpeechSynthesizer callbacks can fire on the main thread
         var caughtError: Error?
-        group.enter()
         Task {
             do {
-                try await cmd.run()
+                if var asyncCmd = cmd as? AsyncParsableCommand {
+                    try await asyncCmd.run()
+                } else {
+                    try cmd.run()
+                }
             } catch {
                 caughtError = error
             }
-            group.leave()
+            CFRunLoopStop(CFRunLoopGetMain())
         }
-        group.wait()
+        CFRunLoopRun()
         if let error = caughtError {
             throw error
         }

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -1376,11 +1376,26 @@ if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "mlx" {
     }
 } else if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "speech" {
     var args = Array(CommandLine.arguments.dropFirst(2))
-    // Legacy: if the first arg isn't a known subcommand, assume it's a file path
-    // or flag for transcribe (e.g. "afm speech file.wav" or "afm speech -f file.wav").
+    // Legacy shim: pre-subcommand CLI accepted `afm speech file.wav`,
+    // `afm speech -f file.wav`, and `afm speech --list-voices`. Route each
+    // legacy form to the matching subcommand so existing muscle memory keeps
+    // working. Root options would otherwise swallow subcommand options like
+    // `--locale`, so the root stays deliberately flagless (except --help-json).
     let subcommands: Set<String> = ["synthesize", "transcribe", "voices", "help"]
-    if let first = args.first, !subcommands.contains(first), !first.hasPrefix("-") {
-        args.insert("transcribe", at: 0)
+    let transcribeFlags: Set<String> = ["-f", "--file", "--format", "--language", "--timestamps"]
+    if let firstIdx = args.firstIndex(of: "--list-voices") {
+        // Drop the flag and prepend `voices` so any remaining flags (e.g. --locale)
+        // bind to SpeechVoicesCommand.
+        args.remove(at: firstIdx)
+        args.insert("voices", at: 0)
+    } else if let first = args.first, !subcommands.contains(first) {
+        if !first.hasPrefix("-") {
+            // Bare positional — treat as transcribe file path
+            args.insert(contentsOf: ["transcribe", "-f"], at: 0)
+        } else if transcribeFlags.contains(first) {
+            args.insert("transcribe", at: 0)
+        }
+        // Other flags (e.g. --help, --help-json) fall through to SpeechCommand.
     }
     do {
         var cmd = try SpeechCommand.parseAsRoot(args)


### PR DESCRIPTION
Closes #110 (Part 1)

## Summary

- Add speech-to-text via Apple Speech framework with word/segment timestamps and rich transcription formats (json, verbose_json, srt, vtt, text)
- Add text-to-speech via AVSpeechSynthesizer with PCM/AAC encoding and voice selection
- Wire up `/v1/audio/transcriptions`, `/v1/audio/speech`, `/v1/audio/voices` API endpoints
- Add CLI commands: `afm speech transcribe`, `afm speech synthesize`, `afm speech voices`
- Everything runs on-device. No API keys, no network, no data leaving the machine.

## Test results

- [x] `swift build` passes clean
- [x] 293/293 unit tests pass
- [x] `afm speech --list-voices` lists available system voices with identifiers
- [x] `afm speech synthesize "Hello world" -o output.aac` produces valid AAC audio (16KB)
- [x] `afm speech synthesize "Hello world" -o output.wav --format wav` produces valid WAV audio (155KB)
- [x] `afm speech transcribe -f audio.wav` returns correct transcription text
- [x] `afm speech transcribe -f audio.wav --format verbose_json` returns JSON with segments, timestamps, confidence, duration
- [x] `afm speech transcribe -f audio.wav --format srt` returns valid SRT subtitles
- [x] `afm speech transcribe -f audio.wav --format vtt` returns valid WebVTT subtitles
- [x] `afm speech transcribe -f audio.wav --format text` returns plain text
- [x] Round-trip test: synthesize text to WAV, transcribe back — output matches input

## Summary by Sourcery

Add on-device speech transcription and text-to-speech capabilities, exposing them via HTTP APIs and CLI commands with support for multiple formats and voice management.

New Features:
- Expose text-to-speech synthesis over a new /v1/audio/speech endpoint with configurable format, locale, speed, and voice selection.
- Expose a /v1/audio/voices endpoint and corresponding CLI support to list available system voices, optionally filtered by locale.
- Extend transcription API and CLI to support multiple output formats (text, json, verbose_json with word/segment timing, srt, vtt) and language/locale selection, including per-audio-part settings in chat completions.

Enhancements:
- Refine speech transcription service to return structured transcription results with timing metadata and convenience formatting to SRT and WebVTT.
- Improve chat completions audio handling by concurrently transcribing multiple input audio parts and propagating per-part language settings.
- Update CLI speech command to an async, subcommand-based interface with richer help text and legacy-usage compatibility.
- Adjust server capability reporting so audio modality is only advertised when supported on the running macOS version.
- Standardize error handling for speech APIs, mapping internal speech errors to structured HTTP responses compatible with OpenAI-style error objects.

Tests:
- Wire the speech CLI into the generic help-json mechanism to support automated capability discovery for AI agents.