### PR TITLE
Feature: Expand vision API with barcode, classify, and saliency modes

### DIFF
--- a/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
+++ b/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
@@ -496,22 +496,32 @@ struct VisionAPIController: RouteCollection {
                 }
 
                 if #available(macOS 26.0, *) {
-                    let documents = try await effectiveInputs.asyncMap { input in
-                        let result = try await visionService.extractTextWithDetails(from: input.path, options: options)
-                        return Self.mapDocument(result, sourceType: input.sourceType)
+                    // In auto mode, treat a per-input "no text found" as an empty OCR
+                    // result rather than failing the whole request — other submode
+                    // results (barcode, classify) should still come back.
+                    var documents: [VisionOCRDocument] = []
+                    for input in effectiveInputs {
+                        do {
+                            let result = try await visionService.extractTextWithDetails(from: input.path, options: options)
+                            documents.append(Self.mapDocument(result, sourceType: input.sourceType))
+                        } catch VisionError.noTextFound {
+                            continue
+                        }
                     }
 
-                    let combinedText = documents.map(\.fullText).joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
-                    let hints = Array(Set(documents.flatMap(\.documentHints))).sorted()
-                    modesRun.append("text")
-                    textResponse = VisionOCRResponse(
-                        object: "vision.ocr",
-                        mode: "text",
-                        documents: documents,
-                        combinedText: combinedText,
-                        documentHints: hints,
-                        debugOutput: nil
-                    )
+                    if !documents.isEmpty {
+                        let combinedText = documents.map(\.fullText).joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
+                        let hints = Array(Set(documents.flatMap(\.documentHints))).sorted()
+                        modesRun.append("text")
+                        textResponse = VisionOCRResponse(
+                            object: "vision.ocr",
+                            mode: "text",
+                            documents: documents,
+                            combinedText: combinedText,
+                            documentHints: hints,
+                            debugOutput: nil
+                        )
+                    }
                 }
 
                 modesRun.append("barcode")

--- a/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
+++ b/Sources/MacLocalAPI/Controllers/VisionAPIController.swift
@@ -2,17 +2,30 @@ import Vapor
 import Foundation
 
 protocol VisionServing {
+    @available(macOS 26.0, *)
     func extractText(from filePath: String) async throws -> String
+    @available(macOS 26.0, *)
     func extractText(from filePath: String, options: VisionRequestOptions) async throws -> String
+    @available(macOS 26.0, *)
     func extractTextWithDetails(from filePath: String) async throws -> VisionResult
+    @available(macOS 26.0, *)
     func extractTextWithDetails(from filePath: String, options: VisionRequestOptions) async throws -> VisionResult
+    @available(macOS 26.0, *)
     func extractTables(from filePath: String) async throws -> [TableResult]
+    @available(macOS 26.0, *)
     func extractTables(from filePath: String, options: VisionRequestOptions) async throws -> [TableResult]
+    @available(macOS 26.0, *)
     func debugRawDetection(from filePath: String) async throws -> String
+    @available(macOS 26.0, *)
     func debugRawDetection(from filePath: String, options: VisionRequestOptions) async throws -> String
+
+    // New modes (macOS 13+)
+    func detectBarcodes(from filePath: String, options: VisionRequestOptions) throws -> [BarcodeResult]
+    func classifyImage(from filePath: String, maxLabels: Int) throws -> ClassifyResult
+    func detectSaliency(from filePath: String, type: String, includeHeatMap: Bool) throws -> SaliencyResult
+    func autoCrop(imageData: Data) throws -> Data
 }
 
