### PR TITLE
Serve /v1/embeddings on the main server + unify Apple-native endpoint advertising (#132, #133)

### DIFF
--- a/Sources/MacLocalAPI/Controllers/EmbeddingsController.swift
+++ b/Sources/MacLocalAPI/Controllers/EmbeddingsController.swift
@@ -4,20 +4,25 @@ import Foundation
 struct EmbeddingsController: RouteCollection {
     private static let maxRequestBodySize: ByteCount = "1mb"
 
-    private let modelEntry: EmbeddingModelEntry
-    private let backend: any EmbeddingBackend
+    private let resolver: any EmbeddingBackendResolver
+    /// The unified main server (#132) owns `/v1/models`, so the embeddings
+    /// controller must not register it there (it would collide). The standalone
+    /// `afm embed` server has no other `/v1/models`, so it does register it.
+    private let registersModelsRoute: Bool
 
-    init(modelEntry: EmbeddingModelEntry, backend: any EmbeddingBackend) {
-        self.modelEntry = modelEntry
-        self.backend = backend
+    init(resolver: any EmbeddingBackendResolver, registersModelsRoute: Bool = true) {
+        self.resolver = resolver
+        self.registersModelsRoute = registersModelsRoute
     }
 
     func boot(routes: RoutesBuilder) throws {
         let v1 = routes.grouped("v1")
         v1.on(.POST, "embeddings", body: .collect(maxSize: Self.maxRequestBodySize), use: createEmbeddings)
         v1.on(.OPTIONS, "embeddings", use: handleOptions)
-        v1.get("models", use: listModels)
-        v1.on(.OPTIONS, "models", use: handleOptions)
+        if registersModelsRoute {
+            v1.get("models", use: listModels)
+            v1.on(.OPTIONS, "models", use: handleOptions)
+        }
     }
 
     private func handleOptions(req: Request) async throws -> Response {
@@ -27,26 +32,19 @@ struct EmbeddingsController: RouteCollection {
     }
 
     private func listModels(req: Request) async throws -> Response {
-        // Advertise only the model this server actually loaded. Advertising the
-        // full shipped-model list would cause 404s when clients discovered and
-        // then requested an ID the running backend can't serve.
-        let model = EmbeddingModelInfo(
-            id: modelEntry.id,
-            created: modelEntry.createdEpoch,
-            ownedBy: "apple"
-        )
-        let response = EmbeddingModelsResponse(data: [model])
+        let models = await resolver.advertisedModels().map {
+            EmbeddingModelInfo(id: $0.id, created: $0.createdEpoch, ownedBy: "apple")
+        }
+        let response = EmbeddingModelsResponse(data: models)
         return try jsonResponse(for: response, request: req)
     }
 
     private func createEmbeddings(req: Request) async throws -> Response {
         do {
             let request = try req.content.decode(EmbeddingsRequest.self)
-            let requestedModelID = (request.model ?? modelEntry.id)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            guard requestedModelID == modelEntry.id else {
-                throw EmbeddingError.modelNotFound(requestedModelID)
-            }
+            // Resolve (and, on the unified server, lazily load) the backend for the
+            // requested model. Unknown ids throw EmbeddingError.modelNotFound.
+            let (modelEntry, backend) = try await resolver.resolve(requestedModelID: request.model)
 
             if request.input.isEmpty {
                 throw EmbeddingError.invalidInput("Input must not be empty")

--- a/Sources/MacLocalAPI/EmbeddingsCommand.swift
+++ b/Sources/MacLocalAPI/EmbeddingsCommand.swift
@@ -230,6 +230,9 @@ final class EmbeddingHTTPServer: @unchecked Sendable {
             )
         }
 
-        try app.register(collection: EmbeddingsController(modelEntry: modelEntry, backend: backend))
+        try app.register(collection: EmbeddingsController(
+            resolver: PreloadedEmbeddingResolver(entry: modelEntry, backend: backend),
+            registersModelsRoute: true
+        ))
     }
 }

--- a/Sources/MacLocalAPI/Models/EmbeddingBackendResolver.swift
+++ b/Sources/MacLocalAPI/Models/EmbeddingBackendResolver.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Resolves the embedding model entry + backend for a request.
+///
+/// This lets `EmbeddingsController` serve embeddings in two deployments without
+/// duplicating the request logic:
+/// - **Standalone** (`afm embed`): a single backend is loaded up front
+///   (`PreloadedEmbeddingResolver`).
+/// - **Unified main server** (`:9999`, #132): Apple NaturalLanguage backends are
+///   loaded lazily on first use (`LazyAppleEmbeddingResolver`), so a chat-only
+///   server pays nothing for embeddings until the first request. The lazy path
+///   only ever touches Apple NL — it never triggers `MLXMetalLibrary` init.
+protocol EmbeddingBackendResolver: Sendable {
+    /// Resolve the backend for the requested model id (`nil` → the default model).
+    /// Throws `EmbeddingError.modelNotFound` for an unknown id.
+    func resolve(requestedModelID: String?) async throws -> (entry: EmbeddingModelEntry, backend: any EmbeddingBackend)
+
+    /// Models to advertise (used by the standalone server's `/v1/models`).
+    func advertisedModels() async -> [EmbeddingModelEntry]
+}
+
+/// Serves a single, already-loaded backend (the `afm embed` standalone server).
+struct PreloadedEmbeddingResolver: EmbeddingBackendResolver {
+    let entry: EmbeddingModelEntry
+    let backend: any EmbeddingBackend
+
+    func resolve(requestedModelID: String?) async throws -> (entry: EmbeddingModelEntry, backend: any EmbeddingBackend) {
+        let requested = (requestedModelID ?? entry.id).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard requested == entry.id else { throw EmbeddingError.modelNotFound(requested) }
+        return (entry, backend)
+    }
+
+    func advertisedModels() async -> [EmbeddingModelEntry] { [entry] }
+}
+
+/// Lazily loads + caches Apple NaturalLanguage contextual embedding backends on
+/// first use. Apple-only; never initializes MLX. Used by the unified main server.
+actor LazyAppleEmbeddingResolver: EmbeddingBackendResolver {
+    private let registry = EmbeddingModelRegistry()
+    private var cache: [String: (entry: EmbeddingModelEntry, backend: any EmbeddingBackend)] = [:]
+
+    func resolve(requestedModelID: String?) async throws -> (entry: EmbeddingModelEntry, backend: any EmbeddingBackend) {
+        let requested = (requestedModelID ?? EmbeddingModelRegistry.defaultModelID)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let shipped = registry.resolve(modelID: requested) else {
+            throw EmbeddingError.modelNotFound(requested)
+        }
+        if let hit = cache[shipped.id] { return hit }
+
+        let backend = try NLContextualEmbeddingBackend(modelID: shipped.id)
+        try await backend.prepare()
+        guard let resolved = registry.makeResolvedAppleEntry(
+            modelID: shipped.id,
+            nativeDimension: await backend.nativeDimension,
+            maxInputTokens: await backend.maxInputTokens
+        ) else {
+            throw EmbeddingError.backendUnavailable(id: shipped.id, reason: "Failed to resolve Apple embedding metadata")
+        }
+
+        let pair: (entry: EmbeddingModelEntry, backend: any EmbeddingBackend) = (resolved, backend)
+        cache[shipped.id] = pair
+        return pair
+    }
+
+    func advertisedModels() async -> [EmbeddingModelEntry] { registry.shippedModels() }
+}

--- a/Sources/MacLocalAPI/Server.swift
+++ b/Sources/MacLocalAPI/Server.swift
@@ -295,6 +295,17 @@ class Server: @unchecked Sendable {
         }
 
         app.get("v1", "models") { req async -> ModelsResponse in
+            // Apple NL embedding models are served on the unified endpoint (lazily
+            // loaded on first /v1/embeddings). Advertise them so clients discover
+            // embedding capability on the main server, not just on `afm embed`. (#132/#133)
+            let embeddingCatalog = EmbeddingModelRegistry().shippedModels()
+            let embeddingModelInfos = embeddingCatalog.map { m in
+                ModelInfo(id: m.id, object: "model", created: m.createdEpoch, owned_by: "apple", loaded: false)
+            }
+            let embeddingDetails = embeddingCatalog.map { m in
+                ModelDetails(name: "\(m.id) (Apple NL)", model: m.id, capabilities: ["embeddings"])
+            }
+
             if let mlxModelID = self.mlxModelID {
                 return ModelsResponse(
                     object: "list",
@@ -307,14 +318,14 @@ class Server: @unchecked Sendable {
                             loaded: true,
                             max_context_length: self.contextWindow
                         )
-                    ],
+                    ] + embeddingModelInfos,
                     models: [
                         ModelDetails(
                             name: mlxModelID,
                             model: mlxModelID,
                             capabilities: ["chat", "completion", "vision"]
                         )
-                    ]
+                    ] + embeddingDetails
                 )
             }
 
@@ -353,6 +364,8 @@ class Server: @unchecked Sendable {
                 }
             }
 
+            models += embeddingModelInfos
+            details += embeddingDetails
             return ModelsResponse(object: "list", data: models, models: details)
         }
 
