### PR TITLE
docs: document /v1/embeddings API and list embed/speech in help card

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ afm is built for agentic clients — OpenCode, OpenClaw, Cline, Continue.dev, Ai
 | **`stream_options.include_usage` honored** | Suppress the final usage chunk when the client doesn't want it (matches OpenAI strict mode) | `Models/OpenAIRequest.swift:StreamOptions` |
 | **`parallel_tool_calls: false` honored** | Truncate to a single tool call per turn for agents that want serial execution | `Controllers/MLXChatCompletionsController.swift:finalizeAssistantTurn` |
 | **Speech (transcribe + TTS) and Vision OCR** | `/v1/audio/transcriptions`, `/v1/audio/speech`, `/v1/ocr` — agents can hand off audio/image inputs without a separate service | `Controllers/SpeechAPIController.swift`, `VisionAPIController.swift` |
+| **On-device embeddings for RAG** | `/v1/embeddings` from Apple's NaturalLanguage model — OpenAI-compatible vectors for retrieval/semantic search. Runs as a dedicated `afm embed` server (:9998), separate from the chat endpoint | `Controllers/EmbeddingsController.swift` |
 | **Per-client config generators** | `afm mlx -m <model> --openclaw-config` prints a paste-ready provider config; cookbook recipes in [`docs/clients/`](docs/clients/) cover OpenCode, OpenClaw, Cline, Continue.dev, Aider, Cursor, Hermes | `Sources/MacLocalAPI/main.swift:printOpenClawConfig` |
 
 See [`docs/clients/`](docs/clients/) for one-page recipes per agent.
@@ -218,6 +219,7 @@ afm mlx -m mlx-community/Qwen3-Coder-Next-4bit -t 1.0 --top-p 0.95 --max-tokens 
 - **⚡ LoRA adapter support** - Supports fine-tuning with LoRA adapters using Apple's tuning Toolkit
 - **📱 Apple Foundation Models** - Uses Apple's on-device 3B parameter language model
 - **👁️ Vision OCR** - Extract text from images and PDFs using Apple Vision via CLI and HTTP (`afm vision`, `/v1/vision/ocr`)
+- **🔢 Embeddings** - OpenAI-compatible embeddings from Apple's NaturalLanguage model, on-device, via a dedicated server (`afm embed`, `/v1/embeddings`)
 - **🖥️ Built-in WebUI** - Chat interface with model selection (`afm -w`)
 - **🔒 Privacy-First** - All processing happens locally on your device
 - **⚡ Fast & Lightweight** - No network calls, no API keys required
