### PR TITLE
Harden DeepSeek nightly release validation

### DIFF
--- a/Scripts/feature-mlx-concurrent-batch/validate_mixed_workload.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_mixed_workload.py
@@ -13,6 +13,7 @@ import asyncio, aiohttp, json, time, sys, subprocess, threading, os
 
 URL = os.environ.get("AFM_CHAT_COMPLETIONS_URL", "http://localhost:9999/v1/chat/completions")
 MODEL = os.environ.get("AFM_MODEL", "mlx-community/Qwen3.5-35B-A3B-4bit")
+REQUEST_TIMEOUT_S = int(os.environ.get("AFM_REQUEST_TIMEOUT_S", "1200"))
 
 # --- Short-answer tests (long prompts, expect brief response) ---
 SHORT_ANSWER_TESTS = [
@@ -281,7 +282,8 @@ async def run_batch(batch_size, tests):
     failed = 0
     results = []
 
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT_S + 30, sock_read=REQUEST_TIMEOUT_S)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         for batch_start in range(0, len(tests), batch_size):
             batch = tests[batch_start:batch_start + batch_size]
             tasks = [
@@ -294,8 +296,8 @@ async def run_batch(batch_size, tests):
                 name = test["name"]
                 if isinstance(outcome, Exception):
                     failed += 1
-                    print(f"  FAIL  {name}: exception {outcome}")
-                    results.append({"name": name, "status": "EXCEPTION"})
+                    print(f"  FAIL  {name}: exception {outcome!r}")
+                    results.append({"name": name, "status": "EXCEPTION", "error": repr(outcome)})
                     continue
 
                 r = outcome

--- a/Scripts/feature-mlx-concurrent-batch/validate_responses.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_responses.py
@@ -13,7 +13,7 @@ Prerequisites:
     pip install aiohttp
     Server running on port 9999
 """
-import asyncio, aiohttp, json, time, sys, re, os
+import asyncio, aiohttp, json, time, sys, re, os, unicodedata
 
 URL = os.environ.get("AFM_CHAT_COMPLETIONS_URL", "http://localhost:9999/v1/chat/completions")
 MODEL = os.environ.get("AFM_MODEL", "mlx-community/Qwen3.5-35B-A3B-4bit")
@@ -99,7 +99,7 @@ async def send_request(session, prompt, max_tokens=200):
 
 def check_response(text, expected_substrings):
     """Check if response contains at least one expected substring."""
-    lower = text.lower()
+    lower = unicodedata.normalize("NFKC", text).lower()
     for sub in expected_substrings:
         if sub.lower() in lower:
             return True, sub
@@ -133,7 +133,7 @@ async def run_validation(batch_size):
                 text, elapsed = result
                 ok, matched = check_response(text, expected)
                 # Also check for obvious garbage
-                is_garbage = len(text.strip()) < 2 or text.count('\ufffd') > 5
+                is_garbage = not text.strip() or text.count('\ufffd') > 5
 
                 if is_garbage:
                     failed += 1

--- a/Scripts/gpu-profile-report.py
+++ b/Scripts/gpu-profile-report.py
@@ -30,7 +30,18 @@ PROMPT = sys.argv[3] if len(sys.argv) > 3 else (
 )
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PROJECT_DIR = os.path.dirname(SCRIPT_DIR)
-AFM = os.path.join(PROJECT_DIR, ".build/release/afm")
+AFM = os.environ.get("AFM_BIN", "")
+if not AFM:
+    candidates = [
+        os.path.join(PROJECT_DIR, ".build/arm64-apple-macosx/release/afm"),
+        os.path.join(PROJECT_DIR, ".build/release/afm"),
+    ]
+    AFM = next((path for path in candidates if os.path.isfile(path)), candidates[0])
+if not os.path.isfile(AFM) or not os.access(AFM, os.X_OK):
+    raise SystemExit(
+        f"Release AFM binary not found or executable: {AFM}. "
+        "Build Release first or set AFM_BIN to the full binary path."
+    )
 CACHE = os.environ.get("MACAFM_MLX_MODEL_CACHE", "/Volumes/edata/models/vesta-test-cache")
 TRACE_DURATION = 15
 THEORETICAL_BW = 800.0

--- a/Scripts/regression-test.sh
+++ b/Scripts/regression-test.sh
@@ -12,8 +12,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 AFM="${AFM_BIN:-$ROOT_DIR/.build/arm64-apple-macosx/release/afm}"
 export MACAFM_MLX_MODEL_CACHE="${MACAFM_MLX_MODEL_CACHE:-$ROOT_DIR/.build/model-cache}"
-MLX_SMALL_MODEL="mlx-community/Qwen2.5-0.5B-Instruct-4bit"
-MLX_CACHED_MODEL="mlx-community/lille-130m-instruct-8bit"
+MLX_SMALL_MODEL="${AFM_REGRESSION_MLX_SMALL_MODEL:-mlx-community/Qwen2.5-0.5B-Instruct-4bit}"
+MLX_CACHED_MODEL="${AFM_REGRESSION_MLX_CACHED_MODEL:-mlx-community/lille-130m-instruct-8bit}"
 PORT_AFM=9871
 PORT_MLX=9872
 AFM_TEST_WORK_ROOT="${AFM_TEST_WORK_ROOT:-$ROOT_DIR/.build/test-work/regression}"
@@ -38,6 +38,14 @@ Environment variables:
   AFM_TEST_WORK_ROOT=PATH   Store transient logs and download fixtures under PATH
   AFM_REGRESSION_RESULTS_FILE=PATH
                             Override the JSONL result path
+  AFM_REGRESSION_MLX_SMALL_MODEL=MODEL
+                            Override the MLX download/single-prompt fixture
+  AFM_REGRESSION_MLX_CACHED_MODEL=MODEL
+                            Override the cached MLX server fixture
+  AFM_REGRESSION_MLX_VLM_MODEL=MODEL
+                            Override the VLM fixture
+  AFM_REGRESSION_MLX_MOE_MODEL=MODEL
+                            Override the MoE fixture
 HELP
        exit 0 ;;
     *) echo "Unknown option"; exit 1 ;;
@@ -393,14 +401,17 @@ else:
     delta0 = c0.get('choices', [{}])[0].get('delta', {})
     if 'role' not in delta0:
         errors.append('first chunk delta missing role')
-    # Last chunk should have finish_reason
-    last = chunks[-1]
-    fr = last.get('choices', [{}])[0].get('finish_reason')
+    # A trailing usage-only chunk can have choices: []. The last
+    # choice-bearing chunk carries finish_reason.
+    choice_chunks = [c for c in chunks if c.get('choices')]
+    last_choice = choice_chunks[-1] if choice_chunks else {}
+    fr = (last_choice.get('choices') or [{}])[0].get('finish_reason')
     if fr is None:
         errors.append('last chunk missing finish_reason')
-    # Final chunk should have usage
-    usage = last.get('usage')
-    if usage and isinstance(usage, dict):
+    # Usage can be attached to a trailing choices:[] chunk.
+    usage_chunks = [c for c in chunks if isinstance(c.get('usage'), dict)]
+    usage = usage_chunks[-1].get('usage') if usage_chunks else None
+    if usage:
         for f in ('prompt_tokens', 'completion_tokens', 'total_tokens'):
             if f not in usage: errors.append(f'final usage missing: {f}')
     # All chunks should have consistent id
@@ -484,7 +495,7 @@ header_test() {
   elif [ "$method" = "OPTIONS" ]; then
     headers=$(curl -sI --max-time 30 -X OPTIONS "http://127.0.0.1:${port}${endpoint}" 2>&1) && rc=$? || rc=$?
   else
-    headers=$(curl -sI --max-time 60 -X POST "http://127.0.0.1:${port}${endpoint}" \
+    headers=$(curl -sS -D - -o /dev/null --max-time 60 -X POST "http://127.0.0.1:${port}${endpoint}" \
       -H "Content-Type: application/json" -d "$data" 2>&1) && rc=$? || rc=$?
   fi
   local elapsed=$((SECONDS - t0))
@@ -710,7 +721,8 @@ SEC="MLX Server"
 
 if start_server $PORT_MLX "$AFM" mlx -m "$MLX_CACHED_MODEL" -p $PORT_MLX; then
   api_test "$SEC" "GET /health" $PORT_MLX GET "/health" "" "healthy"
-  api_test "$SEC" "GET /v1/models" $PORT_MLX GET "/v1/models" "" "lille"
+  schema_api_test "$SEC" "GET /v1/models" $PORT_MLX GET "/v1/models" "" \
+    validate_models_response "200"
   api_test "$SEC" "POST chat completion" $PORT_MLX POST "/v1/chat/completions" \
     '{"model":"test","messages":[{"role":"user","content":"Say hi"}],"max_tokens":50}' "choices"
   api_test "$SEC" "POST chat with temperature" $PORT_MLX POST "/v1/chat/completions" \
@@ -761,7 +773,7 @@ echo ""
 echo "━━━ Section 9: MLX VLM Model ━━━"
 SEC="MLX VLM"
 
-MLX_VLM_MODEL="mlx-community/Qwen3-VL-4B-Instruct-4bit"
+MLX_VLM_MODEL="${AFM_REGRESSION_MLX_VLM_MODEL:-mlx-community/Qwen3-VL-4B-Instruct-4bit}"
 if start_server $PORT_MLX "$AFM" mlx -m "$MLX_VLM_MODEL" -p $PORT_MLX; then
   api_test "$SEC" "VLM text-only chat" $PORT_MLX POST "/v1/chat/completions" \
     '{"model":"test","messages":[{"role":"user","content":"What is 2+2?"}],"max_tokens":50}' "choices"
@@ -775,7 +787,7 @@ echo ""
 echo "━━━ Section 10: MLX MoE Model ━━━"
 SEC="MLX MoE"
 
-MLX_MOE_MODEL="mlx-community/Qwen3-30B-A3B-4bit"
+MLX_MOE_MODEL="${AFM_REGRESSION_MLX_MOE_MODEL:-mlx-community/Qwen3-30B-A3B-4bit}"
 if start_server $PORT_MLX "$AFM" mlx -m "$MLX_MOE_MODEL" -p $PORT_MLX; then
   api_test "$SEC" "MoE chat completion" $PORT_MLX POST "/v1/chat/completions" \
     '{"model":"test","messages":[{"role":"user","content":"What is 2+2? Answer briefly."}],"max_tokens":50}' "choices"
@@ -1058,13 +1070,15 @@ if [ "${RUN_GATEWAY_TESTS:-0}" = "1" ]; then
 
     # If Ollama is running, test proxied completion
     if curl -s --max-time 5 "http://127.0.0.1:11434/api/tags" >/dev/null 2>&1; then
-      # Get first available Ollama model
-      OLLAMA_MODEL=$(curl -s "http://127.0.0.1:11434/api/tags" | python3 -c "import json,sys; m=json.load(sys.stdin).get('models',[]); print(m[0]['name'] if m else '')" 2>/dev/null)
+      # Resolve the native Ollama name to the ID advertised by AFM. Gateway
+      # IDs can be namespaced and must be sent back exactly as listed.
+      OLLAMA_NATIVE_MODEL=$(curl -s "http://127.0.0.1:11434/api/tags" | python3 -c "import json,sys; m=json.load(sys.stdin).get('models',[]); print(m[0]['name'] if m else '')" 2>/dev/null)
+      OLLAMA_MODEL=$(curl -s "http://127.0.0.1:${PORT_GW}/v1/models" | python3 -c "import json,sys; models=json.load(sys.stdin).get('data',[]); native='$OLLAMA_NATIVE_MODEL'; candidates=[m.get('id','') for m in models if m.get('owned_by') == 'ollama' and (m.get('id','').endswith(native) or native in m.get('id',''))]; print(candidates[0] if candidates else '')" 2>/dev/null)
       if [ -n "$OLLAMA_MODEL" ]; then
         api_test "$SEC" "Ollama proxy: $OLLAMA_MODEL" $PORT_GW POST "/v1/chat/completions" \
           "{\"model\":\"$OLLAMA_MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hi\"}],\"max_tokens\":50}" "choices"
       else
-        record "$SEC" "Ollama proxy" "SKIP" "Ollama running but no models loaded" "0"
+        record "$SEC" "Ollama proxy" "SKIP" "Ollama model not advertised by AFM gateway" "0"
       fi
     else
       record "$SEC" "Ollama proxy" "SKIP" "Ollama not running on :11434" "0"

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -348,6 +348,14 @@ has_recurrent_layers = any(
     any(marker in str(layer_type).lower() for marker in recurrent_markers)
     for layer_type in layer_types
 )
+model_type = str(text_config.get("model_type") or config.get("model_type") or "").lower()
+architectures = text_config.get("architectures") or config.get("architectures") or []
+architecture_text = " ".join(str(architecture).lower() for architecture in architectures)
+recurrent_architectures = ("deepseek_v4", "deepseekv4")
+has_recurrent_layers = has_recurrent_layers or any(
+    marker in model_type or marker in architecture_text
+    for marker in recurrent_architectures
+)
 print("true" if has_recurrent_layers else "false")
 PY
   )

--- a/Sources/AFMServer/Controllers/ChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/ChatCompletionsController.swift
@@ -207,6 +207,14 @@ struct ChatCompletionsController: RouteCollection {
 
             return try await createSuccessResponse(req: req, response: response)
 
+        } catch let decodingError as DecodingError {
+            req.logger.warning("Invalid chat completion request: \(decodingError)")
+            let error = OpenAIError(
+                message: "Invalid request body: \(Self.describeDecodingError(decodingError))",
+                type: "invalid_request_error"
+            )
+            return try await createErrorResponse(req: req, error: error, status: .badRequest)
+
         } catch let foundationError as FoundationModelError {
             if case .responseTruncated(let maxTokens) = foundationError {
                 let promptTokens = estimateTokens(for: fallbackMessages)
@@ -278,6 +286,19 @@ struct ChatCompletionsController: RouteCollection {
         httpResponse.headers.add(name: .accessControlAllowOrigin, value: "*")
         try httpResponse.content.encode(error)
         return httpResponse
+    }
+
+    private static func describeDecodingError(_ error: DecodingError) -> String {
+        switch error {
+        case .keyNotFound(let key, _):
+            return "Missing required field '\(key.stringValue)'"
+        case .typeMismatch(_, let context),
+             .valueNotFound(_, let context),
+             .dataCorrupted(let context):
+            return context.debugDescription
+        @unknown default:
+            return "The JSON request could not be decoded"
+        }
     }
     
     private func estimateTokens(for messages: [Message]) -> Int {

--- a/build.sh
+++ b/build.sh
@@ -295,9 +295,12 @@ swift package resolve
 
 if $DO_PATCHES; then
   log_step "Applying persistent DeepSeek V4 MLX primitive"
-  "$SCRIPTS_DIR/apply-mlx-official-fp8-loader.sh"
   "$SCRIPTS_DIR/apply-mlx-deepseek-v4-kernels.sh"
   "$SCRIPTS_DIR/apply-mlx-deepseek-v4-kernels.sh" --check
+  # The complete MLX core patch includes the F8_E8M0 loader change. Verify it
+  # only after applying that patch so a clean checkout is never left in the
+  # partial state that the all-or-nothing patch guard correctly rejects.
+  "$SCRIPTS_DIR/apply-mlx-official-fp8-loader.sh"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- apply DeepSeek V4 patches before FP8 loader verification in clean builds
- return OpenAI-compatible 400 responses for malformed chat payloads
- make release/regression harnesses model-selectable and robust to usage-only SSE chunks
- harden long-running DeepSeek batch checks and GPU profile binary discovery

## Validation
- Release Swift suite: 595 XCTest (2 skipped) + 387 Swift Testing, 0 failures
- Canonical regression: 92 passed, 0 failed, 1 intentional Ollama skip
- DeepSeek comprehensive: 182/182 executions passed, AI judge disabled
- Promptfoo: 388 executions, 0 execution errors; 334 assertion passes, 54 model-quality assertion misses

## Summary by Sourcery

Harden DeepSeek release and regression validation around MLX models, gateway behavior, and long-running batch workloads.

New Features:
- Allow overriding MLX regression, VLM, and MoE models via environment variables.
- Return OpenAI-compatible 400 error responses for malformed chat completion JSON payloads.

Bug Fixes:
- Make SSE chat completion validation robust to trailing usage-only chunks without choices.
- Ensure Ollama proxy regression uses the gateway-advertised model ID instead of the native name.
- Improve GPU profile report script robustness by reliably locating an executable AFM release binary.
- Stabilize long-running MLX concurrent batch tests via configurable request timeouts and richer exception reporting.
- Improve DeepSeek batch response validation by normalizing Unicode and tightening garbage detection.

Enhancements:
- Switch MLX /v1/models regression to schema-based validation instead of string matching.
- Extend recurrent-layer detection to recognize DeepSeek V4 architectures.
- Apply DeepSeek V4 MLX kernel patch before FP8 loader verification to avoid partial patch states.

Build:
- Adjust build patch ordering so DeepSeek V4 MLX kernels are applied before FP8 loader verification.

Tests:
- Strengthen regression harnesses for MLX server, VLM, MoE, and gateway proxy scenarios, including SSE usage chunks and Ollama proxy skips.
- Harden DeepSeek mixed workload and response validation scripts for long-duration runs and better diagnostics.