### PR TITLE
fix(mlx): support quantized per_layer_model_projection in Gemma 4 E-series

### DIFF
--- a/Scripts/patches/Gemma4Text.swift
+++ b/Scripts/patches/Gemma4Text.swift
@@ -196,18 +196,76 @@ class Gemma4RMSNormZeroShift: Module {
 // MARK: - Scaled Linear
 
 /// Linear layer with output scaling (for per-layer model projection).
-class Gemma4ScaledLinear: Module {
+///
+/// Quantizable: E-series (MatFormer) quantized checkpoints ship
+/// per_layer_model_projection as quantized weight + scales + biases, so this
+/// layer must participate in the quantize(model:) pass or loading fails with
+/// unhandledKeys(["biases", "scales"]).
+class Gemma4ScaledLinear: Module, Quantizable {
     @ParameterInfo(key: "weight") var weight: MLXArray
     let scalar: Float
+    let inputDims: Int
+    let outputDims: Int
 
     init(inputDims: Int, outputDims: Int, scalar: Float) {
         self.scalar = scalar
+        self.inputDims = inputDims
+        self.outputDims = outputDims
         self._weight.wrappedValue = MLXArray.zeros([outputDims, inputDims])
+        super.init()
+    }
+
+    /// Initializer for subclasses to provide the (possibly quantized) weight directly.
+    init(inputDims: Int, outputDims: Int, scalar: Float, weight: MLXArray) {
+        self.scalar = scalar
+        self.inputDims = inputDims
+        self.outputDims = outputDims
+        self._weight.wrappedValue = weight
         super.init()
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         return (x.matmul(weight.T)) * scalar
+    }
+
+    func toQuantized(groupSize: Int, bits: Int, mode: QuantizationMode) -> Module {
+        QuantizedGemma4ScaledLinear(self, groupSize: groupSize, bits: bits, mode: mode)
+    }
+}
+
+/// Quantized variant of ``Gemma4ScaledLinear``.
+class QuantizedGemma4ScaledLinear: Gemma4ScaledLinear, Quantized {
+    @ParameterInfo(key: "scales") var scales: MLXArray
+    @ParameterInfo(key: "biases") var biases: MLXArray?
+
+    let groupSize: Int
+    let bits: Int
+    let mode: QuantizationMode
+
+    init(
+        _ other: Gemma4ScaledLinear, groupSize: Int = 64, bits: Int = 4,
+        mode: QuantizationMode = .affine
+    ) {
+        self.groupSize = groupSize
+        self.bits = bits
+        self.mode = mode
+
+        let (quantizedWeight, scales, biases) = MLX.quantized(
+            other.weight, groupSize: groupSize, bits: bits, mode: mode)
+        self._scales.wrappedValue = scales
+        self._biases.wrappedValue = biases
+
+        super.init(
+            inputDims: other.inputDims, outputDims: other.outputDims,
+            scalar: other.scalar, weight: quantizedWeight)
+        self.freeze()
+    }
+
+    override func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let y = quantizedMM(
+            x, weight, scales: scales, biases: biases, transpose: true,
+            groupSize: groupSize, bits: bits, mode: mode)
+        return y * scalar
     }
 }
 

--- a/Scripts/patches/Gemma4VLM.swift
+++ b/Scripts/patches/Gemma4VLM.swift
@@ -182,18 +182,76 @@ class Gemma4VLRMSNormZeroShift: Module {
 // ============================================================================
 
 /// Linear layer with output scaling (for per-layer model projection).
-class Gemma4VLScaledLinear: Module {
+///
+/// Quantizable: E-series (MatFormer) quantized checkpoints ship
+/// per_layer_model_projection as quantized weight + scales + biases, so this
+/// layer must participate in the quantize(model:) pass or loading fails with
+/// unhandledKeys(["biases", "scales"]).
+class Gemma4VLScaledLinear: Module, Quantizable {
     @ParameterInfo(key: "weight") var weight: MLXArray
     let scalar: Float
+    let inputDims: Int
+    let outputDims: Int
 
     init(inputDims: Int, outputDims: Int, scalar: Float) {
         self.scalar = scalar
+        self.inputDims = inputDims
+        self.outputDims = outputDims
         self._weight.wrappedValue = MLXArray.zeros([outputDims, inputDims])
+        super.init()
+    }
+
+    /// Initializer for subclasses to provide the (possibly quantized) weight directly.
+    init(inputDims: Int, outputDims: Int, scalar: Float, weight: MLXArray) {
+        self.scalar = scalar
+        self.inputDims = inputDims
+        self.outputDims = outputDims
+        self._weight.wrappedValue = weight
         super.init()
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         return (x.matmul(weight.T)) * scalar
+    }
+
+    func toQuantized(groupSize: Int, bits: Int, mode: QuantizationMode) -> Module {
+        QuantizedGemma4VLScaledLinear(self, groupSize: groupSize, bits: bits, mode: mode)
+    }
+}
+
+/// Quantized variant of ``Gemma4VLScaledLinear``.
+class QuantizedGemma4VLScaledLinear: Gemma4VLScaledLinear, Quantized {
+    @ParameterInfo(key: "scales") var scales: MLXArray
+    @ParameterInfo(key: "biases") var biases: MLXArray?
+
+    let groupSize: Int
+    let bits: Int
+    let mode: QuantizationMode
+
+    init(
+        _ other: Gemma4VLScaledLinear, groupSize: Int = 64, bits: Int = 4,
+        mode: QuantizationMode = .affine
+    ) {
+        self.groupSize = groupSize
+        self.bits = bits
+        self.mode = mode
+
+        let (quantizedWeight, scales, biases) = MLX.quantized(
+            other.weight, groupSize: groupSize, bits: bits, mode: mode)
+        self._scales.wrappedValue = scales
+        self._biases.wrappedValue = biases
+
+        super.init(
+            inputDims: other.inputDims, outputDims: other.outputDims,
+            scalar: other.scalar, weight: quantizedWeight)
+        self.freeze()
+    }
+
+    override func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let y = quantizedMM(
+            x, weight, scales: scales, biases: biases, transpose: true,
+            groupSize: groupSize, bits: bits, mode: mode)
+        return y * scalar
     }
 }
 


### PR DESCRIPTION
Quantized E-series (MatFormer) checkpoints (`mlx-community/gemma-4-e2b-it-4bit`, `gemma-4-e4b-it-4bit`) ship `per_layer_model_projection` as quantized weight + scales + biases. `Gemma4ScaledLinear` / `Gemma4VLScaledLinear` held only a plain weight and did not participate in the `quantize(model:)` pass, so loading failed with `unhandledKeys(..., keys: ["biases", "scales"])`.

This makes both classes `Quantizable` with `Quantized` subclasses following the existing `SwitchLinear`/`QuantizedSwitchLinear` pattern: `quantizedMM` with the checkpoint's scales/biases, then the output scalar.

Verified from Vesta (M-series, 64 GB) against the v0.9.13 patch set:
- gemma-4-e2b-it-4bit: loads, coherent output ("The capital of France is Paris."), 117 tok/s
- gemma-4-e4b-it-4bit: loads, coherent output, 68 tok/s
- Dense/MoE Gemma 4 unaffected (gemma-4-26b-a4b-it-4bit: loads, coherent, 70 tok/s)

Base is the v0.9.13 tag (dedad02).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add quantized support for Gemma 4 per-layer model projection layers to ensure MatFormer E-series checkpoints load correctly.

Bug Fixes:
- Fix loading failures for Gemma 4 E-series quantized checkpoints where per_layer_model_projection included scales and biases.

Enhancements:
- Make Gemma4ScaledLinear and Gemma4VLScaledLinear quantizable and introduce corresponding quantized variants to handle per-layer model projection in quantized models.