### PR TITLE
feat(embeddings): add /v1/embeddings backed by Apple NaturalLanguage

### DIFF
--- a/Sources/MacLocalAPI/Controllers/EmbeddingsController.swift
+++ b/Sources/MacLocalAPI/Controllers/EmbeddingsController.swift
@@ -30,7 +30,11 @@ struct EmbeddingsController: RouteCollection {
         // Advertise only the model this server actually loaded. Advertising the
         // full shipped-model list would cause 404s when clients discovered and
         // then requested an ID the running backend can't serve.
-        let model = EmbeddingModelInfo(id: modelEntry.id, ownedBy: "apple")
+        let model = EmbeddingModelInfo(
+            id: modelEntry.id,
+            created: modelEntry.createdEpoch,
+            ownedBy: "apple"
+        )
         let response = EmbeddingModelsResponse(data: [model])
         return try jsonResponse(for: response, request: req)
     }
@@ -58,7 +62,11 @@ struct EmbeddingsController: RouteCollection {
 
             let embedResult: EmbedResult
             if request.input.isTokenized {
-                embedResult = try await backend.embedTokenIDs(request.input.tokenIDArrays)
+                let tokenIDArrays = request.input.tokenIDArrays
+                if tokenIDArrays.contains(where: { $0.isEmpty }) {
+                    throw EmbeddingError.invalidInput("Token-id inputs must not be empty arrays")
+                }
+                embedResult = try await backend.embedTokenIDs(tokenIDArrays)
             } else {
                 embedResult = try await backend.embed(request.input.strings)
             }
@@ -147,9 +155,11 @@ struct EmbeddingsController: RouteCollection {
         let allowHeaders = requested.flatMap { $0.isEmpty ? nil : $0 } ?? Self.defaultAllowHeaders
         response.headers.replaceOrAdd(name: .accessControlAllowHeaders, value: allowHeaders)
         response.headers.replaceOrAdd(name: "Access-Control-Expose-Headers", value: "X-Embedding-Truncated")
-        // Intermediary caches must vary on these request headers so a preflight
-        // response computed for one client's header set is not served to another.
-        response.headers.replaceOrAdd(name: .vary, value: "Origin, Access-Control-Request-Headers")
+        // Intermediary caches must vary on the requested-headers list so a
+        // preflight response computed for one client's header set is not served
+        // to another. Origin is omitted because Access-Control-Allow-Origin is
+        // the wildcard `*`, which already implies the response is origin-agnostic.
+        response.headers.replaceOrAdd(name: .vary, value: "Access-Control-Request-Headers")
     }
 
     private static func describeDecodingError(_ error: DecodingError) -> String {
@@ -205,10 +215,10 @@ private struct EmbeddingModelInfo: Content {
         case ownedBy = "owned_by"
     }
 
-    init(id: String, ownedBy: String) {
+    init(id: String, created: Int, ownedBy: String) {
         self.id = id
         self.object = "model"
-        self.created = Int(Date().timeIntervalSince1970)
+        self.created = created
         self.ownedBy = ownedBy
     }
 }

--- a/Sources/MacLocalAPI/Controllers/EmbeddingsController.swift
+++ b/Sources/MacLocalAPI/Controllers/EmbeddingsController.swift
@@ -1,0 +1,214 @@
+import Vapor
+import Foundation
+
+struct EmbeddingsController: RouteCollection {
+    private static let maxRequestBodySize: ByteCount = "1mb"
+
+    private let modelEntry: EmbeddingModelEntry
+    private let backend: any EmbeddingBackend
+
+    init(modelEntry: EmbeddingModelEntry, backend: any EmbeddingBackend) {
+        self.modelEntry = modelEntry
+        self.backend = backend
+    }
+
+    func boot(routes: RoutesBuilder) throws {
+        let v1 = routes.grouped("v1")
+        v1.on(.POST, "embeddings", body: .collect(maxSize: Self.maxRequestBodySize), use: createEmbeddings)
+        v1.on(.OPTIONS, "embeddings", use: handleOptions)
+        v1.get("models", use: listModels)
+        v1.on(.OPTIONS, "models", use: handleOptions)
+    }
+
+    private func handleOptions(req: Request) async throws -> Response {
+        let response = Response(status: .ok)
+        applyCORSHeaders(to: response, for: req)
+        return response
+    }
+
+    private func listModels(req: Request) async throws -> Response {
+        // Advertise only the model this server actually loaded. Advertising the
+        // full shipped-model list would cause 404s when clients discovered and
+        // then requested an ID the running backend can't serve.
+        let model = EmbeddingModelInfo(id: modelEntry.id, ownedBy: "apple")
+        let response = EmbeddingModelsResponse(data: [model])
+        return try jsonResponse(for: response, request: req)
+    }
+
+    private func createEmbeddings(req: Request) async throws -> Response {
+        do {
+            let request = try req.content.decode(EmbeddingsRequest.self)
+            let requestedModelID = (request.model ?? modelEntry.id)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard requestedModelID == modelEntry.id else {
+                throw EmbeddingError.modelNotFound(requestedModelID)
+            }
+
+            if request.input.isEmpty {
+                throw EmbeddingError.invalidInput("Input must not be empty")
+            }
+
+            let nativeDimension = await backend.nativeDimension
+
+            if let dimensions = request.dimensions {
+                guard dimensions > 0, dimensions <= nativeDimension else {
+                    throw EmbeddingError.invalidDimensions(requested: dimensions, native: nativeDimension)
+                }
+            }
+
+            let embedResult: EmbedResult
+            if request.input.isTokenized {
+                embedResult = try await backend.embedTokenIDs(request.input.tokenIDArrays)
+            } else {
+                embedResult = try await backend.embed(request.input.strings)
+            }
+            let targetDimensions = request.dimensions ?? nativeDimension
+            let encodingFormat = request.resolvedEncodingFormat
+
+            for (index, vector) in embedResult.vectors.enumerated() where vector.count != nativeDimension {
+                req.logger.error(
+                    "Embeddings backend dimension drift: expected \(nativeDimension), got \(vector.count) at index \(index)"
+                )
+                throw EmbeddingError.internalFailure
+            }
+
+            let data = embedResult.vectors.enumerated().map { index, vector in
+                let outputVector = targetDimensions < vector.count
+                    ? EmbeddingMath.truncateAndNormalize(vector, dimensions: targetDimensions)
+                    : EmbeddingMath.l2Normalize(vector)
+                let payload: EmbeddingVectorPayload
+                switch encodingFormat {
+                case .float:
+                    payload = .float(outputVector)
+                case .base64:
+                    payload = .base64(EmbeddingEncoding.base64LittleEndian(from: outputVector))
+                }
+                return EmbeddingDataItem(index: index, embedding: payload)
+            }
+
+            let response = EmbeddingsResponse(
+                model: modelEntry.id,
+                data: data,
+                promptTokens: embedResult.tokenCounts.reduce(0, +)
+            )
+            let httpResponse = try jsonResponse(for: response, request: req)
+            if embedResult.truncatedInputCount > 0 {
+                httpResponse.headers.replaceOrAdd(
+                    name: "X-Embedding-Truncated",
+                    value: "\(embedResult.truncatedInputCount)"
+                )
+            }
+            return httpResponse
+        } catch let embeddingError as EmbeddingError {
+            return try errorResponse(for: embeddingError, request: req)
+        } catch let decodingError as DecodingError {
+            return try errorResponse(for: .invalidInput(Self.describeDecodingError(decodingError)), request: req)
+        } catch let abortError as AbortError where abortError.status.code >= 400 && abortError.status.code < 500 {
+            return try abortErrorResponse(for: abortError, request: req)
+        } catch {
+            req.logger.error("Embeddings request failed: \(String(reflecting: error))")
+            return try errorResponse(for: .internalFailure, request: req)
+        }
+    }
+
+    private func jsonResponse<T: Content>(for payload: T, request: Request) throws -> Response {
+        let response = Response(status: .ok)
+        response.headers.add(name: .contentType, value: "application/json")
+        applyCORSHeaders(to: response, for: request)
+        try response.content.encode(payload)
+        return response
+    }
+
+    private func errorResponse(for error: EmbeddingError, request: Request) throws -> Response {
+        let response = Response(status: Self.httpStatus(for: error))
+        response.headers.add(name: .contentType, value: "application/json")
+        applyCORSHeaders(to: response, for: request)
+        try response.content.encode(OpenAIError(message: error.localizedDescription, type: "embedding_error"))
+        return response
+    }
+
+    private func abortErrorResponse(for abortError: AbortError, request: Request) throws -> Response {
+        let response = Response(status: abortError.status)
+        response.headers.add(name: .contentType, value: "application/json")
+        applyCORSHeaders(to: response, for: request)
+        try response.content.encode(OpenAIError(message: abortError.reason, type: "embedding_error"))
+        return response
+    }
+
+    private static let defaultAllowHeaders = "Content-Type, Authorization, OpenAI-Organization, OpenAI-Project"
+
+    private func applyCORSHeaders(to response: Response, for request: Request) {
+        response.headers.replaceOrAdd(name: .accessControlAllowOrigin, value: "*")
+        response.headers.replaceOrAdd(name: .accessControlAllowMethods, value: "POST, GET, OPTIONS")
+        // Reflect the browser's preflight request-headers list (which can include
+        // SDK-specific headers like x-stainless-*) and fall back to a default set
+        // that covers the common OpenAI-compatible clients.
+        let requested = request.headers.first(name: "Access-Control-Request-Headers")
+        let allowHeaders = requested.flatMap { $0.isEmpty ? nil : $0 } ?? Self.defaultAllowHeaders
+        response.headers.replaceOrAdd(name: .accessControlAllowHeaders, value: allowHeaders)
+        response.headers.replaceOrAdd(name: "Access-Control-Expose-Headers", value: "X-Embedding-Truncated")
+        // Intermediary caches must vary on these request headers so a preflight
+        // response computed for one client's header set is not served to another.
+        response.headers.replaceOrAdd(name: .vary, value: "Origin, Access-Control-Request-Headers")
+    }
+
+    private static func describeDecodingError(_ error: DecodingError) -> String {
+        switch error {
+        case .dataCorrupted(let ctx):
+            return "Malformed request body: \(ctx.debugDescription)"
+        case .keyNotFound(let key, _):
+            return "Missing required field: \(key.stringValue)"
+        case .typeMismatch(_, let ctx), .valueNotFound(_, let ctx):
+            let path = ctx.codingPath.map(\.stringValue).joined(separator: ".")
+            return path.isEmpty
+                ? "Invalid field value: \(ctx.debugDescription)"
+                : "Invalid value for field '\(path)': \(ctx.debugDescription)"
+        @unknown default:
+            return "Malformed request body"
+        }
+    }
+
+    static func httpStatus(for error: EmbeddingError) -> HTTPStatus {
+        switch error {
+        case .modelNotFound:
+            return .notFound
+        case .invalidInput, .invalidDimensions, .tokenizationFailed:
+            return .badRequest
+        case .backendUnavailable, .assetDownloadRequired, .assetDownloadFailed:
+            return .serviceUnavailable
+        case .internalFailure:
+            return .internalServerError
+        }
+    }
+}
+
+private struct EmbeddingModelsResponse: Content {
+    let object: String
+    let data: [EmbeddingModelInfo]
+
+    init(data: [EmbeddingModelInfo]) {
+        self.object = "list"
+        self.data = data
+    }
+}
+
+private struct EmbeddingModelInfo: Content {
+    let id: String
+    let object: String
+    let created: Int
+    let ownedBy: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case object
+        case created
+        case ownedBy = "owned_by"
+    }
+
+    init(id: String, ownedBy: String) {
+        self.id = id
+        self.object = "model"
+        self.created = Int(Date().timeIntervalSince1970)
+        self.ownedBy = ownedBy
+    }
+}

--- a/Sources/MacLocalAPI/EmbeddingsCommand.swift
+++ b/Sources/MacLocalAPI/EmbeddingsCommand.swift
@@ -223,7 +223,7 @@ final class EmbeddingHTTPServer {
             HealthResponse(
                 status: "healthy",
                 timestamp: Date().timeIntervalSince1970,
-                version: "1.0.0"
+                version: BuildInfo.fullVersion
             )
         }
 

--- a/Sources/MacLocalAPI/EmbeddingsCommand.swift
+++ b/Sources/MacLocalAPI/EmbeddingsCommand.swift
@@ -1,0 +1,232 @@
+import ArgumentParser
+import Foundation
+import Logging
+import Vapor
+
+struct EmbeddingsPayloadTooLargeMiddleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        do {
+            return try await next.respond(to: request)
+        } catch let abort as Abort where abort.status == .payloadTooLarge {
+            let errorResponse = OpenAIError(
+                message: "Embeddings request body exceeds the configured size limit.",
+                type: "payload_too_large"
+            )
+            let response = Response(status: .payloadTooLarge)
+            response.headers.add(name: .contentType, value: "application/json")
+            response.headers.add(name: .accessControlAllowOrigin, value: "*")
+            try response.content.encode(errorResponse)
+            return response
+        }
+    }
+}
+
+private struct EmbeddingShutdownRequestedKey: StorageKey {
+    typealias Value = Bool
+}
+
+/// Installs async-signal-safe SIGINT/SIGTERM observers that drive `server.shutdown()`
+/// from a normal dispatch queue. The kernel signal delivery is captured by
+/// `DispatchSourceSignal`; the shutdown work runs on a Swift queue, so `print()`
+/// and reference-counted Swift state are safe to touch.
+///
+/// Returns an opaque handle that keeps the sources alive for the lifetime of
+/// the command run.
+@discardableResult
+private func installEmbeddingShutdownHandlers(for server: EmbeddingHTTPServer) -> [DispatchSourceSignal] {
+    let queue = DispatchQueue(label: "afm.embeddings.shutdown")
+    let sources = [SIGINT, SIGTERM].map { signo -> DispatchSourceSignal in
+        signal(signo, SIG_IGN)
+        let source = DispatchSource.makeSignalSource(signal: signo, queue: queue)
+        source.setEventHandler { [weak server] in
+            print("\n🛑 Received shutdown signal, shutting down embeddings server...")
+            server?.shutdown()
+        }
+        source.resume()
+        return source
+    }
+    return sources
+}
+
+struct EmbeddingsCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "embed",
+        abstract: "Serve OpenAI-compatible embeddings using Apple NaturalLanguage contextual embeddings"
+    )
+
+    private static let defaultPort = 9998
+    private static let defaultHostname = "127.0.0.1"
+
+    @ArgumentParser.Option(name: [.customShort("m"), .long], help: "Embedding model id")
+    var model: String = EmbeddingModelRegistry.defaultModelID
+
+    @ArgumentParser.Option(name: .shortAndLong, help: "Port to run the embeddings server on")
+    var port: Int = EmbeddingsCommand.defaultPort
+
+    @ArgumentParser.Option(name: [.customShort("H"), .long], help: "Hostname to bind server to")
+    var hostname: String = EmbeddingsCommand.defaultHostname
+
+    @ArgumentParser.Flag(name: .shortAndLong, help: "Enable verbose logging")
+    var verbose: Bool = false
+
+    @ArgumentParser.Flag(name: [.customShort("V"), .long], help: "Enable very verbose logging")
+    var veryVerbose: Bool = false
+
+    @ArgumentParser.Flag(name: .long, help: "List available embedding models and exit")
+    var listModels: Bool = false
+
+    func run() async throws {
+        let registry = EmbeddingModelRegistry()
+
+        if listModels {
+            for modelID in registry.listModelIDs() {
+                print(modelID)
+            }
+            return
+        }
+
+        guard let requestedEntry = registry.resolve(modelID: model) else {
+            throw ValidationError("Unknown embedding model: \(model)")
+        }
+
+        let nlBackend = try NLContextualEmbeddingBackend(modelID: requestedEntry.id)
+        try await nlBackend.prepare()
+        guard let resolvedEntry = registry.makeResolvedAppleEntry(
+            modelID: requestedEntry.id,
+            nativeDimension: nlBackend.nativeDimension,
+            maxInputTokens: nlBackend.maxInputTokens
+        ) else {
+            throw ValidationError("Failed to resolve Apple embedding metadata for \(requestedEntry.id)")
+        }
+
+        let server = try await EmbeddingHTTPServer(
+            port: port,
+            hostname: hostname,
+            verbose: verbose,
+            veryVerbose: veryVerbose,
+            modelEntry: resolvedEntry,
+            backend: nlBackend
+        )
+
+        let shutdownSources = installEmbeddingShutdownHandlers(for: server)
+        defer { shutdownSources.forEach { $0.cancel() } }
+
+        try await server.start()
+    }
+}
+
+final class EmbeddingHTTPServer {
+    private let app: Application
+    private let port: Int
+    private let hostname: String
+    private let modelEntry: EmbeddingModelEntry
+    private let backend: any EmbeddingBackend
+    private let shutdownLock = NSLock()
+
+    init(
+        port: Int,
+        hostname: String,
+        verbose: Bool,
+        veryVerbose: Bool,
+        modelEntry: EmbeddingModelEntry,
+        backend: any EmbeddingBackend
+    ) async throws {
+        self.port = port
+        self.hostname = hostname
+        self.modelEntry = modelEntry
+        self.backend = backend
+
+        let env = Environment(name: "development", arguments: ["afm", "embed"])
+        LoggingSystem.bootstrap { label in
+            CompactLogHandler(label: label)
+        }
+
+        self.app = try await Application.make(env)
+        if veryVerbose {
+            app.logger.logLevel = .trace
+        } else if verbose {
+            app.logger.logLevel = .debug
+        }
+
+        app.http.server.configuration.port = port
+        app.http.server.configuration.hostname = hostname
+        app.middleware.use(EmbeddingsPayloadTooLargeMiddleware())
+
+        try routes()
+    }
+
+    func start() async throws {
+        // A signal can arrive between installing the signal handlers and the
+        // server finishing bind. If shutdown() ran against an un-started
+        // server, its app.server.shutdown() was a no-op, so we need to either
+        // skip the bind entirely or tear it down right after it completes.
+        shutdownLock.lock()
+        let shutdownRequestedBeforeStart = app.storage[EmbeddingShutdownRequestedKey.self] == true
+        shutdownLock.unlock()
+
+        if shutdownRequestedBeforeStart {
+            print("Embeddings server shutdown requested before bind; skipping start.")
+            return
+        }
+
+        print("Starting embeddings server for \(modelEntry.id) on http://\(hostname):\(port)")
+        try await app.server.start(address: .hostname(hostname, port: port))
+
+        // Race window: a shutdown signal delivered between handler install and
+        // this point already marked the flag. The prior shutdown() call ran
+        // app.server.shutdown() on an un-started server (no-op), so tear down
+        // the freshly-bound listener here.
+        shutdownLock.lock()
+        let shutdownRequestedDuringStart = app.storage[EmbeddingShutdownRequestedKey.self] == true
+        shutdownLock.unlock()
+        if shutdownRequestedDuringStart {
+            print("Shutdown requested during start; shutting the just-bound server down.")
+            await app.server.shutdown()
+            return
+        }
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            shutdownLock.lock()
+            let alreadyRequested = app.storage[EmbeddingShutdownRequestedKey.self] == true
+            if !alreadyRequested {
+                app.storage[ContinuationKey.self] = continuation
+            }
+            shutdownLock.unlock()
+
+            if alreadyRequested {
+                continuation.resume()
+            }
+        }
+    }
+
+    func shutdown() {
+        shutdownLock.lock()
+        if app.storage[EmbeddingShutdownRequestedKey.self] == true {
+            shutdownLock.unlock()
+            return
+        }
+        app.storage[EmbeddingShutdownRequestedKey.self] = true
+        let continuation = app.storage[ContinuationKey.self]
+        app.storage[ContinuationKey.self] = nil
+        shutdownLock.unlock()
+
+        Task {
+            await app.server.shutdown()
+            // If start() hadn't registered its continuation yet, its re-entry
+            // path will resume itself after seeing the flag was set.
+            continuation?.resume()
+        }
+    }
+
+    private func routes() throws {
+        app.get("health") { _ async -> HealthResponse in
+            HealthResponse(
+                status: "healthy",
+                timestamp: Date().timeIntervalSince1970,
+                version: "1.0.0"
+            )
+        }
+
+        try app.register(collection: EmbeddingsController(modelEntry: modelEntry, backend: backend))
+    }
+}