@@ -394,6 +407,15 @@ class Server: @unchecked Sendable {
 
         try app.register(collection: VisionAPIController())
         try app.register(collection: SpeechAPIController())
+        // POST /v1/embeddings on the main server (#132). The Apple NL embedding
+        // model is loaded lazily on first request (a chat-only server pays
+        // nothing until used) and this path never triggers MLX init. It does NOT
+        // register /v1/models — the main server owns that route. `afm embed`
+        // remains a standalone option.
+        try app.register(collection: EmbeddingsController(
+            resolver: LazyAppleEmbeddingResolver(),
+            registersModelsRoute: false
+        ))
         // POST /v1/chat/completions/{id}/cancel — agent cancel endpoint (T1.5).
         try app.register(collection: CancelController())
         // POST /v1/tokenize, /v1/count_tokens — agent token-budgeting endpoints (T1.6).

--- a/docs/apple-native-endpoints.md
+++ b/docs/apple-native-endpoints.md
@@ -1,0 +1,56 @@
+# Apple-native endpoints — routing convention (audit for #133)
+
+This is the audit called for in #133: confirm that the Apple-native HTTP capabilities
+(Vision, Speech, Embeddings) are integrated **consistently** on the main server, and define
+the convention that #132 (embeddings on the main server) lands on. Output: the agreed pattern
++ a short list of remaining drift.
+
+## The capabilities and where they live (after #132)
+
+| Capability | Routes (main server `:9999`) | Controller |
+|---|---|---|
+| Vision OCR | `POST /v1/vision/ocr` (+ classify / barcode / saliency / tables) | `VisionAPIController` |
+| Speech | `POST /v1/audio/transcriptions`, `POST /v1/audio/speech`, `GET /v1/audio/voices` | `SpeechAPIController` |
+| Embeddings | `POST /v1/embeddings` | `EmbeddingsController` (unified, lazy Apple-NL) — **new in #132** |
+
+All three are registered on the main `Server.swift` router. `afm embed` remains a dedicated
+standalone server on `:9998` for embeddings-only deployments.
+
+## The convention (what "consistent" means)
+
+1. **Error envelope** — every endpoint returns the OpenAI error shape via `OpenAIError`
+   (`{ "error": { "message", "type", "code"?, "request_id"? } }`). The `type` string is
+   **domain-specific** and stable: `vision_unavailable`, `speech_unavailable` / `speech_error`,
+   `embedding_error`, plus shared `internal_error`. Treat these as a public contract — do not
+   rename existing ones (clients may match on `type`).
+2. **Availability → 503** — when the underlying Apple framework/OS isn't available, return
+   **`503 Service Unavailable`** with the domain `*_unavailable` type (Speech gates macOS 13,
+   Vision gates macOS 26, Embeddings surfaces `backendUnavailable` lazily). A client can treat
+   503 + `*_unavailable` uniformly as "this capability isn't available here."
+3. **CORS** — wildcard `Access-Control-Allow-Origin: *`, reflect the preflight
+   `Access-Control-Request-Headers` (so SDK-specific `x-stainless-*` etc. pass), `Vary` on the
+   requested-headers list, and an `OPTIONS` handler per route group.
+4. **`model` field** — chat/embeddings route on `model` (embeddings validates it against the
+   loaded/known ids and 404s on unknown). Vision/Speech are single-capability endpoints and
+   **ignore `model`** by design (there is one Apple framework behind each).
+5. **`/v1/models` advertising** — the main `/v1/models` lists the chat model **and** the Apple
+   NL embedding models (`capabilities: ["embeddings"]`). The embeddings controller does **not**
+   register its own `/v1/models` on the unified server (the main server owns that route);
+   `afm embed` still serves its own `/v1/models` standalone.
+6. **Capability discovery** — `--help-json` (PR #131) and `OpenAPIController` should list every
+   Apple-native endpoint.
+
+## Drift found (status)
+
+| Item | Status |
+|---|---|
+| `/v1/models` didn't surface embeddings | **Fixed (#132/#133)** — embedding models now advertised on the main server |
+| Embeddings only on `:9998`, not the unified server | **Fixed (#132)** — `POST /v1/embeddings` on `:9999`, lazy Apple-NL load |
+| Each controller hand-rolls CORS (Vision/Speech/Embeddings) | **Open (low priority)** — behavior is consistent; could be factored into one shared middleware. Not done here to avoid behavior risk. |
+| Error `type` strings differ per domain | **Intentional** — domain-specific, stable; documented as contract above. No rename. |
+| Availability gating differs per OS floor | **Consistent enough** — all converge on `503 + *_unavailable`. Documented. |
+| `/v1/models` capability advertising for Vision/Speech | **Partial** — chat row already carries `"vision"`; Speech isn't separately advertised. Acceptable (capabilities are endpoint-discoverable via OpenAPI); revisit if a client needs it. |
+
+## Follow-ups (not blocking)
+- Factor the three hand-rolled CORS implementations into a shared `AppleNativeCORSMiddleware`.
+- Optionally advertise Vision/Speech as capability rows in `/v1/models`.


### PR DESCRIPTION
Fixes the two Apple-native-endpoint issues from @jesserobbins.

## #132 — embeddings on the unified server
`POST /v1/embeddings` is now served on the **main server (`:9999`)** alongside chat/vision/speech, not only via the standalone `afm embed` on `:9998`.

- `EmbeddingsController` now resolves its backend via a new `EmbeddingBackendResolver`:
  - **`PreloadedEmbeddingResolver`** — the standalone `afm embed` server (behavior unchanged; still serves its own `/v1/models`).
  - **`LazyAppleEmbeddingResolver`** — the main server: loads the Apple NL model **lazily on first `/v1/embeddings` request**, so a chat-only server pays nothing until embeddings are used, and the path **never triggers MLX init** (per the issue's note).
- On the main server the controller **does not register `/v1/models`** (the server owns that route) — no collision; `afm embed` still registers its own standalone.
- `afm embed` remains a standalone option (not removed).

## #133 — audit + advertising
- `/v1/models` now advertises the Apple NL embedding models with `capabilities: ["embeddings"]`.
- `docs/apple-native-endpoints.md` records the audit findings + the agreed routing convention (error envelope, 503 availability, CORS, `model` semantics, `/v1/models` advertising) and the remaining low-priority drift (shared CORS middleware).

## Verified at runtime (not just compiled)
Ran a chat server on `:9999`:
- `POST /v1/embeddings` → real **512-dim** Apple NL embedding (lazy-loaded), correct `usage`
- chat still works on the same port (no regression)
- unknown embedding model → **404**
- `/v1/models` lists both embedding models with `["embeddings"]`, no route collision

Note: the standalone `afm embed` server loads its Apple NL asset **at startup** (slow/silent first-use via MobileAsset) — pre-existing behavior, unrelated to this change. The unified lazy-load avoids that startup cost on chat-only servers.

Closes #132
Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Serve Apple NL embeddings from the main unified server with lazy loading and ensure they are properly advertised via /v1/models, while preserving the standalone embeddings server.

New Features:
- Expose POST /v1/embeddings on the main server alongside existing chat, vision, and speech endpoints.
- Introduce a resolver abstraction to support both preloaded and lazily loaded Apple NL embedding backends.
- Add documentation describing the routing and capability conventions for Apple-native endpoints.

Enhancements:
- Advertise Apple NL embedding models and their embeddings capability in the unified /v1/models response.
- Prevent route collisions by allowing the embeddings controller to optionally skip registering /v1/models on the main server.

Documentation:
- Document the Apple-native endpoint routing convention, error semantics, capability advertising, and known drift.