### PR TITLE
fix(vlm): select Gemma4Processor by model type (#149)

### DIFF
--- a/Scripts/patches/VLMModelFactory.swift
+++ b/Scripts/patches/VLMModelFactory.swift
@@ -354,6 +354,10 @@ public final class VLMModelFactory: ModelFactory {
             "mistral3": "Mistral3Processor",
             "qwen3_5": "Qwen3VLProcessor",
             "qwen3_5_moe": "Qwen3VLProcessor",
+            // Gemma 4 repos ship processor_config.json without a top-level
+            // processor_class (only image_processor.image_processor_type),
+            // so the processor must be selected by model type.
+            "gemma4": "Gemma4Processor",
         ]
         let processorType =
             processorTypeOverrides[baseConfig.modelType] ?? baseProcessorConfig.processorClass


### PR DESCRIPTION
Fixes the processor half of #149: Gemma 4 repos ship `processor_config.json` without a top-level `processor_class`, so the VLM factory could not select a processor for `model_type=gemma4`. Adds the model-type mapping, same pattern as `mistral3`/`qwen3_5`.

Verified in Vesta with the identical change (scouzi1966/vesta-mac@b82f785): `mlx-community/gemma-4-e2b-it-4bit` describes a real photo correctly through `Gemma4Processor`. Compiles clean against main (`swift build -c release`).

The other half of #149 (LLM-factory-first loading silently dropping images for dual-capable checkpoints unless forceVLM is passed) is left as a design decision — forcing VLM containers for qwen3_5/gemma4 could interact with the batch/MTP paths, so it deserves a maintainer call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Enable Gemma4 visual language models to correctly select Gemma4Processor when processor_config.json lacks a top-level processor_class.