--- a/Sources/MacLocalAPI/Models/EmbeddingBackend.swift
+++ b/Sources/MacLocalAPI/Models/EmbeddingBackend.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// A local embedding backend.
+///
+/// Conformers must guarantee that `nativeDimension` is finalized by the time
+/// the backend is handed to an `EmbeddingsController` (i.e. any framework
+/// loading required to know the dimension has already run during setup).
+/// The controller relies on this when validating the `dimensions` request
+/// parameter before calling `embed` / `embedTokenIDs`.
+protocol EmbeddingBackend: Actor {
+    var modelID: String { get }
+    var nativeDimension: Int { get }
+    var maxInputTokens: Int { get }
+
+    func embed(_ inputs: [String]) async throws -> EmbedResult
+    func embedTokenIDs(_ inputs: [[Int]]) async throws -> EmbedResult
+}
+
+struct EmbedResult: Sendable {
+    let vectors: [[Float]]
+    let tokenCounts: [Int]
+    let truncatedInputCount: Int
+
+    init(vectors: [[Float]], tokenCounts: [Int], truncatedInputCount: Int = 0) {
+        self.vectors = vectors
+        self.tokenCounts = tokenCounts
+        self.truncatedInputCount = truncatedInputCount
+    }
+}
+
+struct EmbeddingModelEntry: Sendable {
+    let id: String
+    let backend: EmbeddingBackendKind
+    let nativeDimension: Int
+    let supportsMatryoshka: Bool
+    let pooling: PoolingKind
+    let normalized: Bool
+    let maxInputTokens: Int
+    let description: String
+}
+
+enum EmbeddingBackendKind: String, Sendable {
+    case nlContextual
+}
+
+enum PoolingKind: String, Sendable {
+    case mean
+    case cls
+    case lastToken
+}
+
+enum EmbeddingError: Error, Sendable {
+    case modelNotFound(String)
+    case invalidInput(String)
+    case invalidDimensions(requested: Int, native: Int)
+    case backendUnavailable(id: String, reason: String)
+    case assetDownloadRequired(String)
+    case assetDownloadFailed(id: String, reason: String)
+    case tokenizationFailed(String)
+    case internalFailure
+}
+
+extension EmbeddingError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .modelNotFound(let id):
+            return "Embedding model not found: \(id)"
+        case .invalidInput(let reason):
+            return "Invalid embedding input: \(reason)"
+        case .invalidDimensions(let requested, let native):
+            return "Invalid dimensions \(requested); expected a value between 1 and \(native)"
+        case .backendUnavailable(let id, let reason):
+            return "Embedding backend unavailable for \(id): \(reason)"
+        case .assetDownloadRequired(let id):
+            return "Embedding assets are required for \(id)"
+        case .assetDownloadFailed(let id, let reason):
+            return "Embedding asset download failed for \(id): \(reason)"
+        case .tokenizationFailed(let reason):
+            return "Embedding tokenization failed: \(reason)"
+        case .internalFailure:
+            return "Internal embedding failure"
+        }
+    }
+}
+
+enum EmbeddingMath {
+    static let zeroThreshold: Float = 1e-12
+
+    static func l2Normalize(_ vector: [Float]) -> [Float] {
+        let sumSquares = vector.reduce(Float.zero) { partialResult, value in
+            partialResult + (value * value)
+        }
+
+        guard sumSquares > zeroThreshold else {
+            return vector
+        }
+
+        let norm = Foundation.sqrt(sumSquares)
+        return vector.map { $0 / norm }
+    }
+
+    static func truncateAndNormalize(_ vector: [Float], dimensions: Int) -> [Float] {
+        precondition(dimensions > 0, "truncateAndNormalize requires dimensions > 0")
+
+        guard dimensions < vector.count else {
+            return l2Normalize(vector)
+        }
+
+        return l2Normalize(Array(vector.prefix(dimensions)))
+    }
+}
+
+enum EmbeddingEncoding {
+    static func base64LittleEndian(from vector: [Float]) -> String {
+        var data = Data(capacity: vector.count * MemoryLayout<Float>.size)
+
+        for value in vector {
+            var littleEndianValue = value.bitPattern.littleEndian
+            withUnsafeBytes(of: &littleEndianValue) { rawBuffer in
+                data.append(contentsOf: rawBuffer)
+            }
+        }
+
+        return data.base64EncodedString()
+    }
+}

