### PR TITLE
Add DwarfStar tools and macOS 27 provider bridge

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 import PackageDescription
 import Foundation
 
@@ -73,7 +73,11 @@ let package = Package(
         // initialized submodules falls back to the pre-patched URL fork and remains portable.
         mlxSwiftLMDependency,
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
-        .package(url: "https://github.com/huggingface/swift-huggingface.git", from: "0.8.1"),
+        .package(
+            url: "https://github.com/huggingface/swift-huggingface.git",
+            from: "0.8.1",
+            traits: ["Xet"]
+        ),
         // Share the official XGrammar product with host applications such as Vesta.
         // Compiling the vendored implementation here as well as in coreai-models
         // produces duplicate native symbols when both libraries are linked.
@@ -108,7 +112,8 @@ let package = Package(
         .target(
             name: "AFMKitFoundationModels27",
             dependencies: [
-                "AFMKit"
+                "AFMKit",
+                "AFMKitDwarfStar"
             ]
         ),
         .target(
@@ -122,6 +127,7 @@ let package = Package(
             path: "Sources/CDwarfStar",
             sources: [
                 "AFMDwarfStarBridge.c",
+                "CDwarfStarKVStore.c",
                 "CDwarfStarEngine.c",
                 "CDwarfStarDistributed.c",
                 "CDwarfStarTensorParallel.c",
@@ -319,6 +325,7 @@ let package = Package(
         .testTarget(
             name: "AFMKitDwarfStarTests",
             dependencies: [
+                "AFMKitCore",
                 "AFMKitDwarfStar",
             ],
             swiftSettings: [

--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,10 @@ let package = Package(
             targets: ["AFMKitFoundationModels27"]
         ),
         .library(
+            name: "AFMKitFoundationModels27DwarfStar",
+            targets: ["AFMKitFoundationModels27DwarfStar"]
+        ),
+        .library(
             name: "AFMKitServices",
             targets: ["AFMKitServices"]
         ),
@@ -112,8 +116,15 @@ let package = Package(
         .target(
             name: "AFMKitFoundationModels27",
             dependencies: [
+                "AFMKit"
+            ]
+        ),
+        .target(
+            name: "AFMKitFoundationModels27DwarfStar",
+            dependencies: [
                 "AFMKit",
-                "AFMKitDwarfStar"
+                "AFMKitDwarfStar",
+                "AFMKitFoundationModels27"
             ]
         ),
         .target(
@@ -156,10 +167,9 @@ let package = Package(
                 "CDwarfStar"
             ],
             resources: [
-                // `.process` dereferences the source-tree link into the product
-                // bundle. `.copy` preserved the relative symlink, which became
-                // broken once the resource moved under `.build` or an app bundle.
-                .process("Resources/metal")
+                // DS4 compiles these include-style fragments at runtime. Keep the
+                // directory opaque so SwiftPM does not compile each file alone.
+                .copy("../../vendor/ds4/metal")
             ],
             swiftSettings: [
                 .unsafeFlags(["-O"], .when(configuration: .release)),
@@ -304,6 +314,7 @@ let package = Package(
                 "AFMKitMLX",
                 "AFMKitFoundationModels",
                 "AFMKitFoundationModels27",
+                "AFMKitFoundationModels27DwarfStar",
                 "AFMKitServices",
                 "AFMServer",
                 .product(name: "Jinja", package: "swift-jinja"),

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ The repository publishes focused Swift Package Manager products:
 - `AFMOpenAICompat` — OpenAI-compatible request/response types
 - `AFMKitMLX` — MLX model loading and inference
 - `AFMKitFoundationModels` — Apple Foundation Models backend
+- `AFMKitFoundationModels27` — macOS 27 provider protocol adapters
+- `AFMKitFoundationModels27DwarfStar` — opt-in DwarfStar macOS 27 adapter
 - `AFMKitDwarfStar` — DwarfStar runtime integration
 - `AFMKitServices` — vision, speech, and embedding services
 - `AFMKit` — high-level headless inference facade

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -2047,6 +2047,14 @@ private final class MLXLoadReporter: @unchecked Sendable {
     private let lock = NSLock()
     private var stage: MLXLoadStage = .checkingCache
     private var downloadFraction: Double?
+    private var downloadCompletedBytes: Int64?
+    private var downloadTotalBytes: Int64?
+    private var downloadBytesPerSecond: Double?
+    private var downloadETA: TimeInterval?
+    private var downloadCurrentFiles: [String] = []
+    private var downloadCompletedFiles: Int?
+    private var downloadTotalFiles: Int?
+    private var lastDownloadSample: (date: Date, completed: Int64)?
     private var timer: DispatchSourceTimer?
     private var spinnerIndex: Int = 0
     private var startedAt = Date()
@@ -2076,9 +2084,35 @@ private final class MLXLoadReporter: @unchecked Sendable {
     }
 
     func updateDownload(_ progress: Progress) {
+        let now = Date()
+        let completed = max(0, progress.completedUnitCount)
+        let total = max(0, progress.totalUnitCount)
         lock.lock()
         if stage != .resuming { stage = .downloading }
-        downloadFraction = progress.totalUnitCount > 0 ? progress.fractionCompleted : nil
+        downloadFraction = total > 0 ? progress.fractionCompleted : nil
+        downloadCompletedBytes = completed
+        downloadTotalBytes = total > 1 ? total : nil
+        downloadCurrentFiles = progress.userInfo[AFMDownloadProgressUserInfo.currentFiles] as? [String] ?? []
+        downloadCompletedFiles = progress.userInfo[AFMDownloadProgressUserInfo.completedFiles] as? Int
+        downloadTotalFiles = progress.userInfo[AFMDownloadProgressUserInfo.totalFiles] as? Int
+        if let previous = lastDownloadSample {
+            let elapsed = now.timeIntervalSince(previous.date)
+            let delta = completed - previous.completed
+            if elapsed >= 0.1, delta >= 0 {
+                let instantaneous = Double(delta) / elapsed
+                if instantaneous > 0 {
+                    downloadBytesPerSecond = downloadBytesPerSecond.map {
+                        ($0 * 0.7) + (instantaneous * 0.3)
+                    } ?? instantaneous
+                    if total > completed, let speed = downloadBytesPerSecond, speed > 0 {
+                        downloadETA = Double(total - completed) / speed
+                    } else {
+                        downloadETA = nil
+                    }
+                }
+            }
+        }
+        lastDownloadSample = (now, completed)
         lock.unlock()
     }
 
@@ -2087,6 +2121,14 @@ private final class MLXLoadReporter: @unchecked Sendable {
         self.stage = stage
         if stage == .loadingModel || stage == .ready {
             downloadFraction = nil
+            downloadCompletedBytes = nil
+            downloadTotalBytes = nil
+            downloadBytesPerSecond = nil
+            downloadETA = nil
+            downloadCurrentFiles = []
+            downloadCompletedFiles = nil
+            downloadTotalFiles = nil
+            lastDownloadSample = nil
         }
         lock.unlock()
     }
@@ -2112,7 +2154,7 @@ private final class MLXLoadReporter: @unchecked Sendable {
 
         let status = success ? "ready" : "failed"
         var line = String(
-            format: "\r[%@] %@ | mem %.2f GB | %.1fs",
+            format: "[%@] %@ | mem %.2f GB | %.1fs",
             success ? "done" : "fail",
             status,
             memory,
@@ -2121,7 +2163,7 @@ private final class MLXLoadReporter: @unchecked Sendable {
         if let errorMessage, !errorMessage.isEmpty {
             line += " | \(errorMessage)"
         }
-        print(line)
+        print(Self.terminalSafeLine(line, clearExisting: true))
     }
 
     static func finishActiveWithError(_ message: String) {
@@ -2139,6 +2181,13 @@ private final class MLXLoadReporter: @unchecked Sendable {
         }
         let stage = self.stage
         let downloadFraction = self.downloadFraction
+        let completedBytes = self.downloadCompletedBytes
+        let totalBytes = self.downloadTotalBytes
+        let bytesPerSecond = self.downloadBytesPerSecond
+        let eta = self.downloadETA
+        let currentFiles = self.downloadCurrentFiles
+        let completedFiles = self.downloadCompletedFiles
+        let totalFiles = self.downloadTotalFiles
         spinnerIndex = (spinnerIndex + 1) % spinnerFrames.count
         let spinner = spinnerFrames[spinnerIndex]
         let elapsed = Date().timeIntervalSince(startedAt)
@@ -2146,15 +2195,62 @@ private final class MLXLoadReporter: @unchecked Sendable {
 
         let memory = Self.currentResidentMemoryGB()
 
-        let line = String(
-            format: "\r[%@] %@ | mem %.2f GB | %.1fs",
+        var line = String(
+            format: "[%@] %@ | mem %.2f GB | %.1fs",
             spinner,
             stage.rawValue,
             memory,
             elapsed
         )
-        fputs(line, stdout)
+        if stage == .downloading {
+            if let fraction = downloadFraction {
+                line += " | \(Self.progressBar(fraction: fraction, width: 18))"
+                line += String(format: " %5.1f%%", fraction * 100)
+            }
+            if let completedBytes, let totalBytes {
+                line += " | \(Self.formatBytes(completedBytes))/\(Self.formatBytes(totalBytes))"
+            }
+            if let bytesPerSecond, bytesPerSecond > 0 {
+                line += " | \(Self.formatBytes(Int64(bytesPerSecond)))/s"
+            }
+            if let eta, eta.isFinite, eta >= 0 {
+                line += " | ETA \(Self.formatDuration(eta))"
+            }
+            if let completedFiles, let totalFiles {
+                line += " | files \(completedFiles)/\(totalFiles)"
+            }
+            if let first = currentFiles.first {
+                line += " | \(first)"
+                if currentFiles.count > 1 { line += " (+\(currentFiles.count - 1))" }
+            }
+            line += " | transport auto"
+        }
+        fputs(Self.terminalSafeLine(line, clearExisting: true), stdout)
         fflush(stdout)
+    }
+
+    private static func terminalSafeLine(_ line: String, clearExisting: Bool) -> String {
+        guard isatty(STDOUT_FILENO) != 0 else {
+            return "\r\(line)"
+        }
+
+        var size = winsize()
+        let width: Int
+        if ioctl(STDOUT_FILENO, UInt(TIOCGWINSZ), &size) == 0, size.ws_col > 1 {
+            width = Int(size.ws_col) - 1
+        } else {
+            width = 119
+        }
+        let clipped: String
+        if line.count <= width {
+            clipped = line
+        } else if width > 3 {
+            clipped = String(line.prefix(width - 3)) + "..."
+        } else {
+            clipped = String(line.prefix(width))
+        }
+        let erase = clearExisting ? "\u{1B}[2K" : ""
+        return "\r\(erase)\(clipped)"
     }
 
     private static func progressBar(fraction: Double, width: Int) -> String {
@@ -2162,6 +2258,26 @@ private final class MLXLoadReporter: @unchecked Sendable {
         let filled = Int((clamped * Double(width)).rounded(.down))
         let bar = String(repeating: "#", count: filled) + String(repeating: "-", count: max(0, width - filled))
         return "[\(bar)]"
+    }
+
+    private static func formatBytes(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useKB, .useMB, .useGB, .useTB]
+        formatter.countStyle = .file
+        formatter.includesUnit = true
+        formatter.isAdaptive = true
+        return formatter.string(fromByteCount: bytes)
+    }
+
+    private static func formatDuration(_ seconds: TimeInterval) -> String {
+        let rounded = max(0, Int(seconds.rounded()))
+        if rounded >= 3_600 {
+            return String(format: "%dh%02dm", rounded / 3_600, (rounded % 3_600) / 60)
+        }
+        if rounded >= 60 {
+            return String(format: "%dm%02ds", rounded / 60, rounded % 60)
+        }
+        return "\(rounded)s"
     }
 
     private static func currentResidentMemoryGB() -> Double {

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarProvider.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarProvider.swift
@@ -106,7 +106,7 @@ public final class AFMDwarfStarModel: AFMModel, @unchecked Sendable {
             providerID: AFMDwarfStarProviderFactory.providerID,
             modelID: modelID,
             displayName: URL(fileURLWithPath: modelPath).deletingPathExtension().lastPathComponent,
-            capabilities: [.text, .streaming, .prefixCaching],
+            capabilities: [.text, .streaming, .toolCalling, .prefixCaching],
             contextWindow: contextWindow,
             privacyBoundary: .device,
             requiresNetwork: false,
@@ -153,7 +153,7 @@ public final class AFMDwarfStarModel: AFMModel, @unchecked Sendable {
 
     public func respond(to request: AFMRequest) async throws -> AFMModelResponse {
         _ = try await load(progress: nil)
-        let result = try await runtime.generate(request: request) { _, _ in }
+        let result = try await runtime.generate(request: request) { _ in }
         return result.response(modelID: descriptor.modelID.rawValue)
     }
 
@@ -164,10 +164,8 @@ public final class AFMDwarfStarModel: AFMModel, @unchecked Sendable {
             let task = Task {
                 do {
                     _ = try await load(progress: nil)
-                    let result = try await runtime.generate(request: request) { text, count in
-                        continuation.yield(
-                            .responseText(action: .append, text: text, tokenCount: count)
-                        )
+                    let result = try await runtime.generate(request: request) { event in
+                        continuation.yield(event)
                     }
                     continuation.yield(.usage(result.usage))
                     continuation.yield(.metadata(result.metadata))

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarProvider.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarProvider.swift
@@ -106,7 +106,7 @@ public final class AFMDwarfStarModel: AFMModel, @unchecked Sendable {
             providerID: AFMDwarfStarProviderFactory.providerID,
             modelID: modelID,
             displayName: URL(fileURLWithPath: modelPath).deletingPathExtension().lastPathComponent,
-            capabilities: [.text, .streaming, .toolCalling, .prefixCaching],
+            capabilities: [.text, .streaming, .reasoning, .toolCalling, .prefixCaching],
             contextWindow: contextWindow,
             privacyBoundary: .device,
             requiresNetwork: false,

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarRuntime.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarRuntime.swift
@@ -11,9 +11,7 @@ public enum AFMDwarfStarRuntime {
         if let directory = Bundle.module.url(forResource: "metal", withExtension: nil) {
             return directory
         }
-        // SwiftPM `.process` flattens this resource directory. Processing is
-        // intentional because it dereferences the vendor symlink into portable
-        // product resources instead of preserving a broken relative link.
+        // Compatibility with older bundles that flattened this directory.
         if let resources = Bundle.module.resourceURL,
            FileManager.default.fileExists(
                atPath: resources.appendingPathComponent("flash_attn.metal").path)

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarScheduler.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarScheduler.swift
@@ -142,8 +142,9 @@ public actor AFMDwarfStarRuntimeCoordinator {
         var promptSeconds = 0.0
         var generationStart: ContinuousClock.Instant?
         var generatedText = ""
+        var generatedReasoning = ""
         var toolCalls: [AFMToolCall] = []
-        var toolParser = AFMDwarfStarToolCodec.StreamParser()
+        var toolParser: AFMDwarfStarToolCodec.StreamParser
         var pendingUTF8 = Data()
         var outputTokens = 0
         var randomState: UInt64
@@ -167,6 +168,9 @@ public actor AFMDwarfStarRuntimeCoordinator {
             self.continuation = continuation
             randomState = UInt64(bitPattern: Int64(request.options.seed ?? 0x5eed))
             reasoningMode = .resolve(metadata: request.metadata)
+            toolParser = AFMDwarfStarToolCodec.StreamParser(
+                startsInReasoning: reasoningMode != .chat
+            )
         }
 
         var maximumTokens: Int {
@@ -690,26 +694,14 @@ public actor AFMDwarfStarRuntimeCoordinator {
         if let piece = String(data: job.pendingUTF8, encoding: .utf8) {
             job.pendingUTF8.removeAll(keepingCapacity: true)
             do {
-                for output in try job.toolParser.consume(piece) {
-                    switch output {
-                    case .text(let text):
-                        job.generatedText += text
-                        job.onEvent(
-                            .responseText(action: .append, text: text, tokenCount: 1)
-                        )
-                    case .toolCalls(let calls):
-                        job.toolCalls += calls
-                        for call in calls {
-                            job.onEvent(.toolCall(call: call, stage: .started))
-                            job.onEvent(
-                                .toolCall(
-                                    call: call,
-                                    stage: .argumentsDelta(call.arguments)
-                                )
-                            )
-                            job.onEvent(.toolCall(call: call, stage: .completed))
-                        }
-                    }
+                let completedToolCall = process(
+                    try job.toolParser.consume(piece),
+                    for: job,
+                    tokenCount: 1
+                )
+                if completedToolCall {
+                    finish(slotIndex: slotIndex, reason: .toolCalls)
+                    return
                 }
             } catch {
                 finish(slotIndex: slotIndex, throwing: error)
@@ -729,16 +721,12 @@ public actor AFMDwarfStarRuntimeCoordinator {
     private func finish(slotIndex: Int, reason: AFMFinishReason) {
         guard let job = slots[slotIndex].job else { return }
         flushPendingUTF8(job)
-        for output in job.toolParser.finish() {
-            if case .text(let text) = output {
-                job.generatedText += text
-                job.onEvent(.responseText(action: .append, text: text, tokenCount: 0))
-            }
-        }
+        _ = process(job.toolParser.finish(), for: job, tokenCount: 0)
         persistPrefixIfIdle(slotIndex: slotIndex, job: job, reason: "continued")
         let generationSeconds = job.generationStart.map(Self.seconds(since:)) ?? 0
         let result = AFMDwarfStarGenerationResult(
             text: job.generatedText,
+            reasoning: job.generatedReasoning.isEmpty ? nil : job.generatedReasoning,
             usage: AFMUsage(
                 inputTokens: Int(job.prompt.len),
                 cachedInputTokens: job.cachedInputTokens,
@@ -783,11 +771,23 @@ public actor AFMDwarfStarRuntimeCoordinator {
         let piece = String(decoding: job.pendingUTF8, as: UTF8.self)
         job.pendingUTF8.removeAll(keepingCapacity: false)
         guard let outputs = try? job.toolParser.consume(piece) else { return }
+        _ = process(outputs, for: job, tokenCount: 0)
+    }
+
+    @discardableResult
+    private func process(
+        _ outputs: [AFMDwarfStarToolCodec.StreamOutput],
+        for job: GenerationJob,
+        tokenCount: Int
+    ) -> Bool {
         for output in outputs {
             switch output {
             case .text(let text):
                 job.generatedText += text
-                job.onEvent(.responseText(action: .append, text: text, tokenCount: 0))
+                job.onEvent(.responseText(action: .append, text: text, tokenCount: tokenCount))
+            case .reasoning(let text):
+                job.generatedReasoning += text
+                job.onEvent(.reasoningText(action: .append, text: text, tokenCount: tokenCount))
             case .toolCalls(let calls):
                 job.toolCalls += calls
                 for call in calls {
@@ -797,8 +797,10 @@ public actor AFMDwarfStarRuntimeCoordinator {
                     )
                     job.onEvent(.toolCall(call: call, stage: .completed))
                 }
+                return true
             }
         }
+        return false
     }
 
     private func cancelGeneration(id: UUID) {
@@ -927,11 +929,9 @@ public actor AFMDwarfStarRuntimeCoordinator {
                         ds4_chat_append_message(engine, &prompt, rolePointer, textPointer)
                     }
                 }
-                if message.role == .assistant, !message.toolCalls.isEmpty {
-                    let toolCalls = try AFMDwarfStarToolCodec.renderedToolCalls(
-                        message.toolCalls
-                    )
-                    toolCalls.withCString {
+                if message.role == .assistant {
+                    let suffix = try AFMDwarfStarToolCodec.assistantReplaySuffix(for: message)
+                    suffix.withCString {
                         ds4_tokenize_rendered_chat(engine, $0, &prompt)
                     }
                 }
@@ -981,6 +981,7 @@ public actor AFMDwarfStarRuntimeCoordinator {
 
 public struct AFMDwarfStarGenerationResult: Sendable {
     public var text: String
+    public var reasoning: String?
     public var usage: AFMUsage
     public var toolCalls: [AFMToolCall]
     public var finishReason: AFMFinishReason
@@ -991,6 +992,7 @@ public struct AFMDwarfStarGenerationResult: Sendable {
         metadata["modelID"] = .string(modelID)
         return AFMModelResponse(
             text: text,
+            reasoning: reasoning,
             toolCalls: toolCalls,
             usage: usage,
             finishReason: finishReason,

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarScheduler.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarScheduler.swift
@@ -78,13 +78,55 @@ enum AFMDwarfStarSlotPolicy {
     }
 }
 
+enum AFMDwarfStarSchedulingPolicy {
+    static let idlePrefillQuantum = 2_048
+    static let mixedPrefillQuantum = 128
+
+    static func prefillQuantum(activeDecodeCount: Int) -> Int {
+        activeDecodeCount > 0 ? mixedPrefillQuantum : idlePrefillQuantum
+    }
+
+    static func canMixPrefill(currentPosition: Int, activeDecodeCount: Int) -> Bool {
+        currentPosition > 0 && activeDecodeCount > 0
+    }
+
+    static func nextPrefillSlot(lastSlot: Int, waiting: [Bool]) -> Int? {
+        guard !waiting.isEmpty else { return nil }
+        for offset in 1...waiting.count {
+            let index = (lastSlot + offset) % waiting.count
+            if waiting[index] { return index }
+        }
+        return nil
+    }
+}
+
+enum AFMDwarfStarPrefixCachePolicy {
+    static let defaultBudgetMB: UInt64 = 4_096
+
+    static func checkpointKey(path: String, size: UInt64, modified: TimeInterval) -> String {
+        let identity = "\(URL(fileURLWithPath: path).standardizedFileURL.path)|\(size)|\(modified)"
+        let digest = identity.utf8.reduce(UInt64(1_469_598_103_934_665_603)) { partial, byte in
+            (partial ^ UInt64(byte)) &* 1_099_511_628_211
+        }
+        return String(digest, radix: 16)
+    }
+
+    static func budgetMB(environment: [String: String]) -> UInt64 {
+        guard let raw = environment["AFM_DWARFSTAR_PREFIX_CACHE_MB"],
+              let value = UInt64(raw), value > 0 else {
+            return defaultBudgetMB
+        }
+        return value
+    }
+}
+
 public actor AFMDwarfStarRuntimeCoordinator {
     public static let shared = AFMDwarfStarRuntimeCoordinator()
 
     private final class GenerationJob: @unchecked Sendable {
         let id: UUID
         let request: AFMRequest
-        let onText: @Sendable (String, Int) -> Void
+        let onEvent: @Sendable (AFMGenerationEvent) -> Void
         let continuation: CheckedContinuation<AFMDwarfStarGenerationResult, any Error>
         var prompt: ds4_tokens
         var promptReleased = false
@@ -94,6 +136,8 @@ public actor AFMDwarfStarRuntimeCoordinator {
         var promptSeconds = 0.0
         var generationStart: ContinuousClock.Instant?
         var generatedText = ""
+        var toolCalls: [AFMToolCall] = []
+        var toolParser = AFMDwarfStarToolCodec.StreamParser()
         var pendingUTF8 = Data()
         var outputTokens = 0
         var randomState: UInt64
@@ -101,18 +145,19 @@ public actor AFMDwarfStarRuntimeCoordinator {
         let reasoningMode: AFMDwarfStarReasoningMode
         var speculativeCycles = 0
         var speculativeAcceptedTokens = 0
+        var persistedPrefixTokens = 0
 
         init(
             id: UUID,
             request: AFMRequest,
             prompt: ds4_tokens,
-            onText: @escaping @Sendable (String, Int) -> Void,
+            onEvent: @escaping @Sendable (AFMGenerationEvent) -> Void,
             continuation: CheckedContinuation<AFMDwarfStarGenerationResult, any Error>
         ) {
             self.id = id
             self.request = request
             self.prompt = prompt
-            self.onText = onText
+            self.onEvent = onEvent
             self.continuation = continuation
             randomState = UInt64(bitPattern: Int64(request.options.seed ?? 0x5eed))
             reasoningMode = .resolve(metadata: request.metadata)
@@ -136,6 +181,7 @@ public actor AFMDwarfStarRuntimeCoordinator {
     }
 
     private var engine: OpaquePointer?
+    private var prefixCache: OpaquePointer?
     private var slots: [RuntimeSlot] = []
     private var pendingJobs: [GenerationJob] = []
     private var schedulerTask: Task<Void, Never>?
@@ -145,6 +191,7 @@ public actor AFMDwarfStarRuntimeCoordinator {
     private var loadedMaxConcurrent = 0
     private var prefixCachingEnabled = false
     private var dsparkEnabled = false
+    private var lastPrefillSlot = -1
 
     public init() {}
 
@@ -155,6 +202,7 @@ public actor AFMDwarfStarRuntimeCoordinator {
             slot.job?.releasePrompt()
             ds4_session_free(slot.session)
         }
+        if let prefixCache { afm_ds4_prefix_cache_close(prefixCache) }
         if let engine { ds4_engine_close(engine) }
     }
 
@@ -250,7 +298,27 @@ public actor AFMDwarfStarRuntimeCoordinator {
             ds4_session_gpu_warmup(first.session)
         }
 
+        var openedPrefixCache: OpaquePointer?
+        if enablePrefixCaching {
+            let cacheDirectory = try Self.prefixCacheDirectory(modelPath: modelPath)
+            let cacheBudget = Self.prefixCacheBudgetMB()
+            let cacheStatus = cacheDirectory.withCString { directoryPointer in
+                afm_ds4_prefix_cache_open(
+                    &openedPrefixCache,
+                    directoryPointer,
+                    cacheBudget,
+                    &error,
+                    error.count)
+            }
+            guard cacheStatus == 0, openedPrefixCache != nil else {
+                openedSlots.forEach { ds4_session_free($0.session) }
+                ds4_engine_close(openedEngine)
+                throw AFMError.loadingFailed(Self.errorText(error))
+            }
+        }
+
         engine = openedEngine
+        prefixCache = openedPrefixCache
         slots = openedSlots
         loadedModelPath = modelPath
         loadedMappingIdentity = mappingIdentity
@@ -267,15 +335,11 @@ public actor AFMDwarfStarRuntimeCoordinator {
 
     func generate(
         request: AFMRequest,
-        onText: @escaping @Sendable (String, Int) -> Void
+        onEvent: @escaping @Sendable (AFMGenerationEvent) -> Void
     ) async throws -> AFMDwarfStarGenerationResult {
         guard let engine, !slots.isEmpty else {
             throw AFMError.unavailable("DwarfStar is not loaded.")
         }
-        guard request.tools.isEmpty else {
-            throw AFMError.unsupportedCapability("tool calling in the DwarfStar runtime")
-        }
-
         let id = UUID()
         var prompt = try Self.makePrompt(engine: engine, request: request)
         Self.tracePromptIfRequested(request: request, prompt: prompt)
@@ -292,7 +356,7 @@ public actor AFMDwarfStarRuntimeCoordinator {
                         id: id,
                         request: request,
                         prompt: prompt,
-                        onText: onText,
+                        onEvent: onEvent,
                         continuation: continuation)
                 )
                 startSchedulerIfNeeded()
@@ -314,8 +378,8 @@ public actor AFMDwarfStarRuntimeCoordinator {
     private func runScheduler() async {
         while !Task<Never, Never>.isCancelled {
             assignPendingJobs()
-            if let prefillIndex = slots.firstIndex(where: { $0.job?.prefilled == false }) {
-                prefill(slotIndex: prefillIndex)
+            if let prefillIndex = nextPrefillSlot() {
+                prefillCycle(slotIndex: prefillIndex)
             } else if slots.contains(where: { $0.job != nil }) {
                 decodeCycle()
             } else if pendingJobs.isEmpty {
@@ -327,6 +391,15 @@ public actor AFMDwarfStarRuntimeCoordinator {
         if !pendingJobs.isEmpty || slots.contains(where: { $0.job != nil }) {
             startSchedulerIfNeeded()
         }
+    }
+
+    private func nextPrefillSlot() -> Int? {
+        let waiting = slots.map { $0.job?.prefilled == false }
+        let index = AFMDwarfStarSchedulingPolicy.nextPrefillSlot(
+            lastSlot: lastPrefillSlot,
+            waiting: waiting)
+        if let index { lastPrefillSlot = index }
+        return index
     }
 
     private func assignPendingJobs() {
@@ -356,29 +429,83 @@ public actor AFMDwarfStarRuntimeCoordinator {
                 finishPending(job, throwing: CancellationError())
                 continue
             }
-            if !prefixCachingEnabled {
+            var cachedTokens = prefixCachingEnabled ? (commonPrefixes[slotIndex] ?? 0) : 0
+            if prefixCachingEnabled,
+               cachedTokens == 0,
+               let engine,
+               let prefixCache,
+               slots.allSatisfy({ $0.job == nil }) {
+                var error = [CChar](repeating: 0, count: 512)
+                let restored = afm_ds4_prefix_cache_restore(
+                    prefixCache,
+                    engine,
+                    slots[slotIndex].session,
+                    &job.prompt,
+                    &error,
+                    error.count)
+                if restored > 0 {
+                    cachedTokens = Int(restored)
+                } else if restored < 0 {
+                    Self.logPrefixCache(Self.errorText(error))
+                    ds4_session_invalidate(slots[slotIndex].session)
+                }
+            }
+            if !prefixCachingEnabled || cachedTokens == 0 {
                 ds4_session_invalidate(slots[slotIndex].session)
             }
-            job.cachedInputTokens = prefixCachingEnabled ? (commonPrefixes[slotIndex] ?? 0) : 0
+            job.cachedInputTokens = cachedTokens
             slots[slotIndex].job = job
         }
     }
 
-    private func prefill(slotIndex: Int) {
+    /// Advance one bounded prefill quantum. When other slots are decoding, use
+    /// DwarfStar's native mixed prefill/decode entry point so a long prompt
+    /// cannot stall every resident generation until its entire prefill ends.
+    private func prefillCycle(slotIndex: Int) {
         guard let job = slots[slotIndex].job else { return }
         if job.cancelled {
             finish(slotIndex: slotIndex, throwing: CancellationError())
             return
         }
 
+        guard let engine else { return }
+        let session = slots[slotIndex].session
+        let current = max(0, Int(ds4_session_pos(session)))
+        // The upstream mixed API extends a valid checkpoint. A fresh session
+        // must establish its first checkpoint before decode rows can share a
+        // scheduling epoch with subsequent prefill quanta.
+        let decodeBatch = current > 0
+            ? prepareDecodeBatch(engine: engine, excluding: slotIndex)
+            : DecodeBatch(items: [], slotIndices: [])
+        guard slots[slotIndex].job != nil else { return }
+
+        let fullLength = Int(job.prompt.len)
+        let quantum = AFMDwarfStarSchedulingPolicy.prefillQuantum(
+            activeDecodeCount: decodeBatch.items.count)
+        let target = min(fullLength, max(current + quantum, 1))
+        var promptPrefix = job.prompt
+        promptPrefix.len = Int32(target)
+
         var error = [CChar](repeating: 0, count: 512)
         let started = ContinuousClock.now
-        let status = ds4_session_sync(
-            slots[slotIndex].session,
-            &job.prompt,
-            &error,
-            error.count)
-        job.promptSeconds = Self.seconds(since: started)
+        let status: Int32
+        if !AFMDwarfStarSchedulingPolicy.canMixPrefill(
+            currentPosition: current,
+            activeDecodeCount: decodeBatch.items.count) {
+            status = ds4_session_sync(session, &promptPrefix, &error, error.count)
+        } else {
+            var items = decodeBatch.items
+            status = items.withUnsafeMutableBufferPointer { buffer in
+                ds4_sessions_eval_batch_with_prefill(
+                    buffer.baseAddress,
+                    Int32(buffer.count),
+                    session,
+                    &promptPrefix,
+                    &error,
+                    error.count)
+            }
+        }
+        job.promptSeconds += Self.seconds(since: started)
         guard status == 0 else {
             if status == DS4_SESSION_SYNC_INTERRUPTED || job.cancelled {
                 finish(slotIndex: slotIndex, throwing: CancellationError())
@@ -387,21 +514,68 @@ public actor AFMDwarfStarRuntimeCoordinator {
                     slotIndex: slotIndex,
                     throwing: AFMError.generationFailed(Self.errorText(error)))
             }
+            let failure = AFMError.generationFailed(Self.errorText(error))
+            for decodeSlot in decodeBatch.slotIndices where slots[decodeSlot].job != nil {
+                ds4_session_invalidate(slots[decodeSlot].session)
+                finish(slotIndex: decodeSlot, throwing: failure)
+            }
             return
         }
-        job.prefilled = true
-        job.generationStart = .now
-        if job.maximumTokens == 0 {
-            finish(slotIndex: slotIndex, reason: .length)
+
+        recordBatchSize(decodeBatch.slotIndices)
+        if Int(ds4_session_pos(session)) >= fullLength {
+            job.prefilled = true
+            // Persist the exact user prompt while the live checkpoint is still
+            // at that boundary. A post-generation checkpoint includes assistant
+            // output and cannot satisfy a later request that repeats or extends
+            // only the original prompt.
+            persistPrefixIfIdle(slotIndex: slotIndex, job: job, reason: "cold")
+            job.generationStart = .now
+            if job.maximumTokens == 0 {
+                finish(slotIndex: slotIndex, reason: .length)
+            }
         }
     }
 
     private func decodeCycle() {
         guard let engine else { return }
+        let batch = prepareDecodeBatch(engine: engine, excluding: nil)
+        guard !batch.items.isEmpty else { return }
+        recordBatchSize(batch.slotIndices)
+
+        var items = batch.items
+        var error = [CChar](repeating: 0, count: 512)
+        let status = items.withUnsafeMutableBufferPointer { buffer in
+            ds4_sessions_eval_batch(
+                buffer.baseAddress,
+                Int32(buffer.count),
+                &error,
+                error.count)
+        }
+        guard status != 0 else { return }
+
+        let failure = AFMError.generationFailed(Self.errorText(error))
+        for slotIndex in batch.slotIndices {
+            guard slots[slotIndex].job != nil else { continue }
+            ds4_session_invalidate(slots[slotIndex].session)
+            finish(slotIndex: slotIndex, throwing: failure)
+        }
+    }
+
+    private struct DecodeBatch {
+        var items: [ds4_decode_item]
+        var slotIndices: [Int]
+    }
+
+    private func prepareDecodeBatch(
+        engine: OpaquePointer,
+        excluding excludedSlot: Int?
+    ) -> DecodeBatch {
         var evalItems: [ds4_decode_item] = []
         var evalSlots: [Int] = []
 
         for slotIndex in slots.indices {
+            if slotIndex == excludedSlot { continue }
             guard let job = slots[slotIndex].job, job.prefilled else { continue }
             if job.cancelled {
                 finish(slotIndex: slotIndex, throwing: CancellationError())
@@ -469,29 +643,16 @@ public actor AFMDwarfStarRuntimeCoordinator {
             evalItems.append(item)
             evalSlots.append(slotIndex)
         }
+        return DecodeBatch(items: evalItems, slotIndices: evalSlots)
+    }
 
-        guard !evalItems.isEmpty else { return }
-        let batchSize = evalItems.count
-        for slotIndex in evalSlots {
+    private func recordBatchSize(_ slotIndices: [Int]) {
+        let batchSize = slotIndices.count
+        guard batchSize > 0 else { return }
+        for slotIndex in slotIndices {
             slots[slotIndex].job?.peakBatchSize = max(
                 slots[slotIndex].job?.peakBatchSize ?? 1,
                 batchSize)
-        }
-        var error = [CChar](repeating: 0, count: 512)
-        let status = evalItems.withUnsafeMutableBufferPointer { items in
-            ds4_sessions_eval_batch(
-                items.baseAddress,
-                Int32(items.count),
-                &error,
-                error.count)
-        }
-        guard status != 0 else { return }
-
-        let failure = AFMError.generationFailed(Self.errorText(error))
-        for slotIndex in evalSlots {
-            guard slots[slotIndex].job != nil else { continue }
-            ds4_session_invalidate(slots[slotIndex].session)
-            finish(slotIndex: slotIndex, throwing: failure)
         }
     }
 
@@ -518,8 +679,32 @@ public actor AFMDwarfStarRuntimeCoordinator {
 
         if let piece = String(data: job.pendingUTF8, encoding: .utf8) {
             job.pendingUTF8.removeAll(keepingCapacity: true)
-            job.generatedText += piece
-            job.onText(piece, job.outputTokens)
+            do {
+                for output in try job.toolParser.consume(piece) {
+                    switch output {
+                    case .text(let text):
+                        job.generatedText += text
+                        job.onEvent(
+                            .responseText(action: .append, text: text, tokenCount: 1)
+                        )
+                    case .toolCalls(let calls):
+                        job.toolCalls += calls
+                        for call in calls {
+                            job.onEvent(.toolCall(call: call, stage: .started))
+                            job.onEvent(
+                                .toolCall(
+                                    call: call,
+                                    stage: .argumentsDelta(call.arguments)
+                                )
+                            )
+                            job.onEvent(.toolCall(call: call, stage: .completed))
+                        }
+                    }
+                }
+            } catch {
+                finish(slotIndex: slotIndex, throwing: error)
+                return
+            }
             if job.request.options.stopSequences.contains(where: job.generatedText.hasSuffix) {
                 finish(slotIndex: slotIndex, reason: .stop)
                 return
@@ -534,6 +719,13 @@ public actor AFMDwarfStarRuntimeCoordinator {
     private func finish(slotIndex: Int, reason: AFMFinishReason) {
         guard let job = slots[slotIndex].job else { return }
         flushPendingUTF8(job)
+        for output in job.toolParser.finish() {
+            if case .text(let text) = output {
+                job.generatedText += text
+                job.onEvent(.responseText(action: .append, text: text, tokenCount: 0))
+            }
+        }
+        persistPrefixIfIdle(slotIndex: slotIndex, job: job, reason: "continued")
         let generationSeconds = job.generationStart.map(Self.seconds(since:)) ?? 0
         let result = AFMDwarfStarGenerationResult(
             text: job.generatedText,
@@ -541,7 +733,8 @@ public actor AFMDwarfStarRuntimeCoordinator {
                 inputTokens: Int(job.prompt.len),
                 cachedInputTokens: job.cachedInputTokens,
                 outputTokens: job.outputTokens),
-            finishReason: reason,
+            toolCalls: job.toolCalls,
+            finishReason: job.toolCalls.isEmpty ? reason : .toolCalls,
             metadata: [
                 "runtime": .string("dwarfstar"),
                 "backend": .string("metal"),
@@ -556,6 +749,7 @@ public actor AFMDwarfStarRuntimeCoordinator {
                 "dsparkEnabled": .bool(dsparkEnabled),
                 "speculativeCycles": .integer(job.speculativeCycles),
                 "speculativeAcceptedTokens": .integer(job.speculativeAcceptedTokens),
+                "persistedPrefixTokens": .integer(job.persistedPrefixTokens),
             ])
         slots[slotIndex].job = nil
         job.releasePrompt()
@@ -578,8 +772,23 @@ public actor AFMDwarfStarRuntimeCoordinator {
         guard !job.pendingUTF8.isEmpty else { return }
         let piece = String(decoding: job.pendingUTF8, as: UTF8.self)
         job.pendingUTF8.removeAll(keepingCapacity: false)
-        job.generatedText += piece
-        job.onText(piece, job.outputTokens)
+        guard let outputs = try? job.toolParser.consume(piece) else { return }
+        for output in outputs {
+            switch output {
+            case .text(let text):
+                job.generatedText += text
+                job.onEvent(.responseText(action: .append, text: text, tokenCount: 0))
+            case .toolCalls(let calls):
+                job.toolCalls += calls
+                for call in calls {
+                    job.onEvent(.toolCall(call: call, stage: .started))
+                    job.onEvent(
+                        .toolCall(call: call, stage: .argumentsDelta(call.arguments))
+                    )
+                    job.onEvent(.toolCall(call: call, stage: .completed))
+                }
+            }
+        }
     }
 
     private func cancelGeneration(id: UUID) {
@@ -607,6 +816,8 @@ public actor AFMDwarfStarRuntimeCoordinator {
             ds4_session_free(slots[index].session)
         }
         slots.removeAll(keepingCapacity: false)
+        if let prefixCache { afm_ds4_prefix_cache_close(prefixCache) }
+        prefixCache = nil
         if let engine { ds4_engine_close(engine) }
         engine = nil
         loadedModelPath = nil
@@ -615,6 +826,66 @@ public actor AFMDwarfStarRuntimeCoordinator {
         loadedMaxConcurrent = 0
         prefixCachingEnabled = false
         dsparkEnabled = false
+        lastPrefillSlot = -1
+    }
+
+    /// Disk serialization can synchronize GPU state. Keep it off the hot path
+    /// whenever another request is queued or running; resident sessions still
+    /// provide exact-prefix reuse during continuous traffic.
+    private func persistPrefixIfIdle(
+        slotIndex: Int,
+        job: GenerationJob,
+        reason: String
+    ) {
+        guard prefixCachingEnabled,
+              pendingJobs.isEmpty,
+              slots.indices.allSatisfy({ $0 == slotIndex || slots[$0].job == nil }),
+              let engine,
+              let prefixCache else {
+            return
+        }
+        var error = [CChar](repeating: 0, count: 512)
+        let stored = afm_ds4_prefix_cache_store_session(
+            prefixCache,
+            engine,
+            slots[slotIndex].session,
+            reason,
+            &error,
+            error.count)
+        if stored > 0 {
+            job.persistedPrefixTokens = Int(stored)
+        } else if !Self.errorText(error).isEmpty {
+            Self.logPrefixCache(Self.errorText(error))
+        }
+    }
+
+    private static func prefixCacheDirectory(modelPath: String) throws -> String {
+        let fileURL = URL(fileURLWithPath: modelPath).standardizedFileURL
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let size = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+        let modified = (attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        let key = AFMDwarfStarPrefixCachePolicy.checkpointKey(
+            path: fileURL.path,
+            size: size,
+            modified: modified)
+        let root: URL
+        if let configured = ProcessInfo.processInfo.environment["AFM_DWARFSTAR_PREFIX_CACHE"],
+           !configured.isEmpty {
+            root = URL(fileURLWithPath: configured, isDirectory: true)
+        } else {
+            root = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("AFM/DwarfStarPrefixCache", isDirectory: true)
+        }
+        return root.appendingPathComponent(key, isDirectory: true).path
+    }
+
+    private static func prefixCacheBudgetMB() -> UInt64 {
+        AFMDwarfStarPrefixCachePolicy.budgetMB(
+            environment: ProcessInfo.processInfo.environment)
+    }
+
+    private static func logPrefixCache(_ message: String) {
+        FileHandle.standardError.write(Data("[DwarfStarPrefixCache] \(message)\n".utf8))
     }
 
     private static func makePrompt(
@@ -629,11 +900,29 @@ public actor AFMDwarfStarRuntimeCoordinator {
             if let prefix = reasoningMode.promptPrefix {
                 prefix.withCString { ds4_tokenize_text(engine, $0, &prompt) }
             }
+            if !request.tools.isEmpty {
+                let required = request.metadata["toolCallingMode"] == .string("required")
+                let toolsPrompt = try AFMDwarfStarToolCodec.systemPrompt(
+                    for: request.tools,
+                    toolCallingRequired: required
+                )
+                toolsPrompt.withCString {
+                    ds4_tokenize_rendered_chat(engine, $0, &prompt)
+                }
+            }
             for message in request.messages {
-                let text = try textContent(of: message)
+                let text = try AFMDwarfStarToolCodec.textContent(of: message)
                 message.role.rawValue.withCString { rolePointer in
                     text.withCString { textPointer in
                         ds4_chat_append_message(engine, &prompt, rolePointer, textPointer)
+                    }
+                }
+                if message.role == .assistant, !message.toolCalls.isEmpty {
+                    let toolCalls = try AFMDwarfStarToolCodec.renderedToolCalls(
+                        message.toolCalls
+                    )
+                    toolCalls.withCString {
+                        ds4_tokenize_rendered_chat(engine, $0, &prompt)
                     }
                 }
             }
@@ -645,17 +934,6 @@ public actor AFMDwarfStarRuntimeCoordinator {
         }
     }
 
-    private static func textContent(of message: AFMMessage) throws -> String {
-        var result = ""
-        for part in message.content {
-            guard case .text(let text) = part else {
-                throw AFMError.unsupportedCapability("non-text DwarfStar input")
-            }
-            result += text
-        }
-        return result
-    }
-
     private static func tracePromptIfRequested(
         request: AFMRequest,
         prompt: ds4_tokens
@@ -665,7 +943,7 @@ public actor AFMDwarfStarRuntimeCoordinator {
         }
         let roles = request.messages.map(\.role.rawValue).joined(separator: ",")
         let texts = request.messages.map { message in
-            (try? textContent(of: message)) ?? "<non-text>"
+            (try? AFMDwarfStarToolCodec.textContent(of: message)) ?? "<non-text>"
         }
         let tokenIDs: [Int32]
         if let values = prompt.v {
@@ -694,6 +972,7 @@ public actor AFMDwarfStarRuntimeCoordinator {
 public struct AFMDwarfStarGenerationResult: Sendable {
     public var text: String
     public var usage: AFMUsage
+    public var toolCalls: [AFMToolCall]
     public var finishReason: AFMFinishReason
     public var metadata: [String: AFMJSONValue]
 
@@ -702,6 +981,7 @@ public struct AFMDwarfStarGenerationResult: Sendable {
         metadata["modelID"] = .string(modelID)
         return AFMModelResponse(
             text: text,
+            toolCalls: toolCalls,
             usage: usage,
             finishReason: finishReason,
             metadata: metadata)

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarScheduler.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarScheduler.swift
@@ -100,6 +100,12 @@ enum AFMDwarfStarSchedulingPolicy {
     }
 }
 
+enum AFMDwarfStarSpeculativePolicy {
+    static func isAvailable(requested: Bool, draftTokenCount: Int) -> Bool {
+        requested && draftTokenCount > 0
+    }
+}
+
 enum AFMDwarfStarPrefixCachePolicy {
     static let defaultBudgetMB: UInt64 = 4_096
 
@@ -325,7 +331,9 @@ public actor AFMDwarfStarRuntimeCoordinator {
         loadedContextWindow = contextWindow
         loadedMaxConcurrent = residentSessions
         prefixCachingEnabled = enablePrefixCaching
-        dsparkEnabled = dsparkSupportPath != nil && ds4_engine_has_mtp(openedEngine)
+        dsparkEnabled = AFMDwarfStarSpeculativePolicy.isAvailable(
+            requested: dsparkSupportPath != nil,
+            draftTokenCount: Int(ds4_engine_mtp_draft_tokens(openedEngine)))
     }
 
     public func unload(modelPath: String) {
@@ -598,7 +606,9 @@ public actor AFMDwarfStarRuntimeCoordinator {
                 continue
             }
 
-            if dsparkEnabled, temperature <= 0, ds4_engine_has_mtp(engine) {
+            if dsparkEnabled,
+               temperature <= 0,
+               ds4_engine_mtp_draft_tokens(engine) > 0 {
                 let remaining = job.maximumTokens - job.outputTokens
                 let capacity = max(1, min(16, remaining))
                 var accepted = [Int32](repeating: 0, count: capacity)

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarToolCodec.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarToolCodec.swift
@@ -4,9 +4,13 @@ import AFMKitCore
 enum AFMDwarfStarToolCodec {
     static let blockStart = "<｜DSML｜tool_calls>"
     static let blockEnd = "</｜DSML｜tool_calls>"
+    static let thinkStart = "<think>"
+    static let thinkEnd = "</think>"
+    static let endOfSentence = "<｜end▁of▁sentence｜>"
 
     enum StreamOutput: Equatable {
         case text(String)
+        case reasoning(String)
         case toolCalls([AFMToolCall])
     }
 
@@ -60,6 +64,12 @@ enum AFMDwarfStarToolCodec {
         return content
     }
 
+    static func assistantReplaySuffix(for message: AFMMessage) throws -> String {
+        let calls = message.toolCalls
+        guard !calls.isEmpty else { return endOfSentence }
+        return "\n\n" + (try renderedToolCalls(calls)) + endOfSentence
+    }
+
     static func renderedToolCalls(_ calls: [AFMToolCall]) throws -> String {
         var content = blockStart + "\n"
         for call in calls {
@@ -98,55 +108,127 @@ enum AFMDwarfStarToolCodec {
     }
 
     struct StreamParser {
+        private enum Channel {
+            case reasoning
+            case response
+        }
+
         private var buffer = ""
         private var parsingTools = false
+        private var completedToolCall = false
         private var nextCallIndex = 0
+        private var channel: Channel
+
+        init(startsInReasoning: Bool = false) {
+            channel = startsInReasoning ? .reasoning : .response
+        }
 
         mutating func consume(_ text: String) throws -> [StreamOutput] {
+            guard !completedToolCall else { return [] }
             buffer += text
             var outputs: [StreamOutput] = []
 
-            if !parsingTools {
-                if let start = buffer.range(of: blockStart) {
-                    let prefix = String(buffer[..<start.lowerBound])
-                    if !prefix.isEmpty { outputs.append(.text(prefix)) }
-                    buffer = String(buffer[start.lowerBound...])
-                    parsingTools = true
-                } else {
-                    let retained = longestStartPrefixSuffix(in: buffer)
-                    let emitCount = buffer.count - retained
-                    if emitCount > 0 {
-                        let split = buffer.index(buffer.startIndex, offsetBy: emitCount)
-                        outputs.append(.text(String(buffer[..<split])))
-                        buffer = String(buffer[split...])
+            while true {
+                if parsingTools {
+                    guard let end = buffer.range(of: blockEnd) else { return outputs }
+                    let block = String(buffer[..<end.upperBound])
+                    let calls = try parseToolCalls(block, nextIndex: &nextCallIndex)
+                    if !calls.isEmpty {
+                        outputs.append(.toolCalls(calls))
+                        completedToolCall = true
                     }
+                    buffer = ""
+                    parsingTools = false
+                    return outputs
+                }
+
+                switch channel {
+                case .reasoning:
+                    if buffer.hasPrefix(thinkStart) {
+                        buffer.removeFirst(thinkStart.count)
+                        continue
+                    }
+                    if let end = buffer.range(of: thinkEnd) {
+                        append(String(buffer[..<end.lowerBound]), to: .reasoning, in: &outputs)
+                        buffer = String(buffer[end.upperBound...])
+                        channel = .response
+                        continue
+                    }
+                    emitSafePrefix(retaining: [thinkStart, thinkEnd], asReasoning: true, into: &outputs)
+                    return outputs
+
+                case .response:
+                    let toolRange = buffer.range(of: blockStart)
+                    let thinkRange = buffer.range(of: thinkStart)
+                    if let next = earliest(toolRange, thinkRange) {
+                        append(String(buffer[..<next.lowerBound]), to: .response, in: &outputs)
+                        let marker = String(buffer[next])
+                        buffer = String(buffer[next.upperBound...])
+                        if marker == blockStart {
+                            buffer = marker + buffer
+                            parsingTools = true
+                        } else {
+                            channel = .reasoning
+                        }
+                        continue
+                    }
+                    emitSafePrefix(retaining: [blockStart, thinkStart], asReasoning: false, into: &outputs)
                     return outputs
                 }
             }
-
-            guard let end = buffer.range(of: blockEnd) else { return outputs }
-            let block = String(buffer[..<end.upperBound])
-            let calls = try parseToolCalls(block, nextIndex: &nextCallIndex)
-            if !calls.isEmpty { outputs.append(.toolCalls(calls)) }
-            buffer = String(buffer[end.upperBound...])
-            parsingTools = false
-            if !buffer.isEmpty {
-                outputs += try consume("")
-            }
-            return outputs
         }
 
         mutating func finish() -> [StreamOutput] {
+            guard !completedToolCall else { return [] }
             guard !buffer.isEmpty else { return [] }
             defer { buffer = "" }
-            return parsingTools ? [] : [.text(buffer)]
+            guard !parsingTools else { return [] }
+            return channel == .reasoning ? [.reasoning(buffer)] : [.text(buffer)]
         }
 
-        private func longestStartPrefixSuffix(in text: String) -> Int {
-            let maximum = min(text.count, blockStart.count - 1)
+        private func earliest(
+            _ lhs: Range<String.Index>?,
+            _ rhs: Range<String.Index>?
+        ) -> Range<String.Index>? {
+            switch (lhs, rhs) {
+            case (.none, .none): nil
+            case (.some(let range), .none), (.none, .some(let range)): range
+            case (.some(let left), .some(let right)):
+                left.lowerBound < right.lowerBound ? left : right
+            }
+        }
+
+        private mutating func emitSafePrefix(
+            retaining markers: [String],
+            asReasoning: Bool,
+            into outputs: inout [StreamOutput]
+        ) {
+            let retained = markers.map { longestMarkerPrefixSuffix(in: buffer, marker: $0) }.max() ?? 0
+            let emitCount = buffer.count - retained
+            guard emitCount > 0 else { return }
+            let split = buffer.index(buffer.startIndex, offsetBy: emitCount)
+            let value = String(buffer[..<split])
+            outputs.append(asReasoning ? .reasoning(value) : .text(value))
+            buffer = String(buffer[split...])
+        }
+
+        private func append(
+            _ value: String,
+            to channel: Channel,
+            in outputs: inout [StreamOutput]
+        ) {
+            guard !value.isEmpty else { return }
+            switch channel {
+            case .response: outputs.append(.text(value))
+            case .reasoning: outputs.append(.reasoning(value))
+            }
+        }
+
+        private func longestMarkerPrefixSuffix(in text: String, marker: String) -> Int {
+            let maximum = min(text.count, marker.count - 1)
             guard maximum > 0 else { return 0 }
             for count in stride(from: maximum, through: 1, by: -1) {
-                if text.suffix(count) == blockStart.prefix(count) { return count }
+                if text.suffix(count) == marker.prefix(count) { return count }
             }
             return 0
         }

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarToolCodec.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarToolCodec.swift
@@ -1,0 +1,244 @@
+import Foundation
+import AFMKitCore
+
+enum AFMDwarfStarToolCodec {
+    static let blockStart = "<｜DSML｜tool_calls>"
+    static let blockEnd = "</｜DSML｜tool_calls>"
+
+    enum StreamOutput: Equatable {
+        case text(String)
+        case toolCalls([AFMToolCall])
+    }
+
+    static func systemPrompt(
+        for tools: [AFMToolDefinition],
+        toolCallingRequired: Bool = false
+    ) throws -> String {
+        guard !tools.isEmpty else { return "" }
+        let schemas = try tools.map { tool in
+            var value: [String: Any] = [
+                "name": tool.name,
+                "parameters": try jsonObject(tool.inputSchema)
+            ]
+            if let description = tool.description {
+                value["description"] = description
+            }
+            let data = try JSONSerialization.data(
+                withJSONObject: value,
+                options: [.sortedKeys]
+            )
+            return String(decoding: data, as: UTF8.self)
+        }.joined(separator: "\n")
+
+        let requirement = toolCallingRequired
+            ? "You MUST call at least one available tool before answering.\n\n"
+            : ""
+        return """
+        ## Tools
+
+        You have access to tools. Invoke one or more tools using exactly this syntax:
+
+        <｜DSML｜tool_calls>
+        <｜DSML｜invoke name="$TOOL_NAME">
+        <｜DSML｜parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</｜DSML｜parameter>
+        </｜DSML｜invoke>
+        </｜DSML｜tool_calls>
+
+        String parameters use raw text with string="true". Numbers, booleans,
+        arrays, objects, and null use JSON with string="false". Use the exact
+        tool and parameter names from these schemas:
+
+        \(requirement)\(schemas)
+        """
+    }
+
+    static func assistantContent(for message: AFMMessage) throws -> String {
+        var content = try textContent(of: message)
+        guard !message.toolCalls.isEmpty else { return content }
+        if !content.isEmpty { content += "\n\n" }
+        content += try renderedToolCalls(message.toolCalls)
+        return content
+    }
+
+    static func renderedToolCalls(_ calls: [AFMToolCall]) throws -> String {
+        var content = blockStart + "\n"
+        for call in calls {
+            content += "<｜DSML｜invoke name=\"\(escapeAttribute(call.name))\">\n"
+            let object = try argumentsObject(call.arguments)
+            for key in object.keys.sorted() {
+                let value = object[key] as Any
+                if let string = value as? String {
+                    content += "<｜DSML｜parameter name=\"\(escapeAttribute(key))\" string=\"true\">"
+                    content += escapeParameter(string)
+                } else {
+                    let data = try JSONSerialization.data(
+                        withJSONObject: value,
+                        options: [.sortedKeys, .fragmentsAllowed]
+                    )
+                    content += "<｜DSML｜parameter name=\"\(escapeAttribute(key))\" string=\"false\">"
+                    content += String(decoding: data, as: UTF8.self)
+                }
+                content += "</｜DSML｜parameter>\n"
+            }
+            content += "</｜DSML｜invoke>\n"
+        }
+        content += blockEnd
+        return content
+    }
+
+    static func textContent(of message: AFMMessage) throws -> String {
+        var result = ""
+        for part in message.content {
+            guard case .text(let text) = part else {
+                throw AFMError.unsupportedCapability("non-text DwarfStar input")
+            }
+            result += text
+        }
+        return result
+    }
+
+    struct StreamParser {
+        private var buffer = ""
+        private var parsingTools = false
+        private var nextCallIndex = 0
+
+        mutating func consume(_ text: String) throws -> [StreamOutput] {
+            buffer += text
+            var outputs: [StreamOutput] = []
+
+            if !parsingTools {
+                if let start = buffer.range(of: blockStart) {
+                    let prefix = String(buffer[..<start.lowerBound])
+                    if !prefix.isEmpty { outputs.append(.text(prefix)) }
+                    buffer = String(buffer[start.lowerBound...])
+                    parsingTools = true
+                } else {
+                    let retained = longestStartPrefixSuffix(in: buffer)
+                    let emitCount = buffer.count - retained
+                    if emitCount > 0 {
+                        let split = buffer.index(buffer.startIndex, offsetBy: emitCount)
+                        outputs.append(.text(String(buffer[..<split])))
+                        buffer = String(buffer[split...])
+                    }
+                    return outputs
+                }
+            }
+
+            guard let end = buffer.range(of: blockEnd) else { return outputs }
+            let block = String(buffer[..<end.upperBound])
+            let calls = try parseToolCalls(block, nextIndex: &nextCallIndex)
+            if !calls.isEmpty { outputs.append(.toolCalls(calls)) }
+            buffer = String(buffer[end.upperBound...])
+            parsingTools = false
+            if !buffer.isEmpty {
+                outputs += try consume("")
+            }
+            return outputs
+        }
+
+        mutating func finish() -> [StreamOutput] {
+            guard !buffer.isEmpty else { return [] }
+            defer { buffer = "" }
+            return parsingTools ? [] : [.text(buffer)]
+        }
+
+        private func longestStartPrefixSuffix(in text: String) -> Int {
+            let maximum = min(text.count, blockStart.count - 1)
+            guard maximum > 0 else { return 0 }
+            for count in stride(from: maximum, through: 1, by: -1) {
+                if text.suffix(count) == blockStart.prefix(count) { return count }
+            }
+            return 0
+        }
+    }
+
+    private static func parseToolCalls(
+        _ block: String,
+        nextIndex: inout Int
+    ) throws -> [AFMToolCall] {
+        let invoke = try NSRegularExpression(
+            pattern: #"<｜DSML｜invoke\s+name="([^"]+)">(.*?)</｜DSML｜invoke>"#,
+            options: [.dotMatchesLineSeparators]
+        )
+        let parameter = try NSRegularExpression(
+            pattern: #"<｜DSML｜parameter\s+name="([^"]+)"\s+string="(true|false)">(.*?)</｜DSML｜parameter>"#,
+            options: [.dotMatchesLineSeparators]
+        )
+        let source = block as NSString
+        return try invoke.matches(
+            in: block,
+            range: NSRange(location: 0, length: source.length)
+        ).map { match in
+            let name = unescape(source.substring(with: match.range(at: 1)))
+            let body = source.substring(with: match.range(at: 2))
+            let bodySource = body as NSString
+            var arguments: [String: Any] = [:]
+            for item in parameter.matches(
+                in: body,
+                range: NSRange(location: 0, length: bodySource.length)
+            ) {
+                let key = unescape(bodySource.substring(with: item.range(at: 1)))
+                let isString = bodySource.substring(with: item.range(at: 2)) == "true"
+                let raw = unescape(bodySource.substring(with: item.range(at: 3)))
+                if isString {
+                    arguments[key] = raw
+                } else {
+                    let data = Data(raw.utf8)
+                    arguments[key] = try JSONSerialization.jsonObject(
+                        with: data,
+                        options: [.fragmentsAllowed]
+                    )
+                }
+            }
+            nextIndex += 1
+            let data = try JSONSerialization.data(
+                withJSONObject: arguments,
+                options: [.sortedKeys]
+            )
+            return AFMToolCall(
+                id: "call_\(nextIndex)",
+                name: name,
+                arguments: String(decoding: data, as: UTF8.self)
+            )
+        }
+    }
+
+    private static func argumentsObject(_ arguments: String) throws -> [String: Any] {
+        guard !arguments.isEmpty else { return [:] }
+        let value = try JSONSerialization.jsonObject(with: Data(arguments.utf8))
+        guard let object = value as? [String: Any] else {
+            throw AFMError.invalidRequest("DwarfStar tool arguments must be a JSON object.")
+        }
+        return object
+    }
+
+    private static func jsonObject(_ value: AFMJSONValue) throws -> Any {
+        switch value {
+        case .null: return NSNull()
+        case .bool(let value): return value
+        case .integer(let value): return value
+        case .number(let value): return value
+        case .string(let value): return value
+        case .array(let values): return try values.map(jsonObject)
+        case .object(let values): return try values.mapValues(jsonObject)
+        }
+    }
+
+    private static func escapeAttribute(_ value: String) -> String {
+        value.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+
+    private static func escapeParameter(_ value: String) -> String {
+        value.replacingOccurrences(
+            of: "</｜DSML｜parameter>",
+            with: "&lt;/｜DSML｜parameter>"
+        )
+    }
+
+    private static func unescape(_ value: String) -> String {
+        value.replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&amp;", with: "&")
+    }
+}

--- a/Sources/AFMKitDwarfStar/Resources/metal
+++ b/Sources/AFMKitDwarfStar/Resources/metal
@@ -1,1 +1,0 @@
-../../../vendor/ds4/metal

--- a/Sources/AFMKitFoundationModels27/AFMFoundationModelsExecutorBridge.swift
+++ b/Sources/AFMKitFoundationModels27/AFMFoundationModelsExecutorBridge.swift
@@ -1,0 +1,99 @@
+#if canImport(FoundationModels)
+import AFMKit
+import FoundationModels
+
+/// The provider settings AFMKit needs to translate a macOS 27 Foundation
+/// Models request without knowing which inference engine executes it.
+@available(macOS 27.0, *)
+public protocol AFMFoundationModelsModelConfiguration: Sendable {
+    var defaultMaximumResponseTokens: Int { get }
+    var supportsReasoning: Bool { get }
+}
+
+/// Shared implementation for custom `LanguageModelExecutor` providers.
+///
+/// Provider packages keep ownership of model loading and inference. This bridge
+/// owns the macOS 27 contract: transcript conversion, generation options,
+/// tools, structured-output requests, and streaming channel events.
+@available(macOS 27.0, *)
+public enum AFMFoundationModelsExecutorBridge {
+    public static func events(
+        from model: AnyAFMModel,
+        request: AFMRequest
+    ) -> AsyncThrowingStream<AFMStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    _ = try await model.load()
+                    for try await event in model.streamResponse(to: request) {
+                        continuation.yield(streamEvent(from: event))
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    public static func respond(
+        events: AsyncThrowingStream<AFMStreamEvent, Error>,
+        streamingInto channel: LanguageModelExecutorGenerationChannel
+    ) async throws {
+        var adapter = AFMFoundationModelsEventChannelAdapter()
+        let (plans, continuation) = AsyncStream.makeStream(
+            of: AFMFoundationModelsEventChannelAdapter.ChannelPlan.self
+        )
+        let sender = Task.detached(priority: .utility) {
+            for await plan in plans {
+                await AFMFoundationModelsEventChannelAdapter.send(plan, into: channel)
+            }
+        }
+
+        do {
+            for try await event in events {
+                try Task.checkCancellation()
+                for plan in adapter.plans(for: event) {
+                    continuation.yield(plan)
+                }
+            }
+            for plan in adapter.completionPlans() {
+                continuation.yield(plan)
+            }
+            continuation.finish()
+            await sender.value
+        } catch {
+            continuation.finish()
+            sender.cancel()
+            await sender.value
+            throw error
+        }
+    }
+
+    private static func streamEvent(from event: AFMGenerationEvent) -> AFMStreamEvent {
+        switch event {
+        case .responseText(_, let text, let tokenCount):
+            return .text(text, tokenCount: tokenCount)
+        case .reasoningText(_, let text, let tokenCount):
+            return .reasoning(text, tokenCount: tokenCount)
+        case .tokenLogprobs(let values):
+            return .tokenLogprobs(values)
+        case .toolCall(let call, let stage):
+            return .toolCall(call, stage: stage)
+        case .usage(let usage):
+            return .usage(
+                promptTokens: usage.inputTokens,
+                completionTokens: usage.outputTokens,
+                cachedTokens: usage.cachedInputTokens
+            )
+        case .metadata(let metadata):
+            return .metadata(metadata)
+        case .custom(let type, let payload):
+            return .custom(type: type, payload: payload)
+        case .completed(let reason):
+            return .completed(reason)
+        }
+    }
+}
+#endif

--- a/Sources/AFMKitFoundationModels27/DwarfStarFoundationLanguageModel.swift
+++ b/Sources/AFMKitFoundationModels27/DwarfStarFoundationLanguageModel.swift
@@ -1,0 +1,221 @@
+#if canImport(FoundationModels)
+import AFMKit
+import AFMKitDwarfStar
+import Foundation
+import FoundationModels
+
+/// A DwarfStar-backed DeepSeek model that plugs directly into the macOS 27
+/// Foundation Models `LanguageModelSession` API.
+@available(macOS 27.0, *)
+public struct DwarfStarLanguageModel:
+    LanguageModel,
+    AFMFoundationModelsModelConfiguration,
+    Sendable
+{
+    public typealias Executor = DwarfStarLanguageModelExecutor
+
+    public let executorConfiguration: DwarfStarLanguageModelExecutor.Configuration
+
+    public init(
+        modelPath: String,
+        contextWindow: Int = 32_768,
+        prefillChunk: Int = 0,
+        powerPercent: Int = 100,
+        dsparkSupportPath: String? = nil,
+        dsparkDraftTokens: Int = 5,
+        dsparkConfidenceThreshold: Double = 0.7,
+        dsparkStrict: Bool = false,
+        enablePrefixCaching: Bool = true,
+        maxConcurrent: Int = 1,
+        defaultMaximumResponseTokens: Int = 2_048
+    ) {
+        executorConfiguration = .init(
+            modelPath: modelPath,
+            contextWindow: contextWindow,
+            prefillChunk: prefillChunk,
+            powerPercent: powerPercent,
+            dsparkSupportPath: dsparkSupportPath,
+            dsparkDraftTokens: dsparkDraftTokens,
+            dsparkConfidenceThreshold: dsparkConfidenceThreshold,
+            dsparkStrict: dsparkStrict,
+            enablePrefixCaching: enablePrefixCaching,
+            maxConcurrent: maxConcurrent,
+            defaultMaximumResponseTokens: defaultMaximumResponseTokens
+        )
+    }
+
+    public var capabilities: LanguageModelCapabilities {
+        LanguageModelCapabilities([.reasoning, .toolCalling])
+    }
+
+    public var defaultMaximumResponseTokens: Int {
+        executorConfiguration.defaultMaximumResponseTokens
+    }
+
+    public var supportsReasoning: Bool { true }
+}
+
+@available(macOS 27.0, *)
+public final class DwarfStarLanguageModelExecutor:
+    LanguageModelExecutor,
+    @unchecked Sendable
+{
+    public typealias Model = DwarfStarLanguageModel
+
+    public struct Configuration:
+        Hashable,
+        Sendable,
+        AFMFoundationModelsModelConfiguration
+    {
+        public let modelPath: String
+        public let contextWindow: Int
+        public let prefillChunk: Int
+        public let powerPercent: Int
+        public let dsparkSupportPath: String?
+        public let dsparkDraftTokens: Int
+        public let dsparkConfidenceThreshold: Double
+        public let dsparkStrict: Bool
+        public let enablePrefixCaching: Bool
+        public let maxConcurrent: Int
+        public let defaultMaximumResponseTokens: Int
+        public let supportsReasoning = true
+
+        public init(
+            modelPath: String,
+            contextWindow: Int,
+            prefillChunk: Int,
+            powerPercent: Int,
+            dsparkSupportPath: String?,
+            dsparkDraftTokens: Int,
+            dsparkConfidenceThreshold: Double,
+            dsparkStrict: Bool,
+            enablePrefixCaching: Bool,
+            maxConcurrent: Int,
+            defaultMaximumResponseTokens: Int
+        ) {
+            self.modelPath = modelPath
+            self.contextWindow = contextWindow
+            self.prefillChunk = prefillChunk
+            self.powerPercent = powerPercent
+            self.dsparkSupportPath = dsparkSupportPath
+            self.dsparkDraftTokens = dsparkDraftTokens
+            self.dsparkConfidenceThreshold = dsparkConfidenceThreshold
+            self.dsparkStrict = dsparkStrict
+            self.enablePrefixCaching = enablePrefixCaching
+            self.maxConcurrent = maxConcurrent
+            self.defaultMaximumResponseTokens = defaultMaximumResponseTokens
+        }
+    }
+
+    private let runtime: Runtime
+
+    public init(configuration: Configuration) throws {
+        runtime = Runtime(
+            model: AnyAFMModel(
+                AFMDwarfStarModel(
+                    modelID: AFMModelID(
+                        rawValue: URL(fileURLWithPath: configuration.modelPath)
+                            .deletingPathExtension().lastPathComponent
+                    ),
+                    modelPath: configuration.modelPath,
+                    contextWindow: configuration.contextWindow,
+                    prefillChunk: configuration.prefillChunk,
+                    powerPercent: configuration.powerPercent,
+                    dsparkSupportPath: configuration.dsparkSupportPath,
+                    dsparkDraftTokens: configuration.dsparkDraftTokens,
+                    dsparkConfidenceThreshold: configuration.dsparkConfidenceThreshold,
+                    dsparkStrict: configuration.dsparkStrict,
+                    enablePrefixCaching: configuration.enablePrefixCaching,
+                    maxConcurrent: configuration.maxConcurrent
+                )
+            )
+        )
+    }
+
+    deinit {
+        let runtime = runtime
+        Task { await runtime.unload() }
+    }
+
+    public func prewarm(model: Model, transcript: Transcript) {
+        let runtime = runtime
+        Task { _ = try? await runtime.preparedModel() }
+    }
+
+    public nonisolated(nonsending) func respond(
+        to request: LanguageModelExecutorGenerationRequest,
+        model: Model,
+        streamingInto channel: LanguageModelExecutorGenerationChannel
+    ) async throws {
+        if request.schema != nil {
+            throw LanguageModelError.unsupportedCapability(
+                .init(
+                    capability: .guidedGeneration,
+                    debugDescription: "DwarfStar guided generation is not available."
+                )
+            )
+        }
+
+        let messages = try AFMFoundationModelsRequestAdapter.messages(
+            from: request.transcript
+        )
+        guard !messages.isEmpty else {
+            throw LanguageModelError.unsupportedTranscriptContent(
+                .init(
+                    unsupportedContent: Array(request.transcript),
+                    debugDescription: "DwarfStar could not convert the transcript."
+                )
+            )
+        }
+        let options = try AFMFoundationModelsRequestAdapter.generationConfig(
+            from: request,
+            model: model
+        )
+        let afmRequest = try AFMRequest(
+            openAIMessages: messages,
+            generationConfig: options
+        )
+        let providerModel = try await runtime.preparedModel()
+        try await AFMFoundationModelsExecutorBridge.respond(
+            events: AFMFoundationModelsExecutorBridge.events(
+                from: providerModel,
+                request: afmRequest
+            ),
+            streamingInto: channel
+        )
+    }
+}
+
+@available(macOS 27.0, *)
+private actor Runtime {
+    let model: AnyAFMModel
+    private var loadTask: Task<AFMModelDescriptor, Error>?
+
+    init(model: AnyAFMModel) {
+        self.model = model
+    }
+
+    func preparedModel() async throws -> AnyAFMModel {
+        if let loadTask {
+            _ = try await loadTask.value
+            return model
+        }
+        let model = model
+        let task = Task { try await model.load() }
+        loadTask = task
+        do {
+            _ = try await task.value
+            return model
+        } catch {
+            loadTask = nil
+            throw error
+        }
+    }
+
+    func unload() async {
+        loadTask?.cancel()
+        loadTask = nil
+        await model.unload()
+    }
+}
+#endif

--- a/Sources/AFMKitFoundationModels27/MLXFoundationEventChannelAdapter.swift
+++ b/Sources/AFMKitFoundationModels27/MLXFoundationEventChannelAdapter.swift
@@ -4,11 +4,11 @@ import Foundation
 import FoundationModels
 
 @available(macOS 27.0, *)
-struct MLXFoundationEventChannelAdapter {
-    static let textBatchTokenLimit = 16
-    static let textBatchCharacterLimit = 256
+public struct AFMFoundationModelsEventChannelAdapter {
+    public static let textBatchTokenLimit = 16
+    public static let textBatchCharacterLimit = 256
 
-    enum ChannelPlan: Equatable, Sendable {
+    public enum ChannelPlan: Equatable, Sendable {
         case responseText(String, tokenCount: Int)
         case reasoningText(String, tokenCount: Int)
         case usage(AFMUsage)
@@ -22,7 +22,9 @@ struct MLXFoundationEventChannelAdapter {
     private var streamedTokens = 0
     private var pendingText: ChannelPlan?
 
-    mutating func send(
+    public init() {}
+
+    public mutating func send(
         _ event: AFMStreamEvent,
         into channel: LanguageModelExecutorGenerationChannel
     ) async {
@@ -31,12 +33,12 @@ struct MLXFoundationEventChannelAdapter {
         }
     }
 
-    mutating func plans(for event: AFMStreamEvent) -> [ChannelPlan] {
+    public mutating func plans(for event: AFMStreamEvent) -> [ChannelPlan] {
         guard let plan = consume(event) else { return [] }
         return enqueue(plan)
     }
 
-    mutating func consume(_ event: AFMStreamEvent) -> ChannelPlan? {
+    public mutating func consume(_ event: AFMStreamEvent) -> ChannelPlan? {
         switch event {
         case .text(let text, let tokenCount):
             streamedTokens += tokenCount
@@ -75,13 +77,13 @@ struct MLXFoundationEventChannelAdapter {
         }
     }
 
-    mutating func finish(into channel: LanguageModelExecutorGenerationChannel) async {
+    public mutating func finish(into channel: LanguageModelExecutorGenerationChannel) async {
         for plan in completionPlans() {
             await Self.send(plan, into: channel)
         }
     }
 
-    mutating func completionPlans() -> [ChannelPlan] {
+    public mutating func completionPlans() -> [ChannelPlan] {
         var plans = flushPlans()
         if let finishPlan = finishPlan() {
             plans.append(finishPlan)
@@ -89,12 +91,12 @@ struct MLXFoundationEventChannelAdapter {
         return plans
     }
 
-    func finishPlan() -> ChannelPlan? {
+    public func finishPlan() -> ChannelPlan? {
         guard !sentUsage else { return nil }
         return .usage(AFMUsage(outputTokens: streamedTokens))
     }
 
-    mutating func enqueue(_ plan: ChannelPlan) -> [ChannelPlan] {
+    public mutating func enqueue(_ plan: ChannelPlan) -> [ChannelPlan] {
         guard Self.isText(plan) else {
             return flushPlans() + [plan]
         }
@@ -113,7 +115,7 @@ struct MLXFoundationEventChannelAdapter {
         return Self.shouldFlush(combined) ? flushPlans() : []
     }
 
-    mutating func flushPlans() -> [ChannelPlan] {
+    public mutating func flushPlans() -> [ChannelPlan] {
         guard let pendingText else { return [] }
         self.pendingText = nil
         return [pendingText]
@@ -165,7 +167,7 @@ struct MLXFoundationEventChannelAdapter {
         }
     }
 
-    static func send(
+    public static func send(
         _ plan: ChannelPlan,
         into channel: LanguageModelExecutorGenerationChannel
     ) async {
@@ -197,7 +199,7 @@ struct MLXFoundationEventChannelAdapter {
             await channel.send(
                 .response(
                     action: .updateMetadata(
-                        MLXFoundationRequestAdapter.foundationMetadata(values)
+                        AFMFoundationModelsRequestAdapter.foundationMetadata(values)
                     )
                 )
             )
@@ -233,4 +235,7 @@ struct MLXFoundationEventChannelAdapter {
         )
     }
 }
+
+@available(macOS 27.0, *)
+typealias MLXFoundationEventChannelAdapter = AFMFoundationModelsEventChannelAdapter
 #endif

--- a/Sources/AFMKitFoundationModels27/MLXFoundationLanguageModel.swift
+++ b/Sources/AFMKitFoundationModels27/MLXFoundationLanguageModel.swift
@@ -6,7 +6,7 @@ import FoundationModels
 /// An MLX-backed model that participates in the macOS 27 Foundation Models
 /// `LanguageModelSession` API.
 @available(macOS 27.0, *)
-public struct MLXLanguageModel: LanguageModel, Sendable {
+public struct MLXLanguageModel: LanguageModel, AFMFoundationModelsModelConfiguration, Sendable {
     public typealias Executor = MLXLanguageModelExecutor
 
     public let modelID: String
@@ -63,6 +63,14 @@ public struct MLXLanguageModel: LanguageModel, Sendable {
     public var executorConfiguration: MLXLanguageModelExecutor.Configuration {
         engineConfig
     }
+
+    public var defaultMaximumResponseTokens: Int {
+        engineConfig.defaultMaximumResponseTokens
+    }
+
+    public var supportsReasoning: Bool {
+        engineConfig.supportsReasoning
+    }
 }
 
 /// Executes macOS 27 Foundation Models requests through `AFMEngine`.
@@ -70,7 +78,7 @@ public struct MLXLanguageModel: LanguageModel, Sendable {
 public final class MLXLanguageModelExecutor: LanguageModelExecutor, @unchecked Sendable {
     public typealias Model = MLXLanguageModel
 
-    public struct Configuration: Hashable, Sendable {
+    public struct Configuration: Hashable, Sendable, AFMFoundationModelsModelConfiguration {
         public let modelID: String
         public let kvBits: Int?
         public let enablePrefixCaching: Bool
@@ -167,7 +175,7 @@ public final class MLXLanguageModelExecutor: LanguageModelExecutor, @unchecked S
             )
         }
 
-        let messages = try MLXFoundationRequestAdapter.messages(from: request.transcript)
+        let messages = try AFMFoundationModelsRequestAdapter.messages(from: request.transcript)
         guard !messages.isEmpty else {
             throw LanguageModelError.unsupportedTranscriptContent(
                 .init(
@@ -178,36 +186,14 @@ public final class MLXLanguageModelExecutor: LanguageModelExecutor, @unchecked S
         }
 
         let engine = try await runtime.preparedEngine()
-        let options = try MLXFoundationRequestAdapter.generationConfig(from: request, model: model)
-
-        var channelAdapter = MLXFoundationEventChannelAdapter()
-        let (planStream, planContinuation) = AsyncStream.makeStream(
-            of: MLXFoundationEventChannelAdapter.ChannelPlan.self
+        let options = try AFMFoundationModelsRequestAdapter.generationConfig(
+            from: request,
+            model: model.engineConfig
         )
-        let sender = Task.detached(priority: .utility) {
-            for await plan in planStream {
-                await MLXFoundationEventChannelAdapter.send(plan, into: channel)
-            }
-        }
-
-        do {
-            for try await event in engine.streamEvents(to: messages, options) {
-                try Task.checkCancellation()
-                for plan in channelAdapter.plans(for: event) {
-                    planContinuation.yield(plan)
-                }
-            }
-            for plan in channelAdapter.completionPlans() {
-                planContinuation.yield(plan)
-            }
-            planContinuation.finish()
-            await sender.value
-        } catch {
-            planContinuation.finish()
-            sender.cancel()
-            await sender.value
-            throw error
-        }
+        try await AFMFoundationModelsExecutorBridge.respond(
+            events: engine.streamEvents(to: messages, options),
+            streamingInto: channel
+        )
     }
 
 }

--- a/Sources/AFMKitFoundationModels27/MLXFoundationRequestAdapter.swift
+++ b/Sources/AFMKitFoundationModels27/MLXFoundationRequestAdapter.swift
@@ -7,8 +7,8 @@ import ImageIO
 import UniformTypeIdentifiers
 
 @available(macOS 27.0, *)
-enum MLXFoundationRequestAdapter {
-    static func messages(from transcript: Transcript) throws -> [Message] {
+public enum AFMFoundationModelsRequestAdapter {
+    public static func messages(from transcript: Transcript) throws -> [Message] {
         var messages: [Message] = []
 
         for entry in transcript {
@@ -68,9 +68,9 @@ enum MLXFoundationRequestAdapter {
         return messages
     }
 
-    static func generationConfig(
+    public static func generationConfig<Model: AFMFoundationModelsModelConfiguration>(
         from request: LanguageModelExecutorGenerationRequest,
-        model: MLXLanguageModel
+        model: Model
     ) throws -> GenerationConfig {
         var temperature = request.generationOptions.temperature
         var topP: Double?
@@ -120,7 +120,7 @@ enum MLXFoundationRequestAdapter {
                 break
             }
         }
-        if model.engineConfig.supportsReasoning {
+        if model.supportsReasoning {
             metadata["chatTemplateKwargs"] = .object([
                 "enable_thinking": .bool(explicitReasoningRequested)
             ])
@@ -133,7 +133,7 @@ enum MLXFoundationRequestAdapter {
         return GenerationConfig(
             temperature: temperature,
             maxTokens: request.generationOptions.maximumResponseTokens
-                ?? model.engineConfig.defaultMaximumResponseTokens,
+                ?? model.defaultMaximumResponseTokens,
             topP: topP,
             topK: topK,
             seed: seed,
@@ -143,7 +143,7 @@ enum MLXFoundationRequestAdapter {
         )
     }
 
-    static func tools(
+    public static func tools(
         from definitions: [Transcript.ToolDefinition]
     ) throws -> [RequestTool]? {
         guard !definitions.isEmpty else { return nil }
@@ -160,7 +160,7 @@ enum MLXFoundationRequestAdapter {
         }
     }
 
-    static func responseFormat(from schema: GenerationSchema?) throws -> ResponseFormat? {
+    public static func responseFormat(from schema: GenerationSchema?) throws -> ResponseFormat? {
         guard let schema else { return nil }
         return ResponseFormat(
             type: "json_schema",
@@ -173,7 +173,7 @@ enum MLXFoundationRequestAdapter {
         )
     }
 
-    static func foundationMetadata(
+    public static func foundationMetadata(
         _ values: [String: AFMJSONValue]
     ) -> [String: any Sendable & Codable & Equatable] {
         values.reduce(into: [:]) { result, item in
@@ -308,4 +308,7 @@ enum MLXFoundationRequestAdapter {
         }
     }
 }
+
+@available(macOS 27.0, *)
+typealias MLXFoundationRequestAdapter = AFMFoundationModelsRequestAdapter
 #endif

--- a/Sources/AFMKitFoundationModels27DwarfStar/DwarfStarFoundationLanguageModel.swift
+++ b/Sources/AFMKitFoundationModels27DwarfStar/DwarfStarFoundationLanguageModel.swift
@@ -1,6 +1,7 @@
 #if canImport(FoundationModels)
 import AFMKit
 import AFMKitDwarfStar
+import AFMKitFoundationModels27
 import Foundation
 import FoundationModels
 

--- a/Sources/AFMKitMLX/AFMDownloadProgress.swift
+++ b/Sources/AFMKitMLX/AFMDownloadProgress.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// AFM metadata attached to Hugging Face snapshot `Progress` instances.
+///
+/// The official Hub API reports aggregate bytes. AFM augments that progress
+/// with the public repository manifest so terminal clients can also identify
+/// active files without replacing the Hub's Xet/LFS transport or cache logic.
+public enum AFMDownloadProgressUserInfo {
+    public static let currentFiles = ProgressUserInfoKey("com.maclocal.afm.download.current-files")
+    public static let completedFiles = ProgressUserInfoKey("com.maclocal.afm.download.completed-files")
+    public static let totalFiles = ProgressUserInfoKey("com.maclocal.afm.download.total-files")
+
+    struct File: @unchecked Sendable {
+        let path: String
+        let expectedBytes: Int64
+        let destination: URL?
+        let progress: Progress
+    }
+
+    static func enrich(_ progress: Progress, files: [File]) {
+        guard !files.isEmpty else { return }
+        var completed = 0
+        var completedBytes: Int64 = 0
+        var active: [String] = []
+        var firstPending: String?
+        for file in files {
+            let path = file.path
+            let child = file.progress
+            if let destination = file.destination,
+               let attributes = try? FileManager.default.attributesOfItem(atPath: destination.path),
+               let size = (attributes[.size] as? NSNumber)?.int64Value,
+               size > child.completedUnitCount {
+                child.completedUnitCount = min(size, file.expectedBytes)
+            }
+            if child.totalUnitCount > 0,
+               child.completedUnitCount >= child.totalUnitCount {
+                completed += 1
+            } else {
+                if firstPending == nil { firstPending = path }
+                if child.completedUnitCount > 0 { active.append(path) }
+            }
+            completedBytes += min(child.completedUnitCount, file.expectedBytes)
+        }
+        if active.isEmpty, let firstPending { active = [firstPending] }
+        progress.completedUnitCount = min(completedBytes, progress.totalUnitCount)
+        progress.setUserInfoObject(active, forKey: currentFiles)
+        progress.setUserInfoObject(completed, forKey: completedFiles)
+        progress.setUserInfoObject(files.count, forKey: totalFiles)
+    }
+}

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 import Darwin
 import AFMKitCore
 import AFMOpenAICompat
@@ -5037,16 +5038,161 @@ public final class MLXModelService: @unchecked Sendable {
             let cache = HubCache(cacheDirectory: cacheDir)
             print("Download destination: \(cacheDir.path)")
             let client = HuggingFace.HubClient(cache: cache)
-            // No @MainActor progress handler — it deadlocks in single-prompt mode
-            // because MainActor is suspended waiting for downloadSnapshot to return.
-            // The spinner is driven by MLXLoadReporter independently.
-            _ = try await client.downloadSnapshot(
-                of: repoID,
-                matching: ["*.json", "*.jinja", "*.safetensors", "*.txt", "*.model", "*.tiktoken", "tokenizer*", "*.bpe", "*.bin"]
-            )
+            let patterns = ["*.json", "*.jinja", "*.safetensors", "*.txt", "*.model", "*.tiktoken", "tokenizer*", "*.bpe", "*.bin"]
+            let revision = try await client.getModel(repoID).sha
+            let manifest = try await client.listFiles(
+                in: repoID,
+                revision: revision ?? "main").filter { entry in
+                patterns.contains { fnmatch($0, entry.path, 0) == 0 }
+            }
+            if let revision, !manifest.isEmpty {
+                print("Hugging Face transport: automatic (Xet for large files, LFS fallback)")
+                try await downloadManifest(
+                    manifest,
+                    repoID: repoID,
+                    revision: revision,
+                    cache: cache,
+                    client: client,
+                    progressHandler: progress)
+            } else {
+                // Retain the official snapshot fallback for repositories whose
+                // API metadata does not expose a commit SHA.
+                _ = try await client.downloadSnapshot(
+                    of: repoID,
+                    matching: patterns
+                )
+            }
         } catch {
             throw MLXServiceError.downloadFailed("\(modelID): \(error.localizedDescription)")
         }
+    }
+
+    private func downloadManifest(
+        _ entries: [Git.TreeEntry],
+        repoID: HuggingFace.Repo.ID,
+        revision: String,
+        cache: HubCache,
+        client: HuggingFace.HubClient,
+        progressHandler: (@Sendable (Progress) -> Void)?
+    ) async throws {
+        let total = entries.reduce(Int64(0)) { partial, entry in
+            partial + max(Int64(entry.size ?? 1), 1)
+        }
+        let aggregate = Progress(totalUnitCount: max(total, 1))
+        let files = try entries.map { entry in
+            let weight = max(Int64(entry.size ?? 1), 1)
+            let blobKey = Self.hubBlobKey(
+                repoID: repoID,
+                revision: revision,
+                entry: entry)
+            let destination = try cache.blobPath(
+                repo: repoID,
+                kind: .model,
+                etag: blobKey)
+            return AFMDownloadProgressUserInfo.File(
+                path: entry.path,
+                expectedBytes: weight,
+                destination: destination,
+                progress: Progress(totalUnitCount: weight))
+        }
+
+        let monitor = Task {
+            while !Task.isCancelled {
+                AFMDownloadProgressUserInfo.enrich(aggregate, files: files)
+                progressHandler?(aggregate)
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+        }
+        defer { monitor.cancel() }
+
+        let indexed = Array(zip(entries.indices, entries))
+        let lfsEntries = indexed.filter { ($0.1.size ?? 0) < 16 * 1024 * 1024 }
+        let xetEntries = indexed.filter { ($0.1.size ?? 0) >= 16 * 1024 * 1024 }
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            var active = 0
+            for (index, entry) in lfsEntries {
+                while active >= 4 {
+                    if try await group.next() != nil { active -= 1 }
+                }
+                group.addTask {
+                    do {
+                        try FileManager.default.createDirectory(
+                            at: files[index].destination!.deletingLastPathComponent(),
+                            withIntermediateDirectories: true)
+                        _ = try await client.downloadFile(
+                            entry,
+                            from: repoID,
+                            to: files[index].destination,
+                            revision: revision,
+                            progress: files[index].progress,
+                            transport: .lfs)
+                        try await cache.storeFile(
+                            at: files[index].destination!,
+                            repo: repoID,
+                            kind: .model,
+                            revision: revision,
+                            filename: entry.path,
+                            etag: Self.hubBlobKey(
+                                repoID: repoID,
+                                revision: revision,
+                                entry: entry),
+                            ref: "main")
+                        files[index].progress.totalUnitCount = files[index].expectedBytes
+                        files[index].progress.completedUnitCount = files[index].progress.totalUnitCount
+                    } catch {
+                        throw MLXServiceError.downloadFailed("\(entry.path): \(error.localizedDescription)")
+                    }
+                }
+                active += 1
+            }
+            for try await _ in group {}
+        }
+
+        // Match the official snapshot policy: large Xet files are processed
+        // sequentially while each Xet transfer uses its own parallel CAS fetches.
+        for (index, entry) in xetEntries {
+            do {
+                try FileManager.default.createDirectory(
+                    at: files[index].destination!.deletingLastPathComponent(),
+                    withIntermediateDirectories: true)
+                _ = try await client.downloadFile(
+                    entry,
+                    from: repoID,
+                    to: files[index].destination,
+                    revision: revision,
+                    progress: files[index].progress,
+                    transport: .automatic)
+                try await cache.storeFile(
+                    at: files[index].destination!,
+                    repo: repoID,
+                    kind: .model,
+                    revision: revision,
+                    filename: entry.path,
+                    etag: Self.hubBlobKey(
+                        repoID: repoID,
+                        revision: revision,
+                        entry: entry),
+                    ref: "main")
+                files[index].progress.totalUnitCount = files[index].expectedBytes
+                files[index].progress.completedUnitCount = files[index].progress.totalUnitCount
+            } catch {
+                throw MLXServiceError.downloadFailed("\(entry.path): \(error.localizedDescription)")
+            }
+        }
+        AFMDownloadProgressUserInfo.enrich(aggregate, files: files)
+        progressHandler?(aggregate)
+    }
+
+    private static func hubBlobKey(
+        repoID: HuggingFace.Repo.ID,
+        revision: String,
+        entry: Git.TreeEntry
+    ) -> String {
+        let identity = "\(repoID.description)|\(revision)|\(entry.path)|\(entry.oid ?? "")"
+        return SHA256.hash(data: Data(identity.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 
     private func inferToolCallFormat(directory: URL) -> ToolCallFormat? {

--- a/Sources/CDwarfStar/AFMDwarfStarBridge.c
+++ b/Sources/CDwarfStar/AFMDwarfStarBridge.c
@@ -1,4 +1,5 @@
 #include "include/CDwarfStar.h"
+#include "../../vendor/ds4/ds4_kvstore.h"
 
 #include <errno.h>
 #include <limits.h>
@@ -106,4 +107,117 @@ void afm_ds4_tokens_init(ds4_tokens *tokens) {
 
 void afm_ds4_free(void *pointer) {
     free(pointer);
+}
+
+struct afm_ds4_prefix_cache {
+    ds4_kvstore store;
+};
+
+static void afm_ds4_prefix_cache_log(
+        void *unused,
+        ds4_kvstore_log_type type,
+        const char *message) {
+    (void)unused;
+    const char *level = type == DS4_KVSTORE_LOG_WARNING ? "warning" : "info";
+    fprintf(stderr, "[DwarfStarPrefixCache] %s: %s\n", level, message);
+}
+
+int afm_ds4_prefix_cache_open(
+        afm_ds4_prefix_cache **out,
+        const char *directory,
+        uint64_t budget_mb,
+        char *error,
+        size_t error_capacity) {
+    if (!out || !directory || !directory[0]) {
+        snprintf(error, error_capacity, "DwarfStar prefix-cache directory is missing");
+        return -1;
+    }
+    afm_ds4_prefix_cache *cache = calloc(1, sizeof(*cache));
+    if (!cache) {
+        snprintf(error, error_capacity, "Unable to allocate DwarfStar prefix cache");
+        return -1;
+    }
+    ds4_kvstore_options options = ds4_kvstore_default_options();
+    if (!ds4_kvstore_open(
+            &cache->store,
+            directory,
+            budget_mb,
+            true,
+            options,
+            "AFM",
+            afm_ds4_prefix_cache_log,
+            NULL)) {
+        free(cache);
+        snprintf(error, error_capacity, "Unable to open DwarfStar prefix cache at %s", directory);
+        return -1;
+    }
+    *out = cache;
+    return 0;
+}
+
+void afm_ds4_prefix_cache_close(afm_ds4_prefix_cache *cache) {
+    if (!cache) return;
+    ds4_kvstore_close(&cache->store);
+    free(cache);
+}
+
+int afm_ds4_prefix_cache_restore(
+        afm_ds4_prefix_cache *cache,
+        ds4_engine *engine,
+        ds4_session *session,
+        ds4_tokens *prompt,
+        char *error,
+        size_t error_capacity) {
+    if (!cache || !engine || !session || !prompt) return 0;
+    size_t text_length = 0;
+    char *text = ds4_kvstore_render_tokens_text(engine, prompt, &text_length);
+    if (!text) return 0;
+
+    ds4_tokens effective = {0};
+    ds4_kvstore_load_result result = {0};
+    int loaded = ds4_kvstore_try_load_text(
+        &cache->store,
+        engine,
+        session,
+        text,
+        &effective,
+        &result,
+        NULL,
+        false);
+    free(text);
+    ds4_kvstore_load_result_free(&result);
+
+    if (loaded > 0) {
+        ds4_tokens_free(prompt);
+        *prompt = effective;
+        return loaded;
+    }
+    ds4_tokens_free(&effective);
+    if (loaded < 0) {
+        snprintf(error, error_capacity, "DwarfStar prefix-cache restore failed");
+        return -1;
+    }
+    return 0;
+}
+
+int afm_ds4_prefix_cache_store_session(
+        afm_ds4_prefix_cache *cache,
+        ds4_engine *engine,
+        ds4_session *session,
+        const char *reason,
+        char *error,
+        size_t error_capacity) {
+    if (!cache || !engine || !session) return 0;
+    const ds4_tokens *tokens = ds4_session_tokens(session);
+    if (!tokens || tokens->len <= 0) return 0;
+    return ds4_kvstore_store_live_prefix(
+        &cache->store,
+        engine,
+        session,
+        tokens,
+        tokens->len,
+        reason ? reason : "continued",
+        NULL,
+        error,
+        error_capacity) ? tokens->len : 0;
 }

--- a/Sources/CDwarfStar/CDwarfStarKVStore.c
+++ b/Sources/CDwarfStar/CDwarfStarKVStore.c
@@ -1,0 +1,1 @@
+#include "../../vendor/ds4/ds4_kvstore.c"

--- a/Sources/CDwarfStar/include/CDwarfStar.h
+++ b/Sources/CDwarfStar/include/CDwarfStar.h
@@ -21,4 +21,31 @@ int afm_ds4_engine_open(
 void afm_ds4_tokens_init(ds4_tokens *tokens);
 void afm_ds4_free(void *pointer);
 
+typedef struct afm_ds4_prefix_cache afm_ds4_prefix_cache;
+
+int afm_ds4_prefix_cache_open(
+    afm_ds4_prefix_cache **out,
+    const char *directory,
+    uint64_t budget_mb,
+    char *error,
+    size_t error_capacity
+);
+void afm_ds4_prefix_cache_close(afm_ds4_prefix_cache *cache);
+int afm_ds4_prefix_cache_restore(
+    afm_ds4_prefix_cache *cache,
+    ds4_engine *engine,
+    ds4_session *session,
+    ds4_tokens *prompt,
+    char *error,
+    size_t error_capacity
+);
+int afm_ds4_prefix_cache_store_session(
+    afm_ds4_prefix_cache *cache,
+    ds4_engine *engine,
+    ds4_session *session,
+    const char *reason,
+    char *error,
+    size_t error_capacity
+);
+
 #endif

--- a/Tests/AFMKitDwarfStarTests/AFMDwarfStarProviderTests.swift
+++ b/Tests/AFMKitDwarfStarTests/AFMDwarfStarProviderTests.swift
@@ -149,6 +149,21 @@ final class AFMDwarfStarProviderTests: XCTestCase {
                 currentPosition: 128, activeDecodeCount: 0))
     }
 
+    func testDSparkAvailabilityUsesGeneralizedDraftDepth() {
+        XCTAssertFalse(
+            AFMDwarfStarSpeculativePolicy.isAvailable(
+                requested: false,
+                draftTokenCount: 5))
+        XCTAssertFalse(
+            AFMDwarfStarSpeculativePolicy.isAvailable(
+                requested: true,
+                draftTokenCount: 0))
+        XCTAssertTrue(
+            AFMDwarfStarSpeculativePolicy.isAvailable(
+                requested: true,
+                draftTokenCount: 5))
+    }
+
     func testSchedulerRotatesAcrossWaitingPrefills() {
         XCTAssertEqual(
             AFMDwarfStarSchedulingPolicy.nextPrefillSlot(

--- a/Tests/AFMKitDwarfStarTests/AFMDwarfStarProviderTests.swift
+++ b/Tests/AFMKitDwarfStarTests/AFMDwarfStarProviderTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import AFMKitCore
 @testable import AFMKitDwarfStar
 
 final class AFMDwarfStarProviderTests: XCTestCase {
@@ -52,6 +53,7 @@ final class AFMDwarfStarProviderTests: XCTestCase {
         XCTAssertEqual(model.descriptor.providerID, "dwarfstar")
         XCTAssertFalse(model.descriptor.capabilities.contains(.reasoning))
         XCTAssertTrue(model.descriptor.capabilities.contains(.streaming))
+        XCTAssertTrue(model.descriptor.capabilities.contains(.toolCalling))
     }
 
     func testModelDescriptorPublishesResidentSessionConfiguration() {
@@ -121,6 +123,151 @@ final class AFMDwarfStarProviderTests: XCTestCase {
                 commonPrefixes: [12, nil, 30, 30],
                 prefixCachingEnabled: true),
             2)
+    }
+
+    func testSchedulerUsesLargePrefillQuantumWhenNoDecodeIsActive() {
+        XCTAssertEqual(
+            AFMDwarfStarSchedulingPolicy.prefillQuantum(activeDecodeCount: 0),
+            2_048)
+    }
+
+    func testSchedulerUsesBoundedPrefillQuantumDuringContinuousDecode() {
+        XCTAssertEqual(
+            AFMDwarfStarSchedulingPolicy.prefillQuantum(activeDecodeCount: 3),
+            128)
+    }
+
+    func testSchedulerEstablishesCheckpointBeforeMixedPrefill() {
+        XCTAssertFalse(
+            AFMDwarfStarSchedulingPolicy.canMixPrefill(
+                currentPosition: 0, activeDecodeCount: 3))
+        XCTAssertTrue(
+            AFMDwarfStarSchedulingPolicy.canMixPrefill(
+                currentPosition: 128, activeDecodeCount: 3))
+        XCTAssertFalse(
+            AFMDwarfStarSchedulingPolicy.canMixPrefill(
+                currentPosition: 128, activeDecodeCount: 0))
+    }
+
+    func testSchedulerRotatesAcrossWaitingPrefills() {
+        XCTAssertEqual(
+            AFMDwarfStarSchedulingPolicy.nextPrefillSlot(
+                lastSlot: 0,
+                waiting: [true, true, false, true]),
+            1)
+        XCTAssertEqual(
+            AFMDwarfStarSchedulingPolicy.nextPrefillSlot(
+                lastSlot: 1,
+                waiting: [true, true, false, true]),
+            3)
+        XCTAssertEqual(
+            AFMDwarfStarSchedulingPolicy.nextPrefillSlot(
+                lastSlot: 3,
+                waiting: [true, true, false, true]),
+            0)
+    }
+
+    func testSchedulerReturnsNilWhenNoPromptNeedsPrefill() {
+        XCTAssertNil(
+            AFMDwarfStarSchedulingPolicy.nextPrefillSlot(
+                lastSlot: 2,
+                waiting: [false, false, false]))
+    }
+
+    func testPrefixCacheCheckpointIdentitySeparatesModelRevisions() {
+        let original = AFMDwarfStarPrefixCachePolicy.checkpointKey(
+            path: "/models/deepseek.gguf", size: 100, modified: 10)
+        XCTAssertEqual(
+            original,
+            AFMDwarfStarPrefixCachePolicy.checkpointKey(
+                path: "/models/deepseek.gguf", size: 100, modified: 10))
+        XCTAssertNotEqual(
+            original,
+            AFMDwarfStarPrefixCachePolicy.checkpointKey(
+                path: "/models/deepseek.gguf", size: 101, modified: 10))
+        XCTAssertNotEqual(
+            original,
+            AFMDwarfStarPrefixCachePolicy.checkpointKey(
+                path: "/models/deepseek.gguf", size: 100, modified: 11))
+    }
+
+    func testPrefixCacheBudgetUsesSafeDefaultAndEnvironmentOverride() {
+        XCTAssertEqual(AFMDwarfStarPrefixCachePolicy.budgetMB(environment: [:]), 4_096)
+        XCTAssertEqual(
+            AFMDwarfStarPrefixCachePolicy.budgetMB(
+                environment: ["AFM_DWARFSTAR_PREFIX_CACHE_MB": "8192"]),
+            8_192)
+        XCTAssertEqual(
+            AFMDwarfStarPrefixCachePolicy.budgetMB(
+                environment: ["AFM_DWARFSTAR_PREFIX_CACHE_MB": "0"]),
+            4_096)
+    }
+
+    func testToolPromptPublishesSchemasInDeepSeekDSMLFormat() throws {
+        let prompt = try AFMDwarfStarToolCodec.systemPrompt(for: [
+            AFMToolDefinition(
+                name: "weather",
+                description: "Look up weather.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "city": .object(["type": .string("string")])
+                    ])
+                ])
+            )
+        ])
+
+        XCTAssertTrue(prompt.contains("<｜DSML｜tool_calls>"))
+        XCTAssertTrue(prompt.contains("\"name\":\"weather\""))
+        XCTAssertTrue(prompt.contains("\"city\""))
+    }
+
+    func testToolParserHandlesSplitMarkersAndParallelCalls() throws {
+        var parser = AFMDwarfStarToolCodec.StreamParser()
+        XCTAssertEqual(try parser.consume("I will check. <｜DSML｜tool_"), [.text("I will check. ")])
+        XCTAssertEqual(try parser.consume("calls>\n<｜DSML｜invoke name=\"weather\">\n"), [])
+        XCTAssertEqual(
+            try parser.consume(
+                "<｜DSML｜parameter name=\"city\" string=\"true\">Paris</｜DSML｜parameter>\n"
+                    + "</｜DSML｜invoke>\n<｜DSML｜invoke name=\"clock\">\n"
+                    + "<｜DSML｜parameter name=\"offset\" string=\"false\">-4</｜DSML｜parameter>\n"
+                    + "</｜DSML｜invoke>\n</｜DSML｜tool_calls>"
+            ),
+            [
+                .toolCalls([
+                    AFMToolCall(
+                        id: "call_1",
+                        name: "weather",
+                        arguments: "{\"city\":\"Paris\"}"
+                    ),
+                    AFMToolCall(
+                        id: "call_2",
+                        name: "clock",
+                        arguments: "{\"offset\":-4}"
+                    )
+                ])
+            ]
+        )
+    }
+
+    func testAssistantToolCallsRoundTripThroughDSML() throws {
+        let message = AFMMessage(
+            role: .assistant,
+            content: [.text("Checking")],
+            toolCalls: [
+                AFMToolCall(
+                    id: "original",
+                    name: "weather",
+                    arguments: "{\"city\":\"Montréal\",\"days\":2}"
+                )
+            ]
+        )
+        let rendered = try AFMDwarfStarToolCodec.assistantContent(for: message)
+
+        XCTAssertTrue(rendered.hasPrefix("Checking\n\n<｜DSML｜tool_calls>"))
+        XCTAssertTrue(rendered.contains("name=\"weather\""))
+        XCTAssertTrue(rendered.contains("name=\"city\" string=\"true\">Montréal"))
+        XCTAssertTrue(rendered.contains("name=\"days\" string=\"false\">2"))
     }
 
 }

--- a/Tests/AFMKitDwarfStarTests/AFMDwarfStarProviderTests.swift
+++ b/Tests/AFMKitDwarfStarTests/AFMDwarfStarProviderTests.swift
@@ -51,7 +51,7 @@ final class AFMDwarfStarProviderTests: XCTestCase {
         let availability = await model.availability()
         XCTAssertFalse(availability.isAvailable)
         XCTAssertEqual(model.descriptor.providerID, "dwarfstar")
-        XCTAssertFalse(model.descriptor.capabilities.contains(.reasoning))
+        XCTAssertTrue(model.descriptor.capabilities.contains(.reasoning))
         XCTAssertTrue(model.descriptor.capabilities.contains(.streaming))
         XCTAssertTrue(model.descriptor.capabilities.contains(.toolCalling))
     }
@@ -265,6 +265,46 @@ final class AFMDwarfStarProviderTests: XCTestCase {
         )
     }
 
+    func testToolMarkupInsideReasoningIsNotExecuted() throws {
+        var parser = AFMDwarfStarToolCodec.StreamParser(startsInReasoning: true)
+        let fakeCall = "<｜DSML｜tool_calls><｜DSML｜invoke name=\"unsafe\"></｜DSML｜invoke></｜DSML｜tool_calls>"
+
+        XCTAssertEqual(
+            try parser.consume("consider \(fakeCall)</think>answer"),
+            [.reasoning("consider \(fakeCall)"), .text("answer")]
+        )
+    }
+
+    func testCompletedToolCallTerminatesParserAndDiscardsTrailingOutput() throws {
+        var parser = AFMDwarfStarToolCodec.StreamParser()
+        let call = "<｜DSML｜tool_calls><｜DSML｜invoke name=\"weather\"></｜DSML｜invoke></｜DSML｜tool_calls>"
+
+        let outputs = try parser.consume(call + "must not become response text")
+        guard case .toolCalls(let calls) = try XCTUnwrap(outputs.first) else {
+            return XCTFail("Expected a completed tool call")
+        }
+        XCTAssertEqual(calls.map(\.name), ["weather"])
+        XCTAssertEqual(outputs.count, 1)
+        XCTAssertEqual(try parser.consume("also ignored"), [])
+        XCTAssertEqual(parser.finish(), [])
+    }
+
+    func testReasoningMarkersCanSpanChunks() throws {
+        var parser = AFMDwarfStarToolCodec.StreamParser(startsInReasoning: true)
+
+        XCTAssertEqual(try parser.consume("analysis</thi"), [.reasoning("analysis")])
+        XCTAssertEqual(try parser.consume("nk>final"), [.text("final")])
+    }
+
+    func testResponseCanEnterAndLeaveExplicitReasoning() throws {
+        var parser = AFMDwarfStarToolCodec.StreamParser()
+
+        XCTAssertEqual(
+            try parser.consume("before<think>private</think>after"),
+            [.text("before"), .reasoning("private"), .text("after")]
+        )
+    }
+
     func testAssistantToolCallsRoundTripThroughDSML() throws {
         let message = AFMMessage(
             role: .assistant,
@@ -283,6 +323,28 @@ final class AFMDwarfStarProviderTests: XCTestCase {
         XCTAssertTrue(rendered.contains("name=\"weather\""))
         XCTAssertTrue(rendered.contains("name=\"city\" string=\"true\">Montréal"))
         XCTAssertTrue(rendered.contains("name=\"days\" string=\"false\">2"))
+    }
+
+    func testAssistantToolReplayUsesCanonicalSeparatorAndBoundary() throws {
+        let message = AFMMessage(
+            role: .assistant,
+            content: [.text("Checking")],
+            toolCalls: [
+                AFMToolCall(id: "call", name: "weather", arguments: "{\"city\":\"Paris\"}")
+            ]
+        )
+
+        let suffix = try AFMDwarfStarToolCodec.assistantReplaySuffix(for: message)
+        XCTAssertTrue(suffix.hasPrefix("\n\n<｜DSML｜tool_calls>"))
+        XCTAssertTrue(suffix.hasSuffix("<｜end▁of▁sentence｜>"))
+    }
+
+    func testAssistantTextReplayEndsWithConversationBoundary() throws {
+        let message = AFMMessage(role: .assistant, content: [.text("Done")])
+        XCTAssertEqual(
+            try AFMDwarfStarToolCodec.assistantReplaySuffix(for: message),
+            "<｜end▁of▁sentence｜>"
+        )
     }
 
 }

--- a/Tests/MacLocalAPITests/AFMDownloadProgressTests.swift
+++ b/Tests/MacLocalAPITests/AFMDownloadProgressTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import XCTest
+@testable import AFMKitMLX
+
+final class AFMDownloadProgressTests: XCTestCase {
+    func testEnrichmentReportsActiveAndCompletedFiles() {
+        let root = Progress(totalUnitCount: 300)
+        let complete = Progress(totalUnitCount: 100)
+        let active = Progress(totalUnitCount: 100)
+        let pending = Progress(totalUnitCount: 100)
+        complete.completedUnitCount = 100
+        active.completedUnitCount = 25
+
+        let files = [
+            AFMDownloadProgressUserInfo.File(path: "config.json", expectedBytes: 100, destination: nil, progress: complete),
+            AFMDownloadProgressUserInfo.File(path: "weights-01.safetensors", expectedBytes: 100, destination: nil, progress: active),
+            AFMDownloadProgressUserInfo.File(path: "weights-02.safetensors", expectedBytes: 100, destination: nil, progress: pending),
+        ]
+        AFMDownloadProgressUserInfo.enrich(root, files: files)
+
+        XCTAssertEqual(root.userInfo[AFMDownloadProgressUserInfo.completedFiles] as? Int, 1)
+        XCTAssertEqual(root.userInfo[AFMDownloadProgressUserInfo.totalFiles] as? Int, 3)
+        XCTAssertEqual(
+            root.userInfo[AFMDownloadProgressUserInfo.currentFiles] as? [String],
+            ["weights-01.safetensors"])
+    }
+
+    func testEnrichmentNamesFirstPendingFileBeforeBytesArrive() {
+        let root = Progress(totalUnitCount: 200)
+        let first = Progress(totalUnitCount: 100)
+        let second = Progress(totalUnitCount: 100)
+
+        AFMDownloadProgressUserInfo.enrich(
+            root,
+            files: [
+                AFMDownloadProgressUserInfo.File(path: "a.bin", expectedBytes: 100, destination: nil, progress: first),
+                AFMDownloadProgressUserInfo.File(path: "b.bin", expectedBytes: 100, destination: nil, progress: second),
+            ])
+
+        XCTAssertEqual(
+            root.userInfo[AFMDownloadProgressUserInfo.currentFiles] as? [String],
+            ["a.bin"])
+        XCTAssertEqual(root.userInfo[AFMDownloadProgressUserInfo.completedFiles] as? Int, 0)
+    }
+
+    func testEnrichmentSamplesGrowingXetDestination() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let destination = directory.appendingPathComponent("weights.safetensors")
+        try Data(repeating: 0xA5, count: 64).write(to: destination)
+
+        let root = Progress(totalUnitCount: 100)
+        let child = Progress(totalUnitCount: 100)
+        AFMDownloadProgressUserInfo.enrich(
+            root,
+            files: [
+                AFMDownloadProgressUserInfo.File(
+                    path: "weights.safetensors",
+                    expectedBytes: 100,
+                    destination: destination,
+                    progress: child),
+            ])
+
+        XCTAssertEqual(child.completedUnitCount, 64)
+        XCTAssertEqual(root.completedUnitCount, 64)
+        XCTAssertEqual(
+            root.userInfo[AFMDownloadProgressUserInfo.currentFiles] as? [String],
+            ["weights.safetensors"])
+    }
+}

--- a/Tests/MacLocalAPITests/MLXFoundationLanguageModelTests.swift
+++ b/Tests/MacLocalAPITests/MLXFoundationLanguageModelTests.swift
@@ -28,6 +28,23 @@ final class MLXFoundationLanguageModelTests: XCTestCase {
         let content: Content
     }
 
+    func testDwarfStarLanguageModelPublishesAppleToolCallingContract() {
+        let model = DwarfStarLanguageModel(
+            modelPath: "/models/deepseek-v4-flash.gguf",
+            contextWindow: 65_536,
+            enablePrefixCaching: true,
+            maxConcurrent: 4,
+            defaultMaximumResponseTokens: 1_024
+        )
+
+        XCTAssertTrue(model.capabilities.contains(.reasoning))
+        XCTAssertTrue(model.capabilities.contains(.toolCalling))
+        XCTAssertEqual(model.defaultMaximumResponseTokens, 1_024)
+        XCTAssertEqual(model.executorConfiguration.contextWindow, 65_536)
+        XCTAssertTrue(model.executorConfiguration.enablePrefixCaching)
+        XCTAssertEqual(model.executorConfiguration.maxConcurrent, 4)
+    }
+
     func testLanguageModelPlanProjectsAFMKitDescriptorCapabilities() {
         let descriptor = AFMModelDescriptor(
             providerID: "afmkit.mlx",

--- a/Tests/MacLocalAPITests/MLXFoundationLanguageModelTests.swift
+++ b/Tests/MacLocalAPITests/MLXFoundationLanguageModelTests.swift
@@ -3,6 +3,7 @@ import CoreImage
 import FoundationModels
 @testable import AFMKit
 @testable import AFMKitFoundationModels27
+@testable import AFMKitFoundationModels27DwarfStar
 import XCTest
 
 @available(macOS 27.0, *)

--- a/docs/afmkit-public-api.md
+++ b/docs/afmkit-public-api.md
@@ -18,6 +18,42 @@ The package exposes dependency-scoped products:
 these products so existing consumers do not need immediate import changes.
 New libraries should import only the products they use.
 
+## macOS 27 Provider Contract
+
+The primary extension surface on macOS 27 is Apple's own `LanguageModel` and
+`LanguageModelExecutor` protocol pair. AFMKit does not replace that contract.
+It supplies reusable public adapters so a Swift package can implement an
+execution engine while retaining the behavior expected by
+`LanguageModelSession`:
+
+- `AFMFoundationModelsRequestAdapter` converts Apple transcripts, tool schemas,
+  sampling options, reasoning levels, and structured-output schemas.
+- `AFMFoundationModelsExecutorBridge` converts portable AFMKit generation events
+  into Apple's response, reasoning, tool-call, usage, metadata, and completion
+  channel events.
+- `AFMFoundationModelsModelConfiguration` declares the small amount of model
+  configuration needed by the shared request adapter.
+
+AFMKit includes `MLXLanguageModel` and `DwarfStarLanguageModel` as concrete
+examples. Applications use either one with Apple's API directly:
+
+```swift
+import AFMKitFoundationModels27
+import FoundationModels
+
+let model = DwarfStarLanguageModel(
+    modelPath: "/path/to/deepseek-v4-flash.gguf"
+)
+let session = LanguageModelSession(model: model)
+let response = try await session.respond(to: "Use the available tools if needed.")
+```
+
+A third-party provider follows the same pattern: define a `LanguageModel`,
+implement its `LanguageModelExecutor`, translate the Apple generation request
+with the public request adapter, and send typed events through the public
+executor bridge. This preserves source-level compatibility with Apple's macOS
+27 framework while allowing the inference engine to be replaced independently.
+
 ## MLX Provider
 
 Applications register `AFMMLXProviderFactory` with an `AFMProviderRegistry`,

--- a/docs/afmkit-public-api.md
+++ b/docs/afmkit-public-api.md
@@ -12,6 +12,8 @@ The package exposes dependency-scoped products:
 - `AFMKitFoundationModels`: Apple's Foundation Models service and schema bridge.
 - `AFMKitFoundationModels27`: macOS 27 adapters that expose AFMKit models through
   Apple's `LanguageModel` and `LanguageModelExecutor` protocols.
+- `AFMKitFoundationModels27DwarfStar`: opt-in macOS 27 DwarfStar adapter. Keeping
+  it separate prevents MLX-only consumers from linking the DS4 runtime and resources.
 - `AFMKitServices`: Apple Vision, Speech, synthesis, and NaturalLanguage embeddings.
 
 `AFMKit` remains the compatibility umbrella during migration. It re-exports
@@ -38,7 +40,7 @@ AFMKit includes `MLXLanguageModel` and `DwarfStarLanguageModel` as concrete
 examples. Applications use either one with Apple's API directly:
 
 ```swift
-import AFMKitFoundationModels27
+import AFMKitFoundationModels27DwarfStar
 import FoundationModels
 
 let model = DwarfStarLanguageModel(

--- a/docs/dwarfstar-runtime.md
+++ b/docs/dwarfstar-runtime.md
@@ -26,15 +26,38 @@ to use the DwarfStar runtime.
 - Temperature, top-k, top-p, min-p, seed, stop sequences, and token limits
 - Concurrent resident sessions and batched prefill/decode
 - Prefix caching
+- DeepSeek DSML tool definitions, tool calls, and tool-result continuation
+- Parallel tool calls through both AFMKit events and the macOS 27 Foundation
+  Models executor channel
 - DeepSeek thinking modes and budgets
 - DwarfStar DSpark speculative decoding
 - OpenAI-compatible HTTP transport, cancellation, usage, and timing
 
+## Continuous Batching
+
+`--concurrent <n>` creates that many resident DwarfStar sessions. Decode-ready
+sessions are evaluated together with DwarfStar's native batch API. New prompts
+are admitted round-robin in bounded prefill quanta; while decode work is active,
+AFM uses the upstream mixed prefill/decode API so a long prompt does not stop
+tokens from otherwise ready requests. A fresh session first establishes the
+checkpoint required by DwarfStar before it joins a mixed scheduling epoch.
+
+## Prefix Cache
+
+`--enable-prefix-caching` enables both resident exact-prefix reuse and
+DwarfStar's persistent disk KV store. The default disk location is
+`~/Library/Caches/AFM/DwarfStarPrefixCache/<checkpoint-key>`, isolated by model
+path, size, and modification time. Set `AFM_DWARFSTAR_PREFIX_CACHE` to place it
+on another volume and `AFM_DWARFSTAR_PREFIX_CACHE_MB` to change the default
+4096 MB budget.
+
+Disk restore/store can synchronize GPU state, so AFM performs those operations
+only while the engine is otherwise idle. Concurrent traffic continues to use
+resident session reuse without introducing disk I/O into the decode hot path.
+
 ## Known Limitations
 
 - Text only; no image or multimodal encoder
-- Tool requests are rejected because vanilla DwarfStar does not expose AFM's
-  tool-prompt and tool-event integration
 - Repetition and presence penalties are unavailable because the public sampler
   does not expose mutable logits and token-frequency state
 - Token logprobs and top-logprobs are unavailable because candidate
@@ -46,6 +69,12 @@ to use the DwarfStar runtime.
 - MLX MTP and EAGLE options do not apply; DwarfStar uses DSpark
 - Reasoning generation is supported, but reasoning and final-answer event
   separation is not yet complete in the AFM adapter
+
+Tool calling is implemented in AFM-owned interface code, without modifying the
+DwarfStar dependency. AFM renders tool schemas and prior calls using DeepSeek's
+DSML contract, passes tool results back as transcript messages, and converts
+generated DSML blocks into typed `AFMGenerationEvent.toolCall` events. DwarfStar
+still owns tokenization, sampling, cache state, batching, and Metal execution.
 
 These limitations are reported as capability errors. They do not modify or
 replace the corresponding MLX functionality.

--- a/docs/dwarfstar-runtime.md
+++ b/docs/dwarfstar-runtime.md
@@ -67,8 +67,8 @@ resident session reuse without introducing disk I/O into the decode hot path.
 - KV-cache quantization is unavailable through AFM because DwarfStar owns its
   cache representation
 - MLX MTP and EAGLE options do not apply; DwarfStar uses DSpark
-- Reasoning generation is supported, but reasoning and final-answer event
-  separation is not yet complete in the AFM adapter
+- Reasoning and final-answer streams are separated for both AFMKit consumers
+  and the macOS 27 Foundation Models executor channel
 
 Tool calling is implemented in AFM-owned interface code, without modifying the
 DwarfStar dependency. AFM renders tool schemas and prior calls using DeepSeek's


### PR DESCRIPTION
## Summary

- add DwarfStar tool-call encoding, parsing, streaming events, and tool-result continuation
- expose DwarfStar through the AFMKit and macOS 27 Foundation Models provider interfaces
- wire DSpark speculative decoding through the generalized draft-depth capability
- add Hugging Face download progress reporting
- document the AFMKit public surface and DwarfStar runtime behavior

## Why

DwarfStar previously provided fast DeepSeek V4 inference but did not participate in the same AFMKit tool and Foundation Models contracts as the MLX runtime. DSpark support could also load successfully without being recognized as an active speculative provider because availability was checked through the legacy MTP-only capability.

## Validation

- Release XCTest: 610 executed, 2 fixture skips, 0 failures
- Swift Testing: 387 tests in 31 suites, 0 failures
- DeepSeek V4 Flash 0731 deterministic assertions: 450/477 passed, 2 skipped
- Comprehensive model matrix: 182 executions across 91 configurations, run without an AI judge
- Promptfoo: 336 passed, 50 failed, 2 errors
- DSpark activation confirmed through engine telemetry
- DSpark high-acceptance generation: 51.6 tok/s
- DSpark low-acceptance generation: 38.8 tok/s
- OpenAI required tool call passed with parsed arguments
- 4,071-token prefix cache reuse passed

## Known limitations

The remaining model-backed failures correspond to documented DwarfStar parity gaps: constrained decoding, logprobs, stop-text stripping, selected penalties, and disabled batch/file routes.

## Summary by Sourcery

Integrate DwarfStar as a full-featured AFMKit and macOS 27 Foundation Models provider, adding tool calling, reasoning streams, speculative decoding improvements, prefix caching, and enhanced Hugging Face download progress reporting.

New Features:
- Enable DeepSeek DSML-based tool calling and reasoning streams in the DwarfStar runtime and AFMKit model APIs.
- Expose a DwarfStar-backed `LanguageModel` and executor for macOS 27 Foundation Models, using a shared AFM FoundationModels adapter bridge.
- Provide a reusable AFM FoundationModels executor bridge and event channel adapter for translating AFMKit generation events into Apple’s `LanguageModelSession` contract.

Bug Fixes:
- Ensure DSpark speculative decoding activation is gated by generalized draft-depth availability instead of legacy MTP-only checks.

Enhancements:
- Add DwarfStar continuous batching policies, including mixed prefill/decode scheduling and rotating prefill slots to avoid prompt-induced stalls.
- Implement a DwarfStar prefix cache backed by the DS4 KV store with disk-backed checkpointing, environment-configurable budgets, and runtime telemetry.
- Extend DwarfStar generation results and streaming to include reasoning text, structured tool-call events, and prefix-cache statistics.
- Refactor macOS 27 Foundation Models request and event handling into public AFMFoundationModels adapters usable by multiple providers.
- Improve CLI model loading output with terminal-safe download progress bars, throughput, ETA, file-level status, and transport reporting.
- Augment Hugging Face model downloads with manifest-driven, per-file progress tracking and Xet/LFS-aware transport selection.

Build:
- Bump Swift tools version to 6.1 and add an opt-in `AFMKitFoundationModels27DwarfStar` product wired to the DwarfStar runtime and Foundation Models adapters.
- Adjust DwarfStar Metal resources to copy the upstream DS4 `metal` directory and add DS4 KV-store C shims for prefix caching.

Documentation:
- Document the AFMKit macOS 27 provider contract, including shared request adapters, executor bridge, and example MLX/DwarfStar models.
- Expand the DwarfStar runtime documentation with continuous batching behavior, prefix cache configuration, DSML tool calling, and reasoning/event separation.
- Update the README to mention the macOS 27 provider adapters and the opt-in DwarfStar provider product.

Tests:
- Add unit tests for DwarfStar scheduling, speculative policy, prefix cache identity and budgeting, DSML tool codec parsing/rendering, and tool/reasoning streaming behavior.
- Add macOS 27 tests verifying the DwarfStar `LanguageModel` publishes reasoning and tool-calling capabilities and respects executor configuration.
- Add tests for Hugging Face download progress enrichment, including active/completed file reporting and Xet-backed file size sampling.
- Update DwarfStar provider tests to assert reasoning and toolCalling capabilities are advertised.