### PR TITLE
fix(toolcall): prevent server crash on scalar JSON arg value (#128)

### DIFF
--- a/Sources/MacLocalAPI/Models/MLXModelService.swift
+++ b/Sources/MacLocalAPI/Models/MLXModelService.swift
@@ -3383,14 +3383,31 @@ final class MLXModelService: @unchecked Sendable {
         for (k, v) in parsed {
             if let s = v as? String {
                 arguments[k] = s
-            } else if let data = try? JSONSerialization.data(withJSONObject: v),
-                      let s = String(data: data, encoding: .utf8) {
+            } else if let s = jsonValueToString(v) {
                 arguments[k] = s
             } else {
                 arguments[k] = "\(v)"
             }
         }
         return ToolCall(function: .init(name: name, arguments: arguments))
+    }
+
+    /// Serialize a JSON value (parsed via `JSONSerialization`) to its string form.
+    ///
+    /// `JSONSerialization.data(withJSONObject:)` raises an Objective-C
+    /// `NSInvalidArgumentException` ("Invalid top-level type in JSON write") when the
+    /// top-level value is a scalar — a number, boolean, or null. That exception is NOT a
+    /// Swift `Error`, so `try?` cannot catch it and the process crashes. We wrap the value
+    /// in a single-element array (always a valid top-level type), serialize, then strip the
+    /// enclosing brackets to recover the value's JSON representation. Mirrors the idiom in
+    /// `ToolCallStreamingRuntime.jsonEncodeString`.
+    private static func jsonValueToString(_ value: Any) -> String? {
+        guard let data = try? JSONSerialization.data(withJSONObject: [value]),
+              let wrapped = String(data: data, encoding: .utf8),
+              wrapped.count >= 2 else {
+            return nil
+        }
+        return String(wrapped.dropFirst().dropLast())
     }
 
     /// Regex-based XML function parser with entity decoding.

--- a/Tests/MacLocalAPITests/XMLToolCallParsingTests.swift
+++ b/Tests/MacLocalAPITests/XMLToolCallParsingTests.swift
@@ -359,6 +359,34 @@ struct XMLToolCallParsingTests {
         #expect(path == "/tmp/a.txt")
     }
 
+    @Test("XML+embedded-JSON tool call with scalar arg values does not crash (regression)")
+    func embeddedJSONScalarValuesNoCrash() {
+        // Regression: model emits the hybrid form <function=NAME, "arguments":{...}} where
+        // a value is a JSON scalar (number / bool / null). JSONSerialization.data(withJSONObject:)
+        // raises an *uncaught* ObjC NSInvalidArgumentException ("Invalid top-level type in JSON
+        // write") for scalar top-level types — try? cannot catch it, so the server crashed.
+        // Values must be wrapped before serialization.
+        let text = #"<tool_call><function=set_options, "arguments": {"index": 5, "enabled": true, "ratio": 1.5, "note": null}}</tool_call>"#
+        let (calls, _) = MLXModelService.extractToolCallsFallback(from: text)
+        #expect(calls.count == 1)
+        #expect(calls[0].function.name == "set_options")
+        #expect(calls[0].function.arguments["index"]?.anyValue as? String == "5")
+        #expect(calls[0].function.arguments["enabled"]?.anyValue as? String == "true")
+        #expect(calls[0].function.arguments["ratio"]?.anyValue as? String == "1.5")
+        #expect(calls[0].function.arguments["note"]?.anyValue as? String == "null")
+    }
+
+    @Test("XML+embedded-JSON tool call preserves nested object/array values")
+    func embeddedJSONNestedValues() {
+        let text = #"<tool_call><function=configure, "arguments": {"name": "left", "opts": {"a": 1}, "ids": [1, 2, 3]}}</tool_call>"#
+        let (calls, _) = MLXModelService.extractToolCallsFallback(from: text)
+        #expect(calls.count == 1)
+        #expect(calls[0].function.name == "configure")
+        #expect(calls[0].function.arguments["name"]?.anyValue as? String == "left")
+        #expect(calls[0].function.arguments["opts"]?.anyValue as? String == #"{"a":1}"#)
+        #expect(calls[0].function.arguments["ids"]?.anyValue as? String == "[1,2,3]")
+    }
+
     @Test("JSON-in-XML with no arguments key still parses name")
     func parsesJSONInXMLNameOnly() {
         let text = """


### PR DESCRIPTION
Fixes #128

## Problem

The server **terminates the entire process** with an uncaught Objective-C `NSInvalidArgumentException` when a model emits a tool call in the hybrid embedded-JSON form (`<function=NAME, "arguments": {…}}`) where an argument value is a JSON scalar (number, bool, or `null`):

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException',
    reason: '*** +[NSJSONSerialization dataWithJSONObject:options:error:]: Invalid top-level type in JSON write'
```

## Root cause

`MLXModelService.parseXMLFunctionWithEmbeddedJSON` passed each parsed value to `JSONSerialization.data(withJSONObject: v)`. That API only accepts an array or dictionary at the top level; for a scalar it raises an **Objective-C exception** — not a Swift `Error` — so the surrounding `try?` cannot catch it and the server crashes on the streaming tool-call finalize path.

## Fix

Extract a `jsonValueToString` helper that wraps the value in a single-element array (always a valid top-level type), serializes, then strips the enclosing brackets to recover the value's JSON form. This mirrors the existing idiom in `ToolCallStreamingRuntime.jsonEncodeString`. Scalars, nested objects, and arrays all serialize correctly with no exception:

| value | result |
|-------|--------|
| `5` | `5` |
| `true` | `true` |
| `1.5` | `1.5` |
| `null` | `null` |
| `{"a":1}` | `{"a":1}` |
| `[1,2,3]` | `[1,2,3]` |

## Testing

- Two regression tests added to `XMLToolCallParsingTests` (scalar values + nested object/array preservation).
- **Proven to guard the regression:** reverting only the source fix and rerunning crashes the test runner with the *same* stack frames as the production crash (`parseXMLFunctionWithEmbeddedJSON` → `+[NSJSONSerialization …] + 240`); restoring the fix passes.
- Full `XMLToolCallParsingTests` suite: **100/100 passing**.

## Scope

Source change is limited to `MLXModelService.swift` (+ tests). Audited the other `data(withJSONObject:)` call sites — the only sibling that handles arbitrary values (`extractToolCallsFallback` line ~3169) is fed `[[String: Any]]` items, so it is not at risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent server crashes when parsing XML tool calls with embedded JSON scalar arguments by safely serializing arbitrary JSON values and add regression coverage.

Bug Fixes:
- Handle JSON scalar argument values in embedded-JSON XML tool calls without triggering NSInvalidArgumentException and crashing the process.

Enhancements:
- Introduce a helper to robustly convert arbitrary JSONSerialization-parsed values to their string representation for tool call arguments.

Tests:
- Add regression tests to verify scalar and nested object/array argument handling for XML tool calls with embedded JSON.