### PR TITLE
Improve DeepSeek V4 concurrent cache batching

### DIFF
--- a/Scripts/patches/DeepseekV4.swift
+++ b/Scripts/patches/DeepseekV4.swift
@@ -552,6 +552,9 @@ class DeepseekV4Attention: Module {
             precondition(
                 batchCache.count == x.dim(0),
                 "DeepSeek V4 batch cache count must match the hidden-state batch")
+            precondition(
+                x.dim(1) == 1,
+                "DeepSeek V4 cache batching supports decode-only single-token rows")
             // DwarfStar keeps one mutable cache timeline per request, but
             // executes the model projections for all decode-ready sessions as
             // one GPU batch. Mirror that split here: Q/KV projections and head
@@ -858,7 +861,8 @@ class DeepseekV4Attention: Module {
         var grouped = derotated.transposed(0, 2, 1, 3)
             .reshaped(batch, length, oGroups, groupFeatures)
 
-        if let quantized = woA as? DeepseekV4QuantizedLinear,
+        if Self.quantizedGroupedWoA,
+            let quantized = woA as? DeepseekV4QuantizedLinear,
             quantized.usesSymmetricQ8Storage || quantized.usesQ80Storage
         {
             let projectedA = quantized.symmetricQ8Grouped(
@@ -867,7 +871,8 @@ class DeepseekV4Attention: Module {
             return woB(projectedA)
         }
 
-        if let quantized = woA as? QuantizedLinear,
+        if Self.quantizedGroupedWoA,
+            let quantized = woA as? QuantizedLinear,
             quantized.mode == .mxfp8,
             quantized.groupSize == 32,
             quantized.bits == 8,

--- a/Scripts/patches/DeepseekV4.swift
+++ b/Scripts/patches/DeepseekV4.swift
@@ -138,6 +138,10 @@ private enum DeepseekV4RuntimeOptions {
         return kernels == "native"
             && enabled("VMLX_DSV4_DSPARK_HEAD_GEMV", default: true)
     }
+
+    static var dwarfStarCacheBatchingEnabled: Bool {
+        enabled("VMLX_DSV4_DWARFSTAR_CACHE_BATCH", default: true)
+    }
 }
 
 private enum DeepseekV4NumericTrace {
@@ -528,11 +532,11 @@ class DeepseekV4Attention: Module {
     func callAsFunction(
         _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
     ) -> MLXArray {
-        if let batchCache = cache as? BatchDeepseekV4Cache {
-            precondition(
-                batchCache.count == x.dim(0),
-                "DeepSeek V4 batch cache count must match the hidden-state batch")
-            let rows = (0..<batchCache.count).map { index -> MLXArray in
+        if let batchCache = cache as? BatchDeepseekV4Cache,
+            !DeepseekV4RuntimeOptions.dwarfStarCacheBatchingEnabled
+        {
+            precondition(batchCache.count == x.dim(0))
+            return concatenated((0..<batchCache.count).map { index in
                 let row = x[index ..< index + 1]
                 let rowCache = batchCache.cache(at: index)
                 let rowMask = createAttentionMask(
@@ -540,8 +544,57 @@ class DeepseekV4Attention: Module {
                     cache: rowCache,
                     returnArray: row.dim(1) > 1 && rowCache.offset > 0)
                 return callAsFunction(row, mask: rowMask, cache: rowCache)
+            }, axis: 0)
+        }
+        if let batchCache = cache as? BatchDeepseekV4Cache,
+            DeepseekV4RuntimeOptions.dwarfStarCacheBatchingEnabled
+        {
+            precondition(
+                batchCache.count == x.dim(0),
+                "DeepSeek V4 batch cache count must match the hidden-state batch")
+            // DwarfStar keeps one mutable cache timeline per request, but
+            // executes the model projections for all decode-ready sessions as
+            // one GPU batch. Mirror that split here: Q/KV projections and head
+            // normalization are cache-independent, so build them once for B
+            // rows. Only RoPE, compressor/indexer state, cache update, and
+            // attention remain request-specific below.
+            let projected = projectUnrotatedBatch(x)
+            let compressorProjected = compressor?.project(x)
+            let indexerCompressorProjected = indexer?.compressor.project(x)
+            var descriptors: [DeepseekV4DecodeDescriptor] = []
+            descriptors.reserveCapacity(batchCache.count)
+            for index in 0..<batchCache.count {
+                let row = x[index ..< index + 1]
+                let rowCache = batchCache.cache(at: index)
+                let offset = rowCache.offset
+                let (cosT, sinT) = rope.cosSin(offset: offset, length: row.dim(1))
+                let cosExpanded = cosT.expandedDimensions(axes: [0, 1])
+                let sinExpanded = sinT.expandedDimensions(axes: [0, 1])
+                let q = DeepseekV4Math.applyPartialRoPE(
+                    projected.q[index ..< index + 1],
+                    cos: cosExpanded, sin: sinExpanded, ropeDim: ropeDim)
+                var kv = DeepseekV4Math.applyPartialRoPE(
+                    projected.kv[index ..< index + 1],
+                    cos: cosExpanded, sin: sinExpanded, ropeDim: ropeDim)
+                let nopeDim = headDim - ropeDim
+                if config.activationQATEnabled && nopeDim >= 64 {
+                    kv = DeepseekV4Math.e4m3KVActivationRoundTrip(kv, ropeDim: ropeDim)
+                }
+                descriptors.append(prepareDecodeDescriptor(
+                    x: row,
+                    q: q,
+                    kv: kv,
+                    qResidual: projected.qResidual[index ..< index + 1],
+                    compressorKV: compressorProjected?.kv[index ..< index + 1],
+                    compressorGate: compressorProjected?.gate[index ..< index + 1],
+                    indexerCompressorKV: indexerCompressorProjected?.kv[index ..< index + 1],
+                    indexerCompressorGate: indexerCompressorProjected?.gate[index ..< index + 1],
+                    cosT: cosT,
+                    sinT: sinT,
+                    cache: rowCache,
+                    offset: offset))
             }
-            return concatenated(rows, axis: 0)
+            return attendDecodeBatch(descriptors)
         }
 
         let B = x.dim(0)
@@ -646,6 +699,207 @@ class DeepseekV4Attention: Module {
             mask: mask,
             cache: cache,
             offset: offset)
+    }
+
+    private func projectUnrotatedBatch(
+        _ x: MLXArray
+    ) -> (q: MLXArray, kv: MLXArray, qResidual: MLXArray) {
+        let batch = x.dim(0)
+        let length = x.dim(1)
+        let qResidual = qNorm(wqA(x))
+        var q = wqB(qResidual).reshaped(batch, length, numHeads, headDim)
+        let qDType = q.dtype
+        let qFloat = q.asType(.float32)
+        q = (qFloat * rsqrt(
+            (qFloat * qFloat).mean(axis: -1, keepDims: true)
+                + config.rmsNormEps)).asType(qDType)
+        q = q.transposed(0, 2, 1, 3)
+
+        let kv = kvNorm(wkv(x))
+            .reshaped(batch, length, 1, headDim)
+            .transposed(0, 2, 1, 3)
+        return (q, kv, qResidual)
+    }
+
+    /// The MLX equivalent of a DwarfStar decode-session descriptor. Mutable
+    /// cache state stays owned by the request; only its ready attention view
+    /// is gathered into the current GPU execution epoch.
+    private struct DeepseekV4DecodeDescriptor {
+        let q: MLXArray
+        let fullKV: MLXArray
+        let cos: MLXArray
+        let sin: MLXArray
+    }
+
+    private func prepareDecodeDescriptor(
+        x: MLXArray,
+        q: MLXArray,
+        kv: MLXArray,
+        qResidual: MLXArray,
+        compressorKV: MLXArray?,
+        compressorGate: MLXArray?,
+        indexerCompressorKV: MLXArray?,
+        indexerCompressorGate: MLXArray?,
+        cosT: MLXArray,
+        sinT: MLXArray,
+        cache: DeepseekV4Cache,
+        offset: Int
+    ) -> DeepseekV4DecodeDescriptor {
+        precondition(x.dim(0) == 1 && x.dim(1) == 1)
+        var (fullKV, _) = cache.update(keys: kv, values: kv)
+
+        if compressRatio > 0, let comp = compressor {
+            let fallbackProjection = (compressorKV == nil || compressorGate == nil)
+                ? comp.project(x) : nil
+            let projectedKV = compressorKV ?? fallbackProjection!.kv
+            let projectedGate = compressorGate ?? fallbackProjection!.gate
+            var pooled = comp.updateProjected(
+                kv: projectedKV,
+                gate: projectedGate,
+                inputDType: x.dtype,
+                rope: rope,
+                v4Cache: cache,
+                startPos: offset)
+            let pooledCount = pooled.dim(1)
+            var topK: MLXArray? = nil
+            if compressRatio == 4, let idx = indexer {
+                if let indexerCompressorKV, let indexerCompressorGate {
+                    topK = idx.callAsFunctionProjected(
+                        x, qResidual: qResidual,
+                        compressorKV: indexerCompressorKV,
+                        compressorGate: indexerCompressorGate,
+                        rope: rope, positionRope: rope,
+                        v4Cache: cache, startPos: offset)
+                } else {
+                    topK = idx(
+                        x, qResidual: qResidual, rope: rope,
+                        positionRope: rope, v4Cache: cache, startPos: offset)
+                }
+            }
+            if pooledCount > 0 {
+                if let topK {
+                    let selectedCount = topK.dim(-1)
+                    let expanded = pooled.expandedDimensions(axes: [1, 2])
+                    let pooledBroad = broadcast(
+                        expanded, to: [1, 1, 1, pooledCount, headDim])
+                    let indexBroad = broadcast(
+                        topK.expandedDimensions(axes: [1, 4]),
+                        to: [1, 1, 1, selectedCount, headDim])
+                    pooled = takeAlong(pooledBroad, indexBroad, axis: 3)
+                        .reshaped(1, 1, selectedCount, headDim)
+                } else {
+                    pooled = pooled.expandedDimensions(axis: 1)
+                }
+                if pooled.dim(2) > 0 {
+                    fullKV = concatenated([fullKV, pooled], axis: 2)
+                }
+            }
+        }
+
+        return DeepseekV4DecodeDescriptor(
+            q: q, fullKV: fullKV, cos: cosT, sin: sinT)
+    }
+
+    private func attendDecodeBatch(
+        _ descriptors: [DeepseekV4DecodeDescriptor]
+    ) -> MLXArray {
+        precondition(!descriptors.isEmpty)
+        let maximumKeyCount = descriptors.map { $0.fullKV.dim(2) }.max() ?? 0
+        var keyRows: [MLXArray] = []
+        var maskRows: [MLXArray] = []
+        keyRows.reserveCapacity(descriptors.count)
+        maskRows.reserveCapacity(descriptors.count)
+
+        for descriptor in descriptors {
+            let keyCount = descriptor.fullKV.dim(2)
+            let padding = maximumKeyCount - keyCount
+            if padding > 0 {
+                let zeroPadding = MLXArray.zeros(
+                    [1, 1, padding, headDim], dtype: descriptor.fullKV.dtype)
+                keyRows.append(concatenated([zeroPadding, descriptor.fullKV], axis: 2))
+                maskRows.append(concatenated([
+                    MLXArray.zeros([1, 1, 1, padding], dtype: .bool),
+                    MLXArray.ones([1, 1, 1, keyCount], dtype: .bool),
+                ], axis: -1))
+            } else {
+                keyRows.append(descriptor.fullKV)
+                maskRows.append(MLXArray.ones(
+                    [1, 1, 1, keyCount], dtype: .bool))
+            }
+        }
+
+        let output = MLXFast.scaledDotProductAttention(
+            queries: concatenated(descriptors.map(\.q), axis: 0),
+            keys: concatenated(keyRows, axis: 0),
+            values: concatenated(keyRows, axis: 0),
+            scale: scale,
+            mask: .array(concatenated(maskRows, axis: 0)),
+            sinks: config.useAttnSink
+                ? attnSink.asType(descriptors[0].q.dtype) : nil)
+
+        // RoPE offsets remain session-specific. The inverse transform is
+        // lightweight; the expensive grouped wo_a/wo_b projection below is
+        // executed once for the complete batch.
+        let derotated = concatenated(descriptors.indices.map { index in
+            DeepseekV4Math.applyPartialRoPE(
+                output[index ..< index + 1],
+                cos: descriptors[index].cos.expandedDimensions(axes: [0, 1]),
+                sin: descriptors[index].sin.expandedDimensions(axes: [0, 1]),
+                ropeDim: ropeDim,
+                inverse: true)
+        }, axis: 0)
+        return projectDerotatedAttentionOutput(derotated)
+    }
+
+    private func projectDerotatedAttentionOutput(_ derotated: MLXArray) -> MLXArray {
+        let batch = derotated.dim(0)
+        let length = derotated.dim(2)
+        let groupFeatures = (numHeads * headDim) / oGroups
+        var grouped = derotated.transposed(0, 2, 1, 3)
+            .reshaped(batch, length, oGroups, groupFeatures)
+
+        if let quantized = woA as? DeepseekV4QuantizedLinear,
+            quantized.usesSymmetricQ8Storage || quantized.usesQ80Storage
+        {
+            let projectedA = quantized.symmetricQ8Grouped(
+                grouped, outputGroups: oGroups)
+                .reshaped(batch, length, oGroups * oLoraRank)
+            return woB(projectedA)
+        }
+
+        if let quantized = woA as? QuantizedLinear,
+            quantized.mode == .mxfp8,
+            quantized.groupSize == 32,
+            quantized.bits == 8,
+            quantized.biases == nil
+        {
+            if Self.quantizedGroupedWoAActivationQAT {
+                grouped = DeepseekV4ActivationQuant.e4m3RoundTripIfNeeded(
+                    grouped, mode: .mxfp8)
+            }
+            let packedWeight = quantized.weight.reshaped(
+                oGroups, oLoraRank, quantized.weight.dim(-1))
+            let groupedScales = quantized.scales.reshaped(
+                oGroups, oLoraRank, quantized.scales.dim(-1))
+            let projectedA = quantizedMM(
+                grouped.expandedDimensions(axis: -2),
+                packedWeight,
+                scales: groupedScales,
+                biases: nil,
+                transpose: true,
+                groupSize: 32,
+                bits: 8,
+                mode: .mxfp8
+            ).squeezed(axis: -2)
+                .reshaped(batch, length, oGroups * oLoraRank)
+            return woB(projectedA)
+        }
+
+        let projectedA = einsum(
+            "bsgd,grd->bsgr", grouped,
+            groupedOutputWeight(dtype: derotated.dtype))
+            .reshaped(batch, length, oGroups * oLoraRank)
+        return woB(projectedA)
     }
 
     private func attend(

--- a/Scripts/patches/DeepseekV4Compressor.swift
+++ b/Scripts/patches/DeepseekV4Compressor.swift
@@ -907,12 +907,43 @@ public final class DeepseekV4Compressor: Module {
         startPos: Int,
         branch: DeepseekV4Cache.BranchKey = .compressor
     ) -> MLXArray {
-        let B = x.dim(0)
+        let projected = project(x)
+        return updateProjected(
+            kv: projected.kv,
+            gate: projected.gate,
+            inputDType: x.dtype,
+            rope: rope,
+            v4Cache: v4Cache,
+            startPos: startPos,
+            branch: branch)
+    }
+
+    /// Cache-independent compressor projections. Batch decode calls execute
+    /// these two linears once for all ready sessions, then feed each row into
+    /// its private cache timeline with `updateProjected`.
+    func project(_ x: MLXArray) -> (kv: MLXArray, gate: MLXArray) {
         // Official 0731 stages the compressor projections and pooling state
         // in fp32. This must happen before the linears, not merely after them.
         let projectionInput = x.asType(.float32)
-        var kv = wkv(projectionInput)
-        var gate = wgate(projectionInput)
+        return (wkv(projectionInput), wgate(projectionInput))
+    }
+
+    /// Advances one request's compressor state from already-projected rows.
+    /// The tensors must retain a batch dimension of one because pool windows,
+    /// offsets, and incomplete tails are deliberately request-owned.
+    func updateProjected(
+        kv projectedKV: MLXArray,
+        gate projectedGate: MLXArray,
+        inputDType: DType,
+        rope: DeepseekV4RoPE,
+        v4Cache: DeepseekV4Cache?,
+        startPos: Int,
+        branch: DeepseekV4Cache.BranchKey = .compressor
+    ) -> MLXArray {
+        precondition(projectedKV.dim(0) == 1 && projectedGate.dim(0) == 1)
+        let B = projectedKV.dim(0)
+        var kv = projectedKV
+        var gate = projectedGate
 
         var poolBase = startPos
         let alreadyWindowed: Bool
@@ -956,7 +987,7 @@ public final class DeepseekV4Compressor: Module {
         }
 
         if kv.dim(1) == 0 {
-            let empty = MLXArray.zeros([B, 0, headDim], dtype: x.dtype)
+            let empty = MLXArray.zeros([B, 0, headDim], dtype: inputDType)
             if let cache = v4Cache {
                 return cache.getPooled(branch) ?? empty
             }
@@ -989,7 +1020,7 @@ public final class DeepseekV4Compressor: Module {
             softmax(gateWin.asType(.float32), axis: 2, precise: true).asType(
                 kvWin.dtype)
         var pooled = (kvWin * weights).sum(axis: 2)
-        pooled = norm(pooled.asType(x.dtype))
+        pooled = norm(pooled.asType(inputDType))
 
         // Apply RoPE at the chunk centers (position = chunk_idx * ratio
         // + pool_base).
@@ -1241,9 +1272,33 @@ public final class DeepseekV4Indexer: Module {
         v4Cache: DeepseekV4Cache?,
         startPos: Int
     ) -> MLXArray? {
-        let pooled = compressor(
-            x, rope: rope, v4Cache: v4Cache,
-            startPos: startPos, branch: .indexer)
+        let projected = compressor.project(x)
+        return callAsFunctionProjected(
+            x, qResidual: qResidual,
+            compressorKV: projected.kv,
+            compressorGate: projected.gate,
+            rope: rope, positionRope: positionRope,
+            v4Cache: v4Cache, startPos: startPos)
+    }
+
+    func callAsFunctionProjected(
+        _ x: MLXArray,
+        qResidual: MLXArray,
+        compressorKV: MLXArray,
+        compressorGate: MLXArray,
+        rope: DeepseekV4RoPE,
+        positionRope: DeepseekV4RoPE,
+        v4Cache: DeepseekV4Cache?,
+        startPos: Int
+    ) -> MLXArray? {
+        let pooled = compressor.updateProjected(
+            kv: compressorKV,
+            gate: compressorGate,
+            inputDType: x.dtype,
+            rope: rope,
+            v4Cache: v4Cache,
+            startPos: startPos,
+            branch: .indexer)
         let pooledLen = pooled.dim(1)
         if pooledLen == 0 { return nil }
 

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -23,6 +23,7 @@ BIN=".build/release/afm"
 SECTION=""  # empty = run all sections; set to a number to run only that section
 GRAMMAR_CONSTRAINTS=false  # set via --grammar-constraints when server has --enable-grammar-constraints
 SAFE_PARTIAL_CACHE_MISS=false
+STRICT_TOOL_GRAMMAR_CAPABILITY="${AFM_ASSERTIONS_STRICT_TOOL_GRAMMAR:-auto}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 REPORT_DIR="${AFM_ASSERTIONS_REPORT_DIR:-$PROJECT_ROOT/test-reports}"
@@ -203,6 +204,9 @@ if should_run_section U && min_tier unit && [[ "${MACAFM_SWIFT_TEST_SKIP:-0}" !=
 
   t0=$(now_ms)
   swift_test_args=(test)
+  if [[ -n "${MACAFM_SWIFT_TEST_CONFIGURATION:-}" ]]; then
+    swift_test_args+=(-c "$MACAFM_SWIFT_TEST_CONFIGURATION")
+  fi
   if [[ -n "${MACAFM_SWIFT_TEST_SCRATCH_PATH:-}" ]]; then
     swift_test_args+=(--scratch-path "$MACAFM_SWIFT_TEST_SCRATCH_PATH")
   fi
@@ -333,6 +337,16 @@ if [ -f "$MODEL/config.json" ]; then
   model_config="$MODEL/config.json"
 elif [ -n "${MACAFM_MLX_MODEL_CACHE:-}" ] && [ -f "${MACAFM_MLX_MODEL_CACHE%/}/$MODEL/config.json" ]; then
   model_config="${MACAFM_MLX_MODEL_CACHE%/}/$MODEL/config.json"
+elif [ -n "${HF_HUB_CACHE:-}" ]; then
+  hf_model_dir="${HF_HUB_CACHE%/}/models--${MODEL//\//--}/snapshots"
+  if [ -d "$hf_model_dir" ]; then
+    for candidate in "$hf_model_dir"/*/config.json; do
+      if [ -f "$candidate" ]; then
+        model_config="$candidate"
+        break
+      fi
+    done
+  fi
 fi
 if [ -n "$model_config" ]; then
   SAFE_PARTIAL_CACHE_MISS=$(python3 - "$model_config" <<'PY'
@@ -342,7 +356,13 @@ with open(sys.argv[1], "r", encoding="utf-8") as handle:
     config = json.load(handle)
 
 text_config = config.get("text_config") or {}
-layer_types = text_config.get("layer_types") or config.get("layer_types") or []
+layer_types = (
+    text_config.get("layer_types")
+    or config.get("layer_types")
+    or text_config.get("layers_block_type")
+    or config.get("layers_block_type")
+    or []
+)
 recurrent_markers = ("linear", "mamba", "ssm", "delta", "recurrent")
 has_recurrent_layers = any(
     any(marker in str(layer_type).lower() for marker in recurrent_markers)
@@ -359,6 +379,21 @@ has_recurrent_layers = has_recurrent_layers or any(
 print("true" if has_recurrent_layers else "false")
 PY
   )
+  if [ "$STRICT_TOOL_GRAMMAR_CAPABILITY" = "auto" ]; then
+    STRICT_TOOL_GRAMMAR_CAPABILITY=$(python3 - "$model_config" <<'PY'
+import json, sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    config = json.load(handle)
+
+text_config = config.get("text_config") or {}
+model_type = str(text_config.get("model_type") or config.get("model_type") or "").lower()
+# DeepSeek V4 uses its native DSML parser. It supports tool calls, but the
+# xgrammar strict-tool backend currently supports only XML parser families.
+print("false" if model_type in {"deepseek_v4", "deepseekv4"} else "true")
+PY
+    )
+  fi
 fi
 if [ "$SAFE_PARTIAL_CACHE_MISS" = "true" ]; then
   echo "  Cache policy: recurrent hybrid; safe cold fallback is valid"
@@ -3693,21 +3728,25 @@ if should_run_section 14; then
   # the response should include X-Grammar-Constraints: downgraded.
   # When server DOES have --enable-grammar-constraints, the header should be absent.
   t0=$(now_ms)
-  header_resp=$(api_call_headers "{\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris?\"}],\"tools\":$STRICT_TOOL_14,\"max_tokens\":200,\"stream\":false,\"temperature\":0}")
-  dur=$(( $(now_ms) - t0 ))
-  if [ "$GRAMMAR_CONSTRAINTS" = true ]; then
+  if [ "$STRICT_TOOL_GRAMMAR_CAPABILITY" = "false" ]; then
+    run_test "StrictWiring" "Strict tool grammar header (unsupported parser)" "capability-aware skip" "SKIP" "$(( $(now_ms) - t0 ))"
+  else
+    header_resp=$(api_call_headers "{\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris?\"}],\"tools\":$STRICT_TOOL_14,\"max_tokens\":200,\"stream\":false,\"temperature\":0}")
+    dur=$(( $(now_ms) - t0 ))
+    if [ "$GRAMMAR_CONSTRAINTS" = true ]; then
     # Grammar enabled: header should be ABSENT
     if echo "$header_resp" | grep -qi 'X-Grammar-Constraints'; then
       run_test "StrictWiring" "Header absent when grammar enabled (tool strict:true)" "no header" "FAIL: header present" "$dur"
     else
       run_test "StrictWiring" "Header absent when grammar enabled (tool strict:true)" "no header" "PASS" "$dur"
     fi
-  else
+    else
     # Grammar not enabled: header should be "downgraded"
     if echo "$header_resp" | grep -qi 'X-Grammar-Constraints: downgraded'; then
       run_test "StrictWiring" "X-Grammar-Constraints: downgraded header (tool strict:true)" "downgraded" "PASS" "$dur"
     else
       run_test "StrictWiring" "X-Grammar-Constraints: downgraded header (tool strict:true)" "downgraded" "FAIL: header missing" "$dur"
+    fi
     fi
   fi
 

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -338,14 +338,14 @@ if [ -f "$MODEL/config.json" ]; then
 elif [ -n "${MACAFM_MLX_MODEL_CACHE:-}" ] && [ -f "${MACAFM_MLX_MODEL_CACHE%/}/$MODEL/config.json" ]; then
   model_config="${MACAFM_MLX_MODEL_CACHE%/}/$MODEL/config.json"
 elif [ -n "${HF_HUB_CACHE:-}" ]; then
-  hf_model_dir="${HF_HUB_CACHE%/}/models--${MODEL//\//--}/snapshots"
-  if [ -d "$hf_model_dir" ]; then
-    for candidate in "$hf_model_dir"/*/config.json; do
-      if [ -f "$candidate" ]; then
-        model_config="$candidate"
-        break
-      fi
-    done
+  hf_repo_dir="${HF_HUB_CACHE%/}/models--${MODEL//\//--}"
+  hf_main_ref="$hf_repo_dir/refs/main"
+  if [ -f "$hf_main_ref" ]; then
+    hf_revision=$(tr -d '\r\n' < "$hf_main_ref")
+    candidate="$hf_repo_dir/snapshots/$hf_revision/config.json"
+    if [ -f "$candidate" ]; then
+      model_config="$candidate"
+    fi
   fi
 fi
 if [ -n "$model_config" ]; then

--- a/Sources/AFMKitMLX/AFMDownloadProgress.swift
+++ b/Sources/AFMKitMLX/AFMDownloadProgress.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// AFM metadata attached to Hugging Face snapshot `Progress` instances.
 ///
@@ -9,12 +10,36 @@ public enum AFMDownloadProgressUserInfo {
     public static let currentFiles = ProgressUserInfoKey("com.maclocal.afm.download.current-files")
     public static let completedFiles = ProgressUserInfoKey("com.maclocal.afm.download.completed-files")
     public static let totalFiles = ProgressUserInfoKey("com.maclocal.afm.download.total-files")
+    public static let currentTransports = ProgressUserInfoKey("com.maclocal.afm.download.current-transports")
 
     struct File: @unchecked Sendable {
         let path: String
         let expectedBytes: Int64
         let destination: URL?
         let progress: Progress
+        let transport: OSAllocatedUnfairLock<String>
+
+        init(
+            path: String,
+            expectedBytes: Int64,
+            destination: URL?,
+            progress: Progress,
+            transport: String = "pending"
+        ) {
+            self.path = path
+            self.expectedBytes = expectedBytes
+            self.destination = destination
+            self.progress = progress
+            self.transport = OSAllocatedUnfairLock(initialState: transport)
+        }
+
+        func setTransport(_ value: String) {
+            transport.withLock { $0 = value }
+        }
+
+        var currentTransport: String {
+            transport.withLock { $0 }
+        }
     }
 
     static func enrich(_ progress: Progress, files: [File]) {
@@ -22,10 +47,13 @@ public enum AFMDownloadProgressUserInfo {
         var completed = 0
         var completedBytes: Int64 = 0
         var active: [String] = []
+        var activeTransports: [String] = []
         var firstPending: String?
+        var firstPendingTransport: String?
         for file in files {
             let path = file.path
             let child = file.progress
+            let transport = file.currentTransport
             if let destination = file.destination,
                let attributes = try? FileManager.default.attributesOfItem(atPath: destination.path),
                let size = (attributes[.size] as? NSNumber)?.int64Value,
@@ -36,14 +64,24 @@ public enum AFMDownloadProgressUserInfo {
                child.completedUnitCount >= child.totalUnitCount {
                 completed += 1
             } else {
-                if firstPending == nil { firstPending = path }
-                if child.completedUnitCount > 0 { active.append(path) }
+                if firstPending == nil {
+                    firstPending = path
+                    firstPendingTransport = transport
+                }
+                if child.completedUnitCount > 0 {
+                    active.append(path)
+                    activeTransports.append(transport)
+                }
             }
             completedBytes += min(child.completedUnitCount, file.expectedBytes)
         }
-        if active.isEmpty, let firstPending { active = [firstPending] }
+        if active.isEmpty, let firstPending {
+            active = [firstPending]
+            activeTransports = [firstPendingTransport ?? "pending"]
+        }
         progress.completedUnitCount = min(completedBytes, progress.totalUnitCount)
         progress.setUserInfoObject(active, forKey: currentFiles)
+        progress.setUserInfoObject(activeTransports, forKey: currentTransports)
         progress.setUserInfoObject(completed, forKey: completedFiles)
         progress.setUserInfoObject(files.count, forKey: totalFiles)
     }

--- a/Sources/AFMKitMLX/AFMDownloadProgress.swift
+++ b/Sources/AFMKitMLX/AFMDownloadProgress.swift
@@ -46,10 +46,8 @@ public enum AFMDownloadProgressUserInfo {
         guard !files.isEmpty else { return }
         var completed = 0
         var completedBytes: Int64 = 0
-        var active: [String] = []
-        var activeTransports: [String] = []
-        var firstPending: String?
-        var firstPendingTransport: String?
+        var activePairs: [(path: String, transport: String)] = []
+        var firstPendingPair: (path: String, transport: String)?
         for file in files {
             let path = file.path
             let child = file.progress
@@ -64,21 +62,20 @@ public enum AFMDownloadProgressUserInfo {
                child.completedUnitCount >= child.totalUnitCount {
                 completed += 1
             } else {
-                if firstPending == nil {
-                    firstPending = path
-                    firstPendingTransport = transport
+                if firstPendingPair == nil {
+                    firstPendingPair = (path, transport)
                 }
                 if child.completedUnitCount > 0 {
-                    active.append(path)
-                    activeTransports.append(transport)
+                    activePairs.append((path, transport))
                 }
             }
             completedBytes += min(child.completedUnitCount, file.expectedBytes)
         }
-        if active.isEmpty, let firstPending {
-            active = [firstPending]
-            activeTransports = [firstPendingTransport ?? "pending"]
+        if activePairs.isEmpty, let firstPendingPair {
+            activePairs = [firstPendingPair]
         }
+        let active = activePairs.map(\.path)
+        let activeTransports = activePairs.map(\.transport)
         progress.completedUnitCount = min(completedBytes, progress.totalUnitCount)
         progress.setUserInfoObject(active, forKey: currentFiles)
         progress.setUserInfoObject(activeTransports, forKey: currentTransports)

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -227,6 +227,13 @@ actor BatchScheduler {
             || (cache as? RotatingKVCache)?.isBatchable == true
     }
 
+    /// Copy cache tensors into independent MLX storage before retaining them
+    /// beyond the current decode step. Views and already-contiguous arrays may
+    /// otherwise alias mutable rotating-cache buffers.
+    nonisolated static func snapshotCacheState(_ state: [MLXArray]) -> [MLXArray] {
+        state.map { $0 * 1 }
+    }
+
     private func unsafeExactReplaySuffix() -> Int? {
         let env = ProcessInfo.processInfo.environment
         guard let rawValue = env["AFM_PREFIX_CACHE_ALLOW_UNSAFE_EXACT_REPLAY"]?
@@ -631,7 +638,13 @@ actor BatchScheduler {
             return requests
         }
 
-        try? await Task.sleep(nanoseconds: admissionWindowNanoseconds)
+        do {
+            try await Task.sleep(nanoseconds: admissionWindowNanoseconds)
+        } catch {
+            // The generation loop is cancelled by shutdown. Return the locally
+            // held requests so the loop can reject them before any GPU work.
+            return requests
+        }
         let remainingCapacity = max(0, maxConcurrent - requests.count)
         if remainingCapacity > 0 {
             requests.append(contentsOf: drainPendingQueue(limit: remainingCapacity))
@@ -711,6 +724,20 @@ actor BatchScheduler {
             // Drain nonisolated queue. When idle, wait a bounded admission
             // window so same-burst concurrent requests start together.
             let newRequests = await drainAdmissionBatch()
+            if Task.isCancelled || _isShutdown.withLock({ $0 }) {
+                for req in newRequests {
+                    _inFlightCount.withLock { $0 = max(0, $0 - 1) }
+                    req.continuation.finish(
+                        throwing: MLXServiceError.serviceShuttingDown)
+                    StatsAggregator.shared.requestSucceeded(reason: "abort")
+                    StatsAggregator.shared.requestCompleted()
+                }
+                if !slots.isEmpty {
+                    // Drain in-flight GPU work before shutdown tears down cache.
+                    Stream.gpu.synchronize()
+                }
+                return
+            }
             if !newRequests.isEmpty {
                 // Separate capacity-limited requests from overflow
                 var accepted: [PendingRequest] = []
@@ -1167,7 +1194,11 @@ actor BatchScheduler {
                 recurrentState = model(leading, cache: cache, state: nil).state
             }
             let states = cache.map { layerCache in
-                layerCache.state.map { MLX.contiguous($0) }
+                // `contiguous` may return the original storage when the source
+                // is already contiguous. Rotating caches mutate that storage in
+                // place, so force an independent allocation for the retained
+                // prompt-minus-one snapshot.
+                Self.snapshotCacheState(layerCache.state)
             }
             MLX.eval(states.flatMap { $0 })
             prefixCacheTokens = Array(inputTokens.dropLast())

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -44,6 +44,10 @@ actor BatchScheduler {
 
     /// Default maximum concurrent generations.
     static let defaultMaxConcurrent = 8
+    /// Small admission window for concurrent bursts. Without this, the first
+    /// request can start a one-slot prefill/decode before peer requests created
+    /// by the same client batch reach the queue, which looks like serial TTFT.
+    static let defaultAdmissionWindowNanoseconds: UInt64 = 8_000_000
 
     let maxConcurrent: Int
     private let model: any LanguageModel
@@ -52,6 +56,7 @@ actor BatchScheduler {
     private let processor: any UserInputProcessor
     private let configuration: ModelConfiguration
     private let cacheProfilePath: String?
+    private let admissionWindowNanoseconds: UInt64
 
     /// EOS token IDs built once at init.
     private let eosTokenIds: Set<Int>
@@ -476,7 +481,8 @@ actor BatchScheduler {
         configuration: ModelConfiguration,
         maxConcurrent: Int = BatchScheduler.defaultMaxConcurrent,
         enablePrefixCaching: Bool = false,
-        cacheProfilePath: String? = nil
+        cacheProfilePath: String? = nil,
+        admissionWindowNanoseconds: UInt64 = BatchScheduler.defaultAdmissionWindowNanoseconds
     ) {
         self.model = model
         self.tokenizer = tokenizer
@@ -484,6 +490,7 @@ actor BatchScheduler {
         self.configuration = configuration
         self.maxConcurrent = maxConcurrent
         self.cacheProfilePath = cacheProfilePath
+        self.admissionWindowNanoseconds = admissionWindowNanoseconds
 
         let debug = ProcessInfo.processInfo.environment["AFM_DEBUG"] == "1"
         self.radixCache = RadixTreeCache(
@@ -587,12 +594,40 @@ actor BatchScheduler {
 
     /// Drain all pending requests from the nonisolated queue.
     /// Called from within the actor-isolated generationLoop.
-    private func drainPendingQueue() -> [PendingRequest] {
+    private func drainPendingQueue(limit: Int? = nil) -> [PendingRequest] {
         _pendingQueue.withLock { q in
-            let result = q
-            q.removeAll()
+            let result: [PendingRequest]
+            if let limit, q.count > limit {
+                result = Array(q.prefix(limit))
+                q.removeFirst(limit)
+            } else {
+                result = q
+                q.removeAll()
+            }
             return result
         }
+    }
+
+    /// Give same-burst requests a bounded chance to join an empty scheduler.
+    /// This is intentionally tiny and only applies before the first active slot;
+    /// it improves fairness for concurrent/batch clients without adding per-token
+    /// latency once generation is in progress.
+    private func drainAdmissionBatch() async -> [PendingRequest] {
+        var requests = drainPendingQueue(limit: maxConcurrent)
+        guard slots.isEmpty,
+              requests.count == 1,
+              maxConcurrent > 1,
+              admissionWindowNanoseconds > 0
+        else {
+            return requests
+        }
+
+        try? await Task.sleep(nanoseconds: admissionWindowNanoseconds)
+        let remainingCapacity = max(0, maxConcurrent - requests.count)
+        if remainingCapacity > 0 {
+            requests.append(contentsOf: drainPendingQueue(limit: remainingCapacity))
+        }
+        return requests
     }
 
     /// Gracefully shut down.
@@ -664,8 +699,9 @@ actor BatchScheduler {
         while !_isShutdown.withLock({ $0 }) {
             let stepStart = debugTiming ? Date() : Date.distantPast
 
-            // Drain nonisolated queue — no Task.yield() needed for request pickup
-            let newRequests = drainPendingQueue()
+            // Drain nonisolated queue. When idle, wait a bounded admission
+            // window so same-burst concurrent requests start together.
+            let newRequests = await drainAdmissionBatch()
             if !newRequests.isEmpty {
                 // Separate capacity-limited requests from overflow
                 var accepted: [PendingRequest] = []
@@ -722,6 +758,14 @@ actor BatchScheduler {
 
             // --- Batched decode: build graph from lastTokenArray (CPU, ~2.7ms) ---
             let activeB = slots.count
+            if activeB > 1, stepCount == 0 || stepCount % 256 == 0 {
+                let deepseekHybrid = batchCaches.contains {
+                    $0 is BatchDeepseekV4Cache || $0 is DeepseekV4Cache
+                }
+                if deepseekHybrid {
+                    print("[\(batchTs())] [BatchScheduler] DeepSeek V4 hybrid decode: B=\(activeB) row-split attention path")
+                }
+            }
             let tokens: MLXArray
             if activeB == 1 {
                 tokens = slots[0].lastTokenArray.reshaped([1, 1])

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -87,6 +87,10 @@ actor BatchScheduler {
         var firstTokenAt: Date?
         let inputTokens: [Int]
         let cachedTokens: Int
+        /// Token boundary represented by the persisted prefix snapshot. DeepSeek
+        /// stores prompt-minus-one so replay can restore recurrent state and
+        /// evaluate the final prompt token to recover the next-token logits.
+        let prefixCacheTokens: [Int]
         /// Snapshotted per-layer KV state from prefill (for prefix cache save).
         /// Stored as arrays rather than live KVCache references to avoid mutation
         /// by the decode loop (batchCaches shares objects in .unbatched mode).
@@ -136,6 +140,9 @@ actor BatchScheduler {
             inputTokens: [Int],
             cachedTokens: Int,
             prefillCaches: [KVCache],
+            prefixCacheTokens: [Int]? = nil,
+            prefixCacheStates: [[MLXArray]]? = nil,
+            prefixCacheMetaStates: [[String]]? = nil,
             lastTokenId: Int,
             lastTokenArray: MLXArray,
             sampler: LogitSampler,
@@ -161,13 +168,15 @@ actor BatchScheduler {
             self.inputTokens = inputTokens
             self.cachedTokens = cachedTokens
             self.prefillCaches = prefillCaches
+            self.prefixCacheTokens = prefixCacheTokens ?? inputTokens
             // Snapshot prefill KV state for radix cache save.
             // Must contiguous-copy the arrays — MLX sliced views share the underlying
             // buffer with batchCaches, so batched decode mutations would corrupt the snapshot.
-            self.prefillStates = prefillCaches.map { cache in
+            self.prefillStates = prefixCacheStates ?? prefillCaches.map { cache in
                 cache.state.map { MLX.contiguous($0) }
             }
-            self.prefillMetaStates = prefillCaches.map { $0.metaState }
+            self.prefillMetaStates = prefixCacheMetaStates
+                ?? prefillCaches.map { $0.metaState }
             self.lastTokenId = lastTokenId
             self.lastTokenArray = lastTokenArray
             self.sampler = sampler
@@ -763,7 +772,14 @@ actor BatchScheduler {
                     $0 is BatchDeepseekV4Cache || $0 is DeepseekV4Cache
                 }
                 if deepseekHybrid {
-                    print("[\(batchTs())] [BatchScheduler] DeepSeek V4 hybrid decode: B=\(activeB) row-split attention path")
+                    let enabled = ProcessInfo.processInfo.environment[
+                        "VMLX_DSV4_DWARFSTAR_CACHE_BATCH"]
+                        .map { !["0", "false", "off"].contains($0.lowercased()) }
+                        ?? true
+                    let mode = enabled
+                        ? "DwarfStar-style private cache descriptors + batched attention"
+                        : "legacy row-split attention"
+                    print("[\(batchTs())] [BatchScheduler] DeepSeek V4 hybrid decode: B=\(activeB) \(mode)")
                 }
             }
             let tokens: MLXArray
@@ -996,18 +1012,20 @@ actor BatchScheduler {
         forcedSuffix: Int?,
         sourceTokenCount: Int? = nil
     ) -> Int {
-        if matchedPrefix == inputTokenCount && hasRecurrentLayers && forcedSuffix == nil {
-            return 0
-        }
         if matchedPrefix == inputTokenCount, let forcedSuffix {
             return max(0, inputTokenCount - forcedSuffix)
         }
+        if hasRecurrentLayers && forcedSuffix == nil {
+            // A recurrent state is reusable only at the exact token boundary
+            // where it was captured, with at least one suffix token left to
+            // recover logits. Never trim a longer descendant recurrent state.
+            guard matchedPrefix < inputTokenCount,
+                  sourceTokenCount == matchedPrefix
+            else { return 0 }
+            return matchedPrefix
+        }
         let minSuffix = 16
         let effectivePrefix = min(matchedPrefix, max(0, inputTokenCount - minSuffix))
-        if hasRecurrentLayers && forcedSuffix == nil,
-           let sourceTokenCount, sourceTokenCount != effectivePrefix {
-            return 0
-        }
         return effectivePrefix
     }
 
@@ -1128,9 +1146,41 @@ actor BatchScheduler {
         let logitSampler = req.parameters.sampler()
         logitProcessor?.prompt(generateInput.text.tokens)
 
-        // Run model on full prompt (B=1)
-        let prefillInput = generateInput.text[text: .newAxis]  // [1, seqLen]
-        let result = model(prefillInput, cache: cache, state: nil)
+        // DeepSeek's compressor/indexer state is not safely rewindable from a
+        // longer descendant snapshot. Persist the exact prompt-minus-one
+        // boundary instead: restore that state later and evaluate the final
+        // prompt token to reproduce the original next-token logits.
+        let hasDeepseekCache = cache.contains { $0 is DeepseekV4Cache }
+        let shouldCaptureDeepseekBoundary = radixCache != nil
+            && hasDeepseekCache
+            && !inputTokens.isEmpty
+        var prefixCacheTokens: [Int]? = nil
+        var prefixCacheStates: [[MLXArray]]? = nil
+        var prefixCacheMetaStates: [[String]]? = nil
+        let suffixTokens = generateInput.text.tokens.reshaped(-1).asArray(Int.self)
+        let result: LMOutput
+        if shouldCaptureDeepseekBoundary, let finalToken = suffixTokens.last {
+            var recurrentState: LMOutput.State? = nil
+            if suffixTokens.count > 1 {
+                let leading = LMInput.Text(
+                    tokens: MLXArray(Array(suffixTokens.dropLast()))[.newAxis])
+                recurrentState = model(leading, cache: cache, state: nil).state
+            }
+            let states = cache.map { layerCache in
+                layerCache.state.map { MLX.contiguous($0) }
+            }
+            MLX.eval(states.flatMap { $0 })
+            prefixCacheTokens = Array(inputTokens.dropLast())
+            prefixCacheStates = states
+            prefixCacheMetaStates = cache.map { $0.metaState }
+            result = model(
+                LMInput.Text(tokens: MLXArray([finalToken]).reshaped([1, 1])),
+                cache: cache,
+                state: recurrentState)
+        } else {
+            let prefillInput = generateInput.text[text: .newAxis]  // [1, seqLen]
+            result = model(prefillInput, cache: cache, state: nil)
+        }
 
         // Extract last-position logits and sample first token.
         // Use [0, -1, 0...] to collapse batch dim → [vocabSize] (scalar sample output).
@@ -1193,6 +1243,9 @@ actor BatchScheduler {
             inputTokens: inputTokens,
             cachedTokens: cachedTokens,
             prefillCaches: cache,
+            prefixCacheTokens: prefixCacheTokens,
+            prefixCacheStates: prefixCacheStates,
+            prefixCacheMetaStates: prefixCacheMetaStates,
             lastTokenId: firstToken,
             lastTokenArray: tokenArray,  // already eval'd — used as model input for first decode step
             sampler: logitSampler,
@@ -1722,7 +1775,7 @@ actor BatchScheduler {
         var saveTrimTime: Double? = nil
         var saveTruncateTime: Double? = nil
         var saveInsertTime: Double? = nil
-        if let radix = radixCache, !slot.inputTokens.isEmpty, !wasCancelled {
+        if let radix = radixCache, !slot.prefixCacheTokens.isEmpty, !wasCancelled {
             let tSave0 = Date.timeIntervalSinceReferenceDate
             // Use pre-snapshotted state from prefill time — immune to decode mutations.
             let layerStates = slot.prefillStates
@@ -1730,7 +1783,7 @@ actor BatchScheduler {
             let tSaveTrim = tSave0
             let tSaveTruncate = tSave0
             radix.insert(
-                tokens: slot.inputTokens,
+                tokens: slot.prefixCacheTokens,
                 layerStates: layerStates,
                 layerMetaStates: layerMetaStates
             )
@@ -1743,17 +1796,17 @@ actor BatchScheduler {
             }
             let maxOffset = layerStates.map { $0.isEmpty ? 0 : $0[0].dim(2) }.max() ?? 0
             print(
-                "[\(batchTs())] [PrefixCache] Save complete: mode=batch | stored_tokens=\(slot.inputTokens.count) | " +
+                "[\(batchTs())] [PrefixCache] Save complete: mode=batch | stored_tokens=\(slot.prefixCacheTokens.count) | " +
                     "radix_entries=\(radix.count) | trim=\(String(format: "%.6f", saveTrimTime ?? 0))s | " +
                     "truncate=\(String(format: "%.6f", saveTruncateTime ?? 0))s | insert=\(String(format: "%.6f", saveInsertTime ?? 0))s | " +
                     "layers=\(layerStates.count) active_layers=\(activeLayers) max_offset=\(maxOffset)"
             )
-            DebugLogger.log("[BatchScheduler] Prefix cache save: \(slot.inputTokens.count) tokens")
+            DebugLogger.log("[BatchScheduler] Prefix cache save: \(slot.prefixCacheTokens.count) tokens")
         }
         logCacheProfile(
             phase: "save",
             mode: "batch",
-            outcome: slot.inputTokens.isEmpty || wasCancelled ? "skip" : "save",
+            outcome: slot.prefixCacheTokens.isEmpty || wasCancelled ? "skip" : "save",
             inputTokenCount: slot.inputTokens.count,
             cachedTokenCount: slot.cachedTokens,
             promptTime: slot.prefillTime,

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -5046,7 +5046,7 @@ public final class MLXModelService: @unchecked Sendable {
                 patterns.contains { fnmatch($0, entry.path, 0) == 0 }
             }
             if let revision, !manifest.isEmpty {
-                print("Hugging Face transport: automatic (Xet for large files, LFS fallback)")
+                print("Hugging Face transport: explicit (small=LFS, large=Xet-first with LFS fallback)")
                 try await downloadManifest(
                     manifest,
                     repoID: repoID,
@@ -5117,6 +5117,7 @@ public final class MLXModelService: @unchecked Sendable {
                 }
                 group.addTask {
                     do {
+                        files[index].setTransport("lfs")
                         try FileManager.default.createDirectory(
                             at: files[index].destination!.deletingLastPathComponent(),
                             withIntermediateDirectories: true)
@@ -5149,20 +5150,37 @@ public final class MLXModelService: @unchecked Sendable {
             for try await _ in group {}
         }
 
-        // Match the official snapshot policy: large Xet files are processed
-        // sequentially while each Xet transfer uses its own parallel CAS fetches.
+        // Large files are processed sequentially while each Xet transfer uses
+        // its own parallel CAS fetches. Try Xet explicitly so logs/progress can
+        // report the transport that actually succeeded; fall back to LFS only
+        // when Xet is unavailable for that file/environment.
         for (index, entry) in xetEntries {
             do {
                 try FileManager.default.createDirectory(
                     at: files[index].destination!.deletingLastPathComponent(),
                     withIntermediateDirectories: true)
-                _ = try await client.downloadFile(
-                    entry,
-                    from: repoID,
-                    to: files[index].destination,
-                    revision: revision,
-                    progress: files[index].progress,
-                    transport: .automatic)
+                do {
+                    files[index].setTransport("xet")
+                    print("Hugging Face transport selected: xet file=\(entry.path)")
+                    _ = try await client.downloadFile(
+                        entry,
+                        from: repoID,
+                        to: files[index].destination,
+                        revision: revision,
+                        progress: files[index].progress,
+                        transport: .xet)
+                } catch {
+                    files[index].setTransport("xet-fallback-lfs")
+                    print("Hugging Face transport fallback: xet failed for \(entry.path): \(error.localizedDescription); retrying with lfs")
+                    try? FileManager.default.removeItem(at: files[index].destination!)
+                    _ = try await client.downloadFile(
+                        entry,
+                        from: repoID,
+                        to: files[index].destination,
+                        revision: revision,
+                        progress: files[index].progress,
+                        transport: .lfs)
+                }
                 try await cache.storeFile(
                     at: files[index].destination!,
                     repo: repoID,

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -5169,7 +5169,10 @@ public final class MLXModelService: @unchecked Sendable {
                         revision: revision,
                         progress: files[index].progress,
                         transport: .xet)
+                } catch is CancellationError {
+                    throw CancellationError()
                 } catch {
+                    guard !Task.isCancelled else { throw CancellationError() }
                     files[index].setTransport("xet-fallback-lfs")
                     print("Hugging Face transport fallback: xet failed for \(entry.path): \(error.localizedDescription); retrying with lfs")
                     try? FileManager.default.removeItem(at: files[index].destination!)
@@ -5194,6 +5197,8 @@ public final class MLXModelService: @unchecked Sendable {
                     ref: "main")
                 files[index].progress.totalUnitCount = files[index].expectedBytes
                 files[index].progress.completedUnitCount = files[index].progress.totalUnitCount
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
                 throw MLXServiceError.downloadFailed("\(entry.path): \(error.localizedDescription)")
             }

--- a/Tests/MacLocalAPITests/AFMDownloadProgressTests.swift
+++ b/Tests/MacLocalAPITests/AFMDownloadProgressTests.swift
@@ -12,9 +12,9 @@ final class AFMDownloadProgressTests: XCTestCase {
         active.completedUnitCount = 25
 
         let files = [
-            AFMDownloadProgressUserInfo.File(path: "config.json", expectedBytes: 100, destination: nil, progress: complete),
-            AFMDownloadProgressUserInfo.File(path: "weights-01.safetensors", expectedBytes: 100, destination: nil, progress: active),
-            AFMDownloadProgressUserInfo.File(path: "weights-02.safetensors", expectedBytes: 100, destination: nil, progress: pending),
+            AFMDownloadProgressUserInfo.File(path: "config.json", expectedBytes: 100, destination: nil, progress: complete, transport: "lfs"),
+            AFMDownloadProgressUserInfo.File(path: "weights-01.safetensors", expectedBytes: 100, destination: nil, progress: active, transport: "xet"),
+            AFMDownloadProgressUserInfo.File(path: "weights-02.safetensors", expectedBytes: 100, destination: nil, progress: pending, transport: "pending"),
         ]
         AFMDownloadProgressUserInfo.enrich(root, files: files)
 
@@ -23,6 +23,9 @@ final class AFMDownloadProgressTests: XCTestCase {
         XCTAssertEqual(
             root.userInfo[AFMDownloadProgressUserInfo.currentFiles] as? [String],
             ["weights-01.safetensors"])
+        XCTAssertEqual(
+            root.userInfo[AFMDownloadProgressUserInfo.currentTransports] as? [String],
+            ["xet"])
     }
 
     func testEnrichmentNamesFirstPendingFileBeforeBytesArrive() {
@@ -40,7 +43,31 @@ final class AFMDownloadProgressTests: XCTestCase {
         XCTAssertEqual(
             root.userInfo[AFMDownloadProgressUserInfo.currentFiles] as? [String],
             ["a.bin"])
+        XCTAssertEqual(
+            root.userInfo[AFMDownloadProgressUserInfo.currentTransports] as? [String],
+            ["pending"])
         XCTAssertEqual(root.userInfo[AFMDownloadProgressUserInfo.completedFiles] as? Int, 0)
+    }
+
+    func testEnrichmentPublishesFallbackTransportForPendingFile() {
+        let root = Progress(totalUnitCount: 100)
+        let child = Progress(totalUnitCount: 100)
+        let file = AFMDownloadProgressUserInfo.File(
+            path: "weights.safetensors",
+            expectedBytes: 100,
+            destination: nil,
+            progress: child,
+            transport: "xet")
+        file.setTransport("xet-fallback-lfs")
+
+        AFMDownloadProgressUserInfo.enrich(root, files: [file])
+
+        XCTAssertEqual(
+            root.userInfo[AFMDownloadProgressUserInfo.currentFiles] as? [String],
+            ["weights.safetensors"])
+        XCTAssertEqual(
+            root.userInfo[AFMDownloadProgressUserInfo.currentTransports] as? [String],
+            ["xet-fallback-lfs"])
     }
 
     func testEnrichmentSamplesGrowingXetDestination() throws {

--- a/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
+++ b/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
@@ -228,7 +228,8 @@ struct ConcurrentBatchTests {
             matchedPrefix: 59,
             inputTokenCount: 59,
             hasRecurrentLayers: true,
-            forcedSuffix: nil
+            forcedSuffix: nil,
+            sourceTokenCount: 59
         ) == 0)
         #expect(BatchScheduler.effectiveCachedPrefixLength(
             matchedPrefix: 59,
@@ -254,6 +255,17 @@ struct ConcurrentBatchTests {
             forcedSuffix: nil,
             sourceTokenCount: 60
         ) == 60)
+    }
+
+    @Test("BatchScheduler restores exact DeepSeek prompt-minus-one boundary")
+    func recurrentExactBoundaryRestore() {
+        #expect(BatchScheduler.effectiveCachedPrefixLength(
+            matchedPrefix: 58,
+            inputTokenCount: 59,
+            hasRecurrentLayers: true,
+            forcedSuffix: nil,
+            sourceTokenCount: 58
+        ) == 58)
     }
 
     @Test("BatchScheduler emits only completed tool calls from slot runtime events")

--- a/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
+++ b/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
@@ -268,6 +268,18 @@ struct ConcurrentBatchTests {
         ) == 58)
     }
 
+    @Test("BatchScheduler cache snapshot owns independent MLX storage")
+    func cacheSnapshotOwnsIndependentStorage() {
+        let backing = MLXArray([Int32(10), Int32(20), Int32(30), Int32(40)])
+        let snapshot = BatchScheduler.snapshotCacheState([backing])[0]
+        MLX.eval([snapshot])
+
+        backing[..<3] = MLXArray([Int32(90), Int32(91), Int32(92)])
+        MLX.eval([backing])
+
+        #expect(snapshot.asArray(Int32.self) == [10, 20, 30, 40])
+    }
+
     @Test("BatchScheduler emits only completed tool calls from slot runtime events")
     func completedToolCallsFromEvents() {
         let placeholder = ResponseToolCall(

--- a/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
+++ b/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
@@ -134,6 +134,12 @@ struct ConcurrentBatchTests {
         #expect(BatchScheduler.defaultMaxConcurrent == 8)
     }
 
+    @Test("BatchScheduler admission window is enabled for burst fairness")
+    func defaultAdmissionWindowEnabled() {
+        #expect(BatchScheduler.defaultAdmissionWindowNanoseconds > 0)
+        #expect(BatchScheduler.defaultAdmissionWindowNanoseconds <= 20_000_000)
+    }
+
     @Test("BatchScheduler supports DeepSeek hybrid cache through its batch container")
     func supportsDeepseekHybridCacheBatching() {
         let cache = DeepseekV4Cache(slidingWindow: 128, compressRatio: 4)

--- a/docs/deepseek-v4-0731-rejected-experiments.md
+++ b/docs/deepseek-v4-0731-rejected-experiments.md
@@ -184,15 +184,33 @@ profiling unless Apple exposes a scriptable shader-profiler export.
 
 - Never benchmark Debug. It has repeatedly produced misleadingly poor and
   irregular throughput.
-- Do not close DeepSeek V4 MLX concurrency regressions solely because the old
-  reshape crash path is gone. A Release live run on 2026-08-11 with four
-  simultaneous `DeepSeek-V4-Flash-0731-AFM-MLX` requests showed the scheduler
-  entering `DeepSeek V4 hybrid decode: B=4 row-split attention path`; per-request
-  decode was still roughly 11-14 tok/s for the concurrent short workload while
-  single-request natural-language decode remained about 27 tok/s. The admission
-  window helps same-burst fairness and makes the behavior visible, but true
-  production parity requires a dense DeepSeek V4 batch cache/attention path,
-  not only scheduler tuning.
+- The 2026-08-11 DeepSeek V4 concurrency work replaced row-split decode with
+  DwarfStar-style private request cache descriptors plus batched Q/KV,
+  compressor/indexer, attention, and output projections. A controlled Release
+  A/B with four simultaneous requests improved aggregate median throughput from
+  38.40 tok/s to 42.81 tok/s (11.5%). The greedy 128-token parity probe was
+  byte-identical in both modes with SHA-256
+  `fe1fdf5d49caa68c1ef2f8a341413cb2c3826023aef1113c6c289dcd86193b32`.
+  Raw parity responses are under
+  `/Volumes/edata/test-reports/deepseek-cache-batch-ab`. Do not restore the old
+  row-split path as a production default. A subsequent four-request live probe
+  completed uneven 10-, 19-, 256-, and 299-token generations without cache
+  corruption. Terminating a streaming client during generation also left the
+  server healthy and the next request returned the exact `RECOVERED` sentinel.
+  Artifacts are under
+  `/Volumes/edata/test-reports/deepseek-cache-batch-validation-20260811`.
+  Reusable prefix state is now supported by capturing the exact prompt-minus-one
+  recurrent boundary. A repeated 29-token deterministic request restored 28
+  tokens (96.6% reuse), reduced prefill from 0.294 s to 0.051 s, and returned
+  byte-identical output with SHA-256
+  `d8ad0e36d91402c6583faaee184faa66f5f9a82cbcc08fcc78c47c6eb890779e`.
+  The final prompt token is deliberately replayed after restoration to recover
+  the same next-token logits; never trim a longer descendant recurrent state.
+  Artifacts are under
+  `/Volumes/edata/test-reports/deepseek-prefix-live-20260811`. The explicit
+  request-id cancel probe returned 404 when supplied an inbound `X-Request-ID`;
+  investigate the registry/correlation-id contract separately from the
+  validated client-disconnect cancellation path.
 - Do not include model loading in decode throughput. Use one warmed Release
   server and report both server generation time and request wall time.
 - Do not use a counting prompt alone as proof of general DSpARK performance;

--- a/docs/deepseek-v4-0731-rejected-experiments.md
+++ b/docs/deepseek-v4-0731-rejected-experiments.md
@@ -184,6 +184,15 @@ profiling unless Apple exposes a scriptable shader-profiler export.
 
 - Never benchmark Debug. It has repeatedly produced misleadingly poor and
   irregular throughput.
+- Do not close DeepSeek V4 MLX concurrency regressions solely because the old
+  reshape crash path is gone. A Release live run on 2026-08-11 with four
+  simultaneous `DeepSeek-V4-Flash-0731-AFM-MLX` requests showed the scheduler
+  entering `DeepSeek V4 hybrid decode: B=4 row-split attention path`; per-request
+  decode was still roughly 11-14 tok/s for the concurrent short workload while
+  single-request natural-language decode remained about 27 tok/s. The admission
+  window helps same-burst fairness and makes the behavior visible, but true
+  production parity requires a dense DeepSeek V4 batch cache/attention path,
+  not only scheduler tuning.
 - Do not include model loading in decode throughput. Use one warmed Release
   server and report both server generation time and request wall time.
 - Do not use a counting prompt alone as proof of general DSpARK performance;


### PR DESCRIPTION
## Summary

- batch DeepSeek V4 cache-independent projections and padded attention across active requests
- retain private compressor, indexer, and recurrent cache timelines per request
- persist exact prompt-minus-one recurrent cache boundaries for correctness-preserving prefix reuse
- add focused cache/concurrency regression tests and capability-aware assertion handling
- document rejected optimization experiments and measured results

## Validation

- full Release Swift suite: 389 tests passed
- focused Release regressions: 47 XCTest + 25 Swift Testing cases passed
- controlled concurrent A/B: aggregate throughput improved from 38.40 to 42.81 tok/s (+11.5%) with identical deterministic output
- live four-way prefix test: cold wave cached 0 tokens; warm wave reused 77 tokens on every branch with no cross-request leakage
- full live runtime assertions covered streaming, non-streaming, tool calls, structured output, batch APIs, long context, and 8-way divergent concurrency

## Notes

DeepSeek's native DSML parser supports tool calls but does not advertise token-level strict-tool grammar. The assertion harness now skips that unsupported header expectation while continuing to test best-effort strict tool behavior and strict JSON-schema wiring.

The generated `vendor/mlx-swift-lm` patch state is intentionally not part of this commit; authoritative dependency changes live under `Scripts/patches`.

## Summary by Sourcery

Introduce DwarfStar-style batched decode for DeepSeek V4 with safer recurrent prefix caching, fairer concurrent scheduling, transport-aware Hugging Face downloads, and capability-sensitive assertion and test coverage.

New Features:
- Enable DwarfStar-style batched DeepSeek V4 attention, compressor, and indexer processing while preserving per-request cache timelines.
- Add a bounded admission window to the batch scheduler to improve fairness for concurrent/bursting requests.
- Track and expose Hugging Face download transport types per file, including explicit Xet-first with LFS fallback behavior.

Bug Fixes:
- Ensure prefix cache reuse for recurrent models only at the exact prompt-minus-one boundary to avoid corrupt or non-reproducible state.
- Adjust strict tool grammar assertion handling to respect model-specific parser capabilities, avoiding invalid expectations for DeepSeek V4.

Enhancements:
- Refine prefix caching to persist prompt-minus-one KV snapshots and reuse them safely during subsequent requests.
- Improve logging and diagnostics around DeepSeek V4 hybrid batch decode mode and prefix cache saves.
- Extend download progress metadata with current transport information to better surface active transfer behavior.

Documentation:
- Document DeepSeek V4 concurrency and prefix-caching experiments, including measured throughput improvements and correctness probes.

Tests:
- Add concurrency and prefix cache regression tests for DeepSeek V4, including admission window behavior and exact boundary restore semantics.
- Expand download progress tests to cover transport tracking and fallback reporting.
- Update assertion harness tests to be capability-aware for strict tool grammar headers and Swift test configuration/scratch-path wiring.