### PR TITLE
fix(cli): run async utility commands off the main actor

### DIFF
--- a/Sources/MacLocalAPI/main.swift
+++ b/Sources/MacLocalAPI/main.swift
@@ -1519,7 +1519,7 @@ if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "mlx" {
         let group = DispatchGroup()
         var caughtError: Error?
         group.enter()
-        Task {
+        Task.detached {
             do {
                 try await cmd.run()
             } catch {
@@ -1541,7 +1541,7 @@ if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "mlx" {
         let group = DispatchGroup()
         var caughtError: Error?
         group.enter()
-        Task {
+        Task.detached {
             do {
                 try await cmd.run()
             } catch {


### PR DESCRIPTION
The top-level dispatcher waits synchronously for some async utility subcommands to finish. Under Swift 6, creating a plain `Task` from that context can inherit the main actor, so the immediate `DispatchGroup.wait()` blocks the executor that needs to run the command. In practice, `afm embed --list-models` can hang before it prints anything, and the standalone embeddings server path can fail to make progress even though argument parsing succeeds.

Running those utility command bodies in detached tasks avoids starving the async work while preserving the existing synchronous process lifecycle. The same dispatcher pattern existed for `vision`, so this applies the same fix there instead of leaving a second latent hang.

I reproduced the source-built `afm embed --list-models` hang, then confirmed the patched binary lists both Apple NL embedding models, starts the embeddings server, reports healthy, and serves a real 512-dimensional `apple-nl-contextual-en` embedding. I also exercised kata semantic search end-to-end against the patched source-built endpoint.

## Summary by Sourcery

Bug Fixes:
- Prevent MacLocalAPI CLI utility subcommands from hanging under Swift 6 when run via the synchronous dispatcher.