-@available(macOS 26.0, *)
 extension VisionService: VisionServing {}
 
 struct VisionOCRRequest: Content {
@@ -29,6 +42,14 @@ struct VisionOCRRequest: Content {
     let usesLanguageCorrection: Bool?
     let languages: [String]?
     let maxPages: Int?
+    // New parameters
+    let mode: String?
+    let detail: String?
+    let autoCrop: Bool?
+    let responseFormat: String?
+    let maxLabels: Int?
+    let saliencyType: String?
+    let includeHeatMap: Bool?
 
     enum CodingKeys: String, CodingKey {
         case file
@@ -44,6 +65,88 @@ struct VisionOCRRequest: Content {
         case usesLanguageCorrection = "uses_language_correction"
         case languages
         case maxPages = "max_pages"
+        case mode
+        case detail
+        case autoCrop = "auto_crop"
+        case responseFormat = "response_format"
+        case maxLabels = "max_labels"
+        case saliencyType = "saliency_type"
+        case includeHeatMap = "include_heat_map"
+    }
+}
+
+// MARK: - New vision mode response types
+
+struct VisionBarcodeResponse: Content {
+    let object: String
+    let mode: String
+    let results: [VisionBarcodeItem]
+}
+
+struct VisionBarcodeItem: Content {
+    let type: String
+    let payload: String
+    let boundingBox: VisionOCRBoundingBox
+    let confidence: Float
+
+    enum CodingKeys: String, CodingKey {
+        case type, payload
+        case boundingBox = "bounding_box"
+        case confidence
+    }
+}
+
+struct VisionClassifyResponse: Content {
+    let object: String
+    let mode: String
+    let labels: [VisionClassifyLabel]
+    let salientRegions: [VisionOCRBoundingBox]
+
+    enum CodingKeys: String, CodingKey {
+        case object, mode, labels
+        case salientRegions = "salient_regions"
+    }
+}
+
+struct VisionClassifyLabel: Content {
+    let label: String
+    let confidence: Float
+}
+
+struct VisionSaliencyResponse: Content {
+    let object: String
+    let mode: String
+    let regions: [VisionSaliencyRegionItem]
+    let heatMap: String?
+
+    enum CodingKeys: String, CodingKey {
+        case object, mode, regions
+        case heatMap = "heat_map"
+    }
+}
+
+struct VisionSaliencyRegionItem: Content {
+    let type: String
+    let boundingBox: VisionOCRBoundingBox
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case boundingBox = "bounding_box"
+    }
+}
+
+struct VisionAutoResponse: Content {
+    let object: String
+    let mode: String
+    let modesRun: [String]
+    let text: VisionOCRResponse?
+    let barcodes: [VisionBarcodeItem]?
+    let labels: [VisionClassifyLabel]?
+
+    enum CodingKeys: String, CodingKey {
+        case object, mode
+        case modesRun = "modes_run"
+        case text, barcodes, labels
     }
 }
 
@@ -216,44 +319,229 @@ struct VisionAPIController: RouteCollection {
 
         defer { cleanup(parsed.cleanupURLs) }
 
+        // Resolve mode: explicit mode > legacy flags > default "text"
         let wantsDebug = parsed.request.debug ?? false
         let wantsTable = parsed.request.table ?? false
-        let mode = wantsDebug ? "debug" : (wantsTable ? "table" : "text")
+        let resolvedMode: String
+        if wantsDebug {
+            resolvedMode = "debug"
+        } else if let explicitMode = parsed.request.mode?.lowercased(), !explicitMode.isEmpty {
+            resolvedMode = explicitMode
+        } else if wantsTable {
+            resolvedMode = "table"
+        } else {
+            resolvedMode = "text"
+        }
+
+        // Apply auto_crop preprocessing if requested
+        var effectiveInputs = parsed.inputs
+        var cropCleanupURLs: [URL] = []
+        if parsed.request.autoCrop ?? false {
+            effectiveInputs = try effectiveInputs.map { input in
+                let fileURL = URL(fileURLWithPath: input.path)
+                let attrs = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+                if let fileSize = attrs[.size] as? Int, fileSize > VisionRequestOptions.defaultMaxFileBytes {
+                    throw VisionError.fileTooLarge(bytes: fileSize, maxBytes: VisionRequestOptions.defaultMaxFileBytes)
+                }
+                let imageData: Data
+                do {
+                    imageData = try Data(contentsOf: fileURL)
+                } catch {
+                    throw VisionError.imageLoadingFailed
+                }
+                let croppedData = try visionService.autoCrop(imageData: imageData)
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("afm_vision_crop_\(UUID().uuidString).png")
+                try croppedData.write(to: tempURL)
+                cropCleanupURLs.append(tempURL)
+                return VisionResolvedInput(path: tempURL.path, sourceType: input.sourceType, cleanupURLs: input.cleanupURLs)
+            }
+        }
+        defer { cleanup(cropCleanupURLs) }
 
         do {
-            if wantsDebug {
-                let outputs = try await parsed.inputs.asyncMap { input in
-                    try await visionService.debugRawDetection(from: input.path, options: options)
-                }
-                return try await createSuccessResponse(
-                    VisionOCRResponse(
-                        object: "vision.ocr",
-                        mode: mode,
-                        documents: [],
-                        combinedText: "",
-                        documentHints: [],
-                        debugOutput: outputs.joined(separator: "\n\n")
+            switch resolvedMode {
+            case "debug":
+                if #available(macOS 26.0, *) {
+                    let outputs = try await effectiveInputs.asyncMap { input in
+                        try await visionService.debugRawDetection(from: input.path, options: options)
+                    }
+                    return try await createSuccessResponse(
+                        VisionOCRResponse(
+                            object: "vision.ocr",
+                            mode: resolvedMode,
+                            documents: [],
+                            combinedText: "",
+                            documentHints: [],
+                            debugOutput: outputs.joined(separator: "\n\n")
+                        )
                     )
-                )
-            }
+                } else {
+                    return try await createErrorResponse(
+                        message: VisionError.modeRequiresMacOS26("debug").localizedDescription,
+                        status: .notImplemented
+                    )
+                }
 
-            let documents = try await parsed.inputs.asyncMap { input in
-                let result = try await visionService.extractTextWithDetails(from: input.path, options: options)
-                return Self.mapDocument(result, sourceType: input.sourceType)
-            }
+            case "text", "table":
+                if #available(macOS 26.0, *) {
+                    let documents = try await effectiveInputs.asyncMap { input in
+                        let result = try await visionService.extractTextWithDetails(from: input.path, options: options)
+                        return Self.mapDocument(result, sourceType: input.sourceType)
+                    }
+                    let combinedText = documents.map(\.fullText).joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
+                    let hints = Array(Set(documents.flatMap(\.documentHints))).sorted()
 
-            let combinedText = documents.map(\.fullText).joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
-            let hints = Array(Set(documents.flatMap(\.documentHints))).sorted()
-            return try await createSuccessResponse(
-                VisionOCRResponse(
+                    // Handle response_format
+                    let responseFormat = parsed.request.responseFormat?.lowercased() ?? "json"
+                    if responseFormat == "text" {
+                        let response = Response(status: .ok)
+                        response.headers.add(name: .contentType, value: "text/plain")
+                        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+                        response.body = .init(string: combinedText)
+                        return response
+                    }
+
+                    return try await createSuccessResponse(
+                        VisionOCRResponse(
+                            object: "vision.ocr",
+                            mode: resolvedMode,
+                            documents: documents,
+                            combinedText: combinedText,
+                            documentHints: hints,
+                            debugOutput: nil
+                        )
+                    )
+                } else {
+                    return try await createErrorResponse(
+                        message: VisionError.modeRequiresMacOS26(resolvedMode).localizedDescription,
+                        status: .notImplemented
+                    )
+                }
+
+            case "barcode":
+                let allBarcodes = try effectiveInputs.flatMap { input in
+                    try visionService.detectBarcodes(from: input.path, options: options)
+                }
+                let items = allBarcodes.map { b in
+                    VisionBarcodeItem(
+                        type: b.type,
+                        payload: b.payload,
+                        boundingBox: VisionOCRBoundingBox(b.boundingBox),
+                        confidence: b.confidence
+                    )
+                }
+                return try await createJSONResponse(VisionBarcodeResponse(
                     object: "vision.ocr",
-                    mode: mode,
-                    documents: documents,
-                    combinedText: combinedText,
-                    documentHints: hints,
-                    debugOutput: nil
+                    mode: "barcode",
+                    results: items
+                ))
+
+            case "classify":
+                let maxLabels = parsed.request.maxLabels ?? 5
+                let allResults = try effectiveInputs.map { input in
+                    try visionService.classifyImage(from: input.path, maxLabels: maxLabels)
+                }
+                let labels = allResults.flatMap { $0.labels }.map {
+                    VisionClassifyLabel(label: $0.label, confidence: $0.confidence)
+                }
+                let regions = allResults.flatMap { $0.salientRegions }.map {
+                    VisionOCRBoundingBox($0)
+                }
+                return try await createJSONResponse(VisionClassifyResponse(
+                    object: "vision.ocr",
+                    mode: "classify",
+                    labels: labels,
+                    salientRegions: regions
+                ))
+
+            case "saliency":
+                let saliencyType = parsed.request.saliencyType ?? "attention"
+                let includeHeatMap = parsed.request.includeHeatMap ?? false
+                let allResults = try effectiveInputs.map { input in
+                    try visionService.detectSaliency(from: input.path, type: saliencyType, includeHeatMap: includeHeatMap)
+                }
+                let regions = allResults.flatMap { $0.regions }.map {
+                    VisionSaliencyRegionItem(type: $0.type, boundingBox: VisionOCRBoundingBox($0.boundingBox))
+                }
+                let heatMap = allResults.compactMap(\.heatMapPNG).first.map { $0.base64EncodedString() }
+                return try await createJSONResponse(VisionSaliencyResponse(
+                    object: "vision.ocr",
+                    mode: "saliency",
+                    regions: regions,
+                    heatMap: heatMap
+                ))
+
+            case "auto":
+                // Run barcode, classify (sync), then text (async)
+                let maxLabels = parsed.request.maxLabels ?? 5
+
+                // Filter to image-only inputs for barcode/classify (they reject PDFs)
+                let imageInputs = effectiveInputs.filter { input in
+                    let ext = URL(fileURLWithPath: input.path).pathExtension.lowercased()
+                    return VisionService.imageOnlyExtensions.contains(ext)
+                }
+
+                var modesRun: [String] = []
+                var barcodeItems: [VisionBarcodeItem]?
+                var classifyLabels: [VisionClassifyLabel]?
+                var textResponse: VisionOCRResponse?
+
+                // Barcode and classify are synchronous Vision framework calls
+                let barcodes = try imageInputs.flatMap { input in
+                    try visionService.detectBarcodes(from: input.path, options: options)
+                }
+                let classified = try imageInputs.map { input in
+                    try visionService.classifyImage(from: input.path, maxLabels: maxLabels)
+                }
+
+                if #available(macOS 26.0, *) {
+                    let documents = try await effectiveInputs.asyncMap { input in
+                        let result = try await visionService.extractTextWithDetails(from: input.path, options: options)
+                        return Self.mapDocument(result, sourceType: input.sourceType)
+                    }
+
+                    let combinedText = documents.map(\.fullText).joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
+                    let hints = Array(Set(documents.flatMap(\.documentHints))).sorted()
+                    modesRun.append("text")
+                    textResponse = VisionOCRResponse(
+                        object: "vision.ocr",
+                        mode: "text",
+                        documents: documents,
+                        combinedText: combinedText,
+                        documentHints: hints,
+                        debugOutput: nil
+                    )
+                }
+
+                modesRun.append("barcode")
+                if !barcodes.isEmpty {
+                    barcodeItems = barcodes.map {
+                        VisionBarcodeItem(type: $0.type, payload: $0.payload, boundingBox: VisionOCRBoundingBox($0.boundingBox), confidence: $0.confidence)
+                    }
+                }
+
+                let labels = classified.flatMap(\.labels)
+                modesRun.append("classify")
+                if !labels.isEmpty {
+                    classifyLabels = labels.map { VisionClassifyLabel(label: $0.label, confidence: $0.confidence) }
+                }
+
+                return try await createJSONResponse(VisionAutoResponse(
+                    object: "vision.ocr",
+                    mode: "auto",
+                    modesRun: modesRun,
+                    text: textResponse,
+                    barcodes: barcodeItems,
+                    labels: classifyLabels
+                ))
+
+            default:
+                return try await createErrorResponse(
+                    message: "Unknown mode '\(resolvedMode)'. Supported: text, table, barcode, classify, saliency, auto",
+                    status: .badRequest
                 )
-            )
+            }
         } catch let visionError as VisionError {
             return try await createErrorResponse(
                 message: visionError.localizedDescription,
@@ -288,7 +576,14 @@ struct VisionAPIController: RouteCollection {
                 recognitionLevel: stringField(req, "recognition_level"),
                 usesLanguageCorrection: boolField(req, "uses_language_correction"),
                 languages: arrayField(req, "languages"),
-                maxPages: intField(req, "max_pages")
+                maxPages: intField(req, "max_pages"),
+                mode: stringField(req, "mode"),
+                detail: stringField(req, "detail"),
+                autoCrop: boolField(req, "auto_crop"),
+                responseFormat: stringField(req, "response_format"),
+                maxLabels: intField(req, "max_labels"),
+                saliencyType: stringField(req, "saliency_type"),
+                includeHeatMap: boolField(req, "include_heat_map")
             )
         } else {
             request = try req.content.decode(VisionOCRRequest.self)
@@ -349,6 +644,14 @@ struct VisionAPIController: RouteCollection {
                 throw Abort(.badRequest, reason: "recognition_level must be 'accurate' or 'fast'")
             }
             level = parsed
+        } else if let detail = request.detail?.lowercased(), !detail.isEmpty {
+            // detail is an alias: high -> accurate, low -> fast
+            switch detail {
+            case "high": level = .accurate
+            case "low": level = .fast
+            default:
+                throw Abort(.badRequest, reason: "detail must be 'high' or 'low'")
+            }
         } else {
             level = .accurate
         }
@@ -359,6 +662,14 @@ struct VisionAPIController: RouteCollection {
             recognitionLanguages: request.languages ?? [],
             maxPages: request.maxPages ?? VisionRequestOptions.defaultMaxPages
         )
+    }
+
+    private func createJSONResponse<T: Content>(_ payload: T) async throws -> Response {
+        let response = Response(status: .ok)
+        response.headers.add(name: .contentType, value: "application/json")
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        try response.content.encode(payload)
+        return response
     }
 
     private func createSuccessResponse(_ payload: VisionOCRResponse) async throws -> Response {
@@ -492,13 +803,6 @@ struct VisionAPIController: RouteCollection {
     }
 
     static func writeTempFile(data: Data, filename: String, mediaType: String?) throws -> URL {
-        if data.count > VisionRequestOptions.defaultMaxFileBytes {
-            throw VisionError.requestTooLarge(
-                actualBytes: data.count,
-                maxBytes: VisionRequestOptions.defaultMaxFileBytes
-            )
-        }
-
         let ext = inferExtension(filename: filename, mediaType: mediaType)
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("afm_vision_\(UUID().uuidString).\(ext)")
@@ -629,20 +933,19 @@ struct VisionAPIController: RouteCollection {
             return .badRequest
         case .fileNotFound:
             return .notFound
-        case .requestTooLarge:
+        case .fileTooLarge:
             return .payloadTooLarge
         case .pageLimitExceeded, .imageDimensionsExceeded, .imageLoadingFailed, .textRecognitionFailed, .noTextFound, .noTablesFound, .documentSegmentationFailed:
             return .unprocessableEntity
         case .platformUnavailable:
             return .serviceUnavailable
+        case .modeRequiresMacOS26:
+            return .notImplemented
         }
     }
 
     private static func defaultVisionServiceFactory() -> (any VisionServing)? {
-        if #available(macOS 26.0, *) {
-            return VisionService()
-        }
-        return nil
+        return VisionService()
     }
 }
 

