### PR TITLE
Fix Xet transport reporting and DeepSeek admission visibility

### DIFF
--- a/Sources/AFMKitMLX/AFMDownloadProgress.swift
+++ b/Sources/AFMKitMLX/AFMDownloadProgress.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// AFM metadata attached to Hugging Face snapshot `Progress` instances.
 ///
@@ -9,12 +10,36 @@ public enum AFMDownloadProgressUserInfo {
     public static let currentFiles = ProgressUserInfoKey("com.maclocal.afm.download.current-files")
     public static let completedFiles = ProgressUserInfoKey("com.maclocal.afm.download.completed-files")
     public static let totalFiles = ProgressUserInfoKey("com.maclocal.afm.download.total-files")
+    public static let currentTransports = ProgressUserInfoKey("com.maclocal.afm.download.current-transports")
 
     struct File: @unchecked Sendable {
         let path: String
         let expectedBytes: Int64
         let destination: URL?
         let progress: Progress
+        let transport: OSAllocatedUnfairLock<String>
+
+        init(
+            path: String,
+            expectedBytes: Int64,
+            destination: URL?,
+            progress: Progress,
+            transport: String = "pending"
+        ) {
+            self.path = path
+            self.expectedBytes = expectedBytes
+            self.destination = destination
+            self.progress = progress
+            self.transport = OSAllocatedUnfairLock(initialState: transport)
+        }
+
+        func setTransport(_ value: String) {
+            transport.withLock { $0 = value }
+        }
+
+        var currentTransport: String {
+            transport.withLock { $0 }
+        }
     }
 
     static func enrich(_ progress: Progress, files: [File]) {
@@ -22,10 +47,13 @@ public enum AFMDownloadProgressUserInfo {
         var completed = 0
         var completedBytes: Int64 = 0
         var active: [String] = []
+        var activeTransports: [String] = []
         var firstPending: String?
+        var firstPendingTransport: String?
         for file in files {
             let path = file.path
             let child = file.progress
+            let transport = file.currentTransport
             if let destination = file.destination,
                let attributes = try? FileManager.default.attributesOfItem(atPath: destination.path),
                let size = (attributes[.size] as? NSNumber)?.int64Value,
@@ -36,14 +64,24 @@ public enum AFMDownloadProgressUserInfo {
                child.completedUnitCount >= child.totalUnitCount {
                 completed += 1
             } else {
-                if firstPending == nil { firstPending = path }
-                if child.completedUnitCount > 0 { active.append(path) }
+                if firstPending == nil {
+                    firstPending = path
+                    firstPendingTransport = transport
+                }
+                if child.completedUnitCount > 0 {
+                    active.append(path)
+                    activeTransports.append(transport)
+                }
             }
             completedBytes += min(child.completedUnitCount, file.expectedBytes)
         }
-        if active.isEmpty, let firstPending { active = [firstPending] }
+        if active.isEmpty, let firstPending {
+            active = [firstPending]
+            activeTransports = [firstPendingTransport ?? "pending"]
+        }
         progress.completedUnitCount = min(completedBytes, progress.totalUnitCount)
         progress.setUserInfoObject(active, forKey: currentFiles)
+        progress.setUserInfoObject(activeTransports, forKey: currentTransports)
         progress.setUserInfoObject(completed, forKey: completedFiles)
         progress.setUserInfoObject(files.count, forKey: totalFiles)
     }

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -44,6 +44,10 @@ actor BatchScheduler {
 
     /// Default maximum concurrent generations.
     static let defaultMaxConcurrent = 8
+    /// Small admission window for concurrent bursts. Without this, the first
+    /// request can start a one-slot prefill/decode before peer requests created
+    /// by the same client batch reach the queue, which looks like serial TTFT.
+    static let defaultAdmissionWindowNanoseconds: UInt64 = 8_000_000
 
     let maxConcurrent: Int
     private let model: any LanguageModel
@@ -52,6 +56,7 @@ actor BatchScheduler {
     private let processor: any UserInputProcessor
     private let configuration: ModelConfiguration
     private let cacheProfilePath: String?
+    private let admissionWindowNanoseconds: UInt64
 
     /// EOS token IDs built once at init.
     private let eosTokenIds: Set<Int>
@@ -476,7 +481,8 @@ actor BatchScheduler {
         configuration: ModelConfiguration,
         maxConcurrent: Int = BatchScheduler.defaultMaxConcurrent,
         enablePrefixCaching: Bool = false,
-        cacheProfilePath: String? = nil
+        cacheProfilePath: String? = nil,
+        admissionWindowNanoseconds: UInt64 = BatchScheduler.defaultAdmissionWindowNanoseconds
     ) {
         self.model = model
         self.tokenizer = tokenizer
@@ -484,6 +490,7 @@ actor BatchScheduler {
         self.configuration = configuration
         self.maxConcurrent = maxConcurrent
         self.cacheProfilePath = cacheProfilePath
+        self.admissionWindowNanoseconds = admissionWindowNanoseconds
 
         let debug = ProcessInfo.processInfo.environment["AFM_DEBUG"] == "1"
         self.radixCache = RadixTreeCache(
@@ -587,12 +594,40 @@ actor BatchScheduler {
 
     /// Drain all pending requests from the nonisolated queue.
     /// Called from within the actor-isolated generationLoop.
-    private func drainPendingQueue() -> [PendingRequest] {
+    private func drainPendingQueue(limit: Int? = nil) -> [PendingRequest] {
         _pendingQueue.withLock { q in
-            let result = q
-            q.removeAll()
+            let result: [PendingRequest]
+            if let limit, q.count > limit {
+                result = Array(q.prefix(limit))
+                q.removeFirst(limit)
+            } else {
+                result = q
+                q.removeAll()
+            }
             return result
         }
+    }
+
+    /// Give same-burst requests a bounded chance to join an empty scheduler.
+    /// This is intentionally tiny and only applies before the first active slot;
+    /// it improves fairness for concurrent/batch clients without adding per-token
+    /// latency once generation is in progress.
+    private func drainAdmissionBatch() async -> [PendingRequest] {
+        var requests = drainPendingQueue(limit: maxConcurrent)
+        guard slots.isEmpty,
+              requests.count == 1,
+              maxConcurrent > 1,
+              admissionWindowNanoseconds > 0
+        else {
+            return requests
+        }
+
+        try? await Task.sleep(nanoseconds: admissionWindowNanoseconds)
+        let remainingCapacity = max(0, maxConcurrent - requests.count)
+        if remainingCapacity > 0 {
+            requests.append(contentsOf: drainPendingQueue(limit: remainingCapacity))
+        }
+        return requests
     }
 
     /// Gracefully shut down.
@@ -664,8 +699,9 @@ actor BatchScheduler {
         while !_isShutdown.withLock({ $0 }) {
             let stepStart = debugTiming ? Date() : Date.distantPast
 
-            // Drain nonisolated queue — no Task.yield() needed for request pickup
-            let newRequests = drainPendingQueue()
+            // Drain nonisolated queue. When idle, wait a bounded admission
+            // window so same-burst concurrent requests start together.
+            let newRequests = await drainAdmissionBatch()
             if !newRequests.isEmpty {
                 // Separate capacity-limited requests from overflow
                 var accepted: [PendingRequest] = []
@@ -722,6 +758,14 @@ actor BatchScheduler {
 
             // --- Batched decode: build graph from lastTokenArray (CPU, ~2.7ms) ---
             let activeB = slots.count
+            if activeB > 1, stepCount == 0 || stepCount % 256 == 0 {
+                let deepseekHybrid = batchCaches.contains {
+                    $0 is BatchDeepseekV4Cache || $0 is DeepseekV4Cache
+                }
+                if deepseekHybrid {
+                    print("[\(batchTs())] [BatchScheduler] DeepSeek V4 hybrid decode: B=\(activeB) row-split attention path")
+                }
+            }
             let tokens: MLXArray
             if activeB == 1 {
                 tokens = slots[0].lastTokenArray.reshaped([1, 1])

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -5046,7 +5046,7 @@ public final class MLXModelService: @unchecked Sendable {
                 patterns.contains { fnmatch($0, entry.path, 0) == 0 }
             }
             if let revision, !manifest.isEmpty {
-                print("Hugging Face transport: automatic (Xet for large files, LFS fallback)")
+                print("Hugging Face transport: explicit (small=LFS, large=Xet-first with LFS fallback)")
                 try await downloadManifest(
                     manifest,
                     repoID: repoID,
@@ -5117,6 +5117,7 @@ public final class MLXModelService: @unchecked Sendable {
                 }
                 group.addTask {
                     do {
+                        files[index].setTransport("lfs")
                         try FileManager.default.createDirectory(
                             at: files[index].destination!.deletingLastPathComponent(),
                             withIntermediateDirectories: true)
@@ -5149,20 +5150,37 @@ public final class MLXModelService: @unchecked Sendable {
             for try await _ in group {}
         }
 
-        // Match the official snapshot policy: large Xet files are processed
-        // sequentially while each Xet transfer uses its own parallel CAS fetches.
+        // Large files are processed sequentially while each Xet transfer uses
+        // its own parallel CAS fetches. Try Xet explicitly so logs/progress can
+        // report the transport that actually succeeded; fall back to LFS only
+        // when Xet is unavailable for that file/environment.
         for (index, entry) in xetEntries {
             do {
                 try FileManager.default.createDirectory(
                     at: files[index].destination!.deletingLastPathComponent(),
                     withIntermediateDirectories: true)
-                _ = try await client.downloadFile(
-                    entry,
-                    from: repoID,
-                    to: files[index].destination,
-                    revision: revision,
-                    progress: files[index].progress,
-                    transport: .automatic)
+                do {
+                    files[index].setTransport("xet")
+                    print("Hugging Face transport selected: xet file=\(entry.path)")
+                    _ = try await client.downloadFile(
+                        entry,
+                        from: repoID,
+                        to: files[index].destination,
+                        revision: revision,
+                        progress: files[index].progress,
+                        transport: .xet)
+                } catch {
+                    files[index].setTransport("xet-fallback-lfs")
+                    print("Hugging Face transport fallback: xet failed for \(entry.path): \(error.localizedDescription); retrying with lfs")
+                    try? FileManager.default.removeItem(at: files[index].destination!)
+                    _ = try await client.downloadFile(
+                        entry,
+                        from: repoID,
+                        to: files[index].destination,
+                        revision: revision,
+                        progress: files[index].progress,
+                        transport: .lfs)
+                }
                 try await cache.storeFile(
                     at: files[index].destination!,
                     repo: repoID,

--- a/Tests/MacLocalAPITests/AFMDownloadProgressTests.swift
+++ b/Tests/MacLocalAPITests/AFMDownloadProgressTests.swift
@@ -12,9 +12,9 @@ final class AFMDownloadProgressTests: XCTestCase {
         active.completedUnitCount = 25
 
         let files = [
-            AFMDownloadProgressUserInfo.File(path: "config.json", expectedBytes: 100, destination: nil, progress: complete),
-            AFMDownloadProgressUserInfo.File(path: "weights-01.safetensors", expectedBytes: 100, destination: nil, progress: active),
-            AFMDownloadProgressUserInfo.File(path: "weights-02.safetensors", expectedBytes: 100, destination: nil, progress: pending),
+            AFMDownloadProgressUserInfo.File(path: "config.json", expectedBytes: 100, destination: nil, progress: complete, transport: "lfs"),
+            AFMDownloadProgressUserInfo.File(path: "weights-01.safetensors", expectedBytes: 100, destination: nil, progress: active, transport: "xet"),
+            AFMDownloadProgressUserInfo.File(path: "weights-02.safetensors", expectedBytes: 100, destination: nil, progress: pending, transport: "pending"),
         ]
         AFMDownloadProgressUserInfo.enrich(root, files: files)
 
@@ -23,6 +23,9 @@ final class AFMDownloadProgressTests: XCTestCase {
         XCTAssertEqual(
             root.userInfo[AFMDownloadProgressUserInfo.currentFiles] as? [String],
             ["weights-01.safetensors"])
+        XCTAssertEqual(
+            root.userInfo[AFMDownloadProgressUserInfo.currentTransports] as? [String],
+            ["xet"])
     }
 
     func testEnrichmentNamesFirstPendingFileBeforeBytesArrive() {
@@ -40,7 +43,31 @@ final class AFMDownloadProgressTests: XCTestCase {
         XCTAssertEqual(
             root.userInfo[AFMDownloadProgressUserInfo.currentFiles] as? [String],
             ["a.bin"])
+        XCTAssertEqual(
+            root.userInfo[AFMDownloadProgressUserInfo.currentTransports] as? [String],
+            ["pending"])
         XCTAssertEqual(root.userInfo[AFMDownloadProgressUserInfo.completedFiles] as? Int, 0)
+    }
+
+    func testEnrichmentPublishesFallbackTransportForPendingFile() {
+        let root = Progress(totalUnitCount: 100)
+        let child = Progress(totalUnitCount: 100)
+        let file = AFMDownloadProgressUserInfo.File(
+            path: "weights.safetensors",
+            expectedBytes: 100,
+            destination: nil,
+            progress: child,
+            transport: "xet")
+        file.setTransport("xet-fallback-lfs")
+
+        AFMDownloadProgressUserInfo.enrich(root, files: [file])
+
+        XCTAssertEqual(
+            root.userInfo[AFMDownloadProgressUserInfo.currentFiles] as? [String],
+            ["weights.safetensors"])
+        XCTAssertEqual(
+            root.userInfo[AFMDownloadProgressUserInfo.currentTransports] as? [String],
+            ["xet-fallback-lfs"])
     }
 
     func testEnrichmentSamplesGrowingXetDestination() throws {

--- a/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
+++ b/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
@@ -134,6 +134,12 @@ struct ConcurrentBatchTests {
         #expect(BatchScheduler.defaultMaxConcurrent == 8)
     }
 
+    @Test("BatchScheduler admission window is enabled for burst fairness")
+    func defaultAdmissionWindowEnabled() {
+        #expect(BatchScheduler.defaultAdmissionWindowNanoseconds > 0)
+        #expect(BatchScheduler.defaultAdmissionWindowNanoseconds <= 20_000_000)
+    }
+
     @Test("BatchScheduler supports DeepSeek hybrid cache through its batch container")
     func supportsDeepseekHybridCacheBatching() {
         let cache = DeepseekV4Cache(slidingWindow: 128, compressRatio: 4)

--- a/docs/deepseek-v4-0731-rejected-experiments.md
+++ b/docs/deepseek-v4-0731-rejected-experiments.md
@@ -184,6 +184,15 @@ profiling unless Apple exposes a scriptable shader-profiler export.
 
 - Never benchmark Debug. It has repeatedly produced misleadingly poor and
   irregular throughput.
+- Do not close DeepSeek V4 MLX concurrency regressions solely because the old
+  reshape crash path is gone. A Release live run on 2026-08-11 with four
+  simultaneous `DeepSeek-V4-Flash-0731-AFM-MLX` requests showed the scheduler
+  entering `DeepSeek V4 hybrid decode: B=4 row-split attention path`; per-request
+  decode was still roughly 11-14 tok/s for the concurrent short workload while
+  single-request natural-language decode remained about 27 tok/s. The admission
+  window helps same-burst fairness and makes the behavior visible, but true
+  production parity requires a dense DeepSeek V4 batch cache/attention path,
+  not only scheduler tuning.
 - Do not include model loading in decode throughput. Use one warmed Release
   server and report both server generation time and request wall time.
 - Do not use a counting prompt alone as proof of general DSpARK performance;


### PR DESCRIPTION
## Summary

- enable explicit large-file Xet-first downloads with visible LFS fallback and transport metadata in aggregate progress
- preserve small-file LFS concurrency while reporting active transport state for download progress consumers
- add a bounded BatchScheduler admission window so same-burst concurrent requests can enter together before decode begins
- log when DeepSeek V4 MLX concurrency is using the hybrid row-split attention path
- document that #162 is not fully closed by scheduler tuning; the remaining bottleneck is the DeepSeek V4 dense/concurrent cache-attention path

Closes #164
Refs #162

## Validation

- `Scripts/swiftpm-reliable.sh test -c release --filter 'AFMDownloadProgressTests|ConcurrentBatchTests'`\n- Live Release DeepSeek 0731 MLX run on `/Volumes/edata/models/vesta-test-cache/deepseek-ai/DeepSeek-V4-Flash-0731-AFM-MLX` with `--concurrent 4` confirmed the new diagnostic marker and showed the remaining row-split limitation: B=4 concurrent short workload decoded around 11-14 tok/s per request.\n

## Summary by Sourcery

Improve Hugging Face download transport reporting and DeepSeek V4 batch scheduling visibility and fairness.

New Features:
- Expose per-file transport state in aggregated download progress, including pending, Xet, and Xet-fallback-to-LFS states.
- Log DeepSeek V4 hybrid row-split attention usage during batched decode to make concurrency path selection visible.
- Add a bounded BatchScheduler admission window so concurrent burst requests can enter together before the first decode begins.

Enhancements:
- Prefer explicit Xet-first downloads for large files with an LFS fallback so logs and progress reflect the actual transport used.

Documentation:
- Clarify that DeepSeek V4 concurrency regressions are only partially addressed by scheduler tuning and still require a dense batch cache/attention path for full parity.

Tests:
- Extend AFM download progress tests to cover transport metadata propagation and fallback reporting.
- Add a BatchScheduler test ensuring the admission window is enabled and bounded for burst fairness.