### PR TITLE
Support patched MLX in Xcode checkouts

### DIFF
--- a/Scripts/apply-mlx-deepseek-v4-kernels.sh
+++ b/Scripts/apply-mlx-deepseek-v4-kernels.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-CHECKOUT="$ROOT_DIR/.build/checkouts/mlx-swift"
+CHECKOUT="${MLX_SWIFT_CHECKOUT:-$ROOT_DIR/.build/checkouts/mlx-swift}"
 PATCH_DIR="$ROOT_DIR/Scripts/patches/mlx-swift-deepseek-v4"
 MODE="${1:-apply}"
 
@@ -62,4 +62,3 @@ apply_one \
     "MLX C API" \
     "$CHECKOUT/Source/Cmlx/mlx-c" \
     "$PATCH_DIR/mlx-c.patch"
-

--- a/Scripts/apply-mlx-official-fp8-loader.sh
+++ b/Scripts/apply-mlx-official-fp8-loader.sh
@@ -7,7 +7,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TARGET="$ROOT_DIR/.build/checkouts/mlx-swift/Source/Cmlx/mlx/mlx/io/safetensors.cpp"
+CHECKOUT="${MLX_SWIFT_CHECKOUT:-$ROOT_DIR/.build/checkouts/mlx-swift}"
+TARGET="$CHECKOUT/Source/Cmlx/mlx/mlx/io/safetensors.cpp"
 MARKER="AFM_PATCH_F8_E8M0_SAFETENSORS"
 
 if [[ ! -f "$TARGET" ]]; then

--- a/Scripts/swiftpm-reliable.sh
+++ b/Scripts/swiftpm-reliable.sh
@@ -163,14 +163,14 @@ if [[ ! -f "$MLX_SAFETENSORS_SOURCE" ]]; then
     swift package resolve
 fi
 run_required_patch_step \
-    "official FP8 loader" \
-    "$ROOT_DIR/Scripts/apply-mlx-official-fp8-loader.sh"
-run_required_patch_step \
     "DeepSeek V4 kernels" \
     "$ROOT_DIR/Scripts/apply-mlx-deepseek-v4-kernels.sh"
 run_required_patch_step \
     "DeepSeek V4 kernel verification" \
     "$ROOT_DIR/Scripts/apply-mlx-deepseek-v4-kernels.sh" --check
+run_required_patch_step \
+    "official FP8 loader verification" \
+    "$ROOT_DIR/Scripts/apply-mlx-official-fp8-loader.sh"
 # Keep the persistent vendor checkout synchronized with the authoritative
 # Swift sources under Scripts/patches before SwiftPM evaluates dependencies.
 # Without this, a Release build can succeed while compiling stale vendored


### PR DESCRIPTION
## Summary
- allow DeepSeek MLX patches to target an explicit package checkout
- apply the atomic DeepSeek patch before standalone FP8 verification
- support Vesta Xcode Release builds against the merged AFMKit runtime

## Validation
- `Scripts/swiftpm-reliable.sh test -c release --filter DeepseekV4DSparkWeightLoadingTests` (11/11)
- Vesta `Scripts/build-from-scratch.sh --release --incremental` (succeeded)

## Summary by Sourcery

Support applying DeepSeek MLX patches and FP8 loader verification against configurable mlx-swift checkouts and adjust patch ordering for FP8 verification.

Enhancements:
- Allow MLX DeepSeek V4 kernel patches and official FP8 loader patches to target a configurable mlx-swift checkout path via MLX_SWIFT_CHECKOUT.
- Reorder DeepSeek and official FP8 patch steps so DeepSeek patches are applied before standalone FP8 loader verification in the reliable SwiftPM script.