--- a/Sources/MacLocalAPI/Models/VisionService.swift
+++ b/Sources/MacLocalAPI/Models/VisionService.swift
@@ -13,7 +13,6 @@ enum VisionError: Error, LocalizedError {
     case remoteURLNotSupported
     case unsupportedURLScheme(String)
     case invalidDataURL
-    case requestTooLarge(actualBytes: Int, maxBytes: Int)
     case pageLimitExceeded(actualPages: Int, maxPages: Int)
     case imageDimensionsExceeded(width: Int, height: Int, maxDimension: Int)
     case imageLoadingFailed
@@ -21,6 +20,8 @@ enum VisionError: Error, LocalizedError {
     case noTextFound
     case noTablesFound
     case documentSegmentationFailed(String)
+    case fileTooLarge(bytes: Int, maxBytes: Int)
+    case modeRequiresMacOS26(String)
 
     var errorDescription: String? {
         switch self {
@@ -42,8 +43,6 @@ enum VisionError: Error, LocalizedError {
             return "Unsupported image URL scheme: \(scheme)"
         case .invalidDataURL:
             return "Invalid data URL or base64 payload"
-        case .requestTooLarge(let actualBytes, let maxBytes):
-            return "Input size \(actualBytes) bytes exceeds the limit of \(maxBytes) bytes"
         case .pageLimitExceeded(let actualPages, let maxPages):
             return "Document has \(actualPages) pages which exceeds the limit of \(maxPages)"
         case .imageDimensionsExceeded(let width, let height, let maxDimension):
@@ -58,6 +57,10 @@ enum VisionError: Error, LocalizedError {
             return "No tables were found in the document"
         case .documentSegmentationFailed(let message):
             return "Document segmentation failed: \(message)"
+        case .fileTooLarge(let bytes, let maxBytes):
+            return "File size \(bytes / 1024 / 1024) MB exceeds the limit of \(maxBytes / 1024 / 1024) MB"
+        case .modeRequiresMacOS26(let mode):
+            return "Vision mode '\(mode)' requires macOS 26.0 or later"
         }
     }
 }
@@ -77,9 +80,9 @@ enum VisionRecognitionLevel: String, Sendable {
 }
 
 struct VisionRequestOptions: Sendable {
-    static let defaultMaxFileBytes = 25 * 1024 * 1024
     static let defaultMaxPages = 50
     static let defaultMaxImageDimension = 4096
+    static let defaultMaxFileBytes: Int = 25 * 1024 * 1024  // 25 MB
 
     /// Single source of truth for file extensions accepted by the Vision OCR
     /// pipeline.  CGImageSource handles the image formats natively; PDF is
@@ -94,7 +97,6 @@ struct VisionRequestOptions: Sendable {
     let usesLanguageCorrection: Bool
     let recognitionLanguages: [String]
     let maxPages: Int
-    let maxFileBytes: Int
     let maxImageDimension: Int
 
     init(
@@ -102,35 +104,70 @@ struct VisionRequestOptions: Sendable {
         usesLanguageCorrection: Bool = true,
         recognitionLanguages: [String] = [],
         maxPages: Int = VisionRequestOptions.defaultMaxPages,
-        maxFileBytes: Int = VisionRequestOptions.defaultMaxFileBytes,
         maxImageDimension: Int = VisionRequestOptions.defaultMaxImageDimension
     ) {
         self.recognitionLevel = recognitionLevel
         self.usesLanguageCorrection = usesLanguageCorrection
         self.recognitionLanguages = recognitionLanguages
         self.maxPages = maxPages
-        self.maxFileBytes = maxFileBytes
         self.maxImageDimension = maxImageDimension
     }
 }
 
-@available(macOS 26.0, *)
+// MARK: - New vision mode result types
+
+struct BarcodeResult: Sendable {
+    let type: String
+    let payload: String
+    let boundingBox: CGRect
+    let confidence: Float
+}
+
+struct ClassificationLabel: Sendable {
+    let label: String
+    let confidence: Float
+}
+
+struct ClassifyResult: Sendable {
+    let labels: [ClassificationLabel]
+    let salientRegions: [CGRect]
+}
+
+struct SaliencyRegion: Sendable {
+    let type: String
+    let boundingBox: CGRect
+}
+
+struct SaliencyResult: Sendable {
+    let regions: [SaliencyRegion]
+    let heatMapPNG: Data?
+}
+
+// MARK: - VisionService (no class-level macOS restriction)
+
 final class VisionService {
+    static let imageOnlyExtensions: Set<String> = ["png", "jpg", "jpeg", "heic"]
     private static let pdfRenderScale: CGFloat = 2.0
 
+    // MARK: - Text extraction (macOS 26+)
+
+    @available(macOS 26.0, *)
     func extractText(from filePath: String) async throws -> String {
         try await extractText(from: filePath, options: VisionRequestOptions())
     }
 
+    @available(macOS 26.0, *)
     func extractText(from filePath: String, options: VisionRequestOptions) async throws -> String {
         let result = try await extractTextWithDetails(from: filePath, options: options)
         return result.fullText
     }
 
+    @available(macOS 26.0, *)
     func extractTextWithDetails(from filePath: String) async throws -> VisionResult {
         try await extractTextWithDetails(from: filePath, options: VisionRequestOptions())
     }
 
+    @available(macOS 26.0, *)
     func extractTextWithDetails(from filePath: String, options: VisionRequestOptions) async throws -> VisionResult {
         let document = try analyzeDocument(at: filePath, options: options)
         let textBlocks = document.pages.flatMap(\.textBlocks)
@@ -146,10 +183,12 @@ final class VisionService {
         )
     }
 
+    @available(macOS 26.0, *)
     func extractTables(from filePath: String) async throws -> [TableResult] {
         try await extractTables(from: filePath, options: VisionRequestOptions())
     }
 
+    @available(macOS 26.0, *)
     func extractTables(from filePath: String, options: VisionRequestOptions) async throws -> [TableResult] {
         let document = try analyzeDocument(at: filePath, options: options)
         let tables = document.pages.flatMap(\.tables)
@@ -159,12 +198,14 @@ final class VisionService {
         return tables
     }
 
+    @available(macOS 26.0, *)
     func debugRawDetection(from filePath: String) async throws -> String {
         try await debugRawDetection(from: filePath, options: VisionRequestOptions())
     }
 
+    @available(macOS 26.0, *)
     func debugRawDetection(from filePath: String, options: VisionRequestOptions) async throws -> String {
-        let (url, fileExtension) = try validateFile(at: filePath, maxBytes: options.maxFileBytes)
+        let (url, fileExtension) = try validateFile(at: filePath)
         let pageSources = try createPageSources(from: url, fileExtension: fileExtension, options: options)
         var sections: [String] = []
 
@@ -203,8 +244,174 @@ final class VisionService {
         return output
     }
 
+    // MARK: - Barcode detection (macOS 13+)
+
+    func detectBarcodes(from filePath: String, options: VisionRequestOptions = VisionRequestOptions()) throws -> [BarcodeResult] {
+        let (url, _) = try validateFile(at: filePath, allowedExtensions: Self.imageOnlyExtensions)
+        guard let imageData = try? Data(contentsOf: url) else {
+            throw VisionError.imageLoadingFailed
+        }
+
+        let handler = VNImageRequestHandler(data: imageData)
+        let request = VNDetectBarcodesRequest()
+
+        try handler.perform([request])
+
+        guard let observations = request.results else { return [] }
+        return observations.map { obs in
+            BarcodeResult(
+                type: obs.symbology.rawValue.replacingOccurrences(of: "VNBarcodeSymbology", with: ""),
+                payload: obs.payloadStringValue ?? "",
+                boundingBox: obs.boundingBox,
+                confidence: obs.confidence
+            )
+        }
+    }
+
+    // MARK: - Image classification (macOS 13+)
+
+    func classifyImage(from filePath: String, maxLabels: Int = 5) throws -> ClassifyResult {
+        let clampedMaxLabels = max(maxLabels, 0)
+        let (url, _) = try validateFile(at: filePath, allowedExtensions: Self.imageOnlyExtensions)
+        guard let imageData = try? Data(contentsOf: url) else {
+            throw VisionError.imageLoadingFailed
+        }
+
+        let handler = VNImageRequestHandler(data: imageData)
+        let classifyRequest = VNClassifyImageRequest()
+        let saliencyRequest = VNGenerateAttentionBasedSaliencyImageRequest()
+
+        try handler.perform([classifyRequest, saliencyRequest])
+
+        let labels: [ClassificationLabel]
+        if let observations = classifyRequest.results {
+            labels = observations
+                .sorted { $0.confidence > $1.confidence }
+                .prefix(clampedMaxLabels)
+                .map { ClassificationLabel(label: $0.identifier, confidence: $0.confidence) }
+        } else {
+            labels = []
+        }
+
+        let salientRegions: [CGRect]
+        if let saliencyObs = saliencyRequest.results?.first,
+           let salientObjects = saliencyObs.salientObjects {
+            salientRegions = salientObjects.map(\.boundingBox)
+        } else {
+            salientRegions = []
+        }
+
+        return ClassifyResult(labels: labels, salientRegions: salientRegions)
+    }
+
+    // MARK: - Saliency detection (macOS 13+)
+
+    func detectSaliency(from filePath: String, type: String = "attention", includeHeatMap: Bool = false) throws -> SaliencyResult {
+        let (url, _) = try validateFile(at: filePath, allowedExtensions: Self.imageOnlyExtensions)
+        guard let imageData = try? Data(contentsOf: url) else {
+            throw VisionError.imageLoadingFailed
+        }
+
+        let handler = VNImageRequestHandler(data: imageData)
+        let request: VNImageBasedRequest
+        if type == "objectness" {
+            request = VNGenerateObjectnessBasedSaliencyImageRequest()
+        } else {
+            request = VNGenerateAttentionBasedSaliencyImageRequest()
+        }
+
+        try handler.perform([request])
+
+        var regions: [SaliencyRegion] = []
+        var heatMapPNG: Data? = nil
+
+        if let saliencyObs = (request.results as? [VNSaliencyImageObservation])?.first {
+            if let salientObjects = saliencyObs.salientObjects {
+                regions = salientObjects.map { obj in
+                    SaliencyRegion(type: type, boundingBox: obj.boundingBox)
+                }
+            }
+
+            if includeHeatMap {
+                let pixelBuffer = saliencyObs.pixelBuffer
+                heatMapPNG = renderHeatMapPNG(from: pixelBuffer)
+            }
+        }
+
+        return SaliencyResult(regions: regions, heatMapPNG: heatMapPNG)
+    }
+
+    // MARK: - Auto-crop via document segmentation (macOS 13+)
+
+    func autoCrop(imageData: Data) throws -> Data {
+        let handler = VNImageRequestHandler(data: imageData)
+        let request = VNDetectDocumentSegmentationRequest()
+
+        try handler.perform([request])
+
+        guard let observation = request.results?.first else {
+            // No document region found — return original
+            return imageData
+        }
+
+        // Crop the image to the detected document region
+        guard let source = CGImageSourceCreateWithData(imageData as CFData, nil),
+              let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            return imageData
+        }
+
+        let box = observation.boundingBox
+        let imageWidth = CGFloat(cgImage.width)
+        let imageHeight = CGFloat(cgImage.height)
+        let cropRect = CGRect(
+            x: box.origin.x * imageWidth,
+            y: (1.0 - box.origin.y - box.height) * imageHeight,
+            width: box.width * imageWidth,
+            height: box.height * imageHeight
+        )
+
+        guard let croppedImage = cgImage.cropping(to: cropRect) else {
+            return imageData
+        }
+
+        let mutableData = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(mutableData, "public.png" as CFString, 1, nil) else {
+            return imageData
+        }
+        CGImageDestinationAddImage(destination, croppedImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            return imageData
+        }
+        return mutableData as Data
+    }
+
+    // MARK: - Internal helpers
+
+    func validateFile(at filePath: String, maxBytes: Int = VisionRequestOptions.defaultMaxFileBytes, allowedExtensions: Set<String>? = nil) throws -> (URL, String) {
+        let url = URL(fileURLWithPath: filePath)
+        guard FileManager.default.fileExists(atPath: filePath) else {
+            throw VisionError.fileNotFound
+        }
+
+        let fileExtension = url.pathExtension.lowercased()
+        let extensions = allowedExtensions ?? VisionRequestOptions.supportedExtensions
+        guard extensions.contains(fileExtension) else {
+            throw VisionError.unsupportedFormat
+        }
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: filePath)
+        if let fileSize = attrs[.size] as? Int, fileSize > maxBytes {
+            throw VisionError.fileTooLarge(bytes: fileSize, maxBytes: maxBytes)
+        }
+
+        return (url, fileExtension)
+    }
+
+    // MARK: - Private helpers
+
+    @available(macOS 26.0, *)
     private func analyzeDocument(at filePath: String, options: VisionRequestOptions) throws -> VisionDocumentResult {
-        let (url, fileExtension) = try validateFile(at: filePath, maxBytes: options.maxFileBytes)
+        let (url, fileExtension) = try validateFile(at: filePath)
         let pageSources = try createPageSources(from: url, fileExtension: fileExtension, options: options)
         var pageResults: [VisionPageResult] = []
         let analyzer = TableAnalyzer()
@@ -268,26 +475,6 @@ final class VisionService {
             pages: pageResults,
             documentHints: deriveDocumentHints(from: pageResults)
         )
-    }
-
-    private func validateFile(at filePath: String, maxBytes: Int) throws -> (URL, String) {
-        let url = URL(fileURLWithPath: filePath)
-        guard FileManager.default.fileExists(atPath: filePath) else {
-            throw VisionError.fileNotFound
-        }
-
-        let values = try url.resourceValues(forKeys: [.fileSizeKey])
-        let fileSize = values.fileSize ?? 0
-        if fileSize > maxBytes {
-            throw VisionError.requestTooLarge(actualBytes: fileSize, maxBytes: maxBytes)
-        }
-
-        let fileExtension = url.pathExtension.lowercased()
-        guard VisionRequestOptions.supportedExtensions.contains(fileExtension) else {
-            throw VisionError.unsupportedFormat
-        }
-
-        return (url, fileExtension)
     }
 
     private func createPageSources(from url: URL, fileExtension: String, options: VisionRequestOptions) throws -> [VisionPageSource] {
@@ -390,6 +577,7 @@ final class VisionService {
         return CGSize(width: width, height: height)
     }
 
+    @available(macOS 26.0, *)
     private func makeTextRequest(options: VisionRequestOptions) -> VNRecognizeTextRequest {
         let request = VNRecognizeTextRequest()
         request.recognitionLevel = options.recognitionLevel.requestLevel
@@ -422,6 +610,25 @@ final class VisionService {
             hints.append("document")
         }
         return hints
+    }
+
+    private func renderHeatMapPNG(from pixelBuffer: CVPixelBuffer) -> Data? {
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        let context = CIContext()
+        let width = CVPixelBufferGetWidth(pixelBuffer)
+        let height = CVPixelBufferGetHeight(pixelBuffer)
+        guard let cgImage = context.createCGImage(ciImage, from: CGRect(x: 0, y: 0, width: width, height: height)) else {
+            return nil
+        }
+        let mutableData = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(mutableData, "public.png" as CFString, 1, nil) else {
+            return nil
+        }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            return nil
+        }
+        return mutableData as Data
     }
 }
 

--- a/Sources/MacLocalAPI/VisionCommand.swift
+++ b/Sources/MacLocalAPI/VisionCommand.swift
@@ -4,53 +4,97 @@ import Foundation
 struct VisionCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "vision",
-        abstract: "Extract text from images using Apple's Vision framework",
+        abstract: "Extract text, barcodes, and classifications from images using Apple's Vision framework",
         discussion: """
         ---
         name: afm-vision
-        description: Extract text and tables from images and documents using Apple's Vision framework OCR. Outputs plain text or CSV-formatted tables. Runs locally on-device with no network access required.
-        tags: [vision, ocr, text-extraction, table-extraction, pdf, image, csv, apple-vision, on-device]
+        description: Extract text, tables, barcodes, classifications, and saliency from images and documents using Apple's Vision framework. Runs locally on-device with no network access required.
+        tags: [vision, ocr, text-extraction, table-extraction, barcode, classify, saliency, pdf, image, csv, apple-vision, on-device]
         repository: https://github.com/scouzi1966/maclocal-api
         supported_formats: [PNG, JPG, JPEG, HEIC, PDF]
+        modes: [text, table, barcode, classify, saliency, auto]
         triggers:
           - extract text from image
           - OCR document
           - extract table from image
           - convert image to text
           - PDF text extraction
+          - scan barcode
+          - classify image
+          - detect saliency
         examples:
           - afm vision -f image.png
           - afm vision --file /path/to/document.pdf
           - afm vision -f report.png --table
           - afm vision -f invoice.pdf -t --verbose
+          - afm vision -f photo.jpg --mode classify
+          - afm vision -f photo.jpg --mode barcode
+          - afm vision -f photo.jpg --mode saliency --heat-map
+          - afm vision -f photo.jpg --mode auto
+          - afm vision -f doc.png --auto-crop
+          - afm vision -f doc.png --detail low
         ---
 
-        Use Apple's Vision framework to perform OCR (Optical Character Recognition) on images and documents.
+        Use Apple's Vision framework to perform OCR, barcode detection, image classification,
+        and saliency analysis on images and documents.
 
         Supported formats: PNG, JPG, JPEG, HEIC, PDF
 
+        Modes:
+          text       Extract text (default, requires macOS 26)
+          table      Extract tables as CSV (requires macOS 26)
+          barcode    Detect barcodes and QR codes
+          classify   Classify image content with labels
+          saliency   Detect salient regions (attention or objectness)
+          auto       Run text + barcode + classify together
+
         Examples:
-          afm vision -f image.png                    # Extract all text
-          afm vision --file /path/to/document.pdf    # Extract text from PDF
-          afm vision -f report.png --table           # Extract tables as CSV
-          afm vision -f invoice.pdf -t --verbose     # Extract tables with details
+          afm vision -f image.png                              # Extract text
+          afm vision -f image.png --mode barcode               # Detect barcodes
+          afm vision -f photo.jpg --mode classify              # Classify image
+          afm vision -f photo.jpg --mode saliency --heat-map   # Saliency with heat map
+          afm vision -f photo.jpg --mode auto                  # Run all modes
+          afm vision -f doc.png --auto-crop                    # Auto-crop before OCR
+          afm vision -f doc.png --detail low                   # Fast recognition
         """
     )
-    
+
     @Option(name: [.short, .long], help: "Path to the image or document file")
     var file: String
-    
+
     @Flag(name: .long, help: "Show detailed output with confidence scores and bounding boxes")
     var verbose: Bool = false
-    
+
     @Flag(name: [.customShort("t"), .long], help: "Extract tables and output as CSV format")
     var table: Bool = false
-    
+
     @Flag(name: [.customShort("D")], help: .hidden)
     var debug: Bool = false
 
     @Flag(name: .long, help: "Print machine-readable JSON capability card for AI agents and exit")
     var helpJson: Bool = false
+
+    // New flags
+    @Option(name: .long, help: "Vision mode: text, table, barcode, classify, saliency, auto (default: text)")
+    var mode: String?
+
+    @Option(name: .long, help: "Recognition detail: high or low (default: high)")
+    var detail: String = "high"
+
+    @Flag(name: .long, help: "Auto-crop document region before processing")
+    var autoCrop: Bool = false
+
+    @Option(name: .long, help: "Output format: json, text (default: text for CLI)")
+    var format: String = "text"
+
+    @Option(name: .long, help: "Max classification labels to return (default: 5)")
+    var maxLabels: Int = 5
+
+    @Option(name: .long, help: "Saliency type: attention or objectness (default: attention)")
+    var saliencyType: String = "attention"
+
+    @Flag(name: .long, help: "Include saliency heat map as base64 PNG")
+    var heatMap: Bool = false
 
     func run() async throws {
         if helpJson {
@@ -58,76 +102,200 @@ struct VisionCommand: ParsableCommand {
             return
         }
 
-        // Validate that the file path was provided
         guard !file.isEmpty else {
             print("Error: File path is required. Use -f or --file to specify the input file.")
             throw ExitCode.failure
         }
-        
-        // Expand tilde and resolve relative paths
+
         let expandedPath = NSString(string: file).expandingTildeInPath
         let resolvedPath = URL(fileURLWithPath: expandedPath).standardized.path
-        
-        // Run vision processing
+
+        // Validate options
+        let validModes: Set<String> = ["text", "table", "barcode", "classify", "saliency", "auto", "debug"]
+        let validFormats: Set<String> = ["text", "json"]
+        let validSaliencyTypes: Set<String> = ["attention", "objectness"]
+        let validDetails: Set<String> = ["high", "low"]
+
+        if let mode = mode, !validModes.contains(mode.lowercased()) {
+            print("Error: Unknown mode '\(mode)'. Supported: \(validModes.sorted().joined(separator: ", "))")
+            throw ExitCode.failure
+        }
+        if !validFormats.contains(format.lowercased()) {
+            print("Error: Unknown format '\(format)'. Supported: \(validFormats.sorted().joined(separator: ", "))")
+            throw ExitCode.failure
+        }
+        if !validSaliencyTypes.contains(saliencyType.lowercased()) {
+            print("Error: Unknown saliency-type '\(saliencyType)'. Supported: \(validSaliencyTypes.sorted().joined(separator: ", "))")
+            throw ExitCode.failure
+        }
+        if !validDetails.contains(detail.lowercased()) {
+            print("Error: Unknown detail '\(detail)'. Supported: \(validDetails.sorted().joined(separator: ", "))")
+            throw ExitCode.failure
+        }
+
+        // Resolve effective mode: --mode takes precedence; --table is legacy fallback
+        let effectiveMode: String
+        if let mode = mode {
+            if table {
+                fputs("Warning: --table ignored because --mode \(mode) was specified\n", stderr)
+            }
+            effectiveMode = mode.lowercased()
+        } else if table {
+            effectiveMode = "table"
+        } else {
+            effectiveMode = "text"
+        }
+
         do {
-            if #available(macOS 26.0, *) {
-                let visionService = VisionService()
-                
-                let output: String
-                
-                if debug {
-                    // Debug mode: output raw Vision framework detection
-                    output = try await visionService.debugRawDetection(from: resolvedPath)
-                } else if table {
-                    // Table extraction mode
-                    let tableResults = try await visionService.extractTables(from: resolvedPath)
-                    
+            let visionService = VisionService()
+
+            // Apply auto-crop preprocessing
+            var processPath = resolvedPath
+            var tempCropURL: URL?
+            if autoCrop {
+                let imageData = try Data(contentsOf: URL(fileURLWithPath: resolvedPath))
+                if imageData.count > VisionRequestOptions.defaultMaxFileBytes {
+                    throw VisionError.fileTooLarge(bytes: imageData.count, maxBytes: VisionRequestOptions.defaultMaxFileBytes)
+                }
+                let croppedData = try visionService.autoCrop(imageData: imageData)
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("afm_vision_crop_\(UUID().uuidString).png")
+                try croppedData.write(to: tempURL)
+                processPath = tempURL.path
+                tempCropURL = tempURL
+            }
+            defer { if let url = tempCropURL { try? FileManager.default.removeItem(at: url) } }
+
+            // Map detail to recognition level
+            let recognitionLevel: VisionRecognitionLevel = detail.lowercased() == "low" ? .fast : .accurate
+            let options = VisionRequestOptions(recognitionLevel: recognitionLevel)
+
+            let output: String
+
+            switch effectiveMode {
+            case "barcode":
+                let results = try visionService.detectBarcodes(from: processPath, options: options)
+                if results.isEmpty {
+                    output = "No barcodes found."
+                } else if format == "json" {
+                    let items = results.map { r in
+                        ["type": r.type, "payload": r.payload, "confidence": String(format: "%.2f", r.confidence)]
+                    }
+                    let data = try JSONSerialization.data(withJSONObject: items, options: [.prettyPrinted])
+                    output = String(data: data, encoding: .utf8) ?? "[]"
+                } else {
+                    output = results.map { r in
+                        "\(r.type): \(r.payload) (confidence: \(String(format: "%.2f", r.confidence)))"
+                    }.joined(separator: "\n")
+                }
+
+            case "classify":
+                let result = try visionService.classifyImage(from: processPath, maxLabels: maxLabels)
+                if result.labels.isEmpty {
+                    output = "No classifications found."
+                } else if format == "json" {
+                    let items = result.labels.map { l in
+                        ["label": l.label, "confidence": String(format: "%.4f", l.confidence)]
+                    }
+                    let data = try JSONSerialization.data(withJSONObject: items, options: [.prettyPrinted])
+                    output = String(data: data, encoding: .utf8) ?? "[]"
+                } else {
+                    output = result.labels.map { l in
+                        "\(l.label): \(String(format: "%.4f", l.confidence))"
+                    }.joined(separator: "\n")
+                }
+
+            case "saliency":
+                let result = try visionService.detectSaliency(from: processPath, type: saliencyType, includeHeatMap: heatMap)
+                if result.regions.isEmpty {
+                    output = "No salient regions found."
+                } else {
+                    var lines = result.regions.map { r in
+                        let box = r.boundingBox
+                        return "\(r.type): x=\(String(format: "%.3f", box.origin.x)), y=\(String(format: "%.3f", box.origin.y)), w=\(String(format: "%.3f", box.width)), h=\(String(format: "%.3f", box.height))"
+                    }
+                    if let heatMapData = result.heatMapPNG {
+                        lines.append("heat_map_base64: \(heatMapData.base64EncodedString())")
+                    }
+                    output = lines.joined(separator: "\n")
+                }
+
+            case "auto":
+                var sections: [String] = []
+
+                let barcodes = try visionService.detectBarcodes(from: processPath, options: options)
+                if !barcodes.isEmpty {
+                    sections.append("=== Barcodes ===\n" + barcodes.map { "\($0.type): \($0.payload)" }.joined(separator: "\n"))
+                }
+
+                let classified = try visionService.classifyImage(from: processPath, maxLabels: maxLabels)
+                if !classified.labels.isEmpty {
+                    sections.append("=== Classifications ===\n" + classified.labels.map { "\($0.label): \(String(format: "%.4f", $0.confidence))" }.joined(separator: "\n"))
+                }
+
+                if #available(macOS 26.0, *) {
+                    let text = try await visionService.extractText(from: processPath, options: options)
+                    sections.append("=== Text ===\n" + text)
+                }
+
+                output = sections.isEmpty ? "No results found." : sections.joined(separator: "\n\n")
+
+            case "debug":
+                if #available(macOS 26.0, *) {
+                    output = try await visionService.debugRawDetection(from: processPath, options: options)
+                } else {
+                    throw VisionError.modeRequiresMacOS26("debug")
+                }
+
+            case "table":
+                if #available(macOS 26.0, *) {
+                    let tableResults = try await visionService.extractTables(from: processPath, options: options)
                     if verbose {
-                        var verboseOutput = "📄 File: \(resolvedPath)\n"
-                        verboseOutput += "🗂️  Found \(tableResults.count) table(s)\n\n"
-                        
-                        for (index, table) in tableResults.enumerated() {
-                            verboseOutput += "📊 Table \(index + 1):\n"
-                            verboseOutput += "Rows: \(table.rows.count), Columns: \(table.columnCount)\n"
-                            verboseOutput += "Confidence: \(String(format: "%.2f", table.averageConfidence))\n\n"
-                            verboseOutput += table.csvData
+                        var verboseOutput = "File: \(resolvedPath)\n"
+                        verboseOutput += "Found \(tableResults.count) table(s)\n\n"
+                        for (index, tbl) in tableResults.enumerated() {
+                            verboseOutput += "Table \(index + 1):\n"
+                            verboseOutput += "Rows: \(tbl.rows.count), Columns: \(tbl.columnCount)\n"
+                            verboseOutput += "Confidence: \(String(format: "%.2f", tbl.averageConfidence))\n\n"
+                            verboseOutput += tbl.csvData
                             if index < tableResults.count - 1 {
                                 verboseOutput += "\n" + String(repeating: "-", count: 50) + "\n\n"
                             }
                         }
-                        
                         output = verboseOutput
                     } else {
-                        // Simple CSV output with table headers
-                        let csvSections = tableResults.enumerated().map { (index, table) in
-                            let tableHeader = "Detected Table \(index + 1)"
-                            return tableHeader + "\n" + table.csvData
+                        let csvSections = tableResults.enumerated().map { (index, tbl) in
+                            "Detected Table \(index + 1)\n" + tbl.csvData
                         }
                         let csvOutput = csvSections.joined(separator: "\n")
                         output = csvOutput.isEmpty ? "No tables found in the document." : csvOutput
                     }
-                } else if verbose {
-                    // Get detailed results with confidence scores
-                    let visionResult = try await visionService.extractTextWithDetails(from: resolvedPath)
-                    var verboseOutput = "📄 File: \(visionResult.filePath)\n"
-                    verboseOutput += "📝 Text Content:\n\n"
-                    verboseOutput += visionResult.fullText
-                    verboseOutput += "\n\n📊 Details:\n"
-                    
-                    for (index, block) in visionResult.textBlocks.enumerated() {
-                        verboseOutput += "Block \(index + 1): \"\(block.text)\" (confidence: \(String(format: "%.2f", block.confidence)))\n"
-                    }
-                    
-                    output = verboseOutput
                 } else {
-                    // Simple text extraction
-                    output = try await visionService.extractText(from: resolvedPath)
+                    throw VisionError.modeRequiresMacOS26("table")
                 }
-                
-                print(output)
-            } else {
-                throw VisionError.textRecognitionFailed("Vision framework requires macOS 26.0 or later")
+
+            default:
+                // text mode (default)
+                if #available(macOS 26.0, *) {
+                    if verbose {
+                        let visionResult = try await visionService.extractTextWithDetails(from: processPath, options: options)
+                        var verboseOutput = "File: \(visionResult.filePath)\n"
+                        verboseOutput += "Text Content:\n\n"
+                        verboseOutput += visionResult.fullText
+                        verboseOutput += "\n\nDetails:\n"
+                        for (index, block) in visionResult.textBlocks.enumerated() {
+                            verboseOutput += "Block \(index + 1): \"\(block.text)\" (confidence: \(String(format: "%.2f", block.confidence)))\n"
+                        }
+                        output = verboseOutput
+                    } else {
+                        output = try await visionService.extractText(from: processPath, options: options)
+                    }
+                } else {
+                    throw VisionError.modeRequiresMacOS26("text")
+                }
             }
+
+            print(output)
         } catch {
             if let visionError = error as? VisionError {
                 print("Error: \(visionError.localizedDescription)")

--- a/Sources/MacLocalAPI/VisionCommand.swift
+++ b/Sources/MacLocalAPI/VisionCommand.swift
@@ -223,19 +223,31 @@ struct VisionCommand: ParsableCommand {
             case "auto":
                 var sections: [String] = []
 
-                let barcodes = try visionService.detectBarcodes(from: processPath, options: options)
-                if !barcodes.isEmpty {
-                    sections.append("=== Barcodes ===\n" + barcodes.map { "\($0.type): \($0.payload)" }.joined(separator: "\n"))
-                }
+                // Barcode and classify are image-only. Skip them for PDFs so
+                // `--mode auto` still runs OCR on documents.
+                let fileExt = URL(fileURLWithPath: processPath).pathExtension.lowercased()
+                let isImage = VisionService.imageOnlyExtensions.contains(fileExt)
 
-                let classified = try visionService.classifyImage(from: processPath, maxLabels: maxLabels)
-                if !classified.labels.isEmpty {
-                    sections.append("=== Classifications ===\n" + classified.labels.map { "\($0.label): \(String(format: "%.4f", $0.confidence))" }.joined(separator: "\n"))
+                if isImage {
+                    let barcodes = try visionService.detectBarcodes(from: processPath, options: options)
+                    if !barcodes.isEmpty {
+                        sections.append("=== Barcodes ===\n" + barcodes.map { "\($0.type): \($0.payload)" }.joined(separator: "\n"))
+                    }
+
+                    let classified = try visionService.classifyImage(from: processPath, maxLabels: maxLabels)
+                    if !classified.labels.isEmpty {
+                        sections.append("=== Classifications ===\n" + classified.labels.map { "\($0.label): \(String(format: "%.4f", $0.confidence))" }.joined(separator: "\n"))
+                    }
                 }
 
                 if #available(macOS 26.0, *) {
-                    let text = try await visionService.extractText(from: processPath, options: options)
-                    sections.append("=== Text ===\n" + text)
+                    do {
+                        let text = try await visionService.extractText(from: processPath, options: options)
+                        sections.append("=== Text ===\n" + text)
+                    } catch VisionError.noTextFound {
+                        // Auto mode: an image with no text is fine as long as
+                        // another submode produced something.
+                    }
                 }
 
                 output = sections.isEmpty ? "No results found." : sections.joined(separator: "\n\n")

--- a/Tests/MacLocalAPITests/VisionAPIControllerTests.swift
+++ b/Tests/MacLocalAPITests/VisionAPIControllerTests.swift
@@ -228,6 +228,26 @@ private final class FakeVisionService: VisionServing {
         if let debugError { throw debugError }
         return debugResult
     }
+
+    func detectBarcodes(from filePath: String, options: VisionRequestOptions) throws -> [BarcodeResult] {
+        lastPath = filePath
+        lastOptions = options
+        return []
+    }
+
+    func classifyImage(from filePath: String, maxLabels: Int) throws -> ClassifyResult {
+        lastPath = filePath
+        return ClassifyResult(labels: [], salientRegions: [])
+    }
+
+    func detectSaliency(from filePath: String, type: String, includeHeatMap: Bool) throws -> SaliencyResult {
+        lastPath = filePath
+        return SaliencyResult(regions: [], heatMapPNG: nil)
+    }
+
+    func autoCrop(imageData: Data) throws -> Data {
+        return imageData
+    }
 }
 
 private func makeVisionResult(filePath: String) -> VisionResult {


### PR DESCRIPTION
Closes #120

## Motivation

AFM already exposes OCR and describe from Apple's Vision framework, but the framework offers a lot more on-device — barcode/QR reading, classification, saliency. Leaving those out meant local agents that needed structured signal from an image still had to reach for a cloud API or a separate model. The whole point of AFM is that you don't have to. This closes the gap.

## Summary

- Add barcode scanning, image classification, and saliency detection modes to VisionService alongside existing OCR and describe
- Add `mode`, `detail`, `auto_crop`, `response_format` parameters to the vision API endpoint
- Add corresponding CLI flags: `afm vision --mode barcode|classify|saliency --detail high --auto-crop`
- All new modes run on-device via Apple Vision framework

## Test plan

- [x] `swift build` passes clean
- [x] 293/293 unit tests pass
- [x] `afm vision -f image.png --mode classify` returns classification labels with confidence scores (document: 0.73, screenshot: 0.73, chart: 0.19)
- [x] `afm vision -f image.png --mode barcode` runs and reports "No barcodes found" on non-barcode image (correct behavior)
- [x] `afm vision -f image.png --mode saliency` returns saliency region coordinates (attention: x=0.000, y=0.049, w=0.740, h=0.951)
- [x] `afm vision -f image.png --mode auto` runs all modes (classify + text + barcode) together
- [x] `afm vision -f image.png --mode text` existing OCR still works unchanged
- [x] `--detail low` and `--auto-crop` flags work correctly
- [x] `--format json` returns structured JSON output for classify mode
- [x] Unsupported file formats produce clear error message

---

*Authored by @jesserobbins, with Claude Code (Opus 4.7).*

## Summary by Sourcery

Extend the vision API and CLI to support multiple on-device analysis modes beyond OCR, including barcode scanning, image classification, saliency detection, and auto-cropping, while refining error handling and platform gating.

New Features:
- Add barcode detection, image classification, saliency detection, and auto mode to the vision HTTP API and underlying VisionService.
- Expose new vision modes, auto-cropping, and output format options through the afm vision CLI with dedicated flags and mode resolution logic.
- Support plain-text and JSON response formats for OCR and new modes, including structured responses for barcode, classify, saliency, and auto results.

Enhancements:
- Introduce centralized file validation with size-based limits and clearer file-too-large errors, replacing the previous request size error handling.
- Relax the macOS availability restriction on VisionService while adding explicit mode-level macOS 26 gating and error reporting.
- Improve CLI capability metadata and examples to reflect the expanded set of vision modes and use cases.

Tests:
- Extend the fake Vision service and tests to cover the new barcode, classify, saliency, and auto-crop pathways in the controller.