### PR TITLE
feat(agent): Tier-0 promotion + Tier-1 quick wins (request id, stream usage, parallel_tool_calls)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,34 @@ MACAFM_MLX_MODEL_CACHE=/path/to/models afm mlx -w
 afm -w
 ```
 
+## Why AFM for agents
+
+afm is built for agentic clients — OpenCode, OpenClaw, Cline, Continue.dev, Aider, Cursor, Hermes — that drive multi-turn tool-using LLM loops against a local OpenAI-compatible endpoint. The capabilities below are already in the box:
+
+| Capability | What it gets you | Where it lives |
+|---|---|---|
+| **7+ tool-call formats, auto-detected** | json, lfm2, xmlFunction (Qwen3-Coder), glm4, gemma, kimiK2, minimaxM2 picked from `model_type` in `config.json` — no per-model tuning | `MLXModelService.swift:inferToolCallFormat` |
+| **`afm_adaptive_xml` parser** | JSON-in-XML fallback, type coercion, nullable schema flatten, fuzzy tool-name match — survives the malformed XML real models emit | `Models/ToolCallStreamingRuntime.swift` |
+| **`tool_choice`: auto / none / required / named function** | Standard OpenAI semantics; named-function forcing routed end-to-end | `Models/OpenAIRequest.swift:ToolChoice` |
+| **Streaming tool-call deltas** | Token-level start/end tag detection; content outside tool calls streams normally | `Controllers/MLXChatCompletionsController.swift` |
+| **`<think>` + harmony channel reasoning extraction** | Routes Qwen/DeepSeek `<think>…</think>` and gpt-oss `<\|channel\|>analysis…` into `reasoning_content` so the WebUI/agent can show it separately | `Controllers/MLXChatCompletionsController.swift:extractThinkTags / extractHarmonyChannels` |
+| **Strict `json_schema` + xgrammar EBNF** | Guaranteed-valid JSON via token-level grammar enforcement when `--enable-grammar-constraints` is on | `Models/XGrammarService.swift` |
+| **`--guided-json` server default** | One CLI flag pins a schema across every chat request that omits its own `response_format` (Foundation + MLX backends) | `Sources/MacLocalAPI/main.swift` |
+| **Deterministic `seed`, `logprobs`, `top_logprobs`** | All sampling controls (temperature, top_p, top_k, min_p, repetition_penalty, presence_penalty, seed, logprobs+top_logprobs up to 20) plumbed end-to-end | `Models/OpenAIRequest.swift` + `Scripts/patches/Evaluate.swift` |
+| **Radix-tree prefix KV cache** | `--enable-prefix-caching` reuses KV across turns — agent loops with stable system prompts get prefill for free | `Models/RadixTreeCache.swift` |
+| **4/8-bit KV quantization** | `--kv-bits 4|8` cuts memory ~2-4× on long-context turns | `Sources/MacLocalAPI/main.swift` |
+| **Concurrent batch decode** | `--concurrent N` runs N requests through one model with fair queueing; vLLM-style metrics expose queue depth | `Models/BatchScheduler.swift` |
+| **vLLM-namespaced Prometheus `/metrics`** | `afm:max_concurrent_slots`, `afm:num_requests_running`, `afm:num_requests_waiting`, plus per-request token/timing histograms | `Controllers/MetricsController.swift` |
+| **`Retry-After: 2` on 503** | Tells well-behaved agents (LangChain, OpenAI SDK) when to retry — no thundering herd | `Controllers/MLXChatCompletionsController.swift` |
+| **Multi-backend gateway mode** | `--gateway` discovers Ollama / LM Studio / Jan on the same machine and proxies them under one OpenAI surface, normalizing `reasoning` → `reasoning_content` | `Models/BackendDiscoveryService.swift` + `BackendProxyService.swift` |
+| **`X-Request-ID` / `OpenAI-Request-ID` echo** | Inbound IDs are honored; otherwise minted as `req_<uuid12>`. Echoed on every response and inside `error.request_id` for retry correlation | `Server.swift:RequestIDMiddleware` |
+| **`stream_options.include_usage` honored** | Suppress the final usage chunk when the client doesn't want it (matches OpenAI strict mode) | `Models/OpenAIRequest.swift:StreamOptions` |
+| **`parallel_tool_calls: false` honored** | Truncate to a single tool call per turn for agents that want serial execution | `Controllers/MLXChatCompletionsController.swift:finalizeAssistantTurn` |
+| **Speech (transcribe + TTS) and Vision OCR** | `/v1/audio/transcriptions`, `/v1/audio/speech`, `/v1/ocr` — agents can hand off audio/image inputs without a separate service | `Controllers/SpeechAPIController.swift`, `VisionAPIController.swift` |
+| **Per-client config generators** | `afm mlx -m <model> --openclaw-config` prints a paste-ready provider config; cookbook recipes in [`docs/clients/`](docs/clients/) cover OpenCode, OpenClaw, Cline, Continue.dev, Aider, Cursor, Hermes | `Sources/MacLocalAPI/main.swift:printOpenClawConfig` |
+
+See [`docs/clients/`](docs/clients/) for one-page recipes per agent.
+
 ## Use with OpenCode
 
 [OpenCode](https://opencode.ai/) is a terminal-based AI coding assistant. Connect it to afm for a fully local coding experience — no cloud, no API keys. No Internet required (other than initially download the model of course!)

--- a/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift
@@ -420,21 +420,26 @@ struct ChatCompletionsController: RouteCollection {
                 if let jsonString = String(data: finalData, encoding: .utf8) {
                     try await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
                 }
-                let usageChunk = ChatCompletionStreamResponse(
-                    id: streamId,
-                    model: chatRequest.model ?? "foundation",
-                    usage: usage,
-                    timings: timings
-                )
-                let usageData = try encoder.encode(usageChunk)
-                if let jsonString = String(data: usageData, encoding: .utf8) {
-                    try await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
+                // Gate the usage chunk on stream_options.include_usage. (T1.2)
+                if chatRequest.includeStreamingUsage {
+                    let usageChunk = ChatCompletionStreamResponse(
+                        id: streamId,
+                        model: chatRequest.model ?? "foundation",
+                        usage: usage,
+                        timings: timings
+                    )
+                    let usageData = try encoder.encode(usageChunk)
+                    if let jsonString = String(data: usageData, encoding: .utf8) {
+                        try await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
+                    }
+                    if self.veryVerbose {
+                        req.logger.info("Foundation stream usage chunk: \(encodeJSON(usageChunk))")
+                    }
                 }
                 if self.veryVerbose {
                     req.logger.info("Foundation full streamed response content: \(fullStreamedContent)")
                     req.logger.info("Foundation stream final usage: \(encodeJSON(usage))")
                     req.logger.info("Foundation stream final chunk: \(encodeJSON(finalChunk))")
-                    req.logger.info("Foundation stream usage chunk: \(encodeJSON(usageChunk))")
                 }
 
                 // Send done marker

--- a/Sources/MacLocalAPI/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/MacLocalAPI/Controllers/MLXChatCompletionsController.swift
@@ -104,7 +104,8 @@ struct MLXChatCompletionsController: RouteCollection {
     private static let debugPipeline = ProcessInfo.processInfo.environment["AFM_DEBUG"] == "1"
 
     func chatCompletions(req: Request) async throws -> Response {
-        let reqId = String(UUID().uuidString.prefix(8))
+        // RequestIDMiddleware sets this; controller piggybacks for log correlation. (T1.1)
+        let reqId = req.afmRequestID
         do {
             let httpArrival = Self.debugPipeline ? Date() : Date.distantPast
             let chatRequest = try req.content.decode(ChatCompletionRequest.self)
@@ -391,6 +392,7 @@ struct MLXChatCompletionsController: RouteCollection {
                 content: result.content,
                 toolCalls: result.toolCalls,
                 toolChoice: chatRequest.toolChoice,
+                parallelToolCalls: chatRequest.parallelToolCalls,
                 extractThinking: extractThinking,
                 thinkStartTag: service.thinkStartTag ?? "<think>",
                 thinkEndTag: service.thinkEndTag ?? "</think>",
@@ -986,6 +988,7 @@ struct MLXChatCompletionsController: RouteCollection {
                     content: fullContent,
                     toolCalls: hasToolCalls ? collectedToolCalls : nil,
                     toolChoice: chatRequest.toolChoice,
+                    parallelToolCalls: chatRequest.parallelToolCalls,
                     extractThinking: extractThinking,
                     thinkStartTag: thinkStartTag ?? "<think>",
                     thinkEndTag: thinkEndTag ?? "</think>",
@@ -1108,15 +1111,18 @@ struct MLXChatCompletionsController: RouteCollection {
                 if let jsonString = String(data: finalData, encoding: .utf8) {
                     try? await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
                 }
-                let usageChunk = ChatCompletionStreamResponse(
-                    id: streamId,
-                    model: res.modelID,
-                    usage: usage,
-                    timings: StreamTimings(prompt_n: promptTokens, prompt_ms: promptTime * 1000, predicted_n: completionTokens, predicted_ms: generateTime * 1000)
-                )
-                let usageData = try encoder.encode(usageChunk)
-                if let jsonString = String(data: usageData, encoding: .utf8) {
-                    try? await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
+                // Gate the usage chunk on stream_options.include_usage. (T1.2)
+                if chatRequest.includeStreamingUsage {
+                    let usageChunk = ChatCompletionStreamResponse(
+                        id: streamId,
+                        model: res.modelID,
+                        usage: usage,
+                        timings: StreamTimings(prompt_n: promptTokens, prompt_ms: promptTime * 1000, predicted_n: completionTokens, predicted_ms: generateTime * 1000)
+                    )
+                    let usageData = try encoder.encode(usageChunk)
+                    if let jsonString = String(data: usageData, encoding: .utf8) {
+                        try? await writer.write(.buffer(.init(string: "data: \(jsonString)\n\n")))
+                    }
                 }
                 // AFM Profile: send as a final SSE event before [DONE]
                 if wantStreamProfile {
@@ -1425,6 +1431,7 @@ struct MLXChatCompletionsController: RouteCollection {
         content: String,
         toolCalls: [ResponseToolCall]?,
         toolChoice: ToolChoice?,
+        parallelToolCalls: Bool? = nil,
         extractThinking: Bool,
         thinkStartTag: String,
         thinkEndTag: String,
@@ -1433,7 +1440,13 @@ struct MLXChatCompletionsController: RouteCollection {
         maxTokens: Int,
         sanitizeContent: (String) -> String
     ) -> FinalizedAssistantTurn {
-        let effectiveToolCalls = applyToolChoice(toolCalls, toolChoice: toolChoice)
+        var effectiveToolCalls = applyToolChoice(toolCalls, toolChoice: toolChoice)
+        // Honor parallel_tool_calls=false by truncating to the first call. (T1.3)
+        if parallelToolCalls == false,
+           let calls = effectiveToolCalls,
+           calls.count > 1 {
+            effectiveToolCalls = [calls[0]]
+        }
         if let effectiveToolCalls, !effectiveToolCalls.isEmpty {
             return FinalizedAssistantTurn(
                 finishReason: "tool_calls",

--- a/Sources/MacLocalAPI/Models/OpenAIRequest.swift
+++ b/Sources/MacLocalAPI/Models/OpenAIRequest.swift
@@ -19,9 +19,11 @@ struct ChatCompletionRequest: Content {
     let topLogprobs: Int?
     let stop: [String]?
     let stream: Bool?
+    let streamOptions: StreamOptions?
     let user: String?
     let tools: [RequestTool]?
     let toolChoice: ToolChoice?
+    let parallelToolCalls: Bool?
     let responseFormat: ResponseFormat?
     let chatTemplateKwargs: [String: AnyCodable]?
 
@@ -43,11 +45,19 @@ struct ChatCompletionRequest: Content {
         case topLogprobs = "top_logprobs"
         case stop
         case stream
+        case streamOptions = "stream_options"
         case user
         case tools
         case toolChoice = "tool_choice"
+        case parallelToolCalls = "parallel_tool_calls"
         case responseFormat = "response_format"
         case chatTemplateKwargs = "chat_template_kwargs"
+    }
+
+    /// Whether the final SSE chunk should carry a `usage` block. Mirrors OpenAI's
+    /// `stream_options.include_usage`. Default true preserves existing behavior. (T1.2)
+    var includeStreamingUsage: Bool {
+        streamOptions?.includeUsage ?? true
     }
 
     var effectiveMaxTokens: Int? {
@@ -56,6 +66,15 @@ struct ChatCompletionRequest: Content {
 
     var effectiveRepetitionPenalty: Double? {
         repetitionPenalty ?? repeatPenalty
+    }
+}
+
+/// OpenAI-compatible `stream_options`. Currently models `include_usage`. (T1.2)
+struct StreamOptions: Content {
+    let includeUsage: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case includeUsage = "include_usage"
     }
 }
 

--- a/Sources/MacLocalAPI/Models/OpenAIResponse.swift
+++ b/Sources/MacLocalAPI/Models/OpenAIResponse.swift
@@ -537,10 +537,17 @@ struct OpenAIError: Content, Error {
         let message: String
         let type: String
         let code: String?
+        /// Correlates with the `X-Request-ID`/`OpenAI-Request-ID` response header. (T1.1)
+        let requestId: String?
+
+        enum CodingKeys: String, CodingKey {
+            case message, type, code
+            case requestId = "request_id"
+        }
     }
 
-    init(message: String, type: String = "invalid_request_error", code: String? = nil) {
-        self.error = ErrorDetail(message: message, type: type, code: code)
+    init(message: String, type: String = "invalid_request_error", code: String? = nil, requestId: String? = nil) {
+        self.error = ErrorDetail(message: message, type: type, code: code, requestId: requestId)
     }
 }
 

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -11,6 +11,49 @@ struct ContinuationKey: StorageKey {
     typealias Value = CheckedContinuation<Void, Error>
 }
 
+/// Storage key for the per-request correlation ID (T1.1).
+/// Set by `RequestIDMiddleware`, read by controllers and error emitters so the
+/// same ID appears on the `X-Request-ID` / `OpenAI-Request-ID` response header,
+/// inside `error.request_id`, and in server logs.
+enum RequestIDKey: StorageKey {
+    typealias Value = String
+}
+
+extension Request {
+    /// The agent-correlatable request ID (T1.1). Always present after the
+    /// `RequestIDMiddleware` has run.
+    var afmRequestID: String {
+        storage[RequestIDKey.self] ?? ""
+    }
+}
+
+/// Mints or echoes a stable request ID for every HTTP request and copies it
+/// to the response headers. Honors inbound `X-Request-ID` (most common) and
+/// `OpenAI-Request-ID` (OpenAI SDK convention); otherwise mints `req_<uuid12>`
+/// matching the format used by `BatchAPIController`. (T1.1)
+struct RequestIDMiddleware: AsyncMiddleware {
+    static let inboundHeaders = ["X-Request-ID", "OpenAI-Request-ID"]
+    static let outboundHeaders = ["X-Request-ID", "OpenAI-Request-ID"]
+
+    static func mint() -> String {
+        "req_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "").prefix(12)
+    }
+
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        let inbound = Self.inboundHeaders
+            .compactMap { request.headers.first(name: $0)?.trimmingCharacters(in: .whitespaces) }
+            .first(where: { !$0.isEmpty })
+        let id = inbound ?? Self.mint()
+        request.storage.set(RequestIDKey.self, to: id)
+
+        let response = try await next.respond(to: request)
+        for name in Self.outboundHeaders {
+            response.headers.replaceOrAdd(name: name, value: id)
+        }
+        return response
+    }
+}
+
 // Middleware to handle payload too large errors with a user-friendly message
 struct PayloadTooLargeMiddleware: AsyncMiddleware {
     func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
@@ -18,9 +61,11 @@ struct PayloadTooLargeMiddleware: AsyncMiddleware {
             return try await next.respond(to: request)
         } catch let abort as Abort where abort.status == .payloadTooLarge {
             // Return a JSON error response compatible with OpenAI format
+            let reqId = request.afmRequestID
             let errorResponse = OpenAIError(
                 message: "Your conversation is too long. Please start a new conversation.",
-                type: "payload_too_large"
+                type: "payload_too_large",
+                requestId: reqId.isEmpty ? nil : reqId
             )
             let response = Response(status: .payloadTooLarge)
             response.headers.add(name: .contentType, value: "application/json")
@@ -132,6 +177,10 @@ class Server {
         // Increase max body size for long conversations (default is 16KB)
         // 100MB should handle very long conversation histories
         app.routes.defaultMaxBodySize = "100mb"
+
+        // Mint/echo X-Request-ID for every request — must run before other
+        // middleware so ID is visible in error paths too. (T1.1)
+        app.middleware.use(RequestIDMiddleware())
 
         // Add custom error middleware to handle payload too large errors
         app.middleware.use(PayloadTooLargeMiddleware())

--- a/Sources/MacLocalAPI/Services/AFMLocalClient.swift
+++ b/Sources/MacLocalAPI/Services/AFMLocalClient.swift
@@ -57,9 +57,11 @@ final class AFMLocalClient {
             topLogprobs: nil,
             stop: nil,
             stream: false,
+            streamOptions: nil,
             user: userTag,
             tools: nil,
             toolChoice: nil,
+            parallelToolCalls: nil,
             responseFormat: nil,
             chatTemplateKwargs: nil
         )

--- a/Tests/MacLocalAPITests/AgentFriendlyTier1Tests.swift
+++ b/Tests/MacLocalAPITests/AgentFriendlyTier1Tests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+
+@testable import MacLocalAPI
+
+/// Unit tests for the Tier-1 agent-friendly changes (PR-1).
+struct AgentFriendlyTier1Tests {
+
+    // ═══════════════════════════════════════════════════════════════════
+    // MARK: - T1.1 — Request ID middleware contract
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test("T1.1 minted request IDs use the documented req_<uuid12> shape")
+    func requestIDMintFormat() {
+        let id = RequestIDMiddleware.mint()
+        #expect(id.hasPrefix("req_"))
+        #expect(id.count == 16) // "req_" + 12 hex chars
+        let suffix = String(id.dropFirst(4))
+        #expect(suffix.count == 12)
+        // 12 lowercase hex chars (uuid stripped of '-')
+        #expect(suffix.allSatisfy { $0.isHexDigit && (!$0.isLetter || $0.isLowercase) })
+    }
+
+    @Test("T1.1 OpenAIError exposes request_id field for correlation")
+    func openAIErrorCarriesRequestID() throws {
+        let err = OpenAIError(
+            message: "boom",
+            type: "internal_error",
+            code: "boom_code",
+            requestId: "req_abc123def456"
+        )
+        let data = try JSONEncoder().encode(err)
+        let json = String(data: data, encoding: .utf8) ?? ""
+        #expect(json.contains("\"request_id\":\"req_abc123def456\""))
+        #expect(json.contains("\"message\":\"boom\""))
+    }
+
+    @Test("T1.1 OpenAIError request_id is omitted when not provided")
+    func openAIErrorRequestIDOptional() throws {
+        let err = OpenAIError(message: "boom")
+        let data = try JSONEncoder().encode(err)
+        let json = String(data: data, encoding: .utf8) ?? ""
+        // request_id absent when nil
+        #expect(!json.contains("\"request_id\""))
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // MARK: - T1.2 — stream_options.include_usage
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Test("T1.2 default is to include usage when stream_options absent")
+    func includeUsageDefaultsTrue() throws {
+        let json = """
+        {"messages":[{"role":"user","content":"hi"}]}
+        """
+        let req = try JSONDecoder().decode(ChatCompletionRequest.self, from: Data(json.utf8))
+        #expect(req.includeStreamingUsage == true)
+        #expect(req.streamOptions == nil)
+    }
+
+    @Test("T1.2 include_usage=false suppresses the usage chunk")
+    func includeUsageFalse() throws {
+        let json = """
+        {"messages":[{"role":"user","content":"hi"}],"stream":true,"stream_options":{"include_usage":false}}
+        """
+        let req = try JSONDecoder().decode(ChatCompletionRequest.self, from: Data(json.utf8))
+        #expect(req.includeStreamingUsage == false)
+    }
+
+    @Test("T1.2 include_usage=true is honored explicitly")
+    func includeUsageTrue() throws {
+        let json = """
+        {"messages":[{"role":"user","content":"hi"}],"stream":true,"stream_options":{"include_usage":true}}
+        """
+        let req = try JSONDecoder().decode(ChatCompletionRequest.self, from: Data(json.utf8))
+        #expect(req.includeStreamingUsage == true)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // MARK: - T1.3 — parallel_tool_calls: false truncation
+    // ═══════════════════════════════════════════════════════════════════
+
+    private func mkToolCall(_ name: String, index: Int) -> ResponseToolCall {
+        ResponseToolCall(
+            index: index,
+            id: "call_\(name)_\(index)",
+            type: "function",
+            function: ResponseToolCallFunction(name: name, arguments: "{}")
+        )
+    }
+
+    @Test("T1.3 parallel_tool_calls=false truncates to first tool call")
+    func parallelToolCallsFalseTruncates() {
+        let multi = [mkToolCall("a", index: 0), mkToolCall("b", index: 1), mkToolCall("c", index: 2)]
+        let turn = MLXChatCompletionsController.finalizeAssistantTurn(
+            content: "",
+            toolCalls: multi,
+            toolChoice: nil,
+            parallelToolCalls: false,
+            extractThinking: false,
+            thinkStartTag: "<think>",
+            thinkEndTag: "</think>",
+            stoppedBySequence: false,
+            completionTokens: 1,
+            maxTokens: 100,
+            sanitizeContent: { $0 }
+        )
+        #expect(turn.finishReason == "tool_calls")
+        #expect(turn.toolCalls?.count == 1)
+        #expect(turn.toolCalls?.first?.function.name == "a")
+    }
+
+    @Test("T1.3 parallel_tool_calls=true (default) preserves all calls")
+    func parallelToolCallsTrueKeepsAll() {
+        let multi = [mkToolCall("a", index: 0), mkToolCall("b", index: 1)]
+        let turn = MLXChatCompletionsController.finalizeAssistantTurn(
+            content: "",
+            toolCalls: multi,
+            toolChoice: nil,
+            parallelToolCalls: true,
+            extractThinking: false,
+            thinkStartTag: "<think>",
+            thinkEndTag: "</think>",
+            stoppedBySequence: false,
+            completionTokens: 1,
+            maxTokens: 100,
+            sanitizeContent: { $0 }
+        )
+        #expect(turn.toolCalls?.count == 2)
+    }
+
+    @Test("T1.3 parallel_tool_calls=nil leaves prior behavior untouched")
+    func parallelToolCallsNilKeepsAll() {
+        let multi = [mkToolCall("a", index: 0), mkToolCall("b", index: 1)]
+        let turn = MLXChatCompletionsController.finalizeAssistantTurn(
+            content: "",
+            toolCalls: multi,
+            toolChoice: nil,
+            parallelToolCalls: nil,
+            extractThinking: false,
+            thinkStartTag: "<think>",
+            thinkEndTag: "</think>",
+            stoppedBySequence: false,
+            completionTokens: 1,
+            maxTokens: 100,
+            sanitizeContent: { $0 }
+        )
+        #expect(turn.toolCalls?.count == 2)
+    }
+
+    @Test("T1.3 parallel_tool_calls=false with single call is a no-op")
+    func parallelToolCallsFalseSingleCall() {
+        let single = [mkToolCall("only", index: 0)]
+        let turn = MLXChatCompletionsController.finalizeAssistantTurn(
+            content: "",
+            toolCalls: single,
+            toolChoice: nil,
+            parallelToolCalls: false,
+            extractThinking: false,
+            thinkStartTag: "<think>",
+            thinkEndTag: "</think>",
+            stoppedBySequence: false,
+            completionTokens: 1,
+            maxTokens: 100,
+            sanitizeContent: { $0 }
+        )
+        #expect(turn.toolCalls?.count == 1)
+        #expect(turn.toolCalls?.first?.function.name == "only")
+    }
+
+    @Test("T1.3 parallel_tool_calls field round-trips through JSON")
+    func parallelToolCallsJSONRoundTrip() throws {
+        let json = """
+        {"messages":[{"role":"user","content":"hi"}],"parallel_tool_calls":false}
+        """
+        let req = try JSONDecoder().decode(ChatCompletionRequest.self, from: Data(json.utf8))
+        #expect(req.parallelToolCalls == false)
+    }
+}

--- a/Tests/MacLocalAPITests/VisionAPIControllerTests.swift
+++ b/Tests/MacLocalAPITests/VisionAPIControllerTests.swift
@@ -154,9 +154,11 @@ final class VisionAPIControllerTests: XCTestCase {
             topLogprobs: nil,
             stop: nil,
             stream: nil,
+            streamOptions: nil,
             user: nil,
             tools: [tool],
             toolChoice: .mode("auto"),
+            parallelToolCalls: nil,
             responseFormat: nil,
             chatTemplateKwargs: nil
         )

--- a/docs/clients/README.md
+++ b/docs/clients/README.md
@@ -1,0 +1,15 @@
+# Agent client cookbooks
+
+One-page recipes for connecting popular agentic clients to `afm`. Each page assumes you've already started a server (e.g. `afm mlx -m mlx-community/Qwen3-Coder-Next-4bit`) on `http://localhost:9999`.
+
+| Client | Page | Notes |
+|---|---|---|
+| OpenCode | [opencode.md](opencode.md) | Terminal coding assistant — already wired in main README |
+| OpenClaw | [openclaw.md](openclaw.md) | `afm mlx --openclaw-config` generates the JSON for you |
+| Cline | [cline.md](cline.md) | VSCode coding agent; OpenAI-compatible provider |
+| Continue.dev | [continue.md](continue.md) | VSCode/JetBrains assistant; OpenAI-compatible |
+| Aider | [aider.md](aider.md) | Git-aware CLI; `OPENAI_API_BASE` env var |
+| Cursor | [cursor.md](cursor.md) | Editor; needs `OpenAI Base URL` setting |
+| Hermes | [hermes.md](hermes.md) | Nous Research agent framework; OpenAI-compatible |
+
+See the main [README — Why AFM for agents](../../README.md#why-afm-for-agents) for the capability matrix.

--- a/docs/clients/aider.md
+++ b/docs/clients/aider.md
@@ -1,0 +1,28 @@
+# Aider
+
+[Aider](https://aider.chat/) is a git-aware terminal pair-programmer.
+
+## 1. Start the server
+
+```bash
+afm mlx -m mlx-community/Qwen3-Coder-Next-4bit \
+  --port 9999 --enable-prefix-caching
+```
+
+## 2. Point Aider at afm
+
+```bash
+export OPENAI_API_BASE=http://localhost:9999/v1
+export OPENAI_API_KEY=x
+aider --model openai/mlx-community/Qwen3-Coder-Next-4bit
+```
+
+## 3. Use it
+
+Aider commits/edits/reverts as usual. All inference is local.
+
+## Tips
+
+- Aider's repo-map prompt grows with codebase size; `--enable-prefix-caching` keeps subsequent turns fast.
+- Aider doesn't stream tool-call deltas — it waits for the final assistant message — so streaming overhead is minimal either way.
+- For very long sessions, add `--kv-bits 8` to halve the KV-cache memory footprint.

--- a/docs/clients/cline.md
+++ b/docs/clients/cline.md
@@ -1,0 +1,29 @@
+# Cline
+
+[Cline](https://github.com/cline/cline) is a VSCode coding agent that supports any OpenAI-compatible provider.
+
+## 1. Start the server
+
+```bash
+afm mlx -m mlx-community/Qwen3-Coder-Next-4bit \
+  --port 9999 --enable-prefix-caching --concurrent 4
+```
+
+## 2. Configure Cline
+
+In VSCode → Cline settings → API Provider:
+
+- **API Provider**: OpenAI Compatible
+- **Base URL**: `http://localhost:9999/v1`
+- **API Key**: any value (afm ignores it)
+- **Model ID**: the same model you started afm with, e.g. `mlx-community/Qwen3-Coder-Next-4bit`
+
+## 3. Use it
+
+Cline will issue streaming chat completions with tools. Tool format is auto-detected from `model_type`.
+
+## Tips
+
+- Cline's system prompt is large (~5–10k tokens) and stable across turns. Run with `--enable-prefix-caching` for instant turn-2+ prefill.
+- For multiple Cline tabs, raise `--concurrent N` to match.
+- Cline aborts mid-turn often (user edits, retries). Mid-stream cancel on client disconnect is on the [roadmap](../../docs/ROADMAP.md) (Tier 1.4); until landed, expect a few seconds of GPU idle after abort.

--- a/docs/clients/continue.md
+++ b/docs/clients/continue.md
@@ -1,0 +1,45 @@
+# Continue.dev
+
+[Continue.dev](https://www.continue.dev/) is an open-source autopilot for VSCode and JetBrains with broad OpenAI-compatible support.
+
+## 1. Start the server
+
+```bash
+afm mlx -m mlx-community/Qwen3-Coder-Next-4bit \
+  --port 9999 --enable-prefix-caching
+```
+
+## 2. Configure Continue
+
+`~/.continue/config.json`:
+
+```json
+{
+  "models": [
+    {
+      "title": "afm (local)",
+      "provider": "openai",
+      "model": "mlx-community/Qwen3-Coder-Next-4bit",
+      "apiBase": "http://localhost:9999/v1",
+      "apiKey": "x"
+    }
+  ],
+  "tabAutocompleteModel": {
+    "title": "afm-autocomplete",
+    "provider": "openai",
+    "model": "mlx-community/Qwen3-Coder-Next-4bit",
+    "apiBase": "http://localhost:9999/v1",
+    "apiKey": "x"
+  }
+}
+```
+
+## 3. Use it
+
+Continue's chat, edit, and tab-autocomplete will all run against afm.
+
+## Tips
+
+- For autocomplete latency, prefer a smaller model (e.g. `mlx-community/Qwen3-1.7B-4bit`) on a separate port.
+- Continue sends large repo-context prompts; `--enable-prefix-caching` is a big win.
+- Tool calling: Continue uses tools for some workflows (search, edit). The auto-detected tool format handles it.

--- a/docs/clients/cursor.md
+++ b/docs/clients/cursor.md
@@ -1,0 +1,33 @@
+# Cursor
+
+[Cursor](https://cursor.com/) is a coding editor with a built-in AI sidebar.
+
+> **Caveat**: Cursor's "Custom OpenAI base URL" requires a publicly reachable HTTPS endpoint for some features (Composer, Chat). For local-only use, expose afm via a tunnel (Cloudflare Tunnel, Tailscale Funnel, ngrok) or use Cursor's local-models setting where available.
+
+## 1. Start the server
+
+```bash
+afm mlx -m mlx-community/Qwen3-Coder-Next-4bit --port 9999
+```
+
+## 2. (Optional) expose via tunnel
+
+```bash
+# Cloudflare quick tunnel — replace with your tool of choice
+cloudflared tunnel --url http://localhost:9999
+```
+
+Note the public HTTPS URL it prints.
+
+## 3. Configure Cursor
+
+Cursor settings → Models → "Add Model":
+
+- **Model name**: `mlx-community/Qwen3-Coder-Next-4bit`
+- **OpenAI Base URL**: `https://your-tunnel-url/v1` (or `http://localhost:9999/v1` if your build allows local)
+- **API Key**: any value
+
+## Tips
+
+- Cursor sends large prompts (system + repo context); `--enable-prefix-caching` is a big win.
+- For Composer multi-turn loops, `--concurrent 2` lets Cursor's parallel calls share the model.

--- a/docs/clients/hermes.md
+++ b/docs/clients/hermes.md
@@ -1,0 +1,41 @@
+# Hermes (Nous Research agent framework)
+
+[Hermes](https://github.com/NousResearch/Hermes-Function-Calling) is Nous Research's open agent framework. It works with any OpenAI-compatible local provider.
+
+> Disambiguation: this page is about the Hermes **agent framework**, not the Nous-Hermes family of LLMs (those would be the "model"). afm also supports the `hermes` tool-call format used by Hermes-derived models, auto-detected when `model_type` matches.
+
+## 1. Start the server
+
+```bash
+afm mlx -m mlx-community/Qwen3-Coder-Next-4bit \
+  --port 9999 --enable-prefix-caching --concurrent 4
+```
+
+## 2. Configure Hermes
+
+Set the OpenAI base URL to afm:
+
+```bash
+export OPENAI_API_BASE=http://localhost:9999/v1
+export OPENAI_API_KEY=x
+```
+
+Or in Hermes config (e.g. YAML/JSON depending on your setup):
+
+```yaml
+provider:
+  type: openai
+  base_url: http://localhost:9999/v1
+  api_key: x
+  model: mlx-community/Qwen3-Coder-Next-4bit
+```
+
+## 3. Run Hermes
+
+Hermes will issue chat completions with tool calling. afm's auto-detected tool format and harmony/think reasoning extraction work with Hermes' loop.
+
+## Tips
+
+- For Hermes' self-improvement loops (trajectory generation), enable structured output: pass `response_format: {"type":"json_schema","json_schema":{...,"strict":true}}` and turn on `--enable-grammar-constraints` server-side.
+- Multi-step trajectories benefit from `--enable-prefix-caching`.
+- Deterministic seeds: pass `seed: <int>` per request — afm threads it through end-to-end (logged via `--vv` for reproducibility).

--- a/docs/clients/openclaw.md
+++ b/docs/clients/openclaw.md
@@ -1,0 +1,32 @@
+# OpenClaw
+
+[OpenClaw](https://github.com/openclaw/openclaw) is an open coding agent that targets local models via the `openai-completions` API mode.
+
+## 1. Generate the provider config
+
+afm prints a paste-ready config for you:
+
+```bash
+afm mlx -m mlx-community/Qwen3-Coder-Next-4bit --openclaw-config
+```
+
+This emits a JSON block with `baseUrl`, `api: "openai-completions"`, model metadata (vision / reasoning detection, context window, max tokens), and zero-cost pricing fields. Copy it into your OpenClaw provider config.
+
+## 2. Start the server
+
+```bash
+afm mlx -m mlx-community/Qwen3-Coder-Next-4bit \
+  --port 9999 --enable-prefix-caching
+```
+
+(`--openclaw-config` defaults to port 9999 unless you pass `-p`.)
+
+## 3. Run OpenClaw
+
+OpenClaw will issue requests against `http://localhost:9999/v1`. Tool calling, streaming, and reasoning extraction all work out of the box.
+
+## Notes
+
+- The generated config detects `<think>` reasoning support automatically.
+- Vision capability is reported as true for VLM-class model IDs.
+- For multi-session use, add `--concurrent N` (each OpenClaw conversation can hold its own slot).

--- a/docs/clients/opencode.md
+++ b/docs/clients/opencode.md
@@ -1,0 +1,48 @@
+# OpenCode
+
+[OpenCode](https://opencode.ai/) is a terminal-based AI coding assistant.
+
+## 1. Start the server
+
+```bash
+afm mlx -m mlx-community/Qwen3-Coder-Next-4bit \
+  -t 1.0 --top-p 0.95 --max-tokens 8192 \
+  --enable-prefix-caching
+```
+
+Recommended:
+- **Model**: `mlx-community/Qwen3-Coder-Next-4bit` (best small coder model with XML tool calling)
+- **Prefix caching**: OpenCode reuses a long system prompt — `--enable-prefix-caching` makes turn-2+ near-instant
+- **Concurrency**: add `--concurrent 4` if you run multiple OpenCode sessions
+
+## 2. Configure OpenCode
+
+`~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "afm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "afm (local)",
+      "options": { "baseURL": "http://localhost:9999/v1" },
+      "models": {
+        "mlx-community/Qwen3-Coder-Next-4bit": {
+          "name": "mlx-community/Qwen3-Coder-Next-4bit"
+        }
+      }
+    }
+  }
+}
+```
+
+## 3. Use it
+
+In OpenCode: `/connect` → scroll to `afm (local)` → select. When prompted for an API key, type any value (afm doesn't gate on it).
+
+## Notes
+
+- Tool format is auto-detected from `model_type` in the model's `config.json`. For Qwen3-Coder this is `xmlFunction`.
+- For zero-parameter tool calls, three safety nets strip stray `</function` suffixes — see [issue #80](https://github.com/scouzi1966/maclocal-api/issues/80).
+- If you want streaming usage suppressed, OpenCode does not currently send `stream_options.include_usage`; pass it through the request body if your client wrapper supports it.

--- a/docs/roadmap/agent-friendly.md
+++ b/docs/roadmap/agent-friendly.md
@@ -1,0 +1,110 @@
+# Roadmap: Make AFM the best local server for agentic clients
+
+## Context
+
+`afm` (this repo) is an OpenAI-compatible local LLM server on Apple Silicon backed by both Apple Foundation Models and HuggingFace MLX models. The user wants AFM to be the obvious pick for agentic clients — OpenCode and OpenClaw (already targeted), Cline / Continue.dev / Aider / Cursor (broader OpenAI-compat ecosystem), Hermes (Nous Research's agent framework), and the OpenAI Responses-API world. The four big differentiators — MCP server mode, persistent KV-cache handles, hybrid Foundation+MLX routing, and `/v1/responses` — are explicitly in scope.
+
+A read-only audit found AFM already implements most of an agent's wishlist (tool calling across 7+ formats with auto-detection, structured output with xgrammar, deterministic seeds, logprobs, Prometheus `/metrics`, prefix caching, concurrent batch decode, gateway-mode normalization), but is missing several high-leverage agent semantics (mid-stream cancel, tokenize endpoints, request-id correlation, parallel_tool_calls flag, schema-validated tool args, persistent KV handles, MCP, hybrid routing, Responses API). The intended outcome is a tiered, multi-PR roadmap that turns AFM's existing surface into a marketable agent platform and adds what's missing in priority order.
+
+## Strategy
+
+Land in four tiers, smallest-and-most-leveraged first. Tiers 0–1 are a week's work and unblock Tier 2; Tier 3 is the moat (Apple-Silicon-native features no other local server can match).
+
+## Tier 0 — Promotion only (no code)
+
+| # | Item | Effort |
+|---|---|---|
+| T0.1 | Agent-readiness matrix in `README.md` covering: 7 tool-call formats auto-detected via `inferToolCallFormat()` (`Sources/MacLocalAPI/Models/MLXModelService.swift:3598`); `afm_adaptive_xml` parser (JSON-in-XML fallback, nullable flatten, EBNF); `tool_choice` (auto/none/required/named); streaming `StreamDeltaToolCall`; `<think>` + harmony channel reasoning extraction; deterministic `seed` and `logprobs/top_logprobs`; strict `json_schema` + xgrammar EBNF + `--guided-json`; radix-tree prefix cache; 4/8-bit kv quant; streaming kv-evict; fair-queue `--concurrent`; vLLM-namespaced Prometheus `/metrics`; `Retry-After: 2` on 503; gateway proxy with `reasoning → reasoning_content` normalization. | S |
+| T0.2 | Per-client cookbook pages under `docs/clients/` (one file each for OpenCode, OpenClaw, Cline, Continue, Aider, Cursor, Hermes): base URL, model id, tool-format note, streaming, concurrency, KV flags. | S |
+
+## Tier 1 — Quick wins (S effort, max agent leverage per LOC)
+
+| # | Item | Surface | Files | Effort |
+|---|---|---|---|---|
+| T1.1 | Echo `X-Request-ID` / `OpenAI-Request-ID`. Read inbound, else mint `req_<uuid12>`; echo on every response and SSE comment line; surface in `error.request_id`. | HTTP header | `Sources/MacLocalAPI/Server.swift` (middleware); `Controllers/MLXChatCompletionsController.swift` already plumbs `requestId` | S |
+| T1.2 | Honor `stream_options.include_usage`. Today usage is always sent; gate it. | Request body | `Models/OpenAIRequest.swift` (new struct); chat controllers' final-chunk emitter | S |
+| T1.3 | Honor `parallel_tool_calls: false`. Emit at most one tool-call/turn when set. | Request body | `Models/OpenAIRequest.swift`; `Models/ToolCallStreamingRuntime.swift`; both chat controllers | S |
+| T1.4 | Mid-stream cancel on client disconnect. Wire Vapor's connection-closed signal to the streaming Task; scheduler already checks `Task.isCancelled` (`Models/BatchScheduler.swift:359, 366, 368, 652`). | invisible | `Controllers/MLXChatCompletionsController.swift:503` (`createStreamingResponse`); `ChatCompletionsController.swift` | S |
+| T1.5 | `POST /v1/chat/completions/{id}/cancel`. In-mem `requestId → Task` map populated by T1.1. | New endpoint | new `Controllers/CancelController.swift`; `Server.swift` route | S, deps T1.1, T1.4 |
+| T1.6 | `POST /v1/tokenize` and `POST /v1/count_tokens` (vLLM/Anthropic style). Pre-flight context-budget for Aider/Cline. Foundation path returns approximate-or-error. | New endpoints | new `Controllers/TokenizeController.swift`; reuse tokenizer from `Models/MLXModelService.swift` | S |
+| T1.7 | Static `GET /openapi.json` + `/docs` (Scalar UI). Self-discovery for Cursor/Continue/Hermes. | New endpoint | `Resources/openapi.json`; `Server.swift` route | S |
+
+## Tier 2 — Core agent semantics (M effort, must-have)
+
+| # | Item | Why | Effort / Deps |
+|---|---|---|---|
+| T2.1 | **Tool-arg schema validation feedback.** Validate model-emitted args against the client's JSON schema; on mismatch, return `tool_call_validation_error` choice. Optional auto-repair via one xgrammar-constrained retry. Modes via request flag `tool_validation: off/warn/repair/strict`. Files: `Models/JSONSchemaConverter.swift`, `Models/ToolCallStreamingRuntime.swift`, `Models/XGrammarService.swift`. | Removes the universal "model returned bad JSON" footgun all agent loops have. | M, deps T1.1 |
+| T2.2 | **Per-request LoRA adapter.** Hot-swap adapter per request (`request.adapter: string`); add `--adapter-registry path.json` for named adapters. Files: `main.swift`, `Models/MLXModelService.swift`, `Models/OpenAIRequest.swift`. Expose `afm:adapter_active` in metrics. | One server, multiple personas (codegen vs chat). | M |
+| T2.3 | **`--<client>-config` parity.** Clone the `--openclaw-config` codepath at `main.swift:854` (`printOpenClawConfig`) for `--cline-config`, `--continue-config`, `--aider-config`, `--cursor-config`, `--opencode-config`, `--hermes-config`. Each prints the exact config stanza that client expects. Templates in `Resources/client-templates/`. | Single-command onboarding is the biggest adoption lever. | M |
+| T2.4 | **OpenAI-conformance test pack.** Golden-file suite under `Tests/AgentConformanceTests/` hitting every endpoint at fixed seed; CI fails on schema drift across macOS-14/15/26. Reuse existing `Scripts/test-all-features.sh` plumbing. | Locks in the surface for the agent ecosystem. | M |
+| T2.5 | **Per-message `cache_control: {type: "ephemeral"}` (Anthropic-style breakpoints).** Pin that prefix in radix cache for session TTL. Closes the gap with Anthropic prompt caching that Hermes/Aider rely on. Files: `Models/RadixTreeCache.swift`, `Models/MLXCacheResolver.swift`. | Anthropic-style breakpoints are de facto industry standard now. | M |
+
+## Tier 3 — Differentiators (L effort, the moat)
+
+| # | Item | Detail |
+|---|---|---|
+| **T3.1** | **Persistent KV-cache session handles.** `POST /v1/sessions` returns `session_id`; subsequent `chat/completions` pass `session_id` and only the *delta* messages — radix cache holds the prefix across turns. LRU + explicit `DELETE /v1/sessions/{id}`. Files: new `Controllers/SessionsController.swift`, new `Models/SessionStore.swift`, hooks in `Models/RadixTreeCache.swift` and `Models/MLXModelService.swift`. **Why first**: agents like Aider/Continue/Cline run multi-turn loops where the system prompt + repo map is 50–200k tokens; re-prefilling each turn dominates wall-clock on Apple Silicon. Single biggest user-visible win available. Effort: L. |
+| **T3.2** | **MCP server mode.** `afm --mcp` (and co-served at `/mcp/sse` + `/mcp/stream`) speaks the Model Context Protocol so Claude Code, Cursor, Cline can call AFM as an MCP tool provider — exposes `chat`, `embed`, `tokenize`, `transcribe`, `tts`, `ocr`, `vision` as MCP tools; gateway-discovered backends as MCP resources. Spec: modelcontextprotocol.io 2025-06. Files: new `Sources/MacLocalAPI/MCP/` (`MCPServer.swift`, `MCPTools.swift`, `MCPResources.swift`); `main.swift` flag. Effort: L, deps T1.6. |
+| **T3.3** | **`/v1/responses` (OpenAI Responses API).** `POST /v1/responses`, `GET /v1/responses/{id}`, `POST /v1/responses/{id}/cancel`; streaming `response.created` / `response.output_text.delta` / `response.completed` events; `previous_response_id` chaining; server-stored `input` & `output`. Files: new `Controllers/ResponsesController.swift`, new `Models/ResponseStore.swift` (sqlite or in-mem), translation to/from existing chat path; reuse `ToolCallStreamingRuntime`. Effort: L, deps T3.1 (chaining via session handles), T1.5 (cancel). |
+| **T3.4** | **Hybrid Foundation+MLX auto-routing.** `model: "auto"` (or `--router policy.json`) picks Foundation Models for short low-latency turns (<1k ctx, no tools, macOS 26+) and MLX otherwise; transparent fallback if Foundation refuses (guardrails / unsupported). Decision exposed in `system_fingerprint` + `X-AFM-Router` header. Files: new `Models/HybridRouter.swift`; hooks in `Controllers/MLXChatCompletionsController.swift` and `ChatCompletionsController.swift`; telemetry to `Models/StatsAggregator.swift`. Effort: L. The Apple-Silicon-native moat — no other server can do this. |
+
+## Sequencing
+
+1. **PR-1**: T0.1 + T0.2 + T1.1 + T1.2 + T1.3 (one stacked PR — README + 3 small request-shape changes that all touch `OpenAIRequest.swift` together).
+2. **PR-2**: T1.4 + T1.5 (cancel pair — same critical path).
+3. **PR-3**: T1.6 + T1.7 (new read-only endpoints).
+4. **PR-4..6**: T2.1, T2.3, T2.4 in parallel (each its own PR).
+5. **PR-7**: T2.2 + T2.5 (cache + adapter, both touch `MLXModelService.swift`).
+6. **PR-8**: T3.1 (sessions) — unlocks T3.3.
+7. **PR-9 / PR-10**: T3.2 (MCP) and T3.4 (hybrid router) in parallel.
+8. **PR-11**: T3.3 (Responses API) last.
+
+## Critical files
+
+- `Sources/MacLocalAPI/Server.swift` — route registration, middleware
+- `Sources/MacLocalAPI/main.swift` — CLI flags, `printOpenClawConfig` (`:854`)
+- `Sources/MacLocalAPI/Controllers/MLXChatCompletionsController.swift` — streaming path
+- `Sources/MacLocalAPI/Controllers/ChatCompletionsController.swift` — Foundation path
+- `Sources/MacLocalAPI/Models/OpenAIRequest.swift` / `OpenAIResponse.swift` — wire shape
+- `Sources/MacLocalAPI/Models/ToolCallStreamingRuntime.swift` — tool-call surface
+- `Sources/MacLocalAPI/Models/RadixTreeCache.swift` — prefix cache
+- `Sources/MacLocalAPI/Models/MLXCacheResolver.swift` — cache resolution
+- `Sources/MacLocalAPI/Models/BatchScheduler.swift` — concurrent decode + cancel checks
+- `Sources/MacLocalAPI/Models/MLXModelService.swift` — model load, tokenizer, format inference (`:3598`)
+
+## Functions to reuse
+
+- `inferToolCallFormat()` — `Sources/MacLocalAPI/Models/MLXModelService.swift:3598` (auto-detect from `model_type`)
+- `printOpenClawConfig()` — `Sources/MacLocalAPI/main.swift:854` (template for Tier 2.3 client configs)
+- `extractHarmonyContent` / `extractHarmonyChannels` — `Controllers/MLXChatCompletionsController.swift` (already harmonized output for gpt-oss; `/v1/responses` reuses)
+- `XGrammarService` — `Models/XGrammarService.swift` (constrained retry for T2.1 tool repair)
+- vLLM-namespace `/metrics` — `Controllers/MetricsController.swift` (extend with `afm:adapter_active`, `afm:router_decisions_total`, session counts)
+- Existing `requestId` plumbing in chat controllers (lines 100/207/267/523) — surface as response header in T1.1
+
+## Verification
+
+| Tier | How to verify |
+|---|---|
+| T0 | README diff renders cleanly; every row links to a working file path. |
+| T1.1 | `curl -D-` shows `x-request-id`; pass inbound id, see it echoed. |
+| T1.2 | OpenAI Python SDK strict mode passes; `include_usage:false` → no usage in last chunk. |
+| T1.3 | Force a two-tool-call response; flag false → only first surfaces. |
+| T1.4 | Start long generation, kill curl; `afm:num_requests_running` drops within 250 ms. |
+| T1.5 | Mid-turn POST cancel → stream ends with `finish_reason:"cancelled"`. |
+| T1.6 | `/v1/tokenize` count matches usage from a 1-token completion. |
+| T1.7 | `npx @scalar/cli` renders `/openapi.json` without error. |
+| T2.1 | Assertion suite: schema requires int, force-string output → repair → valid. |
+| T2.2 | Two parallel requests with different adapters → distinct stylistic output; `afm:adapter_active` reflects both. |
+| T2.3 | Each generated `--<client>-config` smoke-tested against the real client. |
+| T2.4 | GH Actions matrix green on macOS-14/15/26. |
+| T2.5 | Repeat request with same prefix → `cached_tokens > 0`. |
+| T3.1 | Bench: 8 turns × 80k-token prefix → ≥5× TTFT speedup vs no-session. Add to `skills/test-afm-assertions`. |
+| T3.2 | Register AFM in Claude Code `mcp_servers.json`; call `afm.chat` MCP tool; see streamed tokens. |
+| T3.3 | OpenAI SDK `client.responses.create()` works against AFM, both single-shot and `previous_response_id` chaining. |
+| T3.4 | Assertion pack: short prompt → Foundation (<200 ms TTFT); long/tool prompt → MLX; refusal → MLX fallback within one retry; `/metrics` exposes `afm:router_decisions_total{backend=}`. |
+
+## Notes / open questions
+
+- **"Hermes" disambiguation**: interpreted as Nous Research's Hermes Agent Framework (an OpenAI-compat consumer), not the Hermes tool-call parser already supported in `vendor/.../ToolCallFormat.swift`. If you meant the latter, T0.2's Hermes cookbook page collapses into existing tool-format docs.
+- **Foundation Models limits**: Tier 3.4's auto-router needs a probe-and-cache pass for Foundation availability per `os.major`; macOS pre-26 always routes to MLX.
+- **MCP transport**: prefer the newer Streamable HTTP transport over stdio for a server-mode MCP, since AFM is already an HTTP server.


### PR DESCRIPTION
## Summary

First in a stacked series making AFM agent-friendly per [docs/roadmap/agent-friendly.md](docs/roadmap/agent-friendly.md). Lands Tier 0 (promotion-only) and the first three Tier 1 quick wins:

- **T0.1** README "Why AFM for agents" capability matrix with file:line citations for the 7+ tool-call formats, adaptive XML parser, structured output / xgrammar, prefix cache, concurrent batch, etc.
- **T0.2** `docs/clients/` — one-page recipes for OpenCode, OpenClaw, Cline, Continue.dev, Aider, Cursor, Hermes (Nous Research)
- **T1.1** `RequestIDMiddleware` honors inbound `X-Request-ID` / `OpenAI-Request-ID`, mints `req_<uuid12>` otherwise, echoes on every response, surfaces `error.request_id` for retry correlation
- **T1.2** `stream_options.include_usage` honored end-to-end (MLX + Foundation streaming paths). Default true preserves existing behavior
- **T1.3** `parallel_tool_calls: false` truncates to one call per turn in `finalizeAssistantTurn`

## Test plan

- [x] 11 new unit tests in `AgentFriendlyTier1Tests` cover request-id mint shape, OpenAIError carrying request_id, include_usage gating in three shapes, parallel_tool_calls truncation/preservation/JSON round-trip
- [x] Full suite: 304/304 tests pass
- [x] Live e2e: minted `req_ef0fb1d8e46e` echoed; inbound `req_my-test-1234` honored; `include_usage:false` stream ends with finish_reason + [DONE] and no usage block

Stacked: [PR-2 #TBD](feat/agent-friendly-pr2) → [PR-3 #TBD](feat/agent-friendly-pr3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Tier-1 agent-friendly request semantics (request ID correlation, streaming usage gating, parallel_tool_calls behavior), along with documentation and tests to position AFM as a strong backend for agentic clients.

New Features:
- Introduce RequestIDMiddleware to mint or echo X-Request-ID / OpenAI-Request-ID per request and surface it in error responses.
- Add support for OpenAI-compatible stream_options.include_usage to control inclusion of usage blocks in streaming responses.
- Add support for the parallel_tool_calls flag on chat requests to allow limiting tool calls to a single call per assistant turn.

Enhancements:
- Document AFM’s agent-focused capabilities in a new README section and add an agent client cookbook under docs/clients for popular tools.
- Thread new request fields (stream_options, parallel_tool_calls) through existing request/response models and local client helpers without changing default behavior.

Documentation:
- Add a README capability matrix explaining why AFM is suited for agentic clients, with pointers to implementation locations.
- Add per-client setup guides under docs/clients for OpenCode, OpenClaw, Cline, Continue.dev, Aider, Cursor, and Hermes.
- Introduce an agent-friendly roadmap document outlining planned tiers of improvements for agentic use cases.

Tests:
- Add AgentFriendlyTier1Tests to cover request ID format, error request_id serialization, stream_options.include_usage behavior, and parallel_tool_calls truncation semantics.