### PR TITLE
Add NVIDIA Nemotron 3.5 Lightning support

### DIFF
--- a/Scripts/patches/NemotronH.swift
+++ b/Scripts/patches/NemotronH.swift
@@ -772,6 +772,7 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
         var sanitized = [String: MLXArray]()
 
         for (key, value) in weights {
+            guard !key.hasPrefix("mtp.") else { continue }
             var finalValue = value
 
             // Handle conv1d weight axis swap
@@ -883,18 +884,21 @@ public struct NemotronHConfiguration: Codable, Sendable {
         case timeStepLimitMax = "time_step_limit_max"
     }
 
-    /// Separate key for time_step_limit array field (not a stored property)
+    /// Decoder-only aliases used by newer Transformers configurations.
     private enum ExtraCodingKeys: String, CodingKey {
         case timeStepLimit = "time_step_limit"
+        case timeStepMin = "time_step_min"
+        case layersBlockType = "layers_block_type"
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        let extra = try decoder.container(keyedBy: ExtraCodingKeys.self)
 
         modelType = try container.decodeIfPresent(String.self, forKey: .modelType) ?? "nemotron_h"
         vocabSize = try container.decode(Int.self, forKey: .vocabSize)
         hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
-        numHiddenLayers = try container.decode(Int.self, forKey: .numHiddenLayers)
+        numHiddenLayers = try container.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 0
         numAttentionHeads = try container.decode(Int.self, forKey: .numAttentionHeads)
         numKeyValueHeads = try container.decode(Int.self, forKey: .numKeyValueHeads)
         attentionBias = try container.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? false
@@ -927,23 +931,34 @@ public struct NemotronHConfiguration: Codable, Sendable {
         routedScalingFactor =
             try container.decodeIfPresent(Float.self, forKey: .routedScalingFactor) ?? 1.0
 
-        // Handle hybrid_override_pattern - can be string or array of strings
+        // New Nemotron-H configs use descriptive layers_block_type values while
+        // older checkpoints use the compact hybrid_override_pattern alphabet.
         if let patternString = try? container.decode(String.self, forKey: .hybridOverridePattern) {
-            hybridOverridePattern = patternString
+            hybridOverridePattern = try Self.normalizeBlockPattern(
+                Array(patternString).map(String.init),
+                forKey: .hybridOverridePattern,
+                in: container)
         } else if let patternArray = try? container.decode(
             [String].self, forKey: .hybridOverridePattern)
         {
-            hybridOverridePattern = patternArray.joined()
+            hybridOverridePattern = try Self.normalizeBlockPattern(
+                patternArray, forKey: .hybridOverridePattern, in: container)
+        } else if let blockTypes = try? extra.decode([String].self, forKey: .layersBlockType) {
+            hybridOverridePattern = try Self.normalizeBlockPattern(
+                blockTypes, forKey: .hybridOverridePattern, in: container)
         } else {
             throw DecodingError.dataCorruptedError(
                 forKey: .hybridOverridePattern, in: container,
-                debugDescription: "hybrid_override_pattern must be string or array of strings")
+                debugDescription:
+                    "Expected hybrid_override_pattern or layers_block_type to describe the decoder blocks")
         }
+        numHiddenLayers = hybridOverridePattern.count
 
         // Handle time-step limits as an array [min, max] under either the
         // canonical combined key or the legacy `time_step_limit_min` key.
-        // Otherwise, decode the separate scalar min/max fields.
-        let extra = try decoder.container(keyedBy: ExtraCodingKeys.self)
+        // Otherwise, decode the separate runtime limits. New Transformers
+        // configs use time_step_min for the lower runtime bound and reserve
+        // time_step_max for dt initialization; inference has no upper bound.
         let legacyLimits = try? container.decode([Float].self, forKey: .timeStepLimitMin)
         let combinedLimits = try? extra.decode([Float].self, forKey: .timeStepLimit)
         if let limits = legacyLimits ?? combinedLimits, let minimum = limits.first {
@@ -951,11 +966,44 @@ public struct NemotronHConfiguration: Codable, Sendable {
             timeStepLimitMax = limits.count > 1 ? limits[1] : limits[0]
         } else {
             timeStepLimitMin =
-                try container.decodeIfPresent(Float.self, forKey: .timeStepLimitMin) ?? 0.0
+                try container.decodeIfPresent(Float.self, forKey: .timeStepLimitMin)
+                ?? (try extra.decodeIfPresent(Float.self, forKey: .timeStepMin))
+                ?? 0.0
             timeStepLimitMax =
                 try container.decodeIfPresent(Float.self, forKey: .timeStepLimitMax)
                 ?? Float.infinity
         }
+    }
+
+    private static func normalizeBlockPattern(
+        _ blockTypes: [String],
+        forKey key: CodingKeys,
+        in container: KeyedDecodingContainer<CodingKeys>
+    ) throws -> String {
+        let mapping = [
+            "m": "M",
+            "mamba": "M",
+            "linear_attention": "M",
+            "*": "*",
+            "attention": "*",
+            "full_attention": "*",
+            "e": "E",
+            "moe": "E",
+            "-": "-",
+            "mlp": "-",
+        ]
+
+        var pattern = ""
+        for blockType in blockTypes {
+            guard let compact = mapping[blockType.lowercased()] else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: key,
+                    in: container,
+                    debugDescription: "Unsupported Nemotron-H block type: \(blockType)")
+            }
+            pattern += compact
+        }
+        return pattern
     }
 
     /// Memberwise initializer for testing

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -337,14 +337,14 @@ if [ -f "$MODEL/config.json" ]; then
 elif [ -n "${MACAFM_MLX_MODEL_CACHE:-}" ] && [ -f "${MACAFM_MLX_MODEL_CACHE%/}/$MODEL/config.json" ]; then
   model_config="${MACAFM_MLX_MODEL_CACHE%/}/$MODEL/config.json"
 elif [ -n "${HF_HUB_CACHE:-}" ]; then