@@ -366,6 +368,24 @@ curl -X POST http://localhost:9999/v1/vision/ocr \
 ```
 
 The endpoint returns structured JSON with per-document text, per-page text, text blocks, detected tables, document hints, and a top-level `combined_text` field. See [docs/vision-ocr-api.md](docs/vision-ocr-api.md) for request formats, options, and response details.
+
+### Embeddings
+**POST** `/v1/embeddings`
+
+Serves OpenAI-compatible embeddings backed by Apple's NaturalLanguage contextual model, fully on-device. Started with `afm embed` (default port `9998`), separate from the chat server.
+
+```bash
+afm embed                       # start the embeddings server on port 9998
+
+curl -X POST http://localhost:9998/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "apple-nl-contextual-en",
+    "input": "The quick brown fox"
+  }'
+```
+
+Accepts a string, an array of strings, or pre-tokenized ids; supports `float`/`base64` output and Matryoshka-style `dimensions` truncation. See [docs/embeddings-api.md](docs/embeddings-api.md) for models, request fields, response shape, and error semantics.
 
 ### Health Check
 **GET** `/health`

--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -1127,7 +1127,15 @@ struct MacLocalAPI: ParsableCommand {
             description: Extract text and tables from images/PDFs using Apple Vision OCR
             usage: afm vision -f <file> [--table]
             full_details: afm vision --help-json
-        api_endpoints: [/v1/chat/completions, /v1/models, /v1/vision/ocr, /health]
+          speech:
+            description: Transcribe audio to text and synthesize text to speech using Apple Speech/AVFoundation
+            usage: afm speech transcribe -f <file> | afm speech synthesize <text> -o <file>
+            full_details: afm speech --help-json
+          embed:
+            description: Serve OpenAI-compatible embeddings using Apple NaturalLanguage contextual embeddings
+            usage: afm embed -m <model> [--port 9998]
+            full_details: afm embed --list-models
+        api_endpoints: [/v1/chat/completions, /v1/models, /v1/vision/ocr, /v1/embeddings, /health]
         env_vars:
           MACAFM_MLX_MODEL_CACHE: Override model cache directory
           MACAFM_MLX_METALLIB: Override metallib path
@@ -1162,6 +1170,8 @@ struct MacLocalAPI: ParsableCommand {
             - "afm" — Apple Foundation Models (on-device, requires macOS 26+)
             - "afm mlx -m <model>" — MLX open-source models from Hugging Face
             - "afm vision -f <file>" — Vision OCR text/table extraction
+            - "afm speech transcribe -f <file>" — Speech transcription and synthesis
+            - "afm embed -m <model>" — OpenAI-compatible embeddings (Apple NaturalLanguage)
             - "afm -g" — API gateway proxying to local backends
         triggers:
           - start local LLM server
@@ -1170,12 +1180,16 @@ struct MacLocalAPI: ParsableCommand {
           - Apple Foundation Models API
           - local tool calling server
           - vision OCR text extraction
+          - speech transcription and synthesis
+          - local text embeddings for RAG / semantic search
           - API gateway for local LLM backends
         examples:
           - afm --port 9999
           - afm mlx -m Qwen/Qwen3-Coder-Next-4bit --port 9999
           - afm mlx -m mlx-community/Meta-Llama-3.1-8B-Instruct-4bit -s "Hello"
           - afm vision -f image.png
+          - afm speech transcribe -f recording.wav
+          - afm embed -m apple-nl-contextual-en --port 9998
           - afm -g --port 9999
         ---
 
@@ -1205,7 +1219,15 @@ struct RootCommand: ParsableCommand {
             description: Extract text and tables from images/PDFs using Apple Vision OCR
             usage: afm vision -f <file> [--table]
             full_details: afm vision --help-json
-        api_endpoints: [/v1/chat/completions, /v1/models, /v1/vision/ocr, /health]
+          speech:
+            description: Transcribe audio to text and synthesize text to speech using Apple Speech/AVFoundation
+            usage: afm speech transcribe -f <file> | afm speech synthesize <text> -o <file>
+            full_details: afm speech --help-json
+          embed:
+            description: Serve OpenAI-compatible embeddings using Apple NaturalLanguage contextual embeddings
+            usage: afm embed -m <model> [--port 9998]
+            full_details: afm embed --list-models
+        api_endpoints: [/v1/chat/completions, /v1/models, /v1/vision/ocr, /v1/embeddings, /health]
         env_vars:
           MACAFM_MLX_MODEL_CACHE: Override model cache directory
           MACAFM_MLX_METALLIB: Override metallib path
@@ -1240,6 +1262,8 @@ struct RootCommand: ParsableCommand {
             - "afm" — Apple Foundation Models (on-device, requires macOS 26+)
             - "afm mlx -m <model>" — MLX open-source models from Hugging Face
             - "afm vision -f <file>" — Vision OCR text/table extraction
+            - "afm speech transcribe -f <file>" — Speech transcription and synthesis
+            - "afm embed -m <model>" — OpenAI-compatible embeddings (Apple NaturalLanguage)
             - "afm -g" — API gateway proxying to local backends
         triggers:
           - start local LLM server
@@ -1248,12 +1272,16 @@ struct RootCommand: ParsableCommand {
           - Apple Foundation Models API
           - local tool calling server
           - vision OCR text extraction
+          - speech transcription and synthesis
+          - local text embeddings for RAG / semantic search
           - API gateway for local LLM backends
         examples:
           - afm --port 9999
           - afm mlx -m Qwen/Qwen3-Coder-Next-4bit --port 9999
           - afm mlx -m mlx-community/Meta-Llama-3.1-8B-Instruct-4bit -s "Hello"
           - afm vision -f image.png
+          - afm speech transcribe -f recording.wav
+          - afm embed -m apple-nl-contextual-en --port 9998
           - afm -g --port 9999
         ---
 

--- a/docs/embeddings-api.md
+++ b/docs/embeddings-api.md
@@ -1,0 +1,166 @@
+# Embeddings API
+
+`POST /v1/embeddings` exposes Apple's NaturalLanguage contextual embeddings over an OpenAI-compatible HTTP endpoint.
+
+It runs as a dedicated server started by `afm embed`, separate from the chat/MLX server. It is intended for:
+- local-first RAG, semantic search, and clustering workflows that already speak the OpenAI embeddings interface
+- on-device embedding using Apple's own models — no Hugging Face model downloads
+
+The backend is Apple's `NLContextualEmbedding`. There is no MLX or sentence-transformers backend in this release.
+
+Embedding runs entirely on-device. The contextual embedding assets are OS-provided; the framework may download them from Apple on first use if they are not already present (`afm embed` requests them at startup), after which inference is local and offline.
+
+## Requirements
+
+- macOS with Apple's NaturalLanguage contextual embedding support
+- Apple Silicon
+- Network access on first run if the contextual embedding assets are not already installed (they are downloaded once, then cached by the OS)
+
+## Running the Server
+
+```bash
+afm embed                          # default model on port 9998
+afm embed -m apple-nl-contextual-multi --port 9998
+afm embed --list-models            # print shipped model ids and exit
+```
+
+CLI options:
+- `-m, --model`: embedding model id (default: `apple-nl-contextual-en`)
+- `-p, --port`: server port (default: `9998`)
+- `-H, --hostname`: bind address (default: `127.0.0.1`)
+- `-v, --verbose`: enable verbose logging
+- `-V, --very-verbose`: log full requests/responses
+- `--list-models`: list available embedding model ids and exit
+
+The server loads a single model at startup. Native dimension and maximum input length are read from the Apple framework at load time, so they track OS updates rather than being hard-coded.
+
+## Shipped Models
+
+| Model id | Coverage |
+|----------|----------|
+| `apple-nl-contextual-en` | English (default) |
+| `apple-nl-contextual-multi` | Latin-script multilingual |
+
+Apple's multilingual contextual model is Latin-script only; non-Latin scripts are out of scope for this backend.
+
+`GET /v1/models` advertises **only** the model the running server actually loaded — not the full shipped list — so a client cannot discover an id the server can't serve.
+
+## Request
+
+```json
+{
+  "model": "apple-nl-contextual-en",
+  "input": "The quick brown fox",
+  "encoding_format": "float",
+  "dimensions": 256
+}
+```
+
+Fields:
+- `input` (required): one of
+  - a string — `"hello"`
+  - an array of strings — `["hello", "world"]`
+  - a token-id array — `[15, 234, 91]`
+  - an array of token-id arrays — `[[15, 234], [91, 7]]`
+- `model` (optional): must match the loaded model id; any other id returns `404`. Defaults to the loaded model when omitted.
+- `encoding_format` (optional): `float` (default) or `base64`
+- `dimensions` (optional): Matryoshka-style truncation. Must be between `1` and the model's native dimension. The vector is truncated to `dimensions` and L2-renormalized.
+- `user` (optional): accepted and ignored, for OpenAI client compatibility.
+
+All output vectors are L2-normalized. When `dimensions` is omitted the full native vector is returned (normalized).
+
+### Token-id input
+
+Pre-tokenized input is accepted as integer arrays. Empty token-id arrays (e.g. `[[]]` or `[[1,2],[]]`) are rejected with `400` before reaching the backend.
+
+```bash
+curl http://localhost:9998/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{"input": [[15, 234, 91]], "model": "apple-nl-contextual-en"}'
+```
+
+### Base64 output
+
+With `"encoding_format": "base64"`, each embedding is returned as a base64 string of little-endian `float32` values instead of a JSON array.
+
+## Response Shape
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "embedding",
+      "index": 0,
+      "embedding": [0.0123, -0.0456, "..."]
+    }
+  ],
+  "model": "apple-nl-contextual-en",
+  "usage": {
+    "prompt_tokens": 4,
+    "total_tokens": 4
+  }
+}
+```
+
+Notable fields:
+- `data`: one entry per input, in request order, each with its `index` and `embedding`
+- `embedding`: a float array, or a base64 string when `encoding_format` is `base64`
+- `usage.prompt_tokens` / `usage.total_tokens`: summed token counts across all inputs
+
+### Truncation header
+
+Apple's `NLContextualEmbedding` silently truncates inputs longer than the model's maximum sequence length. When any input is truncated, the response includes:
+
+```
+X-Embedding-Truncated: <number of truncated inputs>
+```
+
+The header is exposed to browsers via `Access-Control-Expose-Headers`. It is omitted when nothing was truncated.
+
+## CORS
+
+`POST /v1/embeddings` and `GET /v1/models` both answer CORS preflight (`OPTIONS`). Responses set `Access-Control-Allow-Origin: *` and reflect the browser's `Access-Control-Request-Headers` (falling back to `Content-Type, Authorization, OpenAI-Organization, OpenAI-Project`). Preflight responses set `Vary: Access-Control-Request-Headers` so intermediary caches don't replay a preflight computed for one client's header set against another.
+
+## Error Semantics
+
+The endpoint maps failures to HTTP statuses:
+- `400 Bad Request`: malformed JSON, missing or empty input, empty token-id array, invalid `dimensions` (outside `1…native`), unknown `encoding_format`, tokenization failure
+- `404 Not Found`: requested `model` is not the loaded model
+- `413 Payload Too Large`: request body exceeds 1 MiB
+- `500 Internal Server Error`: backend dimension drift or other internal failure
+- `503 Service Unavailable`: embedding backend or assets unavailable
+
+Other 4xx `AbortError`s (e.g. `415 Unsupported Media Type`) pass through with their original status. Errors use the OpenAI-compatible envelope:
+
+```json
+{
+  "error": {
+    "message": "Embedding model not found: text-embedding-3-small",
+    "type": "embedding_error"
+  }
+}
+```
+
+## Health Check
+
+```bash
+curl http://localhost:9998/health
+```
+
+Reports server status and the build version.
+
+## Deliberately Out of Scope
+
+- MLX / sentence-transformers embedding backend (BGE, etc.)
+- Non-Latin script coverage for the multilingual backend
+- Matryoshka beyond the truncate-and-renormalize behavior above
+- `/v1/batch/embeddings`
+
+## Validation
+
+Covered by the embeddings XCTest suite (controller + registry tests):
+
+```bash
+swift test --disable-sandbox
+```


