### PR TITLE
Fix MLX multimodal routing for dual-mode models

### DIFF
--- a/Sources/AFMKitMLX/AFMMLXLoadedModeSwitchPolicy.swift
+++ b/Sources/AFMKitMLX/AFMMLXLoadedModeSwitchPolicy.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public enum AFMMLXLoadedModeSwitchPlan: Equatable, Sendable {
     case imported(rawPath: String, targetVLM: Bool)
     case currentLoadedModel(targetVLM: Bool)
@@ -11,20 +13,6 @@ public enum AFMMLXLoadedModeSwitchPlan: Equatable, Sendable {
 }
 
 public enum AFMMLXLoadedModeSwitchPolicy {
-    public static func shouldReloadVisionFactoryForMultimodalRequest(
-        loadedModelType: String?,
-        isLoadedModelVLM: Bool,
-        loadedModelDirectoryIsVision: Bool
-    ) -> Bool {
-        let trimmedModelType = loadedModelType?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard !trimmedModelType.isEmpty,
-              AFMMLXModelArchitecture.isDualModeModelType(trimmedModelType),
-              loadedModelDirectoryIsVision else {
-            return false
-        }
-        return !isLoadedModelVLM
-    }
-
     public static func make(
         loadedModelRepoID: String?,
         loadedModelType: String?,
@@ -45,4 +33,75 @@ public enum AFMMLXLoadedModeSwitchPolicy {
         }
         return .currentLoadedModel(targetVLM: targetVLM)
     }
+}
+
+public enum AFMMLXModelFactoryKind: Equatable, Sendable {
+    case llm
+    case vlm
+}
+
+public enum AFMMLXModelFactoryPolicy {
+    public static func initialFactory(
+        forceVLM: Bool,
+        architecture: AFMMLXModelArchitecturePreflight
+    ) -> AFMMLXModelFactoryKind {
+        if forceVLM || architecture.isVisionConfiguration || architecture.requiresVisionModelFactory {
+            return .vlm
+        }
+        return .llm
+    }
+}
+
+public enum AFMMLXRequestMediaKind: Hashable, Sendable {
+    case image
+    case video
+    case audio
+}
+
+public enum AFMMLXRequestMediaPolicy {
+    private static let videoModelTypes: Set<String> = [
+        "qwen2_vl",
+        "qwen2_5_vl",
+        "qwen3_vl",
+        "qwen3_5",
+        "qwen3_5_moe",
+        "qwen3_6",
+        "qwen3_6_moe",
+        "smolvlm",
+    ]
+
+    public static func kind(contentPartType: String, mediaURL: String? = nil) -> AFMMLXRequestMediaKind? {
+        switch contentPartType {
+        case "input_audio":
+            return .audio
+        case "image_url":
+            guard let mediaURL else { return .image }
+            if mediaURL.lowercased().hasPrefix("data:video/") {
+                return .video
+            }
+            if let url = URL(string: mediaURL), videoExtensions.contains(url.pathExtension.lowercased()) {
+                return .video
+            }
+            return .image
+        default:
+            return nil
+        }
+    }
+
+    public static func supports(
+        _ kind: AFMMLXRequestMediaKind,
+        architecture: AFMMLXModelArchitecturePreflight
+    ) -> Bool {
+        switch kind {
+        case .audio:
+            return false
+        case .image:
+            return architecture.isVisionConfiguration
+        case .video:
+            return architecture.isVisionConfiguration
+                && videoModelTypes.contains(architecture.canonicalModelType)
+        }
+    }
+
+    private static let videoExtensions: Set<String> = ["mp4", "mov", "avi", "mkv", "webm", "m4v"]
 }

--- a/Sources/AFMKitMLX/AFMMLXLoadedModeSwitchPolicy.swift
+++ b/Sources/AFMKitMLX/AFMMLXLoadedModeSwitchPolicy.swift
@@ -11,6 +11,20 @@ public enum AFMMLXLoadedModeSwitchPlan: Equatable, Sendable {
 }
 
 public enum AFMMLXLoadedModeSwitchPolicy {
+    public static func shouldReloadVisionFactoryForMultimodalRequest(
+        loadedModelType: String?,
+        isLoadedModelVLM: Bool,
+        loadedModelDirectoryIsVision: Bool
+    ) -> Bool {
+        let trimmedModelType = loadedModelType?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmedModelType.isEmpty,
+              AFMMLXModelArchitecture.isDualModeModelType(trimmedModelType),
+              loadedModelDirectoryIsVision else {
+            return false
+        }
+        return !isLoadedModelVLM
+    }
+
     public static func make(
         loadedModelRepoID: String?,
         loadedModelType: String?,

--- a/Sources/AFMKitMLX/AFMMLXModelArchitecture.swift
+++ b/Sources/AFMKitMLX/AFMMLXModelArchitecture.swift
@@ -216,6 +216,7 @@ public enum AFMMLXModelArchitecture {
         "qwen3_6_moe",
         "idefics3",
         "gemma3",
+        "gemma4",
         "smolvlm",
         "fastvlm",
         "llava_qwen2",

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -228,8 +228,6 @@ public final class MLXModelService: @unchecked Sendable {
     private let stateLock = NSLock()
     private var currentModelID: String?
     private var currentModelArchitecture: AFMMLXModelArchitecturePreflight?
-    private var currentModelDirectory: URL?
-    private var currentLoadedWithVisionFactory = false
     private var currentContainer: ModelContainer?
     private var activeOperations: Int = 0
     private var isShuttingDown = false
@@ -1456,17 +1454,20 @@ public final class MLXModelService: @unchecked Sendable {
         // VLM-only guard: if text_config exists but lacks key architecture fields
         // (num_attention_heads, head_dim), the LLM model will use wrong defaults
         // and crash (e.g. gemma-3 VLM). Skip LLM and go straight to VLM.
-        let vlmOnly = isVLMOnlyConfig(directory: directory)
-        let selectedFactory = (forceVLM || vlmOnly) ? "VLM" : "LLM"
+        let selectedFactory = AFMMLXModelFactoryPolicy.initialFactory(
+            forceVLM: forceVLM,
+            architecture: modelArchitecture
+        )
         print(
             "[\(ts())] [ModelArchitecture] declared=\(modelArchitecture.modelType) "
                 + "canonical=\(modelArchitecture.canonicalModelType) "
                 + "vision=\(modelArchitecture.isVisionConfiguration) "
-                + "factory=\(selectedFactory)"
+                + "factory=\(selectedFactory == .vlm ? "VLM" : "LLM")"
         )
         do {
             let loaded: ModelContainer
-            if forceVLM || vlmOnly {
+            var actualFactory = selectedFactory
+            if selectedFactory == .vlm {
                 loaded = try await VLMModelFactory.shared.loadContainer(configuration: config)
             } else {
                 do {
@@ -1476,18 +1477,21 @@ public final class MLXModelService: @unchecked Sendable {
                     // LLM factory failed — try VLM factory as fallback
                     do {
                         loaded = try await VLMModelFactory.shared.loadContainer(configuration: config)
+                        actualFactory = .vlm
+                        print("[\(ts())] [MLX] Loaded \(modelID) with VLM fallback")
                     } catch let vlmError {
                         print("[\(ts())] [MLX] VLM fallback also failed for \(modelID): \(vlmError)")
                         throw llmError
                     }
                 }
             }
+            if actualFactory != selectedFactory {
+                print("[\(ts())] [ModelArchitecture] actualFactory=VLM (LLM fallback)")
+            }
             withStateLock {
                 currentContainer = loaded
                 currentModelID = modelID
                 currentModelArchitecture = modelArchitecture
-                currentModelDirectory = directory
-                currentLoadedWithVisionFactory = selectedFactory == "VLM"
                 currentToolCallFormat = detectedFormat
             }
             // MTP: if requested and the model ships an mtp.safetensors sidecar, load the head
@@ -1906,6 +1910,7 @@ public final class MLXModelService: @unchecked Sendable {
             }
         }
         let modelID = try await ensureLoaded(model: model, countOperation: false)
+        let container = try validatedContainerForRequest(modelID: modelID, messages: messages)
 
         let promptText = buildPrompt(from: messages)
         let toolSpecs = convertToToolSpecs(tools, includePythonJSON: shouldUseNativePythonToolJSONTemplate(for: tools))
@@ -1917,7 +1922,6 @@ public final class MLXModelService: @unchecked Sendable {
             includeSchemaInPrompt: chatTemplateKwargs?.afmIncludeSchemaInPrompt ?? true
         )
         defer { cleanupTempFiles(mediaTempFiles) }
-        let container = try await containerForRequest(modelID: modelID, messages: messages)
         let wantLogprobs = logprobs == true
         let effectiveMaxTokens = capMaxTokensForCapture(maxTokens ?? 2000)
 
@@ -2834,6 +2838,7 @@ public final class MLXModelService: @unchecked Sendable {
         // is created; the Task itself owns the normal endOperation() call.
 
         let modelID = try await ensureLoaded(model: model, countOperation: false)
+        let container = try validatedContainerForRequest(modelID: modelID, messages: messages)
 
         let promptText = buildPrompt(from: messages)
         let toolSpecs = convertToToolSpecs(tools, includePythonJSON: shouldUseNativePythonToolJSONTemplate(for: tools))
@@ -2854,8 +2859,13 @@ public final class MLXModelService: @unchecked Sendable {
             chatTemplateKwargs: chatTemplateKwargs,
             includeSchemaInPrompt: chatTemplateKwargs?.afmIncludeSchemaInPrompt ?? true
         )
+        var streamOwnsTempFiles = false
+        defer {
+            if !streamOwnsTempFiles {
+                cleanupTempFiles(mediaTempFiles)
+            }
+        }
         let promptTokens = estimateTokens(promptText)
-        let container = try await containerForRequest(modelID: modelID, messages: messages)
         let wantLogprobs = logprobs == true
         let effectiveMaxTokens = capMaxTokensForCapture(maxTokens ?? 2000)
         // /metrics: streaming-path queue timestamp. The actual
@@ -3031,6 +3041,7 @@ public final class MLXModelService: @unchecked Sendable {
                 let thinkStartTag = self.thinkStartTag
                 let stream = AsyncThrowingStream<StreamChunk, Error> { continuation in
                     let task = Task {
+                        defer { self.cleanupTempFiles(mediaTempFiles) }
                         StatsAggregator.shared.requestStarted()
                         if openedThink, let thinkStartTag {
                             continuation.yield(StreamChunk(text: thinkStartTag))
@@ -3096,6 +3107,7 @@ public final class MLXModelService: @unchecked Sendable {
                     // Cancel the decode if the SSE client disconnects (frees the serial lock + GPU).
                     continuation.onTermination = { _ in task.cancel() }
                 }
+                streamOwnsTempFiles = true
                 endOperationOnExit = false
                 return (modelID, stream, promptTokens, nil, nil, self.thinkStartTag, self.thinkEndTag)
             }
@@ -3630,6 +3642,7 @@ public final class MLXModelService: @unchecked Sendable {
             toolTags = nil
         }
 
+        streamOwnsTempFiles = true
         endOperationOnExit = false
         return (modelID, stream, promptTokens, toolTags?.start, toolTags?.end, self.thinkStartTag, self.thinkEndTag)
     }
@@ -3660,8 +3673,6 @@ public final class MLXModelService: @unchecked Sendable {
                 currentContainer = nil
                 currentModelID = nil
                 currentModelArchitecture = nil
-                currentModelDirectory = nil
-                currentLoadedWithVisionFactory = false
             }
         }
 
@@ -5561,19 +5572,6 @@ public final class MLXModelService: @unchecked Sendable {
         return required
     }
 
-    /// Returns true when the model has a VLM config layout that can't be loaded
-    /// correctly by the LLM factory.  VLM models like gemma-3 store architecture
-    /// fields (num_attention_heads, head_dim, etc.) only inside text_config, not at
-    /// the top level.  The LLM factory's Codable config fills in wrong defaults for
-    /// these missing fields, causing inference crashes.
-    ///
-    /// Models like Qwen3.5-35B-A3B also have text_config but their LLM model class
-    /// (Qwen3_5MoE) properly reads from text_config with full field coverage.
-    /// We detect the "sparse text_config" case by checking for missing key fields.
-    private func isVLMOnlyConfig(directory: URL) -> Bool {
-        AFMMLXModelDescriptor.requiresVisionModelFactory(in: directory)
-    }
-
     private func isVisionModel(directory: URL) throws -> Bool {
         let config = directory.appendingPathComponent("config.json")
         guard let data = try? Data(contentsOf: config),
@@ -5599,51 +5597,37 @@ public final class MLXModelService: @unchecked Sendable {
         return false
     }
 
-    private func containerForRequest(
+    private func validatedContainerForRequest(
         modelID: String,
         messages: [AFMOpenAICompat.Message]
-    ) async throws -> ModelContainer {
-        guard !isTextOnlyInput(messages) else {
-            guard let container = withStateLock({ currentContainer }) else { throw MLXServiceError.noModelLoaded }
-            return container
+    ) throws -> ModelContainer {
+        let state = withStateLock { (currentContainer, currentModelArchitecture, currentModelID == modelID) }
+        guard let container = state.0, state.2 else { throw MLXServiceError.noModelLoaded }
+        guard let architecture = state.1 else {
+            throw MLXServiceError.loadFailed("\(modelID): model architecture is unavailable")
         }
 
-        let state = withStateLock { () -> (ModelContainer?, AFMMLXModelArchitecturePreflight?, URL?, Bool, Bool) in
-            (
-                currentContainer,
-                currentModelArchitecture,
-                currentModelDirectory,
-                currentLoadedWithVisionFactory,
-                currentModelID == modelID
-            )
-        }
-        guard let container = state.0, state.4 else { throw MLXServiceError.noModelLoaded }
-        guard let architecture = state.1, let directory = state.2 else { return container }
-
-        let shouldReload = AFMMLXLoadedModeSwitchPolicy.shouldReloadVisionFactoryForMultimodalRequest(
-            loadedModelType: architecture.modelType,
-            isLoadedModelVLM: state.3,
-            loadedModelDirectoryIsVision: architecture.isVisionConfiguration
-        )
-        guard shouldReload else {
-            if architecture.isVisionConfiguration {
-                return container
+        for message in messages {
+            guard let content = message.content, case .parts(let parts) = content else { continue }
+            for part in parts {
+                guard let kind = AFMMLXRequestMediaPolicy.kind(
+                    contentPartType: part.type,
+                    mediaURL: part.image_url?.url
+                ) else { continue }
+                guard AFMMLXRequestMediaPolicy.supports(kind, architecture: architecture) else {
+                    let label: String
+                    switch kind {
+                    case .image: label = "image"
+                    case .video: label = "video"
+                    case .audio: label = "audio"
+                    }
+                    throw MLXServiceError.loadFailed(
+                        "\(modelID): \(label) input is not supported by the loaded MLX model"
+                    )
+                }
             }
-            throw MLXServiceError.loadFailed("\(modelID): request includes image/video input but the loaded model is not vision-capable")
         }
-
-        print("[\(ts())] [MLX] Multimodal request for \(modelID) requires VLM factory; reloading loaded model as VLM")
-        let loaded = try await VLMModelFactory.shared.loadContainer(configuration: ModelConfiguration(directory: directory))
-        if let scheduler = withStateLock({ self.scheduler }) {
-            await scheduler.shutdown()
-        }
-        withStateLock {
-            currentContainer = loaded
-            currentLoadedWithVisionFactory = true
-            scheduler = nil
-            radixCache = nil
-        }
-        return loaded
+        return container
     }
 
     private func buildPrompt(from messages: [AFMOpenAICompat.Message]) -> String {
@@ -5660,6 +5644,12 @@ public final class MLXModelService: @unchecked Sendable {
         var chatMessages: [Chat.Message] = []
         var hasSystemMessage = false
         var allTempFiles: [URL] = []
+        var callerOwnsTempFiles = false
+        defer {
+            if !callerOwnsTempFiles {
+                cleanupTempFiles(allTempFiles)
+            }
+        }
         // Merge consecutive system/developer messages into one so that Jinja
         // templates requiring a single system message at position 0 don't fail
         // (e.g. Qwen3.5). The OpenAI API allows multiple system messages, so
@@ -5795,6 +5785,7 @@ public final class MLXModelService: @unchecked Sendable {
         }
 
         if chatMessages.isEmpty {
+            callerOwnsTempFiles = true
             return (UserInput(prompt: ""), tempFiles: allTempFiles)
         }
 
@@ -5901,6 +5892,7 @@ public final class MLXModelService: @unchecked Sendable {
                 additionalContext: additionalContext,
                 addGenerationPrompt: true
             )
+            callerOwnsTempFiles = true
             return (
                 UserInput(
                     prompt: .text(prompt),
@@ -5922,6 +5914,7 @@ public final class MLXModelService: @unchecked Sendable {
             }
         }
 
+        callerOwnsTempFiles = true
         return (input, tempFiles: allTempFiles)
     }
 
@@ -5999,10 +5992,17 @@ public final class MLXModelService: @unchecked Sendable {
             } else if let url = URL(string: raw),
                       let scheme = url.scheme, scheme == "http" || scheme == "https" {
                 let (data, _) = try awaitURL(url: url)
-                let temp = FileManager.default.temporaryDirectory
-                    .appendingPathComponent("afm_mlx_image_\(UUID().uuidString).\(url.pathExtension.isEmpty ? "jpg" : url.pathExtension)")
+                let ext = url.pathExtension.lowercased()
+                let isVideo = Self.videoExtensions.contains(ext)
+                let temp = FileManager.default.temporaryDirectory.appendingPathComponent(
+                    "afm_mlx_\(isVideo ? "video" : "image")_\(UUID().uuidString).\(ext.isEmpty ? (isVideo ? "mp4" : "jpg") : ext)"
+                )
                 try data.write(to: temp)
-                images.append(.url(temp))
+                if isVideo {
+                    videos.append(.url(temp))
+                } else {
+                    images.append(.url(temp))
+                }
                 tempFiles.append(temp)
             } else if let url = URL(string: raw) {
                 let ext = url.pathExtension.lowercased()
@@ -6371,15 +6371,13 @@ public final class MLXModelService: @unchecked Sendable {
         input.image != nil || input.video != nil
     }
 
-    /// Check the OpenAI request shape before preparing UserInput, so multimodal/audio
-    /// inputs can stay on the legacy container.perform path.
+    /// Keep media requests on the processor-backed path; the lock-free text
+    /// adapter intentionally accepts text-only OpenAI content.
     private func isTextOnlyInput(_ messages: [AFMOpenAICompat.Message]) -> Bool {
         for message in messages {
-            guard let content = message.content else { continue }
-            if case .parts(let parts) = content {
-                if parts.contains(where: { $0.type != "text" }) {
-                    return false
-                }
+            guard let content = message.content, case .parts(let parts) = content else { continue }
+            if parts.contains(where: { $0.type != "text" }) {
+                return false
             }
         }
         return true

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -228,6 +228,8 @@ public final class MLXModelService: @unchecked Sendable {
     private let stateLock = NSLock()
     private var currentModelID: String?
     private var currentModelArchitecture: AFMMLXModelArchitecturePreflight?
+    private var currentModelDirectory: URL?
+    private var currentLoadedWithVisionFactory = false
     private var currentContainer: ModelContainer?
     private var activeOperations: Int = 0
     private var isShuttingDown = false
@@ -1484,6 +1486,8 @@ public final class MLXModelService: @unchecked Sendable {
                 currentContainer = loaded
                 currentModelID = modelID
                 currentModelArchitecture = modelArchitecture
+                currentModelDirectory = directory
+                currentLoadedWithVisionFactory = selectedFactory == "VLM"
                 currentToolCallFormat = detectedFormat
             }
             // MTP: if requested and the model ships an mtp.safetensors sidecar, load the head
@@ -1901,10 +1905,7 @@ public final class MLXModelService: @unchecked Sendable {
                 StatsAggregator.shared.requestCompleted()
             }
         }
-        let requestHasTools = !(tools?.isEmpty ?? true)
-
         let modelID = try await ensureLoaded(model: model, countOperation: false)
-        guard let container = withStateLock({ currentContainer }) else { throw MLXServiceError.noModelLoaded }
 
         let promptText = buildPrompt(from: messages)
         let toolSpecs = convertToToolSpecs(tools, includePythonJSON: shouldUseNativePythonToolJSONTemplate(for: tools))
@@ -1916,6 +1917,7 @@ public final class MLXModelService: @unchecked Sendable {
             includeSchemaInPrompt: chatTemplateKwargs?.afmIncludeSchemaInPrompt ?? true
         )
         defer { cleanupTempFiles(mediaTempFiles) }
+        let container = try await containerForRequest(modelID: modelID, messages: messages)
         let wantLogprobs = logprobs == true
         let effectiveMaxTokens = capMaxTokensForCapture(maxTokens ?? 2000)
 
@@ -2832,7 +2834,6 @@ public final class MLXModelService: @unchecked Sendable {
         // is created; the Task itself owns the normal endOperation() call.
 
         let modelID = try await ensureLoaded(model: model, countOperation: false)
-        guard let container = withStateLock({ currentContainer }) else { throw MLXServiceError.noModelLoaded }
 
         let promptText = buildPrompt(from: messages)
         let toolSpecs = convertToToolSpecs(tools, includePythonJSON: shouldUseNativePythonToolJSONTemplate(for: tools))
@@ -2854,10 +2855,9 @@ public final class MLXModelService: @unchecked Sendable {
             includeSchemaInPrompt: chatTemplateKwargs?.afmIncludeSchemaInPrompt ?? true
         )
         let promptTokens = estimateTokens(promptText)
+        let container = try await containerForRequest(modelID: modelID, messages: messages)
         let wantLogprobs = logprobs == true
         let effectiveMaxTokens = capMaxTokensForCapture(maxTokens ?? 2000)
-        let streamRequestHasTools = !(tools?.isEmpty ?? true)
-
         // /metrics: streaming-path queue timestamp. The actual
         // requestStarted/observe calls happen ONLY in the serial-path
         // task below (the batch path's stats are owned by BatchScheduler).
@@ -3660,6 +3660,8 @@ public final class MLXModelService: @unchecked Sendable {
                 currentContainer = nil
                 currentModelID = nil
                 currentModelArchitecture = nil
+                currentModelDirectory = nil
+                currentLoadedWithVisionFactory = false
             }
         }
 
@@ -5595,6 +5597,53 @@ public final class MLXModelService: @unchecked Sendable {
             return true
         }
         return false
+    }
+
+    private func containerForRequest(
+        modelID: String,
+        messages: [AFMOpenAICompat.Message]
+    ) async throws -> ModelContainer {
+        guard !isTextOnlyInput(messages) else {
+            guard let container = withStateLock({ currentContainer }) else { throw MLXServiceError.noModelLoaded }
+            return container
+        }
+
+        let state = withStateLock { () -> (ModelContainer?, AFMMLXModelArchitecturePreflight?, URL?, Bool, Bool) in
+            (
+                currentContainer,
+                currentModelArchitecture,
+                currentModelDirectory,
+                currentLoadedWithVisionFactory,
+                currentModelID == modelID
+            )
+        }
+        guard let container = state.0, state.4 else { throw MLXServiceError.noModelLoaded }
+        guard let architecture = state.1, let directory = state.2 else { return container }
+
+        let shouldReload = AFMMLXLoadedModeSwitchPolicy.shouldReloadVisionFactoryForMultimodalRequest(
+            loadedModelType: architecture.modelType,
+            isLoadedModelVLM: state.3,
+            loadedModelDirectoryIsVision: architecture.isVisionConfiguration
+        )
+        guard shouldReload else {
+            if architecture.isVisionConfiguration {
+                return container
+            }
+            throw MLXServiceError.loadFailed("\(modelID): request includes image/video input but the loaded model is not vision-capable")
+        }
+
+        print("[\(ts())] [MLX] Multimodal request for \(modelID) requires VLM factory; reloading loaded model as VLM")
+        let loaded = try await VLMModelFactory.shared.loadContainer(configuration: ModelConfiguration(directory: directory))
+        if let scheduler = withStateLock({ self.scheduler }) {
+            await scheduler.shutdown()
+        }
+        withStateLock {
+            currentContainer = loaded
+            currentLoadedWithVisionFactory = true
+            scheduler = nil
+            radixCache = nil
+        }
+        return loaded
     }
 
     private func buildPrompt(from messages: [AFMOpenAICompat.Message]) -> String {

--- a/Tests/MacLocalAPITests/AFMMLXLoadedModeSwitchPolicyTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXLoadedModeSwitchPolicyTests.swift
@@ -50,4 +50,34 @@ final class AFMMLXLoadedModeSwitchPolicyTests: XCTestCase {
         XCTAssertEqual(plan, .currentLoadedModel(targetVLM: false))
         XCTAssertEqual(plan?.targetVLM, false)
     }
+
+    func testMultimodalRequestReloadsDualModeTextFactory() {
+        XCTAssertTrue(
+            AFMMLXLoadedModeSwitchPolicy.shouldReloadVisionFactoryForMultimodalRequest(
+                loadedModelType: "gemma4",
+                isLoadedModelVLM: false,
+                loadedModelDirectoryIsVision: true
+            )
+        )
+    }
+
+    func testMultimodalRequestKeepsAlreadyLoadedVisionFactory() {
+        XCTAssertFalse(
+            AFMMLXLoadedModeSwitchPolicy.shouldReloadVisionFactoryForMultimodalRequest(
+                loadedModelType: "gemma4",
+                isLoadedModelVLM: true,
+                loadedModelDirectoryIsVision: true
+            )
+        )
+    }
+
+    func testMultimodalRequestDoesNotReloadTextOnlyModel() {
+        XCTAssertFalse(
+            AFMMLXLoadedModeSwitchPolicy.shouldReloadVisionFactoryForMultimodalRequest(
+                loadedModelType: "llama",
+                isLoadedModelVLM: false,
+                loadedModelDirectoryIsVision: false
+            )
+        )
+    }
 }

--- a/Tests/MacLocalAPITests/AFMMLXLoadedModeSwitchPolicyTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXLoadedModeSwitchPolicyTests.swift
@@ -51,33 +51,50 @@ final class AFMMLXLoadedModeSwitchPolicyTests: XCTestCase {
         XCTAssertEqual(plan?.targetVLM, false)
     }
 
-    func testMultimodalRequestReloadsDualModeTextFactory() {
-        XCTAssertTrue(
-            AFMMLXLoadedModeSwitchPolicy.shouldReloadVisionFactoryForMultimodalRequest(
-                loadedModelType: "gemma4",
-                isLoadedModelVLM: false,
-                loadedModelDirectoryIsVision: true
-            )
+    func testVisionConfigurationLoadsVLMInitially() {
+        let architecture = AFMMLXModelArchitecturePreflight(
+            modelID: "gemma4-vision",
+            modelType: "gemma4",
+            canonicalModelType: "gemma4",
+            isVisionConfiguration: true,
+            requiresVisionModelFactory: false
         )
+        XCTAssertEqual(AFMMLXModelFactoryPolicy.initialFactory(forceVLM: false, architecture: architecture), .vlm)
     }
 
-    func testMultimodalRequestKeepsAlreadyLoadedVisionFactory() {
-        XCTAssertFalse(
-            AFMMLXLoadedModeSwitchPolicy.shouldReloadVisionFactoryForMultimodalRequest(
-                loadedModelType: "gemma4",
-                isLoadedModelVLM: true,
-                loadedModelDirectoryIsVision: true
-            )
+    func testTextOnlyDualModeConfigurationLoadsLLM() {
+        let architecture = AFMMLXModelArchitecturePreflight(
+            modelID: "qwen-text",
+            modelType: "qwen3_6",
+            canonicalModelType: "qwen3_6",
+            isVisionConfiguration: false,
+            requiresVisionModelFactory: false
         )
+        XCTAssertEqual(AFMMLXModelFactoryPolicy.initialFactory(forceVLM: false, architecture: architecture), .llm)
     }
 
-    func testMultimodalRequestDoesNotReloadTextOnlyModel() {
-        XCTAssertFalse(
-            AFMMLXLoadedModeSwitchPolicy.shouldReloadVisionFactoryForMultimodalRequest(
-                loadedModelType: "llama",
-                isLoadedModelVLM: false,
-                loadedModelDirectoryIsVision: false
-            )
+    func testMediaKindsAndCapabilitiesAreExplicit() {
+        let gemma = AFMMLXModelArchitecturePreflight(
+            modelID: "gemma4-vision",
+            modelType: "gemma4",
+            canonicalModelType: "gemma4",
+            isVisionConfiguration: true,
+            requiresVisionModelFactory: false
         )
+        let qwen = AFMMLXModelArchitecturePreflight(
+            modelID: "qwen-vl",
+            modelType: "qwen3_vl",
+            canonicalModelType: "qwen3_vl",
+            isVisionConfiguration: true,
+            requiresVisionModelFactory: true
+        )
+
+        XCTAssertEqual(AFMMLXRequestMediaPolicy.kind(contentPartType: "image_url", mediaURL: "data:image/png;base64,AA=="), .image)
+        XCTAssertEqual(AFMMLXRequestMediaPolicy.kind(contentPartType: "image_url", mediaURL: "https://example.com/clip.mp4"), .video)
+        XCTAssertEqual(AFMMLXRequestMediaPolicy.kind(contentPartType: "input_audio"), .audio)
+        XCTAssertTrue(AFMMLXRequestMediaPolicy.supports(.image, architecture: gemma))
+        XCTAssertFalse(AFMMLXRequestMediaPolicy.supports(.video, architecture: gemma))
+        XCTAssertTrue(AFMMLXRequestMediaPolicy.supports(.video, architecture: qwen))
+        XCTAssertFalse(AFMMLXRequestMediaPolicy.supports(.audio, architecture: qwen))
     }
 }


### PR DESCRIPTION
Fixes #149.

## Summary

- Recognize Gemma 4 as a dual-mode MLX architecture.
- Track whether the active container was loaded through the LLM or VLM factory.
- Reload a dual-mode model through the VLM factory when a later request contains image or video content.
- Reject multimodal input explicitly for models that are not vision-capable.

## Root cause

The processor mapping added by #150 made Gemma 4 resolvable, but the service still loaded dual-capable models through the LLM factory for text-first sessions. A later multimodal request reused that text-only container and lost its media input.

## Validation

- `Scripts/swiftpm-reliable.sh test -c release --filter 'AFMMLXLoadedModeSwitchPolicyTests|AFMMLXModelArchitectureTests'`
- `Scripts/swiftpm-reliable.sh test -c release --filter 'AFMMLXLoadedModeSwitchPolicyTests|AFMMLXModelArchitectureTests|XMLToolCallParsingTests|IssueRegressionTests|ConcurrentBatchTests'`

Both focused suites pass.

## Summary by Sourcery

Ensure dual-mode MLX models are correctly (re)loaded via the appropriate factory when handling multimodal requests and reject multimodal input for non-vision models.

Bug Fixes:
- Preserve image/video inputs by reloading dual-mode models via the VLM factory when a previously text-only session receives a multimodal request.
- Reject multimodal requests explicitly when the currently loaded model or configuration is not vision-capable.

Enhancements:
- Track the current model directory and whether it was loaded with the vision factory to support dynamic mode switching for dual-mode models.
- Recognize Gemma 4 as a dual-mode MLX architecture and add a policy helper to decide when to reload the vision factory.
- Add tests covering multimodal reload behavior and dual-mode switch policy decisions.