### PR TITLE
build: migrate to Swift 6 language mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,13 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up Swift
-      uses: swift-actions/setup-swift@v1
-      with:
-        swift-version: "5.9"
-    
+
+    # Use the runner's default Xcode toolchain (Swift 6.x on macos-latest),
+    # which is required both for the macOS 26 SDK / Foundation Models APIs and
+    # for Package.swift's `swift-tools-version: 6.0` (Swift 6 language mode).
+    # Do NOT pin an older swift-actions/setup-swift toolchain: Swift < 6.0
+    # cannot build a 6.0 tools-version package, and a swift.org toolchain lacks
+    # the FoundationModels framework.
     - name: Build Release Binary
       run: swift build --configuration release
     

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 import Foundation
 

--- a/Sources/MacLocalAPI/Controllers/MLXChatServing.swift
+++ b/Sources/MacLocalAPI/Controllers/MLXChatServing.swift
@@ -23,7 +23,7 @@ typealias ChatStreamingResult = (
     thinkEndTag: String?
 )
 
-protocol MLXChatServing {
+protocol MLXChatServing: Sendable {
     var maxConcurrent: Int { get }
     var toolCallParser: String? { get }
     var supportsStrictToolGrammar: Bool { get }

--- a/Sources/MacLocalAPI/EmbeddingsCommand.swift
+++ b/Sources/MacLocalAPI/EmbeddingsCommand.swift
@@ -115,7 +115,10 @@ struct EmbeddingsCommand: ParsableCommand {
     }
 }
 
-final class EmbeddingHTTPServer {
+// @unchecked Sendable: owns a Vapor Application (not Sendable-audited). Start/
+// shutdown are driven from a single flow with lock-guarded shared flags, so the
+// shutdown Task can safely capture self.
+final class EmbeddingHTTPServer: @unchecked Sendable {
     private let app: Application
     private let port: Int
     private let hostname: String
@@ -160,9 +163,9 @@ final class EmbeddingHTTPServer {
         // server finishing bind. If shutdown() ran against an un-started
         // server, its app.server.shutdown() was a no-op, so we need to either
         // skip the bind entirely or tear it down right after it completes.
-        shutdownLock.lock()
-        let shutdownRequestedBeforeStart = app.storage[EmbeddingShutdownRequestedKey.self] == true
-        shutdownLock.unlock()
+        let shutdownRequestedBeforeStart = shutdownLock.withLock {
+            app.storage[EmbeddingShutdownRequestedKey.self] == true
+        }
 
         if shutdownRequestedBeforeStart {
             print("Embeddings server shutdown requested before bind; skipping start.")
@@ -176,9 +179,9 @@ final class EmbeddingHTTPServer {
         // this point already marked the flag. The prior shutdown() call ran
         // app.server.shutdown() on an un-started server (no-op), so tear down
         // the freshly-bound listener here.
-        shutdownLock.lock()
-        let shutdownRequestedDuringStart = app.storage[EmbeddingShutdownRequestedKey.self] == true
-        shutdownLock.unlock()
+        let shutdownRequestedDuringStart = shutdownLock.withLock {
+            app.storage[EmbeddingShutdownRequestedKey.self] == true
+        }
         if shutdownRequestedDuringStart {
             print("Shutdown requested during start; shutting the just-bound server down.")
             await app.server.shutdown()

--- a/Sources/MacLocalAPI/Models/BatchScheduler.swift
+++ b/Sources/MacLocalAPI/Models/BatchScheduler.swift
@@ -1,6 +1,8 @@
 import Foundation
 import MLX
-import MLXLMCommon
+// See MLXModelService.swift for rationale: MLXLMCommon value types predate Swift 6
+// concurrency; downgrade their Sendable diagnostics to warnings.
+@preconcurrency import MLXLMCommon
 import Tokenizers
 import os
 
@@ -881,7 +883,11 @@ actor BatchScheduler {
             cacheLookupTime = tLookup1 - tLookup0
             let forcedSuffix = unsafeExactReplaySuffix()
             let effectivePrefix: Int
-            if prefixLen == inputTokens.count && hasRecurrentLayers(cache) && forcedSuffix == nil {
+            // Inlined hasRecurrentLayers(cache): an actor-isolated call would make
+            // the compiler treat the non-Sendable `cache` as "sent", conflicting
+            // with its later in-actor uses. Inlining keeps it in one region.
+            let recurrent = cache.contains { $0 is ArraysCache || $0 is CacheList }
+            if prefixLen == inputTokens.count && recurrent && forcedSuffix == nil {
                 effectivePrefix = 0
                 if prefixLen > 0 {
                     cacheOutcome = "exact-replay-bypass"
@@ -913,8 +919,10 @@ actor BatchScheduler {
                 let tTrim = Date.timeIntervalSinceReferenceDate
                 // Physically truncate trimmed cache arrays to eliminate stale data. (#47)
                 for i in 0..<cache.count {
+                    // Inlined supportsPhysicalTruncation (see note above) to avoid
+                    // sending the non-Sendable cache element across a call boundary.
                     if cache[i].isTrimmable && cache[i].offset > 0
-                        && supportsPhysicalTruncation(cache[i])
+                        && !(cache[i] is RotatingKVCache)
                     {
                         cache[i].truncateToOffset()
                     }
@@ -1844,7 +1852,7 @@ actor BatchScheduler {
         guard let data = rtc.function.arguments.data(using: .utf8),
               let argsDict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return rtc }
         var sendableArgs = [String: any Sendable]()
-        for (key, value) in argsDict { sendableArgs[key] = value }
+        for (key, value) in argsDict { sendableArgs[key] = MLXModelService.asSendableJSON(value) }
         let remapped = MLXModelService.remapArgumentKeys(sendableArgs, toolName: rtc.function.name, tools: tools)
         let remappedAny = remapped.mapValues { $0 as Any }
         guard let newData = try? JSONSerialization.data(withJSONObject: remappedAny, options: [.sortedKeys]),

--- a/Sources/MacLocalAPI/Models/FoundationModelService.swift
+++ b/Sources/MacLocalAPI/Models/FoundationModelService.swift
@@ -194,22 +194,22 @@ enum FoundationModelError: Error, LocalizedError {
 }
 
 @available(macOS 26.0, *)
-class FoundationModelService {
+class FoundationModelService: @unchecked Sendable {
     
     #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
     private var session: LanguageModelSession?
     #endif
     
     // Shared singleton instance
-    static var shared: FoundationModelService?
-    
+    nonisolated(unsafe) static var shared: FoundationModelService?
+
     // Shared adapter for reuse across instances
     #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS && !DISABLE_FOUNDATION_MODELS
-    static var sharedAdapter: SystemLanguageModel.Adapter?
+    nonisolated(unsafe) static var sharedAdapter: SystemLanguageModel.Adapter?
     #else
-    static var sharedAdapter: Any?
+    nonisolated(unsafe) static var sharedAdapter: Any?
     #endif
-    static var sharedAdapterPath: String?
+    nonisolated(unsafe) static var sharedAdapterPath: String?
     
     init(instructions: String = "You are a helpful assistant", adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil, permissiveGuardrails: Bool) async throws {
         #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS && !DISABLE_FOUNDATION_MODELS

--- a/Sources/MacLocalAPI/Models/MLXModelService.swift
+++ b/Sources/MacLocalAPI/Models/MLXModelService.swift
@@ -2937,7 +2937,13 @@ final class MLXModelService: @unchecked Sendable {
         case let dict as [String: Any]: return dict.mapValues { asSendableJSON($0) }
         case let n as NSNumber: return n
         case is NSNull: return NSNull()
-        default: return String(describing: value)
+        default:
+            // Unreachable for the only caller input (`JSONSerialization.jsonObject`
+            // output, which is exclusively NSString/NSNumber/NSNull/NSArray/
+            // NSDictionary). Kept as a non-throwing safety net so an unexpected
+            // value can never crash the tool-call argument path; it degrades to a
+            // string rather than propagating. Revisit if a non-JSON source is added.
+            return String(describing: value)
         }
     }
 
@@ -4588,11 +4594,8 @@ final class MLXModelService: @unchecked Sendable {
         let sem = DispatchSemaphore(value: 0)
         // Box the result so the @Sendable URLSession completion handler can write
         // it without a captured-var data race. The semaphore guarantees the write
-        // happens-before the read below, so @unchecked Sendable is sound.
-        final class ResultBox: @unchecked Sendable {
-            var value: Result<(Data, URLResponse), Error>?
-        }
-        let box = ResultBox()
+        // happens-before the read below, so the SendableBox is sound here.
+        let box = SendableBox<Result<(Data, URLResponse), Error>?>(nil)
         let task = URLSession.shared.dataTask(with: url) { data, response, error in
             if let error {
                 box.value = .failure(error)

--- a/Sources/MacLocalAPI/Models/MLXModelService.swift
+++ b/Sources/MacLocalAPI/Models/MLXModelService.swift
@@ -5,7 +5,11 @@ import MLX
 import Cmlx
 import MLXLLM
 import MLXVLM
-import MLXLMCommon
+// @preconcurrency: MLXLMCommon predates Swift 6 concurrency. Its value types
+// (LMInput, ModelContext, UserInput, GenerateParameters) aren't Sendable-audited;
+// this downgrades cross-boundary Sendable diagnostics for them to warnings without
+// changing runtime behavior. Access is already serialized via ModelContainer.
+@preconcurrency import MLXLMCommon
 import Tokenizers
 import Hub
 import HuggingFace
@@ -96,9 +100,51 @@ private let vvCyan = "\u{1B}[38;5;87m"
 private let vvReset = "\u{1B}[0m"
 /// Module-level trace flag, set by MLXModelService.trace when the service is configured.
 /// Used by static parsing/conversion methods that can't access instance properties.
-private var traceLogging = false
+nonisolated(unsafe) private var traceLogging = false
 /// Module-level grammar constraint flag — enables cross-parameter dedup in the XML parser.
-private var grammarConstraintsActive = false
+nonisolated(unsafe) private var grammarConstraintsActive = false
+
+/// Carries values out of the serialized `container.perform` generation closure.
+///
+/// Swift 6 forbids a `@Sendable` closure from capturing-and-mutating local `var`s.
+/// The generation closure runs under the model's serial-access lock and is fully
+/// awaited before any of these fields are read, so there is no real concurrency —
+/// `@unchecked Sendable` documents that the synchronization is provided externally
+/// by `ModelContainer.perform`. This preserves the prior single-sequence behavior
+/// exactly while moving the mutable storage into a reference the closure can capture.
+private final class NonStreamingScratch: @unchecked Sendable {
+    /// Non-Sendable model input, handed to the closure through this box.
+    var userInput: UserInput!
+    var collectedLogprobs = [TokenLogprobData]()
+    var resolvedLogprobs: [ResolvedLogprob]? = nil
+    var collectedToolCalls = [ToolCall]()
+    var completionInfo: GenerateCompletionInfo? = nil
+    var cachedTokenCount = 0
+    var stoppedBySequence = false
+    var cacheOutcome = "disabled"
+    var cacheLookupTime: Double? = nil
+    var cacheRestoreTime: Double? = nil
+    var cacheTrimTime: Double? = nil
+    var cacheTruncateTime: Double? = nil
+    var cacheInputTokenCount = 0
+    var saveTrimTime: Double? = nil
+    var saveTruncateTime: Double? = nil
+    var saveInsertTime: Double? = nil
+}
+
+/// Streaming counterpart of `NonStreamingScratch`. Holds the non-Sendable model
+/// input and the post-generation metric counters that the nested, serialized
+/// `container.perform` closure fills in. Same justification for `@unchecked
+/// Sendable`: the closure runs under the model lock and is awaited before these
+/// fields are read by the metrics observation below it.
+private final class StreamingScratch: @unchecked Sendable {
+    var userInput: UserInput!
+    var streamStatPromptTokens = 0
+    var streamStatCompletionTokens = 0
+    var streamStatPromptTime = 0.0
+    var streamStatGenerateTime = 0.0
+    var streamStatStoppedBySequence = false
+}
 
 final class MLXModelService: @unchecked Sendable {
     private struct ConstrainedDecodingSetup {
@@ -548,9 +594,9 @@ final class MLXModelService: @unchecked Sendable {
     // DRAM power → bandwidth calibration via GPU memory stress (MLX).
     // Runs a known GPU workload (x + 1 on 1 GiB array) for 1s, measures DRAM power
     // via IOReport, derives GB/s-per-watt from actual GPU→DRAM traffic.
-    private static var dramIdlePowerW = 0.3
-    private static var dramGBsPerWatt = 10.5  // fallback if calibration fails
-    private static var dramCalibrated = false
+    nonisolated(unsafe) private static var dramIdlePowerW = 0.3
+    nonisolated(unsafe) private static var dramGBsPerWatt = 10.5  // fallback if calibration fails
+    nonisolated(unsafe) private static var dramCalibrated = false
 
     /// Thread-safe dispatch_once calibration — runs async on background queue.
     /// Default dramGBsPerWatt (10.5) is used until calibration completes.
@@ -1156,8 +1202,9 @@ final class MLXModelService: @unchecked Sendable {
                 currentToolCallFormat = detectedFormat
             }
             // Detect think start/end tags from tokenizer vocabulary
-            do {
-                let ctx = try await loaded.perform { context in context }
+            // Run the tokenizer-vocabulary inspection inside `perform` so the
+            // non-Sendable ModelContext never crosses the isolation boundary.
+            try await loaded.perform { context in
                 let knownThinkPairs: [(start: String, end: String)] = [
                     ("<|channel>", "<channel|>"),  // Gemma 4 channel-based thinking
                     ("<think>", "</think>"),
@@ -1172,8 +1219,8 @@ final class MLXModelService: @unchecked Sendable {
                     return ids.count == 1 || (ids.count == 2 && tokenizer.decode(tokens: [ids.last!]) == s)
                 }
                 for pair in knownThinkPairs {
-                    if isSingleToken(pair.start, ctx.tokenizer)
-                        && isSingleToken(pair.end, ctx.tokenizer)
+                    if isSingleToken(pair.start, context.tokenizer)
+                        && isSingleToken(pair.end, context.tokenizer)
                     {
                         self.thinkStartTag = pair.start
                         self.thinkEndTag = pair.end
@@ -1455,45 +1502,67 @@ final class MLXModelService: @unchecked Sendable {
         let wantLogprobs = logprobs == true
         let effectiveMaxTokens = capMaxTokensForCapture(maxTokens ?? 2000)
 
-        var params = GenerateParameters(
-            maxTokens: effectiveMaxTokens,
-            kvBits: self.kvBits,
-            kvGroupSize: 64,
-            quantizedKVStart: 0,
-            temperature: normalizedTemperature(temperature),
-            topP: normalizedTopP(topP),
-            repetitionPenalty: normalizedRepetitionPenalty(repetitionPenalty),
-            repetitionContextSize: 64,
-            topK: normalizedTopK(topK),
-            minP: normalizedMinP(minP),
-            presencePenalty: normalizedPresencePenalty(presencePenalty),
-            seed: normalizedSeed(seed),
-            computeLogprobs: wantLogprobs,
-            topLogprobsCount: wantLogprobs ? min(max(topLogprobs ?? 0, 0), 20) : 0,
-            prefillStepSize: self.prefillStepSize
-        )
-
-        var collectedLogprobs = [TokenLogprobData]()
-        var resolvedLogprobs: [ResolvedLogprob]? = nil
-        var collectedToolCalls = [ToolCall]()
-        var completionInfo: GenerateCompletionInfo? = nil
-        var cachedTokenCount = 0
-        var stoppedBySequence = false
-        var cacheOutcome = "disabled"
-        var cacheLookupTime: Double? = nil
-        var cacheRestoreTime: Double? = nil
-        var cacheTrimTime: Double? = nil
-        var cacheTruncateTime: Double? = nil
-        var cacheInputTokenCount = 0
-        var saveTrimTime: Double? = nil
-        var saveTruncateTime: Double? = nil
-        var saveInsertTime: Double? = nil
+        // Mutable generation state lives in a scratch box so the @Sendable
+        // `container.perform` closure (Swift 6) can capture-and-mutate it.
+        // perform serializes the whole generation under the model lock and is
+        // awaited before these fields are read, so access stays single-sequence.
+        let scratch = NonStreamingScratch()
+        scratch.userInput = userInput
         // GPU capture/trace/profile: start before inference
         let capturePath = gpuCapturePath
         let capturing = beginGPUCaptureIfNeeded()
         let tracing = beginGPUTraceIfNeeded()
         if gpuProfile { printGPUProfileHeader() }
         let generated: String = try await container.perform { context in
+            var params = GenerateParameters(
+                maxTokens: effectiveMaxTokens,
+                kvBits: self.kvBits,
+                kvGroupSize: 64,
+                quantizedKVStart: 0,
+                temperature: normalizedTemperature(temperature),
+                topP: normalizedTopP(topP),
+                repetitionPenalty: normalizedRepetitionPenalty(repetitionPenalty),
+                repetitionContextSize: 64,
+                topK: normalizedTopK(topK),
+                minP: normalizedMinP(minP),
+                presencePenalty: normalizedPresencePenalty(presencePenalty),
+                seed: normalizedSeed(seed),
+                computeLogprobs: wantLogprobs,
+                topLogprobsCount: wantLogprobs ? min(max(topLogprobs ?? 0, 0), 20) : 0,
+                prefillStepSize: self.prefillStepSize
+            )
+            var collectedLogprobs = [TokenLogprobData]()
+            var resolvedLogprobs: [ResolvedLogprob]? = nil
+            var collectedToolCalls = [ToolCall]()
+            var completionInfo: GenerateCompletionInfo? = nil
+            var cachedTokenCount = 0
+            var stoppedBySequence = false
+            var cacheOutcome = "disabled"
+            var cacheLookupTime: Double? = nil
+            var cacheRestoreTime: Double? = nil
+            var cacheTrimTime: Double? = nil
+            var cacheTruncateTime: Double? = nil
+            var cacheInputTokenCount = 0
+            var saveTrimTime: Double? = nil
+            var saveTruncateTime: Double? = nil
+            var saveInsertTime: Double? = nil
+            defer {
+                scratch.collectedLogprobs = collectedLogprobs
+                scratch.resolvedLogprobs = resolvedLogprobs
+                scratch.collectedToolCalls = collectedToolCalls
+                scratch.completionInfo = completionInfo
+                scratch.cachedTokenCount = cachedTokenCount
+                scratch.stoppedBySequence = stoppedBySequence
+                scratch.cacheOutcome = cacheOutcome
+                scratch.cacheLookupTime = cacheLookupTime
+                scratch.cacheRestoreTime = cacheRestoreTime
+                scratch.cacheTrimTime = cacheTrimTime
+                scratch.cacheTruncateTime = cacheTruncateTime
+                scratch.cacheInputTokenCount = cacheInputTokenCount
+                scratch.saveTrimTime = saveTrimTime
+                scratch.saveTruncateTime = saveTruncateTime
+                scratch.saveInsertTime = saveInsertTime
+            }
             // Grammar constraint setup (needs tokenizer from context)
             let constrainedDecoding = self.setupConstrainedDecodingProcessor(
                 modelID: modelID,
@@ -1508,7 +1577,7 @@ final class MLXModelService: @unchecked Sendable {
                 params.extraProcessor = constrainedDecoding.processor
             }
 
-            let input = try await context.processor.prepare(input: userInput)
+            let input = try await context.processor.prepare(input: scratch.userInput)
 
             // DEBUG/VV: decode and print the full prompt to see what the template produced
             if debugLogging || self.trace {
@@ -1854,6 +1923,23 @@ final class MLXModelService: @unchecked Sendable {
             return out
         }
 
+        // Re-bind generation outputs from the scratch box so the post-closure
+        // code below reads them by their original names unchanged.
+        let resolvedLogprobs = scratch.resolvedLogprobs
+        let collectedToolCalls = scratch.collectedToolCalls
+        let completionInfo = scratch.completionInfo
+        let cachedTokenCount = scratch.cachedTokenCount
+        let stoppedBySequence = scratch.stoppedBySequence
+        let cacheOutcome = scratch.cacheOutcome
+        let cacheLookupTime = scratch.cacheLookupTime
+        let cacheRestoreTime = scratch.cacheRestoreTime
+        let cacheTrimTime = scratch.cacheTrimTime
+        let cacheTruncateTime = scratch.cacheTruncateTime
+        let cacheInputTokenCount = scratch.cacheInputTokenCount
+        let saveTrimTime = scratch.saveTrimTime
+        let saveTruncateTime = scratch.saveTruncateTime
+        let saveInsertTime = scratch.saveInsertTime
+
         // GPU capture/trace/profile: end after GPU sync completes inside container.perform
         if capturing, let path = capturePath {
             endGPUCapture(path: path)
@@ -2180,15 +2266,34 @@ final class MLXModelService: @unchecked Sendable {
             StatsAggregator.shared.requestStarted()
             // Mutables filled inside container.perform so the final
             // observation can fire just before continuation.finish().
-            var streamStatPromptTokens = 0
-            var streamStatCompletionTokens = 0
-            var streamStatPromptTime = 0.0
-            var streamStatGenerateTime = 0.0
-            var streamStatStoppedBySequence = false
+            // Held in a scratch box so the nested @Sendable perform closure can
+            // mutate them (Swift 6); the box also carries the non-Sendable input.
+            let streamScratch = StreamingScratch()
+            streamScratch.userInput = userInput
             let task = Task {
                 defer { self.endOperation() }
                 do {
                     try await container.perform { context in
+                        // Local generation params (the outer `params` is a captured
+                        // var used by the concurrent path; a fresh local keeps this
+                        // @Sendable closure free of captured-var mutation).
+                        var params = GenerateParameters(
+                            maxTokens: effectiveMaxTokens,
+                            kvBits: self.kvBits,
+                            kvGroupSize: 64,
+                            quantizedKVStart: 0,
+                            temperature: normalizedTemperature(temperature),
+                            topP: normalizedTopP(topP),
+                            repetitionPenalty: normalizedRepetitionPenalty(repetitionPenalty),
+                            repetitionContextSize: 64,
+                            topK: normalizedTopK(topK),
+                            minP: normalizedMinP(minP),
+                            presencePenalty: normalizedPresencePenalty(presencePenalty),
+                            seed: normalizedSeed(seed),
+                            computeLogprobs: wantLogprobs,
+                            topLogprobsCount: wantLogprobs ? min(max(topLogprobs ?? 0, 0), 20) : 0,
+                            prefillStepSize: self.prefillStepSize
+                        )
                         // Grammar constraint setup — see non-streaming path for details.
                         let constrainedDecoding = self.setupConstrainedDecodingProcessor(
                             modelID: modelID,
@@ -2203,7 +2308,7 @@ final class MLXModelService: @unchecked Sendable {
                             params.extraProcessor = constrainedDecoding.processor
                         }
 
-                        let input = try await context.processor.prepare(input: userInput)
+                        let input = try await context.processor.prepare(input: streamScratch.userInput)
 
                         // -VV: decode and print the full prompt (streaming path)
                         if self.trace {
@@ -2430,7 +2535,7 @@ final class MLXModelService: @unchecked Sendable {
                                                     continuation.yield(StreamChunk(text: "", logprobs: resolved, stoppedBySequence: true))
                                                 }
                                             }
-                                            streamStatStoppedBySequence = true  // /metrics: finished_reason=stop
+                                            streamScratch.streamStatStoppedBySequence = true  // /metrics: finished_reason=stop
                                             break
                                         }
                                         // Flush safe portion of the buffer (keep tail that could be partial stop match)
@@ -2475,10 +2580,10 @@ final class MLXModelService: @unchecked Sendable {
                                     )
                                     continuation.yield(StreamChunk(text: "", promptTokens: finalPromptTokens, completionTokens: info.generationTokenCount, promptTime: info.promptTime, generateTime: info.generateTime))
                                     // /metrics: capture for the post-loop observation
-                                    streamStatPromptTokens = finalPromptTokens
-                                    streamStatCompletionTokens = info.generationTokenCount
-                                    streamStatPromptTime = info.promptTime
-                                    streamStatGenerateTime = info.generateTime
+                                    streamScratch.streamStatPromptTokens = finalPromptTokens
+                                    streamScratch.streamStatCompletionTokens = info.generationTokenCount
+                                    streamScratch.streamStatPromptTime = info.promptTime
+                                    streamScratch.streamStatGenerateTime = info.generateTime
                                     // GPU profile: emit footer with real token counts
                                     if streamGpuProfile {
                                         self.printGPUProfileFooter(promptTokens: finalPromptTokens, completionTokens: info.generationTokenCount, promptTime: info.promptTime, generateTime: info.generateTime)
@@ -2584,6 +2689,12 @@ final class MLXModelService: @unchecked Sendable {
                             insertTime: saveInsertTime
                         )
                     }
+                    // Re-bind metric counters from the scratch box so the
+                    // observation below reads them by their original names.
+                    let streamStatPromptTokens = streamScratch.streamStatPromptTokens
+                    let streamStatCompletionTokens = streamScratch.streamStatCompletionTokens
+                    let streamStatPromptTime = streamScratch.streamStatPromptTime
+                    let streamStatStoppedBySequence = streamScratch.streamStatStoppedBySequence
                     self.cleanupTempFiles(mediaTempFiles)
 
                     // /metrics: serial-streaming observation. Mirrors the
@@ -2815,12 +2926,27 @@ final class MLXModelService: @unchecked Sendable {
         }
     }
 
+    /// Recursively convert a `JSONSerialization`-derived value (Foundation `Any`)
+    /// into an `any Sendable` tree. Strings bridge `NSString -> String`; `NSNumber`
+    /// and `NSNull` already conform to `Sendable` and are kept as-is so JSON
+    /// round-tripping through `JSONSerialization` stays byte-identical.
+    static func asSendableJSON(_ value: Any) -> any Sendable {
+        switch value {
+        case let s as String: return s
+        case let arr as [Any]: return arr.map { asSendableJSON($0) }
+        case let dict as [String: Any]: return dict.mapValues { asSendableJSON($0) }
+        case let n as NSNumber: return n
+        case is NSNull: return NSNull()
+        default: return String(describing: value)
+        }
+    }
+
     static func remapResponseToolCallArguments(_ rtc: ResponseToolCall, tools: [RequestTool]?) -> ResponseToolCall {
         guard let tools, !tools.isEmpty else { return rtc }
         guard let data = rtc.function.arguments.data(using: .utf8),
               let argsDict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return rtc }
         var sendableArgs = [String: any Sendable]()
-        for (key, value) in argsDict { sendableArgs[key] = value }
+        for (key, value) in argsDict { sendableArgs[key] = Self.asSendableJSON(value) }
         let remapped = remapArgumentKeys(sendableArgs, toolName: rtc.function.name, tools: tools)
         let remappedAny = remapped.mapValues { $0 as Any }
         guard let newData = try? JSONSerialization.data(withJSONObject: remappedAny, options: [.sortedKeys]),
@@ -3443,7 +3569,7 @@ final class MLXModelService: @unchecked Sendable {
                 if let data = val.data(using: .utf8),
                    let parsed = try? JSONSerialization.jsonObject(with: data),
                    (parsed is [Any] || parsed is [String: Any]) {
-                    arguments[key] = parsed
+                    arguments[key] = Self.asSendableJSON(parsed)
                 } else {
                     arguments[key] = val
                 }
@@ -3469,7 +3595,7 @@ final class MLXModelService: @unchecked Sendable {
                     if let data = decoded.data(using: .utf8),
                        let parsed = try? JSONSerialization.jsonObject(with: data),
                        (parsed is [Any] || parsed is [String: Any]) {
-                        arguments[key] = parsed
+                        arguments[key] = Self.asSendableJSON(parsed)
                     } else {
                         arguments[key] = decoded
                     }
@@ -3568,7 +3694,7 @@ final class MLXModelService: @unchecked Sendable {
         var arguments: [String: any Sendable] = [:]
         if let args = (json["arguments"] as? [String: Any]) ?? (json["parameters"] as? [String: Any]) {
             for (k, v) in args {
-                arguments[k] = v
+                arguments[k] = Self.asSendableJSON(v)
             }
         }
         return ToolCall(function: .init(name: name, arguments: arguments))
@@ -4372,7 +4498,7 @@ final class MLXModelService: @unchecked Sendable {
         }
 
         // Merge chat template kwargs: server defaults first, then request-level overrides
-        var resolvedKwargs: [String: Any] = self.defaultChatTemplateKwargs ?? [:]
+        var resolvedKwargs: [String: any Sendable] = (self.defaultChatTemplateKwargs ?? [:]).mapValues { Self.asSendableJSON($0) }
         if let requestKwargs = chatTemplateKwargs {
             for (key, value) in requestKwargs {
                 resolvedKwargs[key] = value.value.toAny()
@@ -4460,20 +4586,26 @@ final class MLXModelService: @unchecked Sendable {
 
     private func awaitURL(url: URL) throws -> (Data, URLResponse) {
         let sem = DispatchSemaphore(value: 0)
-        var result: Result<(Data, URLResponse), Error>?
+        // Box the result so the @Sendable URLSession completion handler can write
+        // it without a captured-var data race. The semaphore guarantees the write
+        // happens-before the read below, so @unchecked Sendable is sound.
+        final class ResultBox: @unchecked Sendable {
+            var value: Result<(Data, URLResponse), Error>?
+        }
+        let box = ResultBox()
         let task = URLSession.shared.dataTask(with: url) { data, response, error in
             if let error {
-                result = .failure(error)
+                box.value = .failure(error)
             } else if let data, let response {
-                result = .success((data, response))
+                box.value = .success((data, response))
             } else {
-                result = .failure(MLXServiceError.downloadFailed("image download failed"))
+                box.value = .failure(MLXServiceError.downloadFailed("image download failed"))
             }
             sem.signal()
         }
         task.resume()
         sem.wait()
-        switch result {
+        switch box.value {
         case .success(let pair):
             return pair
         case .failure(let error):

--- a/Sources/MacLocalAPI/Models/OpenAIRequest.swift
+++ b/Sources/MacLocalAPI/Models/OpenAIRequest.swift
@@ -302,14 +302,14 @@ struct AnyCodable: Codable, Sendable {
     }
 
     /// Convert to a dictionary suitable for ToolSpec ([String: any Sendable])
-    func toSendable() -> Any {
+    func toSendable() -> any Sendable {
         value.toAny()
     }
 
     /// Convert to a type hierarchy compatible with Jinja Value.init(any:).
     /// Strips null values from dicts (Jinja can't handle NSNull or boxed Optional<Any>).
     /// JSON Schema nulls (e.g. "default": null) are semantically equivalent when omitted.
-    func toJinjaCompatible() -> Any {
+    func toJinjaCompatible() -> any Sendable {
         value.toJinjaCompatible()
     }
 }
@@ -345,7 +345,7 @@ enum AnyCodableValue: Codable, Sendable {
         }
     }
 
-    func toAny() -> Any {
+    func toAny() -> any Sendable {
         switch self {
         case .null: return NSNull()
         case .bool(let b): return b
@@ -364,7 +364,7 @@ enum AnyCodableValue: Codable, Sendable {
     /// equivalent when omitted — templates use `is defined` checks, not null comparisons.
     /// Arrays filter out nulls. Standalone nulls become empty string (shouldn't occur in
     /// practice since null only appears as dict values or array elements in JSON Schema).
-    func toJinjaCompatible() -> Any {
+    func toJinjaCompatible() -> any Sendable {
         switch self {
         case .null: return "" // Standalone null fallback; dict/array nulls are stripped
         case .bool(let b): return b
@@ -372,12 +372,12 @@ enum AnyCodableValue: Codable, Sendable {
         case .double(let d): return d
         case .string(let s): return s
         case .array(let arr):
-            return arr.compactMap { element -> Any? in
+            return arr.compactMap { element -> (any Sendable)? in
                 if case .null = element { return nil }
                 return element.toJinjaCompatible()
             }
         case .object(let dict):
-            var result: [String: Any] = [:]
+            var result: [String: any Sendable] = [:]
             for (key, value) in dict {
                 if case .null = value { continue } // Strip null-valued keys
                 result[key] = value.toJinjaCompatible()
@@ -388,7 +388,7 @@ enum AnyCodableValue: Codable, Sendable {
             // Flatten anyOf/oneOf nullable patterns for Jinja template compatibility.
             // e.g. {"anyOf": [{"type": "string"}, {"type": "null"}]} → {"type": "string"}
             // Templates like Gemma 4 do `value['type'] | upper` which crashes on anyOf dicts.
-            if result["type"] == nil, let anyOf = result["anyOf"] as? [[String: Any]] ?? result["oneOf"] as? [[String: Any]] {
+            if result["type"] == nil, let anyOf = result["anyOf"] as? [[String: any Sendable]] ?? result["oneOf"] as? [[String: any Sendable]] {
                 let nonNull = anyOf.filter { ($0["type"] as? String) != "null" }
                 if nonNull.count == 1, let single = nonNull.first {
                     var flattened = result

--- a/Sources/MacLocalAPI/Models/SpeechService.swift
+++ b/Sources/MacLocalAPI/Models/SpeechService.swift
@@ -100,7 +100,7 @@ struct TranscriptionResult: Sendable, Codable {
 }
 
 @available(macOS 13.0, *)
-final class SpeechService {
+final class SpeechService: Sendable {
 
     func transcribe(from filePath: String) async throws -> String {
         try await transcribe(from: filePath, options: SpeechRequestOptions())
@@ -159,8 +159,14 @@ final class SpeechService {
         // Run recognition with a timeout to prevent hung requests.
         // OSAllocatedUnfairLock guards the one-shot continuation resume.
         let resumed = OSAllocatedUnfairLock(initialState: false)
-        // Holds the SFSpeechRecognitionTask so onCancel can reach it.
-        let taskRef = OSAllocatedUnfairLock<SFSpeechRecognitionTask?>(initialState: nil)
+        // Holds the SFSpeechRecognitionTask so onCancel can reach it. Wrapped
+        // because SFSpeechRecognitionTask isn't Sendable but must live in the
+        // lock's (Sendable) state and be reachable from the @Sendable onCancel.
+        let taskRef = OSAllocatedUnfairLock<UncheckedSendable<SFSpeechRecognitionTask?>>(initialState: UncheckedSendable(nil))
+        // SFSpeechRecognizer / SFSpeechURLRecognitionRequest aren't Sendable, so box
+        // them to carry into the (sending) task-group child without a capture error.
+        let recognizerBox = UncheckedSendable(recognizer)
+        let requestBox = UncheckedSendable(request)
 
         let transcriptionResult: TranscriptionResult = try await withThrowingTaskGroup(of: TranscriptionResult.self) { group in
             group.addTask {
@@ -169,8 +175,9 @@ final class SpeechService {
                         let queue = OperationQueue()
                         queue.qualityOfService = .userInitiated
 
+                        let recognizer = recognizerBox.value
                         recognizer.queue = queue
-                        let task = recognizer.recognitionTask(with: request) { result, error in
+                        let task = recognizer.recognitionTask(with: requestBox.value) { result, error in
                             if let error {
                                 let shouldResume = resumed.withLock { done in
                                     if done { return false }
@@ -227,11 +234,12 @@ final class SpeechService {
                                 segments: segments
                             ))
                         }
-                        taskRef.withLock { $0 = task }
-                        if Task.isCancelled { task.cancel() }
+                        let taskBox = UncheckedSendable<SFSpeechRecognitionTask?>(task)
+                        taskRef.withLock { $0 = taskBox }
+                        if Task.isCancelled { taskRef.withLock { $0.value?.cancel() } }
                     }
                 } onCancel: {
-                    taskRef.withLock { $0?.cancel() }
+                    taskRef.withLock { $0.value?.cancel() }
                 }
             }
             group.addTask {

--- a/Sources/MacLocalAPI/Models/SpeechSynthesisService.swift
+++ b/Sources/MacLocalAPI/Models/SpeechSynthesisService.swift
@@ -1,5 +1,6 @@
 import Foundation
-import AVFoundation
+// AVFoundation audio types (AVAudioPCMBuffer, AVSpeechSynthesizer) aren't Sendable-audited.
+@preconcurrency import AVFoundation
 import os
 
 enum SpeechSynthesisError: Error, LocalizedError {
@@ -162,9 +163,9 @@ final class SpeechSynthesisService: NSObject, @unchecked Sendable {
         utterance.rate = clampRate(options.speed)
 
         let synthesizer = AVSpeechSynthesizer()
-        let allBuffers: [AVAudioPCMBuffer] = try await withThrowingTaskGroup(of: [AVAudioPCMBuffer].self) { group in
+        let allBuffers: [AVAudioPCMBuffer] = try await withThrowingTaskGroup(of: UncheckedSendable<[AVAudioPCMBuffer]>.self) { group in
             group.addTask {
-                let state = OSAllocatedUnfairLock(initialState: (resumed: false, buffers: [AVAudioPCMBuffer](), continuation: nil as CheckedContinuation<[AVAudioPCMBuffer], Error>?))
+                let state = OSAllocatedUnfairLock(initialState: (resumed: false, buffers: [AVAudioPCMBuffer](), continuation: nil as CheckedContinuation<UncheckedSendable<[AVAudioPCMBuffer]>, Error>?))
                 return try await withTaskCancellationHandler {
                     try await withCheckedThrowingContinuation { continuation in
                         state.withLock { $0.continuation = continuation }
@@ -175,7 +176,7 @@ final class SpeechSynthesisService: NSObject, @unchecked Sendable {
                                 state.withLock { s in
                                     guard !s.resumed else { return }
                                     s.resumed = true
-                                    s.continuation?.resume(returning: s.buffers)
+                                    s.continuation?.resume(returning: UncheckedSendable(s.buffers))
                                     s.continuation = nil
                                 }
                             }
@@ -207,7 +208,7 @@ final class SpeechSynthesisService: NSObject, @unchecked Sendable {
             }
             let result = try await group.next()!
             group.cancelAll()
-            return result
+            return result.value
         }
 
         guard !allBuffers.isEmpty else {

--- a/Sources/MacLocalAPI/Models/ToolCallStreamingRuntime.swift
+++ b/Sources/MacLocalAPI/Models/ToolCallStreamingRuntime.swift
@@ -468,7 +468,7 @@ final class ToolCallStreamingRuntime {
             }
             // Use .anyValue to convert JSONValue → plain types before re-init,
             // otherwise JSONValue.from() double-wraps via String(describing:).
-            let plainArgs: [String: any Sendable] = toolCall.function.arguments.mapValues { $0.anyValue }
+            let plainArgs: [String: any Sendable] = toolCall.function.arguments.mapValues { MLXModelService.asSendableJSON($0.anyValue) }
             return ToolCall(function: .init(name: resolvedName, arguments: plainArgs))
         }
     }

--- a/Sources/MacLocalAPI/Models/XGrammarService.swift
+++ b/Sources/MacLocalAPI/Models/XGrammarService.swift
@@ -14,7 +14,7 @@ final class XGrammarService: @unchecked Sendable {
     private let debugLogging: Bool
 
     /// Error message captured from C++ exceptions via the error handler callback.
-    private static var lastError: String?
+    nonisolated(unsafe) private static var lastError: String?
     private static let errorLock = NSLock()
 
     init(vocabSize: Int, debugLogging: Bool = false) {

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -44,7 +44,7 @@ struct RequestIDMiddleware: AsyncMiddleware {
             .compactMap { request.headers.first(name: $0)?.trimmingCharacters(in: .whitespaces) }
             .first(where: { !$0.isEmpty })
         let id = inbound ?? Self.mint()
-        request.storage.set(RequestIDKey.self, to: id)
+        await request.storage.setWithAsyncShutdown(RequestIDKey.self, to: id)
 
         let response = try await next.respond(to: request)
         for name in Self.outboundHeaders {
@@ -162,7 +162,11 @@ struct ActiveConnectionsMiddleware: AsyncMiddleware {
     }
 }
 
-class Server {
+// @unchecked Sendable: the server owns a Vapor Application and assorted service
+// references that aren't Sendable-audited. Lifecycle (start/shutdown) is driven
+// from a single controlling flow and the closures it spawns only read immutable
+// configuration or hop to @MainActor, so cross-task sharing is safe in practice.
+class Server: @unchecked Sendable {
     private let app: Application
     private let port: Int
     private let hostname: String

--- a/Sources/MacLocalAPI/Services/BackendDiscoveryService.swift
+++ b/Sources/MacLocalAPI/Services/BackendDiscoveryService.swift
@@ -258,15 +258,23 @@ actor BackendDiscoveryService {
             using: .tcp
         )
 
+        // Lock-guarded one-shot guard in a Sendable reference so the @Sendable
+        // finish()/state handlers can share it without a captured-var race.
+        final class OneShot: @unchecked Sendable {
+            private let lock = NSLock()
+            private var done = false
+            func fire() -> Bool {
+                lock.lock(); defer { lock.unlock() }
+                if done { return false }
+                done = true
+                return true
+            }
+        }
         return await withCheckedContinuation { continuation in
-            var resumed = false
-            let lock = NSLock()
+            let resumed = OneShot()
 
             @Sendable func finish(_ result: Bool) {
-                lock.lock()
-                defer { lock.unlock() }
-                guard !resumed else { return }
-                resumed = true
+                guard resumed.fire() else { return }
                 connection.cancel()
                 continuation.resume(returning: result)
             }

--- a/Sources/MacLocalAPI/Services/TelegramBridge.swift
+++ b/Sources/MacLocalAPI/Services/TelegramBridge.swift
@@ -447,7 +447,10 @@ actor TelegramActiveRequestStore {
     }
 }
 
-final class TelegramBridge {
+// @unchecked Sendable: bridges Telegram polling to the model service. Mutable
+// state is confined to its own serial watcher task / actor-guarded request map,
+// so the `[weak self]` Tasks it spawns can safely capture it.
+final class TelegramBridge: @unchecked Sendable {
     private let config: TelegramConfiguration
     private let client: AFMLocalClient
     private let bot: TelegramBotClient

--- a/Sources/MacLocalAPI/TerminalModelPicker.swift
+++ b/Sources/MacLocalAPI/TerminalModelPicker.swift
@@ -131,8 +131,8 @@ private func hasConfigAndWeights(_ dir: URL) -> Bool {
 
 // MARK: - Interactive Picker
 
-private var savedTermios = termios()
-private var terminalModified = false
+nonisolated(unsafe) private var savedTermios = termios()
+nonisolated(unsafe) private var terminalModified = false
 
 func runInteractiveModelPicker(models: [CachedModelEntry]) -> String? {
     guard !models.isEmpty else { return nil }

--- a/Sources/MacLocalAPI/Utils/MLXMetalLibrary.swift
+++ b/Sources/MacLocalAPI/Utils/MLXMetalLibrary.swift
@@ -4,7 +4,7 @@ import Darwin
 
 enum MLXMetalLibrary {
     private static let lock = NSLock()
-    private static var initialized = false
+    nonisolated(unsafe) private static var initialized = false
 
     /// Resolve the absolute path to this binary.
     ///

--- a/Sources/MacLocalAPI/Utils/UncheckedSendable.swift
+++ b/Sources/MacLocalAPI/Utils/UncheckedSendable.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Transports a value that the compiler can't prove `Sendable` across a task,
+/// continuation, or actor boundary.
+///
+/// Used for Apple-framework reference types (e.g. `AVAudioPCMBuffer`,
+/// `SFSpeechRecognitionTask`) that predate Swift 6 concurrency annotations.
+/// The wrapper itself is `@unchecked Sendable`; correctness depends on the call
+/// site genuinely handing the value off (no aliased concurrent mutation), which
+/// is the case at every current use — values are produced, transferred once
+/// through a continuation or single-consumer task group, and then read.
+struct UncheckedSendable<Value>: @unchecked Sendable {
+    var value: Value
+    init(_ value: Value) { self.value = value }
+}
+
+/// Reference-typed sibling of `UncheckedSendable`. Lets a `@Sendable` closure
+/// write a result that an enclosing synchronous scope reads after the closure
+/// has provably finished (e.g. a `Task` whose completion is awaited via a
+/// `DispatchGroup`). Use only when that happens-before relationship holds.
+final class SendableBox<Value>: @unchecked Sendable {
+    var value: Value
+    init(_ value: Value) { self.value = value }
+}

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -2,9 +2,12 @@ import ArgumentParser
 import Foundation
 import Darwin
 
-// Global references for signal handling
-private var globalServer: Server?
-private var shouldKeepRunning = true
+// Global references for signal handling. Accessed from the C signal handler
+// (a nonisolated context), so these opt out of the main-actor isolation that
+// Swift 6 infers for top-level globals. Signal-handler access is inherently
+// single-threaded with respect to the run loop, so the unsafety is contained.
+nonisolated(unsafe) private var globalServer: Server?
+nonisolated(unsafe) private var shouldKeepRunning = true
 
 // Signal handler function
 func handleShutdown(_ signal: Int32) {
@@ -722,7 +725,7 @@ struct MlxCommand: ParsableCommand {
         }
 
         let group = DispatchGroup()
-        var output: Result<String, Error>?
+        let output = SendableBox<Result<String, Error>?>(nil)
         // In single-prompt mode, suppress ALL output (stdout + stderr) during model loading
         // and generation. Only the final response goes to stdout. --verbose overrides this.
         let stdoutFD = dup(STDOUT_FILENO)
@@ -785,10 +788,10 @@ struct MlxCommand: ParsableCommand {
                     stop: stopSequences,
                     responseFormat: responseFormat
                 )
-                output = .success(res.content)
+                output.value = .success(res.content)
             } catch {
                 MLXLoadReporter.finishActiveWithError(error.localizedDescription)
-                output = .failure(error)
+                output.value = .failure(error)
             }
             group.leave()
         }
@@ -803,7 +806,7 @@ struct MlxCommand: ParsableCommand {
             close(stderrFD)
         }
 
-        switch output {
+        switch output.value {
         case .success(let text):
             if raw {
                 print(text)
@@ -1496,9 +1499,9 @@ private func ensureMLXMetalLibraryAvailable(verbose: Bool) throws {
     try MLXMetalLibrary.ensureAvailable(verbose: verbose)
 }
 
-private final class MLXLoadReporter {
+private final class MLXLoadReporter: @unchecked Sendable {
     private static let reporterLock = NSLock()
-    private static weak var activeReporter: MLXLoadReporter?
+    nonisolated(unsafe) private static weak var activeReporter: MLXLoadReporter?
 
     private let modelID: String
     private let lock = NSLock()
@@ -1740,7 +1743,7 @@ extension RootCommand {
         DebugLogger.log("Temperature: \(temperature?.description ?? "nil"), Randomness: \(randomness ?? "nil")")
 
         let group = DispatchGroup()
-        var result: Result<String, Error>?
+        let result = SendableBox<Result<String, Error>?>(nil)
 
         group.enter()
         Task {
@@ -1759,21 +1762,21 @@ extension RootCommand {
                         response = try await foundationService.generateResponse(for: [message], temperature: temperature, randomness: randomness)
                     }
                     DebugLogger.log("Response generated successfully")
-                    result = .success(response)
+                    result.value = .success(response)
                 } else {
                     DebugLogger.log("macOS 26+ not available")
-                    result = .failure(FoundationModelError.notAvailable)
+                    result.value = .failure(FoundationModelError.notAvailable)
                 }
             } catch {
                 DebugLogger.log("Error occurred: \(error)")
-                result = .failure(error)
+                result.value = .failure(error)
             }
             group.leave()
         }
         
         group.wait()
         
-        switch result {
+        switch result.value {
         case .success(let response):
             print(response)
         case .failure(let error):

--- a/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
+++ b/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
@@ -394,17 +394,21 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
             toolsJSON: Self.readFileToolsJSON
         )
 
+        // Compute headers up front so the `async let` child tasks don't capture
+        // `self` (XCTestCase is non-Sendable) via requestHeaders(for:).
+        let weatherHeaders = requestHeaders(for: weatherBody)
+        let readmeHeaders = requestHeaders(for: readmeBody)
         async let weatherResponse: XCTHTTPResponse = tester.sendRequest(
             .POST,
             "/v1/chat/completions",
-            headers: requestHeaders(for: weatherBody),
+            headers: weatherHeaders,
             body: weatherBody
         )
 
         async let readmeResponse: XCTHTTPResponse = tester.sendRequest(
             .POST,
             "/v1/chat/completions",
-            headers: requestHeaders(for: readmeBody),
+            headers: readmeHeaders,
             body: readmeBody
         )
 


### PR DESCRIPTION
## Summary

Migrates the package to the **Swift 6 language mode** (`swift-tools-version: 6.0`). Our targets opt into Swift 6; vendor submodules keep their own language mode and are **not touched** (per `CLAUDE.md`'s vendor-patch rule). All ~119 strict-concurrency / data-race errors are resolved with **behavior-preserving transforms only** — no actor re-architecture.

## Key changes

- **Generation hot path** (`MLXModelService.generate`/`generateStreaming`): the ~30 mutable locals captured by the `@Sendable` `container.perform` closure now live in `@unchecked Sendable` scratch boxes. `perform` serializes the entire generation under the model lock and is awaited before the values are read, so runtime behavior is identical.
- **JSON `Any` → `any Sendable`**: `toAny()`/`toJinjaCompatible()` return `any Sendable`; new `asSendableJSON()` converts `JSONSerialization` dicts (NSString→String, keeps the already-Sendable NSNumber/NSNull).
- **`@preconcurrency import`** for un-audited modules (MLXLMCommon, AVFoundation, Speech) + shared `UncheckedSendable`/`SendableBox` wrappers for non-Sendable system types crossing task/continuation boundaries.
- **Sendable conformances**: `MLXChatServing: Sendable`; `Server`/`TelegramBridge`/`EmbeddingHTTPServer`/`FoundationModelService` `@unchecked Sendable`; `SpeechService: Sendable`.
- `nonisolated(unsafe)` for already-synchronized global state; `NSLock.lock()` → `withLock` in async; Vapor `storage.set` → `setWithAsyncShutdown`; one-shot lock boxes for captured-var continuations; sync-over-async results via `SendableBox`.
- **BatchScheduler** actor: inline the pure cache checks so the non-Sendable `cache` stays in one isolation region.

## Verification

- ✅ `swift build` and `swift build --build-tests` — clean (0 errors).
- ✅ Unit/integration suite — **340 Swift Testing + XCTest suites, 0 failures** (covers BatchScheduler, RadixTreeCache, KVCache truncation, LogitProcessor batch, tool-call streaming runtime, streaming controller).
- ✅ Standard-tier assertions on `Qwen3.5-35B-A3B-4bit` — **440/446 (98%)**. The 6 failures (Qwen tool-arg coercion, `#86` concurrent+grammar empty responses, same-seed determinism) **reproduce identically on `main`** via a baseline run, so they are pre-existing — **not** migration regressions.

## Notes

- Release builds require a clean `.build/.../release` the first time after the tools-version bump (stale 5.9 artifacts otherwise fail with `missing required module '_NumericsShims'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Migrate the MacLocalAPI package to Swift 6 language mode and update concurrency usage to satisfy Swift 6 Sendable and isolation rules without changing runtime behavior.

New Features:
- Introduce reusable UncheckedSendable and SendableBox helpers for safely transporting non-Sendable values across task, continuation, and actor boundaries.
- Add a JSONSerialization helper to convert Foundation Any JSON trees into any Sendable for use in tool-call arguments and template kwargs.

Enhancements:
- Update global and static state in services and utilities to use nonisolated(unsafe) where access is externally synchronized, aligning with Swift 6 concurrency checks.
- Refactor MLXModelService generation (streaming and non-streaming) to route mutable state through Sendable scratch containers while preserving serialized execution under the model lock.
- Adjust SpeechService, SpeechSynthesisService, BackendDiscoveryService, EmbeddingHTTPServer, Server, TelegramBridge, and FoundationModelService to be Sendable or use Sendable wrappers where appropriate for Swift 6.
- Adopt @preconcurrency imports for legacy frameworks and modules (MLXLMCommon, AVFoundation) whose types are not fully Sendable-audited.
- Inline selected BatchScheduler cache predicates to keep non-Sendable cache data within a single actor isolation region.
- Make MLXChatServing explicitly Sendable and update related tool-call argument handling to work with Sendable JSON values.
- Tighten up locking patterns and continuation resumption guards to avoid captured-var races in async callbacks and handlers.

Build:
- Bump swift-tools-version to 6.0 in Package.swift to build the package with Swift 6 language mode.

Tests:
- Update chat completions streaming tests to pre-compute request headers, preventing non-Sendable XCTestCase instances from being captured by concurrent async tasks.