--- a/Sources/MacLocalAPI/Models/EmbeddingBackend.swift
+++ b/Sources/MacLocalAPI/Models/EmbeddingBackend.swift
@@ -37,6 +37,11 @@ struct EmbeddingModelEntry: Sendable {
     let normalized: Bool
     let maxInputTokens: Int
     let description: String
+    /// Stable Unix epoch for the `created` field in OpenAI's /v1/models shape.
+    /// Per-model constants keep the response idempotent — the same GET returns
+    /// the same value across process restarts, which is what the OpenAI spec
+    /// implies for a model's intrinsic create time.
+    let createdEpoch: Int
 }
 
 enum EmbeddingBackendKind: String, Sendable {

--- a/Sources/MacLocalAPI/Models/EmbeddingModelRegistry.swift
+++ b/Sources/MacLocalAPI/Models/EmbeddingModelRegistry.swift
@@ -49,9 +49,16 @@ struct EmbeddingModelRegistry {
             pooling: shippedEntry.pooling,
             normalized: shippedEntry.normalized,
             maxInputTokens: maxInputTokens,
-            description: shippedEntry.description
+            description: shippedEntry.description,
+            createdEpoch: shippedEntry.createdEpoch
         )
     }
+
+    // macOS 14.0 release date — NLContextualEmbedding shipped with Sonoma and
+    // has been surface-compatible since then. Using the OS GA as the model's
+    // "created" time gives /v1/models a stable, documented value without
+    // having to track per-macOS-version differences.
+    private static let macOS14ReleaseEpoch = 1_695_686_400 // 2023-09-26 UTC
 
     private static func makeAppleEntry(id: String, description: String) -> EmbeddingModelEntry {
         EmbeddingModelEntry(
@@ -62,7 +69,8 @@ struct EmbeddingModelRegistry {
             pooling: .mean,
             normalized: true,
             maxInputTokens: runtimeResolvedMaxInputTokens,
-            description: description
+            description: description,
+            createdEpoch: macOS14ReleaseEpoch
         )
     }
 }