### PR DESCRIPTION
## Motivation

I shipped the `/v1/embeddings` endpoint and `afm embed` command in #119 but never wrote the user-facing API doc to go with it — Vision OCR has `docs/vision-ocr-api.md`, embeddings had nothing. Separately, the `afm --help-json` capability card (the surface AI agents read to discover what afm can do) still only advertised `mlx` and `vision`, so both `speech` and `embed` were invisible to agents even though `afm --help` listed them.

## Summary

- Add `docs/embeddings-api.md`: shipped Apple NaturalLanguage models, request fields (string / array / token-id input, `encoding_format`, Matryoshka `dimensions`), response shape, the `X-Embedding-Truncated` header, CORS behavior, and the full error table. Documents that contextual-embedding assets are OS-provided and may download once on first run.
- Link the new doc from the README API section, mirroring the Vision OCR entry.
- Add `embed` and `speech` to the YAML capability card in both `discussion` strings (parsed by `--help-json`), plus `/v1/embeddings` in `api_endpoints` and `embed`/`speech` examples.

No behavior change — docs and the `--help-json` capability card only.

## Test plan

- [x] `afm --help-json` now lists `embed` and `speech` under `subcommands` and `/v1/embeddings` under `api_endpoints` (the card is parsed from the discussion YAML by `printHelpJson`).
- [x] Doc claims verified against source: 1 MiB body limit, default model `apple-nl-contextual-en`, default port 9998, `embedding_error` envelope type, asset-download-on-first-use via `requestAssets()`.
- [x] Markdown links resolve (README → `docs/embeddings-api.md`).

## Follow-up

While writing this up, the one thing I kept flagging is that embeddings is the only Apple-native capability not on the unified `:9999` server — Vision and Speech are already registered on `Server.swift`, but `/v1/embeddings` only runs via the standalone `afm embed` process on `:9998`. I filed #132 (serve `/v1/embeddings` on the main server) and #133 (audit Vision/Speech consistency so #132 lands on an established pattern).

For what it's worth: I'm running `afm embed` against msgvault embeddings today and it works extremely well — fast and rock solid as-is. So this is a convenience/unification enhancement, not a fix for anything broken. I'm happy to do the work in #132; if someone wants to pick it up first, great, otherwise I'll come back to it in a few weeks.