-  hf_model_dir="${HF_HUB_CACHE%/}/models--${MODEL//\//--}/snapshots"
-  if [ -d "$hf_model_dir" ]; then
-    for candidate in "$hf_model_dir"/*/config.json; do
-      if [ -f "$candidate" ]; then
-        model_config="$candidate"
-        break
-      fi
-    done
+  hf_repo_dir="${HF_HUB_CACHE%/}/models--${MODEL//\//--}"
+  hf_main_ref="$hf_repo_dir/refs/main"
+  if [ -f "$hf_main_ref" ]; then
+    hf_revision=$(tr -d '\r\n' < "$hf_main_ref")
+    candidate="$hf_repo_dir/snapshots/$hf_revision/config.json"
+    if [ -f "$candidate" ]; then
+      model_config="$candidate"
+    fi
   fi
 fi
 if [ -n "$model_config" ]; then

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -203,6 +203,9 @@ if should_run_section U && min_tier unit && [[ "${MACAFM_SWIFT_TEST_SKIP:-0}" !=
 
   t0=$(now_ms)
   swift_test_args=(test)
+  if [[ -n "${MACAFM_SWIFT_TEST_CONFIGURATION:-}" ]]; then
+    swift_test_args+=(-c "$MACAFM_SWIFT_TEST_CONFIGURATION")
+  fi
   if [[ -n "${MACAFM_SWIFT_TEST_SCRATCH_PATH:-}" ]]; then
     swift_test_args+=(--scratch-path "$MACAFM_SWIFT_TEST_SCRATCH_PATH")
   fi
@@ -333,6 +336,16 @@ if [ -f "$MODEL/config.json" ]; then
   model_config="$MODEL/config.json"
 elif [ -n "${MACAFM_MLX_MODEL_CACHE:-}" ] && [ -f "${MACAFM_MLX_MODEL_CACHE%/}/$MODEL/config.json" ]; then
   model_config="${MACAFM_MLX_MODEL_CACHE%/}/$MODEL/config.json"
+elif [ -n "${HF_HUB_CACHE:-}" ]; then
+  hf_model_dir="${HF_HUB_CACHE%/}/models--${MODEL//\//--}/snapshots"
+  if [ -d "$hf_model_dir" ]; then
+    for candidate in "$hf_model_dir"/*/config.json; do
+      if [ -f "$candidate" ]; then
+        model_config="$candidate"
+        break
+      fi
+    done
+  fi
 fi
 if [ -n "$model_config" ]; then
   SAFE_PARTIAL_CACHE_MISS=$(python3 - "$model_config" <<'PY'
@@ -342,7 +355,13 @@ with open(sys.argv[1], "r", encoding="utf-8") as handle:
     config = json.load(handle)
 
 text_config = config.get("text_config") or {}
-layer_types = text_config.get("layer_types") or config.get("layer_types") or []
+layer_types = (
+    text_config.get("layer_types")
+    or config.get("layer_types")
+    or text_config.get("layers_block_type")
+    or config.get("layers_block_type")
+    or []
+)
 recurrent_markers = ("linear", "mamba", "ssm", "delta", "recurrent")
 has_recurrent_layers = any(
     any(marker in str(layer_type).lower() for marker in recurrent_markers)

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -2092,11 +2092,16 @@ public final class MLXModelService: @unchecked Sendable {
             let seqLen = tokens.dim(ndim - 1)
             var generated = ""
             var templateInjectedThink = false
-            if let thinkStart, seqLen >= 2 {
+            if let thinkStart, seqLen > 0 {
                 let flat = tokens.reshaped(-1)
-                let lastTwo = flat[seqLen - 2 ..< seqLen].asArray(Int.self)
-                let decoded = tokenizer.decode(tokens: lastTwo)
-                if decoded.contains(thinkStart) {
+                let suffixStart = max(0, seqLen - 8)
+                let suffix = flat[suffixStart ..< seqLen].asArray(Int.self)
+                let decoded = tokenizer.decode(tokens: suffix)
+                if Self.promptSuffixOpensThink(
+                    decoded,
+                    startTag: thinkStart,
+                    endTag: self.thinkEndTag
+                ) {
                     generated = thinkStart
                     templateInjectedThink = true
                 }
@@ -2350,11 +2355,16 @@ public final class MLXModelService: @unchecked Sendable {
             let seqLen = tokens.dim(ndim - 1)
             var out = ""
             var templateInjectedThink = false
-            if let thinkStart, seqLen >= 2 {
+            if let thinkStart, seqLen > 0 {
                 let flat = tokens.reshaped(-1)
-                let lastTwo = flat[seqLen - 2 ..< seqLen].asArray(Int.self)
-                let decoded = context.tokenizer.decode(tokens: lastTwo)
-                if decoded.contains(thinkStart) {
+                let suffixStart = max(0, seqLen - 8)
+                let suffix = flat[suffixStart ..< seqLen].asArray(Int.self)
+                let decoded = context.tokenizer.decode(tokens: suffix)
+                if Self.promptSuffixOpensThink(
+                    decoded,
+                    startTag: thinkStart,
+                    endTag: self.thinkEndTag
+                ) {
                     out = thinkStart
                     templateInjectedThink = true
                 }
@@ -2931,11 +2941,16 @@ public final class MLXModelService: @unchecked Sendable {
                 let tokens = input.text.tokens
                 let ndim = tokens.ndim
                 let seqLen = tokens.dim(ndim - 1)
-                guard seqLen >= 2 else { return false }
+                guard seqLen > 0 else { return false }
                 let flat = tokens.reshaped(-1)
-                let lastTwo = flat[seqLen - 2 ..< seqLen].asArray(Int.self)
-                let decoded = scheduler.tokenizer.decode(tokens: lastTwo)
-                return decoded.contains(thinkStart)
+                let suffixStart = max(0, seqLen - 8)
+                let suffix = flat[suffixStart ..< seqLen].asArray(Int.self)
+                let decoded = scheduler.tokenizer.decode(tokens: suffix)
+                return Self.promptSuffixOpensThink(
+                    decoded,
+                    startTag: thinkStart,
+                    endTag: self.thinkEndTag
+                )
             }()
 
             let schedulerStream = scheduler.submit(
@@ -3027,8 +3042,13 @@ public final class MLXModelService: @unchecked Sendable {
                 let ids = self.extractTokenArray(lmInput)
                 if ids.isEmpty { return nil }
                 var opened = false
-                if let ts = self.thinkStartTag, ids.count >= 2 {
-                    opened = context.tokenizer.decode(tokens: Array(ids.suffix(2))).contains(ts)
+                if let ts = self.thinkStartTag, !ids.isEmpty {
+                    let decoded = context.tokenizer.decode(tokens: Array(ids.suffix(8)))
+                    opened = Self.promptSuffixOpensThink(
+                        decoded,
+                        startTag: ts,
+                        endTag: self.thinkEndTag
+                    )
                 }
                 return (ids, opened)
             }
@@ -3187,11 +3207,16 @@ public final class MLXModelService: @unchecked Sendable {
                         let tokens = input.text.tokens
                         let ndim = tokens.ndim
                         let seqLen = tokens.dim(ndim - 1)
-                        if let thinkStart, seqLen >= 2 {
+                        if let thinkStart, seqLen > 0 {
                             let flat = tokens.reshaped(-1)
-                            let lastTwo = flat[seqLen - 2 ..< seqLen].asArray(Int.self)
-                            let decoded = context.tokenizer.decode(tokens: lastTwo)
-                            if decoded.contains(thinkStart) {
+                            let suffixStart = max(0, seqLen - 8)
+                            let suffix = flat[suffixStart ..< seqLen].asArray(Int.self)
+                            let decoded = context.tokenizer.decode(tokens: suffix)
+                            if Self.promptSuffixOpensThink(
+                                decoded,
+                                startTag: thinkStart,
+                                endTag: self.thinkEndTag
+                            ) {
                                 continuation.yield(StreamChunk(text: thinkStart))
                                 templateInjectedThink = true
                             }
@@ -6976,6 +7001,22 @@ public final class MLXModelService: @unchecked Sendable {
         {{- '<|start_header_id|>assistant<|end_header_id|>\\n\\n' }}
     {%- endif %}
     """
+
+    static func promptSuffixOpensThink(
+        _ decodedSuffix: String,
+        startTag: String,
+        endTag: String?
+    ) -> Bool {
+        guard let startRange = decodedSuffix.range(of: startTag, options: .backwards) else {
+            return false
+        }
+        guard let endTag,
+              let endRange = decodedSuffix.range(of: endTag, options: .backwards)
+        else {
+            return true
+        }
+        return startRange.lowerBound > endRange.lowerBound
+    }
 
     /// Adapted from vLLM's tool_chat_template_mistral.jinja — Mistral v7 format.
     /// Modifications: wraps tool calls in <tool_call>/<\/tool_call> instead of [TOOL_CALLS],

--- a/Tests/MacLocalAPITests/Nemotron35CheckpointTests.swift
+++ b/Tests/MacLocalAPITests/Nemotron35CheckpointTests.swift
@@ -39,6 +39,38 @@ final class Nemotron35CheckpointTests: XCTestCase {
         XCTAssertEqual(config.routedScalingFactor, 2.5)
     }
 
+    func testProductionCheckpointNormalizesAll52Layers() throws {
+        let productionLayout = [
+            "mamba", "moe", "mamba", "moe", "mamba", "attention", "moe",
+            "mamba", "moe", "mamba", "moe", "mamba", "attention", "moe",
+            "mamba", "moe", "mamba", "moe", "mamba", "attention", "moe",
+            "mamba", "moe", "mamba", "moe", "mamba", "attention", "moe",
+            "mamba", "moe", "mamba", "moe", "mamba", "attention", "moe",
+            "mamba", "moe", "mamba", "moe", "mamba", "moe", "mamba",
+            "attention", "moe", "mamba", "moe", "mamba", "moe", "mamba",
+            "moe", "mamba", "moe",
+        ]
+        var productionConfiguration = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(checkpointConfigurationJSON.utf8))
+                as? [String: Any]
+        )
+        productionConfiguration["layers_block_type"] = productionLayout
+        let data = try JSONSerialization.data(withJSONObject: productionConfiguration)
+
+        let config = try JSONDecoder().decode(NemotronHConfiguration.self, from: data)
+
+        XCTAssertEqual(config.numHiddenLayers, 52)
+        XCTAssertEqual(config.hybridOverridePattern.count, 52)
+        XCTAssertEqual(config.hybridOverridePattern, productionLayout.map {
+            switch $0 {
+            case "mamba": return "M"
+            case "attention": return "*"
+            case "moe": return "E"
+            default: XCTFail("Unexpected production block type: \($0)"); return "?"
+            }
+        }.joined())
+    }
+
     func testCheckpointRejectsUnknownNamedBlockType() {
         let invalid = checkpointConfigurationJSON.replacingOccurrences(
             of: "\"attention\"",

--- a/Tests/MacLocalAPITests/Nemotron35CheckpointTests.swift
+++ b/Tests/MacLocalAPITests/Nemotron35CheckpointTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import MLXLLM
+import MLXLMCommon
+import XCTest
+
+@testable import AFMKitMLX
+
+final class Nemotron35CheckpointTests: XCTestCase {
+    private let modelID = "mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-mxfp4"
+
+    func testCheckpointArchitectureUsesNemotronHLanguageModelFactory() throws {
+        let preflight = try AFMMLXModelArchitecture.preflightConfiguration(
+            [
+                "architectures": ["NemotronHForCausalLM"],
+                "model_type": "nemotron_h",
+                "layers_block_type": ["mamba", "moe", "attention"],
+                "quantization": ["mode": "mxfp4", "bits": 4, "group_size": 32],
+            ],
+            modelID: modelID
+        )
+
+        XCTAssertEqual(preflight.canonicalModelType, "nemotron_h")
+        XCTAssertFalse(preflight.isVisionConfiguration)
+        XCTAssertFalse(preflight.requiresVisionModelFactory)
+    }
+
+    func testCheckpointConfigurationNormalizesNamedBlockLayout() throws {
+        let config = try JSONDecoder().decode(
+            NemotronHConfiguration.self,
+            from: Data(checkpointConfigurationJSON.utf8)
+        )
+
+        XCTAssertEqual(config.modelType, "nemotron_h")
+        XCTAssertEqual(config.hybridOverridePattern, "MEM*E")
+        XCTAssertEqual(config.numHiddenLayers, 5)
+        XCTAssertEqual(config.timeStepLimitMin, 0.001)
+        XCTAssertEqual(config.timeStepLimitMax, .infinity)
+        XCTAssertEqual(config.nSharedExperts, 1)
+        XCTAssertEqual(config.routedScalingFactor, 2.5)
+    }
+
+    func testCheckpointRejectsUnknownNamedBlockType() {
+        let invalid = checkpointConfigurationJSON.replacingOccurrences(
+            of: "\"attention\"",
+            with: "\"unsupported_attention\""
+        )
+
+        XCTAssertThrowsError(try JSONDecoder().decode(
+            NemotronHConfiguration.self,
+            from: Data(invalid.utf8)
+        ))
+    }
+
+    func testCheckpointToolFormatUsesQwen3CoderXML() {
+        XCTAssertEqual(ToolCallFormat.infer(from: "nemotron_h"), .xmlFunction)
+    }
+
+    func testDisabledThinkingPromptDoesNotReopenClosedBlock() {
+        XCTAssertFalse(MLXModelService.promptSuffixOpensThink(
+            "assistant\n<think>\n\n</think>\n\n",
+            startTag: "<think>",
+            endTag: "</think>"
+        ))
+        XCTAssertTrue(MLXModelService.promptSuffixOpensThink(
+            "assistant\n<think>\n",
+            startTag: "<think>",
+            endTag: "</think>"
+        ))
+    }
+
+    func testCheckpointJinjaAdvertisesReasoningToggle() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Nemotron35Checkpoint-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try Data(#"{"model_type":"nemotron_h","max_position_embeddings":262144}"#.utf8)
+            .write(to: directory.appendingPathComponent("config.json"))
+        try Data(#"{"temperature":1.0,"top_p":0.95}"#.utf8)
+            .write(to: directory.appendingPathComponent("generation_config.json"))
+        try Data("""
+        {%- set enable_thinking = enable_thinking if enable_thinking is defined else True %}
+        {%- if add_generation_prompt %}
+            {%- if enable_thinking %}<|im_start|>assistant\n<think>\n
+            {%- else %}<|im_start|>assistant\n<think></think>
+            {%- endif %}
+        {%- endif %}
+        """.utf8).write(to: directory.appendingPathComponent("chat_template.jinja"))
+
+        let metadata = AFMMLXLocalModelMetadata.inspect(
+            modelDirectory: directory,
+            modelName: "NVIDIA-Nemotron-3.5-Lightning-30B-A3B-mxfp4"
+        )
+
+        XCTAssertEqual(metadata.modelType, "nemotron_h")
+        XCTAssertEqual(metadata.contextWindow, 262_144)
+        XCTAssertEqual(metadata.generationPreset?.temperature, 1.0)
+        XCTAssertEqual(metadata.generationPreset?.topP, 0.95)
+        XCTAssertTrue(metadata.hasImplicitReasoning)
+        XCTAssertTrue(metadata.supportsThinkingToggle)
+    }
+
+    private var checkpointConfigurationJSON: String {
+        """
+        {
+          "architectures": ["NemotronHForCausalLM"],
+          "model_type": "nemotron_h",
+          "vocab_size": 131072,
+          "hidden_size": 64,
+          "num_hidden_layers": 52,
+          "num_attention_heads": 4,
+          "num_key_value_heads": 2,
+          "mamba_num_heads": 4,
+          "mamba_head_dim": 16,
+          "mamba_proj_bias": false,
+          "ssm_state_size": 16,
+          "conv_kernel": 4,
+          "n_groups": 2,
+          "intermediate_size": 128,
+          "moe_intermediate_size": 64,
+          "moe_shared_expert_intermediate_size": 128,
+          "moe_latent_size": null,
+          "n_routed_experts": 8,
+          "n_shared_experts": 1,
+          "num_experts_per_tok": 2,
+          "layers_block_type": ["mamba", "moe", "mamba", "attention", "moe"],
+          "layer_norm_epsilon": 1e-5,
+          "mlp_bias": false,
+          "use_bias": false,
+          "use_conv_bias": true,
+          "tie_word_embeddings": false,
+          "head_dim": 16,
+          "n_group": 1,
+          "topk_group": 1,
+          "norm_topk_prob": true,
+          "routed_scaling_factor": 2.5,
+          "time_step_min": 0.001,
+          "time_step_max": 0.1
+        }
+        """
+    }
+}

--- a/docs/nemotron-3.5-lightning.md
+++ b/docs/nemotron-3.5-lightning.md
@@ -1,0 +1,25 @@
+# Nemotron 3.5 Lightning
+
+AFM supports `mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-mxfp4`
+through the MLX `nemotron_h` architecture path.
+
+Validated behavior:
+
+- streaming and non-streaming chat completions
+- batch dispatch and concurrent generation
+- XML and adaptive-XML tool calls
+- strict JSON-schema structured output
+- long prompts and deterministic seeded replay
+- safe prefix-cache fallback for the hybrid Mamba/KV cache
+
+The hybrid recurrent layers cannot be rewound like a conventional KV cache.
+AFM therefore rejects unsafe partial recurrent-state reuse and performs a cold
+prefill when necessary. The radix cache can identify matching prefixes and hold
+snapshots, but AFM does not restore a hybrid recurrent snapshot unless the
+architecture provides an exact, correctness-preserving replay boundary.
+
+Release validation on Apple Silicon completed 182/182 comprehensive cases and
+475/476 live assertions. The remaining live assertion was model behavior: the
+model returned text instead of a required EBNF tool call. Promptfoo completed
+388 cases with no transport or parser errors; its failures were semantic tool
+selection or argument-quality mismatches rather than malformed protocol output.


### PR DESCRIPTION
## Summary

- support the current Nemotron-H `layers_block_type` checkpoint layout
- normalize named Mamba, attention, MoE, and MLP block descriptors
- decode current time-step configuration and ignore MTP-only checkpoint weights
- correct implicit thinking detection so a closed `<think></think>` suffix is not reopened
- add checkpoint metadata, model-factory, tool-format, reasoning-toggle, and invalid-layout tests
- extend the assertion harness to find Hugging Face snapshot configs and classify hybrid recurrent caches

## Validation

- full Release Swift suite: 387 tests passed
- focused Release provider/checkpoint tests: 39 passed
- comprehensive no-AI-judge matrix: 182/182 passed
- live assertions: 475/476 passed, including streaming, non-streaming, batch dispatch, concurrency, structured output, long context, and adaptive XML tool calls
- Promptfoo: 326/388 passed with zero transport or parser errors; failures were semantic model tool-selection or argument-quality mismatches
- measured live generation: approximately 101-122 tok/s on the test system

## Known limitation

Nemotron-H uses a hybrid Mamba/KV cache. AFM preserves correctness by rejecting unsafe partial recurrent-state replay and using cold prefill where an exact replay boundary is unavailable. One live assertion also observed the model returning text instead of selecting a required EBNF tool; the protocol and parser remained valid.

The generated `vendor/mlx-swift-lm` patch state is intentionally not part of this commit; authoritative dependency changes live under `Scripts/patches`.

## Summary by Sourcery

Add full Nemotron 3.5 Lightning support via the `nemotron_h` architecture, including normalized checkpoint configuration decoding, safe hybrid Mamba/KV cache handling, robust implicit-thinking detection, and extended tests and docs for reasoning and tool-call behavior.

New Features:
- Add support for Nemotron-H checkpoints that use named `layers_block_type` layouts and integrate them with the existing `nemotron_h` architecture path.
- Infer XML tool-call formatting and reasoning toggle capabilities for Nemotron 3.5 Lightning checkpoints from local metadata and chat template files.

Bug Fixes:
- Prevent disabled-thinking prompts from incorrectly reopening a closed `<think></think>` block by detecting only genuinely open reasoning tags in the prompt suffix.
- Ignore MTP-only Nemotron-H checkpoint weights during load to avoid misusing unsupported parameters.
- Decode Nemotron-H time-step configuration correctly by handling new `time_step_min` aliases and treating `time_step_max` as unbounded for inference.

Enhancements:
- Normalize Nemotron-H block layout descriptors by mapping named Mamba, attention, MoE, and MLP layer types to the compact `hybrid_override_pattern` alphabet and deriving the hidden-layer count from the normalized pattern.
- Extend recurrent-layer cache classification to recognize Nemotron-H hybrid Mamba/KV configurations using `layers_block_type` hints in Hugging Face snapshot configs.
- Allow Swift test runs to select a build configuration via environment and locate model configs from Hugging Face hub cache snapshots for assertion harnesses.

Build:
- Allow configuring the Swift test command with a custom build configuration flag derived from an environment variable.

Documentation:
- Add user-facing documentation describing Nemotron 3.5 Lightning support, validated behaviors, hybrid cache safety constraints, and known model-level limitations.

Tests:
- Add Nemotron 3.5 Lightning checkpoint tests covering architecture selection, block layout normalization, time-step limits, tool-call format inference, reasoning-toggle detection, and invalid block-type handling.
- Extend thinking-tag tests to verify correct detection of open versus closed `<think>` blocks in prompt suffixes.
- Update assertion-harness tests to classify hybrid recurrent caches using `layers_block_type` hints from Hugging Face snapshot configurations.