--- a/Sources/MacLocalAPI/Models/EmbeddingModelRegistry.swift
+++ b/Sources/MacLocalAPI/Models/EmbeddingModelRegistry.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+struct EmbeddingModelRegistry {
+    static let defaultModelID = "apple-nl-contextual-en"
+    static let multilingualModelID = "apple-nl-contextual-multi"
+
+    // Apple NL metadata is finalized at backend-load time. These sentinel values
+    // let the registry enumerate shipped model IDs before the backend exists.
+    private static let runtimeResolvedDimension = 0
+    private static let runtimeResolvedMaxInputTokens = 0
+
+    func shippedModels() -> [EmbeddingModelEntry] {
+        [
+            Self.makeAppleEntry(
+                id: Self.defaultModelID,
+                description: "Apple Natural Language contextual embeddings (English)"
+            ),
+            Self.makeAppleEntry(
+                id: Self.multilingualModelID,
+                description: "Apple Natural Language contextual embeddings (Latin-script multilingual)"
+            ),
+        ]
+    }
+
+    func listModelIDs() -> [String] {
+        shippedModels().map(\.id).sorted()
+    }
+
+    func resolve(modelID: String) -> EmbeddingModelEntry? {
+        let trimmedModelID = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedModelID.isEmpty else {
+            return nil
+        }
+
+        return shippedModels().first(where: { $0.id == trimmedModelID })
+    }
+
+    func makeResolvedAppleEntry(modelID: String, nativeDimension: Int, maxInputTokens: Int) -> EmbeddingModelEntry? {
+        let trimmedModelID = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let shippedEntry = shippedModels().first(where: { $0.id == trimmedModelID }) else {
+            return nil
+        }
+
+        return EmbeddingModelEntry(
+            id: shippedEntry.id,
+            backend: shippedEntry.backend,
+            nativeDimension: nativeDimension,
+            supportsMatryoshka: shippedEntry.supportsMatryoshka,
+            pooling: shippedEntry.pooling,
+            normalized: shippedEntry.normalized,
+            maxInputTokens: maxInputTokens,
+            description: shippedEntry.description
+        )
+    }
+
+    private static func makeAppleEntry(id: String, description: String) -> EmbeddingModelEntry {
+        EmbeddingModelEntry(
+            id: id,
+            backend: .nlContextual,
+            nativeDimension: runtimeResolvedDimension,
+            supportsMatryoshka: false,
+            pooling: .mean,
+            normalized: true,
+            maxInputTokens: runtimeResolvedMaxInputTokens,
+            description: description
+        )
+    }
+}

