### PR TITLE
fix(build): cap swift-jinja below 2.4.0 (fresh clones of main fail to compile)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,10 @@ let package = Package(
         // resolve it. RECONFIRMED 2026-05-31: 0.31.3 still produces garbage/empty at >1500 tok
         // (afm decode@16k deficit vs newer-MLX engines is the price of correct long-context output).
         .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.30.3"),
-        // Jinja (transitive via swift-transformers) — exposed for test target
-        .package(url: "https://github.com/huggingface/swift-jinja.git", from: "2.0.0")
+        // Jinja (transitive via swift-transformers) — exposed for test target.
+        // Capped below 2.4.0: swift-jinja 2.4.0 changed object keys to ObjectKey,
+        // which breaks swift-transformers ≤1.3.3 (Hub/Config.swift fails to compile).
+        .package(url: "https://github.com/huggingface/swift-jinja.git", "2.0.0"..<"2.4.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## What

One-line dependency cap: `swift-jinja` `"2.0.0"..<"2.4.0"`.

## Why

`Package.resolved` is not committed, so every fresh clone resolves the floating ranges anew. swift-jinja **2.4.0** changed object keys from `String` to `ObjectKey`, which breaks compilation of swift-transformers ≤ 1.3.3 (`Sources/Hub/Config.swift`: *"cannot convert value of type 'String' to expected dictionary key type 'ObjectKey'"*). **Any clean checkout of main fails to build today** — this is also what blocked the external reviewer's verification build on #145.

## Verification

Resolved on a clean main worktree (with vendor patches applied): jinja **2.3.6** + transformers **1.3.3** — the same pair the full 368-test suite passed against on the #145 branch, where this cap is already applied (`e56bd18`).

Note: #145 carries the identical hunk, so whichever merges second will see a trivial already-applied conflict there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Constrain swift-jinja in Package.swift to versions >=2.0.0 and <2.4.0 to maintain compatibility with existing swift-transformers versions.