--- a/Sources/MacLocalAPI/Models/NLContextualEmbeddingBackend.swift
+++ b/Sources/MacLocalAPI/Models/NLContextualEmbeddingBackend.swift
@@ -1,0 +1,167 @@
+import Foundation
+import NaturalLanguage
+
+actor NLContextualEmbeddingBackend: EmbeddingBackend {
+    private static let multilingualScript = NLScript.latin
+
+    let modelID: String
+    let nativeDimension: Int
+    let maxInputTokens: Int
+
+    private let embedding: NLContextualEmbedding
+    private let language: NLLanguage?
+    private var isLoaded = false
+
+    init(modelID: String) throws {
+        guard let selection = Self.selection(for: modelID) else {
+            throw EmbeddingError.modelNotFound(modelID)
+        }
+
+        self.modelID = modelID
+        self.embedding = selection.embedding
+        self.language = selection.language
+        self.nativeDimension = Int(selection.embedding.dimension)
+        self.maxInputTokens = Int(selection.embedding.maximumSequenceLength)
+    }
+
+    func prepare() async throws {
+        if isLoaded {
+            return
+        }
+        try await ensureAssetsAvailable()
+        try loadIfNeeded()
+    }
+
+    func embed(_ inputs: [String]) async throws -> EmbedResult {
+        guard !inputs.isEmpty else {
+            throw EmbeddingError.invalidInput("At least one input is required")
+        }
+
+        try await prepare()
+
+        var vectors: [[Float]] = []
+        var tokenCounts: [Int] = []
+
+        for input in inputs {
+            guard !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw EmbeddingError.invalidInput("Input strings must not be empty or whitespace-only")
+            }
+
+            let result: NLContextualEmbeddingResult
+            do {
+                result = try embedding.embeddingResult(for: input, language: language)
+            } catch let embeddingError as EmbeddingError {
+                throw embeddingError
+            } catch {
+                throw EmbeddingError.backendUnavailable(
+                    id: modelID,
+                    reason: error.localizedDescription
+                )
+            }
+
+            tokenCounts.append(Int(result.sequenceLength))
+            vectors.append(try poolMeanNormalized(result: result))
+        }
+
+        return EmbedResult(vectors: vectors, tokenCounts: tokenCounts)
+    }
+
+    func embedTokenIDs(_ inputs: [[Int]]) async throws -> EmbedResult {
+        guard !inputs.isEmpty else {
+            throw EmbeddingError.invalidInput("At least one token-id input is required")
+        }
+        throw EmbeddingError.invalidInput("Pre-tokenized input is not supported by Apple NL embeddings")
+    }
+
+    private func ensureAssetsAvailable() async throws {
+        guard !embedding.hasAvailableAssets else {
+            return
+        }
+
+        print("[Embeddings] Requesting Apple NL assets for \(modelID)...")
+
+        do {
+            let result = try await embedding.requestAssets()
+            switch result {
+            case .available:
+                print("[Embeddings] Apple NL assets ready for \(modelID).")
+            case .notAvailable:
+                throw EmbeddingError.assetDownloadFailed(
+                    id: modelID,
+                    reason: "Assets were not available for download"
+                )
+            case .error:
+                throw EmbeddingError.assetDownloadFailed(
+                    id: modelID,
+                    reason: "The NaturalLanguage framework reported an asset download error"
+                )
+            @unknown default:
+                throw EmbeddingError.assetDownloadFailed(
+                    id: modelID,
+                    reason: "The NaturalLanguage framework returned an unknown asset result"
+                )
+            }
+        } catch let embeddingError as EmbeddingError {
+            throw embeddingError
+        } catch {
+            throw EmbeddingError.assetDownloadFailed(id: modelID, reason: error.localizedDescription)
+        }
+    }
+
+    private func loadIfNeeded() throws {
+        guard !isLoaded else {
+            return
+        }
+
+        do {
+            try embedding.load()
+            isLoaded = true
+        } catch {
+            throw EmbeddingError.backendUnavailable(id: modelID, reason: error.localizedDescription)
+        }
+    }
+
+    private func poolMeanNormalized(result: NLContextualEmbeddingResult) throws -> [Float] {
+        var sum = Array(repeating: Float.zero, count: nativeDimension)
+        var tokenCount = 0
+        let fullRange = result.string.startIndex..<result.string.endIndex
+
+        result.enumerateTokenVectors(in: fullRange) { tokenVector, _ in
+            guard tokenVector.count == self.nativeDimension else {
+                return true
+            }
+
+            for (index, value) in tokenVector.enumerated() {
+                sum[index] += Float(value)
+            }
+
+            tokenCount += 1
+            return true
+        }
+
+        guard tokenCount > 0 else {
+            throw EmbeddingError.internalFailure
+        }
+
+        let scale = Float(tokenCount)
+        let mean = sum.map { $0 / scale }
+        return EmbeddingMath.l2Normalize(mean)
+    }
+
+    private static func selection(for modelID: String) -> (embedding: NLContextualEmbedding, language: NLLanguage?)? {
+        switch modelID {
+        case EmbeddingModelRegistry.defaultModelID:
+            guard let embedding = NLContextualEmbedding(language: NLLanguage.english) else {
+                return nil
+            }
+            return (embedding, NLLanguage.english)
+        case EmbeddingModelRegistry.multilingualModelID:
+            guard let embedding = NLContextualEmbedding(script: multilingualScript) else {
+                return nil
+            }
+            return (embedding, nil)
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/MacLocalAPI/Models/NLContextualEmbeddingBackend.swift
+++ b/Sources/MacLocalAPI/Models/NLContextualEmbeddingBackend.swift
@@ -41,6 +41,7 @@ actor NLContextualEmbeddingBackend: EmbeddingBackend {
 
         var vectors: [[Float]] = []
         var tokenCounts: [Int] = []
+        var truncatedInputCount = 0
 
         for input in inputs {
             guard !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -59,11 +60,25 @@ actor NLContextualEmbeddingBackend: EmbeddingBackend {
                 )
             }
 
-            tokenCounts.append(Int(result.sequenceLength))
+            let sequenceLength = Int(result.sequenceLength)
+            tokenCounts.append(sequenceLength)
+            // NLContextualEmbedding silently truncates inputs to maximumSequenceLength.
+            // When the returned sequence length equals the backend cap, treat it as
+            // truncated so clients get an X-Embedding-Truncated signal. This over-
+            // counts inputs that happen to land exactly at the cap, but under-
+            // counting (the previous behavior — always 0) is worse for the
+            // long-document workflows this header exists for.
+            if sequenceLength >= maxInputTokens {
+                truncatedInputCount += 1
+            }
             vectors.append(try poolMeanNormalized(result: result))
         }
 
-        return EmbedResult(vectors: vectors, tokenCounts: tokenCounts)
+        return EmbedResult(
+            vectors: vectors,
+            tokenCounts: tokenCounts,
+            truncatedInputCount: truncatedInputCount
+        )
     }
 
     func embedTokenIDs(_ inputs: [[Int]]) async throws -> EmbedResult {

--- a/Sources/MacLocalAPI/Models/OpenAIRequest.swift
+++ b/Sources/MacLocalAPI/Models/OpenAIRequest.swift
@@ -460,3 +460,113 @@ struct BatchInputLine: Codable {
         case method, url, body
     }
 }
+
+// MARK: - Embeddings API Types
+
+enum EmbeddingInput: Content {
+    case string(String)
+    case array([String])
+    case tokenIDs([Int])
+    case arrayTokenIDs([[Int]])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let array = try? container.decode([String].self) {
+            self = .array(array)
+        } else if let tokenIDs = try? container.decode([Int].self) {
+            self = .tokenIDs(tokenIDs)
+        } else if let arrayTokenIDs = try? container.decode([[Int]].self) {
+            self = .arrayTokenIDs(arrayTokenIDs)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Embedding input must be a string, array of strings, array of token ids, or array of token-id arrays"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let string):
+            try container.encode(string)
+        case .array(let array):
+            try container.encode(array)
+        case .tokenIDs(let tokenIDs):
+            try container.encode(tokenIDs)
+        case .arrayTokenIDs(let arrayTokenIDs):
+            try container.encode(arrayTokenIDs)
+        }
+    }
+
+    var strings: [String] {
+        switch self {
+        case .string(let string):
+            return [string]
+        case .array(let array):
+            return array
+        case .tokenIDs, .arrayTokenIDs:
+            return []
+        }
+    }
+
+    var tokenIDArrays: [[Int]] {
+        switch self {
+        case .string, .array:
+            return []
+        case .tokenIDs(let tokenIDs):
+            return [tokenIDs]
+        case .arrayTokenIDs(let arrayTokenIDs):
+            return arrayTokenIDs
+        }
+    }
+
+    var isEmpty: Bool {
+        switch self {
+        case .string(let string):
+            return string.isEmpty
+        case .array(let array):
+            return array.isEmpty
+        case .tokenIDs(let tokenIDs):
+            return tokenIDs.isEmpty
+        case .arrayTokenIDs(let arrayTokenIDs):
+            return arrayTokenIDs.isEmpty
+        }
+    }
+
+    var isTokenized: Bool {
+        switch self {
+        case .tokenIDs, .arrayTokenIDs:
+            return true
+        case .string, .array:
+            return false
+        }
+    }
+}
+
+enum EmbeddingEncodingFormat: String, Content {
+    case float
+    case base64
+}
+
+struct EmbeddingsRequest: Content {
+    let input: EmbeddingInput
+    let model: String?
+    let encodingFormat: EmbeddingEncodingFormat?
+    let dimensions: Int?
+    let user: String?
+
+    enum CodingKeys: String, CodingKey {
+        case input
+        case model
+        case encodingFormat = "encoding_format"
+        case dimensions
+        case user
+    }
+
+    var resolvedEncodingFormat: EmbeddingEncodingFormat {
+        encodingFormat ?? .float
+    }
+}

--- a/Sources/MacLocalAPI/Models/OpenAIResponse.swift
+++ b/Sources/MacLocalAPI/Models/OpenAIResponse.swift
@@ -665,3 +665,75 @@ struct BatchListResponse: Content {
         self.hasMore = false
     }
 }
+
+// MARK: - Embeddings API Response Types
+
+enum EmbeddingVectorPayload: Content {
+    case float([Float])
+    case base64(String)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let floatVector = try? container.decode([Float].self) {
+            self = .float(floatVector)
+        } else if let base64 = try? container.decode(String.self) {
+            self = .base64(base64)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Embedding payload must be a float array or base64 string"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .float(let vector):
+            try container.encode(vector)
+        case .base64(let string):
+            try container.encode(string)
+        }
+    }
+}
+
+struct EmbeddingDataItem: Content {
+    let object: String
+    let index: Int
+    let embedding: EmbeddingVectorPayload
+
+    init(index: Int, embedding: EmbeddingVectorPayload) {
+        self.object = "embedding"
+        self.index = index
+        self.embedding = embedding
+    }
+}
+
+/// Usage accounting for the /v1/embeddings endpoint.
+///
+/// Scoped separately from the chat `Usage` struct so the Apple-only embeddings
+/// path does not pull in `MLXMetalLibrary.ensureAvailable()`, which mutates the
+/// process working directory when it initializes the MLX Metal library.
+struct EmbeddingsUsage: Content {
+    let promptTokens: Int
+    let totalTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case promptTokens = "prompt_tokens"
+        case totalTokens = "total_tokens"
+    }
+}
+
+struct EmbeddingsResponse: Content {
+    let object: String
+    let data: [EmbeddingDataItem]
+    let model: String
+    let usage: EmbeddingsUsage
+
+    init(model: String, data: [EmbeddingDataItem], promptTokens: Int) {
+        self.object = "list"
+        self.data = data
+        self.model = model
+        self.usage = EmbeddingsUsage(promptTokens: promptTokens, totalTokens: promptTokens)
+    }
+}

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -1246,7 +1246,7 @@ struct RootCommand: ParsableCommand {
         GitHub: https://github.com/scouzi1966/maclocal-api
         """,
         version: MacLocalAPI.buildVersion,
-        subcommands: [MlxCommand.self, VisionCommand.self, SpeechCommand.self]
+        subcommands: [MlxCommand.self, VisionCommand.self, SpeechCommand.self, EmbeddingsCommand.self]
     )
 
     @Option(name: [.customShort("s"), .long], help: "Run a single prompt without starting the server")
@@ -1427,6 +1427,28 @@ if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "mlx" {
         }
     } catch {
         VisionCommand.exit(withError: error)
+    }
+} else if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "embed" {
+    let args = Array(CommandLine.arguments.dropFirst(2))
+    do {
+        let cmd = try EmbeddingsCommand.parse(args)
+        let group = DispatchGroup()
+        var caughtError: Error?
+        group.enter()
+        Task {
+            do {
+                try await cmd.run()
+            } catch {
+                caughtError = error
+            }
+            group.leave()
+        }
+        group.wait()
+        if let error = caughtError {
+            throw error
+        }
+    } catch {
+        EmbeddingsCommand.exit(withError: error)
     }
 } else {
     RootCommand.main()

--- a/Tests/MacLocalAPITests/EmbeddingModelRegistryTests.swift
+++ b/Tests/MacLocalAPITests/EmbeddingModelRegistryTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+@testable import MacLocalAPI
+
+final class EmbeddingModelRegistryTests: XCTestCase {
+    func testAppleEntriesResolve() {
+        let registry = EmbeddingModelRegistry()
+
+        let english = registry.resolve(modelID: EmbeddingModelRegistry.defaultModelID)
+        let multilingual = registry.resolve(modelID: EmbeddingModelRegistry.multilingualModelID)
+
+        XCTAssertEqual(english?.id, EmbeddingModelRegistry.defaultModelID)
+        XCTAssertEqual(english?.backend, .nlContextual)
+        XCTAssertEqual(multilingual?.id, EmbeddingModelRegistry.multilingualModelID)
+        XCTAssertEqual(multilingual?.backend, .nlContextual)
+    }
+
+    func testUnknownModelReturnsNil() {
+        let registry = EmbeddingModelRegistry()
+
+        let entry = registry.resolve(modelID: "unknown-model")
+
+        XCTAssertNil(entry)
+    }
+
+    func testWhitespaceModelIDReturnsNil() {
+        let registry = EmbeddingModelRegistry()
+
+        XCTAssertNil(registry.resolve(modelID: ""))
+        XCTAssertNil(registry.resolve(modelID: "   "))
+    }
+}

--- a/Tests/MacLocalAPITests/EmbeddingsControllerTests.swift
+++ b/Tests/MacLocalAPITests/EmbeddingsControllerTests.swift
@@ -1,0 +1,500 @@
+import XCTest
+import Vapor
+import XCTVapor
+
+@testable import MacLocalAPI
+
+final class EmbeddingsControllerTests: XCTestCase {
+    private var app: Application!
+
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
+    func testSingleStringInputReturnsOpenAIShape() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 3,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 2, 3]], tokenCounts: [4])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input":"hello world","model":"apple-nl-contextual-en"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .ok)
+            do {
+                let decoded = try Self.decodeEmbeddingsResponse(response.body.string)
+                XCTAssertEqual(decoded.object, "list")
+                XCTAssertEqual(decoded.usage.promptTokens, 4)
+                XCTAssertEqual(decoded.data.count, 1)
+                let vector = decoded.data.first?.embedding ?? []
+                Self.assertApproximatelyEqual(vector, [0.26726124, 0.5345225, 0.8017837])
+            } catch {
+                XCTFail("failed to decode response: \(error)\nbody: \(response.body.string)")
+            }
+        }
+    }
+
+    func testArrayInputReturnsOneEmbeddingPerInput() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0], [0, 1]], tokenCounts: [2, 3])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input":["a","b"],"model":"apple-nl-contextual-en"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertContains(response.body.string, #""index":0"#)
+            XCTAssertContains(response.body.string, #""index":1"#)
+            XCTAssertContains(response.body.string, #""total_tokens":5"#)
+        }
+    }
+
+    func testBase64EncodingReturnsStringPayload() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input":"hi","model":"apple-nl-contextual-en","encoding_format":"base64"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertContains(response.body.string, #""embedding":"AACAPwAAAAA=""#)
+        }
+    }
+
+    func testDimensionsTruncateAndRenormalize() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 3,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[3, 4, 12]], tokenCounts: [3])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input":"hi","model":"apple-nl-contextual-en","dimensions":2}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .ok)
+            do {
+                let decoded = try Self.decodeEmbeddingsResponse(response.body.string)
+                let vector = decoded.data.first?.embedding ?? []
+                Self.assertApproximatelyEqual(vector, [0.6, 0.8])
+            } catch {
+                XCTFail("failed to decode response: \(error)\nbody: \(response.body.string)")
+            }
+        }
+    }
+
+    func testDimensionsAboveNativeReturn400() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input":"hi","model":"apple-nl-contextual-en","dimensions":3}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+        }
+    }
+
+    func testUnknownModelReturns404() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input":"hi","model":"other-model"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .notFound)
+        }
+    }
+
+    func testMissingInputFieldReturns400() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"model":"apple-nl-contextual-en"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            XCTAssertContains(response.body.string, "input")
+        }
+    }
+
+    func testUnknownEncodingFormatReturns400() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input":"hi","model":"apple-nl-contextual-en","encoding_format":"bogus"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+        }
+    }
+
+    func testMalformedJSONBodyReturns400() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input": "hi", "#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+        }
+    }
+
+    func testEmptyInputReturns400() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input":"","model":"apple-nl-contextual-en"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+        }
+    }
+
+    func testListModelsReturnsOnlyLoadedModel() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        try await app.testable(method: .running(port: 0)).test(.GET, "/v1/models") { response async in
+            XCTAssertEqual(response.status, .ok)
+            struct ModelsPayload: Decodable {
+                struct Entry: Decodable { let id: String }
+                let object: String
+                let data: [Entry]
+            }
+            do {
+                let decoded = try JSONDecoder().decode(ModelsPayload.self, from: Data(response.body.readableBytesView))
+                XCTAssertEqual(decoded.object, "list")
+                XCTAssertEqual(decoded.data.map(\.id), ["apple-nl-contextual-en"])
+            } catch {
+                XCTFail("failed to decode /v1/models: \(error)\nbody: \(response.body.string)")
+            }
+        }
+    }
+
+    func testCORSPreflightReflectsRequestedHeaders() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.add(name: "Origin", value: "https://example.com")
+        headers.add(name: "Access-Control-Request-Method", value: "POST")
+        headers.add(name: "Access-Control-Request-Headers", value: "Content-Type, Authorization, x-stainless-arch, OpenAI-Organization")
+
+        try await app.testable(method: .running(port: 0)).test(.OPTIONS, "/v1/embeddings", headers: headers) { response async in
+            XCTAssertEqual(response.status, .ok)
+            let allow = response.headers.first(name: .accessControlAllowHeaders) ?? ""
+            XCTAssertContains(allow, "x-stainless-arch")
+            XCTAssertContains(allow, "OpenAI-Organization")
+        }
+    }
+
+    func testUnsupportedMediaTypePreservesStatus() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.add(name: .contentType, value: "application/x-not-a-real-type")
+        let body = ByteBuffer(string: #"{"input":"hi","model":"apple-nl-contextual-en"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .unsupportedMediaType)
+            struct ErrorPayload: Decodable {
+                struct Inner: Decodable { let message: String; let type: String }
+                let error: Inner
+            }
+            do {
+                let decoded = try JSONDecoder().decode(ErrorPayload.self, from: Data(response.body.readableBytesView))
+                XCTAssertEqual(decoded.error.type, "embedding_error")
+                XCTAssertFalse(decoded.error.message.isEmpty)
+            } catch {
+                XCTFail("failed to decode 415 error body: \(error)\nbody: \(response.body.string)")
+            }
+        }
+    }
+
+    func testCORSPreflightOnModelsReturns200WithHeaders() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.add(name: "Origin", value: "https://example.com")
+        headers.add(name: "Access-Control-Request-Method", value: "GET")
+        headers.add(name: "Access-Control-Request-Headers", value: "Authorization")
+
+        try await app.testable(method: .running(port: 0)).test(.OPTIONS, "/v1/models", headers: headers) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertEqual(response.headers.first(name: .accessControlAllowOrigin), "*")
+            XCTAssertContains(response.headers.first(name: .accessControlAllowMethods) ?? "", "GET")
+            XCTAssertContains(response.headers.first(name: .accessControlAllowHeaders) ?? "", "Authorization")
+        }
+    }
+
+    func testOversizedPayloadReturnsEmbeddingsSpecificError() async throws {
+        app.middleware.use(EmbeddingsPayloadTooLargeMiddleware())
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let oversized = String(repeating: "a", count: 2 * 1024 * 1024)
+        let body = ByteBuffer(string: #"{"input":""# + oversized + #"","model":"apple-nl-contextual-en"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .payloadTooLarge)
+            XCTAssertContains(response.body.string, "Embeddings request body")
+            XCTAssertFalse(response.body.string.contains("conversation"))
+        }
+    }
+
+    func testTruncationHeaderIsReturned() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1], truncatedInputCount: 1)
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input":"hi","model":"apple-nl-contextual-en"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertEqual(response.headers.first(name: "X-Embedding-Truncated"), "1")
+        }
+    }
+
+    // Routing contract: a tokenized request reaches the backend's
+    // `embedTokenIDs` path. Backends that do not support token-ID input
+    // (e.g. the Apple NL backend) are expected to reject this at their own
+    // layer; see `testTokenArrayInputRejectedByAppleLikeBackend` below.
+    func testTokenArrayInputRoutesToTokenizedBackendPath() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [3])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input":[1,2,3],"model":"apple-nl-contextual-en"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .ok)
+            let lastTokenIDs = await backend.lastTokenIDInputs
+            XCTAssertEqual(lastTokenIDs, [[1, 2, 3]])
+        }
+    }
+
+    func testTokenArrayInputRejectedByAppleLikeBackend() async throws {
+        let backend = TokenIDsNotSupportedBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input":[1,2,3],"model":"apple-nl-contextual-en"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            XCTAssertContains(response.body.string, "Pre-tokenized input is not supported")
+        }
+    }
+
+    private struct DecodedResponse: Decodable {
+        struct Datum: Decodable {
+            let index: Int
+            let embedding: [Float]
+        }
+        struct Usage: Decodable {
+            let promptTokens: Int
+            let totalTokens: Int
+            enum CodingKeys: String, CodingKey {
+                case promptTokens = "prompt_tokens"
+                case totalTokens = "total_tokens"
+            }
+        }
+        let object: String
+        let model: String
+        let data: [Datum]
+        let usage: Usage
+    }
+
+    private static func decodeEmbeddingsResponse(_ body: String) throws -> DecodedResponse {
+        let data = Data(body.utf8)
+        return try JSONDecoder().decode(DecodedResponse.self, from: data)
+    }
+
+    private static func assertApproximatelyEqual(
+        _ actual: [Float],
+        _ expected: [Float],
+        tolerance: Float = 1e-5,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(actual.count, expected.count, "vector length", file: file, line: line)
+        for (a, e) in zip(actual, expected) {
+            XCTAssertEqual(a, e, accuracy: tolerance, file: file, line: line)
+        }
+    }
+
+    private func makeEntry(id: String) -> EmbeddingModelEntry {
+        EmbeddingModelEntry(
+            id: id,
+            backend: .nlContextual,
+            nativeDimension: 3,
+            supportsMatryoshka: false,
+            pooling: .mean,
+            normalized: true,
+            maxInputTokens: 128,
+            description: "test"
+        )
+    }
+}
+
+private actor TokenIDsNotSupportedBackend: EmbeddingBackend {
+    let modelID: String
+    let nativeDimension: Int
+    let maxInputTokens: Int
+
+    init(modelID: String, nativeDimension: Int, maxInputTokens: Int) {
+        self.modelID = modelID
+        self.nativeDimension = nativeDimension
+        self.maxInputTokens = maxInputTokens
+    }
+
+    func embed(_ inputs: [String]) async throws -> EmbedResult {
+        throw EmbeddingError.invalidInput("Text input not exercised in this test")
+    }
+
+    func embedTokenIDs(_ inputs: [[Int]]) async throws -> EmbedResult {
+        throw EmbeddingError.invalidInput("Pre-tokenized input is not supported by Apple NL embeddings")
+    }
+}
+
+private actor FakeEmbeddingBackend: EmbeddingBackend {
+    let modelID: String
+    let nativeDimension: Int
+    let maxInputTokens: Int
+
+    private let result: EmbedResult
+    private(set) var lastStringInputs: [String] = []
+    private(set) var lastTokenIDInputs: [[Int]] = []
+
+    init(modelID: String, nativeDimension: Int, maxInputTokens: Int, result: EmbedResult) {
+        self.modelID = modelID
+        self.nativeDimension = nativeDimension
+        self.maxInputTokens = maxInputTokens
+        self.result = result
+    }
+
+    func embed(_ inputs: [String]) async throws -> EmbedResult {
+        lastStringInputs = inputs
+        lastTokenIDInputs = []
+        return result
+    }
+
+    func embedTokenIDs(_ inputs: [[Int]]) async throws -> EmbedResult {
+        lastStringInputs = []
+        lastTokenIDInputs = inputs
+        return result
+    }
+}

--- a/Tests/MacLocalAPITests/EmbeddingsControllerTests.swift
+++ b/Tests/MacLocalAPITests/EmbeddingsControllerTests.swift
@@ -229,7 +229,7 @@ final class EmbeddingsControllerTests: XCTestCase {
         try await app.testable(method: .running(port: 0)).test(.GET, "/v1/models") { response async in
             XCTAssertEqual(response.status, .ok)
             struct ModelsPayload: Decodable {
-                struct Entry: Decodable { let id: String }
+                struct Entry: Decodable { let id: String; let created: Int }
                 let object: String
                 let data: [Entry]
             }
@@ -237,9 +237,31 @@ final class EmbeddingsControllerTests: XCTestCase {
                 let decoded = try JSONDecoder().decode(ModelsPayload.self, from: Data(response.body.readableBytesView))
                 XCTAssertEqual(decoded.object, "list")
                 XCTAssertEqual(decoded.data.map(\.id), ["apple-nl-contextual-en"])
+                // `created` should be the per-model stable constant (macOS 14 GA),
+                // not derived from Date() on every request.
+                XCTAssertEqual(decoded.data.first?.created, 1_695_686_400)
             } catch {
                 XCTFail("failed to decode /v1/models: \(error)\nbody: \(response.body.string)")
             }
+        }
+    }
+
+    func testEmptyInnerTokenArrayReturns400() async throws {
+        let backend = FakeEmbeddingBackend(
+            modelID: "apple-nl-contextual-en",
+            nativeDimension: 2,
+            maxInputTokens: 128,
+            result: EmbedResult(vectors: [[1, 0]], tokenCounts: [1])
+        )
+        try EmbeddingsController(modelEntry: makeEntry(id: "apple-nl-contextual-en"), backend: backend).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"input":[[1,2],[]],"model":"apple-nl-contextual-en"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/embeddings", headers: headers, body: body) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            XCTAssertContains(response.body.string, "Token-id")
         }
     }
 
@@ -445,7 +467,8 @@ final class EmbeddingsControllerTests: XCTestCase {
             pooling: .mean,
             normalized: true,
             maxInputTokens: 128,
-            description: "test"
+            description: "test",
+            createdEpoch: 1_695_686_400
         )
     }
 }


### PR DESCRIPTION
Closes #118.

Adds an `afm embed` subcommand that serves an OpenAI-compatible embeddings endpoint on top of Apple's NaturalLanguage `NLContextualEmbedding`. Entirely on-device, no model downloads beyond what macOS already ships, no network dependency — the same local-first story as the rest of afm, applied to RAG/semantic-search/clustering workflows.

Scope is intentionally narrow: one backend (Apple `NLContextualEmbedding`), one new subcommand, purely additive. No MLX embedding backend, no non-Latin script coverage, no batch endpoint — those are explicit follow-ups.

## HTTP surface

- `POST /v1/embeddings`
  - Accepts a string, array of strings, or pre-tokenized IDs
  - `encoding_format`: `float` (default) or `base64`
  - `dimensions`: optional Matryoshka-style truncation + L2 renormalize (rejects values above the backend's native dimension)
  - `X-Embedding-Truncated` response header counts inputs that exceeded the backend's max sequence length
  - Malformed JSON, missing fields, and unknown enum values return 400 with a descriptive reason
  - Other 4xx `AbortError`s (e.g. 415 Unsupported Media Type) pass through with their original status
  - Oversized (>1 MiB) bodies return 413 with an embeddings-specific error message, not the chat server's "conversation too long" text
- `OPTIONS /v1/embeddings` and `OPTIONS /v1/models` register CORS preflight; `Access-Control-Allow-Headers` is reflected from `Access-Control-Request-Headers` (falling back to `Content-Type, Authorization, OpenAI-Organization, OpenAI-Project`), with `Vary: Origin, Access-Control-Request-Headers`
- `GET /v1/models` advertises only the loaded backend's model id so a client can't discover an id the server can't actually serve

## Shipped model ids

- `apple-nl-contextual-en` (English)
- `apple-nl-contextual-multi` (Latin-script multilingual — Apple's NL contextual multilingual model is Latin-only; non-Latin scripts are out of scope for this backend)

Native dimension and max sequence length come from `NLContextualEmbedding.dimension` / `maximumSequenceLength` at load time so values track OS updates.

## CLI

- `afm embed -m <id>` starts the server (default port 9998)
- `afm embed --list-models` enumerates shipped ids

## Architecture

- `EmbeddingBackend` protocol + `NLContextualEmbeddingBackend` actor owning the `NLContextualEmbedding` handle
- `EmbeddingModelRegistry` maps ids to metadata; the CLI `--list-models` path surfaces the full registry while the HTTP surface exposes only the loaded model
- Shutdown uses `DispatchSourceSignal` rather than a raw C `signal()` handler, with the shutdown flag checked on both sides of `app.server.start()` so SIGINT delivered during bind tears the just-bound listener down cleanly
- `EmbeddingsUsage` is scoped separately from the chat `Usage` struct so the Apple-only embeddings path never pulls in `MLXMetalLibrary.ensureAvailable()` side effects (which mutate the process cwd)

## Diff shape

`+1,544 / -1` across 10 files. Touches only `main.swift` (one-line subcommand registration plus an argv branch) — everything else is new files. No changes to the chat, MLX, vision, or speech paths.

## Tests

21 XCTests under `Tests/MacLocalAPITests/`:
- 18 controller tests — single/array/tokenized input, dimensions truncation + renormalization, base64 encoding, unknown model, malformed JSON, missing field, empty/whitespace input, unknown `encoding_format`, truncation header, unsupported-media-type preserves status + body shape, oversized payload, CORS preflight on both routes, reflected allow-headers, list-models shape
- 3 registry tests

## Test plan

- [ ] `swift build -c release`
- [ ] `swift test --filter "EmbeddingsControllerTests|EmbeddingModelRegistryTests"`
- [ ] Smoke: `afm embed -m apple-nl-contextual-en` then `curl -s localhost:9998/v1/embeddings -H 'Content-Type: application/json' -d '{"input":"hello","model":"apple-nl-contextual-en"}' | jq`
- [ ] `afm embed --list-models` prints both shipped ids

## Deliberately out of scope

- MLX embedding backend (sentence-transformers, BGE, etc.)
- Non-Latin script coverage for the multilingual backend
- Matryoshka beyond the truncation+normalize behavior above
- `/v1/batch/embeddings` parity

## Summary by Sourcery

Add an on-device OpenAI-compatible embeddings server and CLI subcommand backed by Apple NaturalLanguage contextual embeddings.

New Features:
- Expose a POST /v1/embeddings HTTP endpoint that accepts text or token-id inputs and returns OpenAI-shaped embedding responses with optional dimensionality truncation and base64 encoding.
- Add a GET /v1/models endpoint in the embeddings server that advertises only the currently loaded embedding model.
- Introduce an `afm embed` CLI subcommand to run the embeddings HTTP server and a `--list-models` option to enumerate available embedding models.
- Implement an Apple NLContextualEmbedding-based backend providing English and Latin-script multilingual embedding models with runtime-discovered dimensions and sequence limits.

Enhancements:
- Add a dedicated embeddings usage accounting type and shared math/encoding utilities for normalization and base64 vector encoding.
- Introduce a registry for embedding models to centralize metadata and resolution of shipped Apple embeddings.
- Add graceful shutdown handling for the embeddings server using dispatch-based signal sources and coordinated server teardown.
- Extend the main entry point to register and dispatch to the new embeddings subcommand.

Tests:
- Add XCTests covering embeddings controller behavior, including request/response shape, error handling, CORS behavior, payload size limits, and tokenized vs text input routing.
- Add tests for the embedding model registry to validate resolution and behavior for known and unknown model identifiers.