### PR TITLE
Resolve DwarfStar GGUF repositories directly

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -164,7 +164,8 @@ let package = Package(
             name: "AFMKitDwarfStar",
             dependencies: [
                 "AFMKitCore",
-                "CDwarfStar"
+                "CDwarfStar",
+                .product(name: "HuggingFace", package: "swift-huggingface")
             ],
             resources: [
                 // DS4 compiles these include-style fragments at runtime. Keep the

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ afm -w
 |---|---|---|
 | **MLX** | Open models, VLMs, agent controls, performance tuning | `afm mlx -m <model>` |
 | **Apple Foundation Models** | Zero-download system model and `.fmadapter` LoRA adapters | `afm` |
-| **DwarfStar** | Compatible fixed-schedule Metal checkpoints | `afm mlx -m <checkpoint> --mlx-runtime dwarfstar` |
+| **DwarfStar** | Compatible fixed-schedule Metal checkpoints | `afm mlx -m <owner/repo>` (auto-resolved) or `afm mlx -m <checkpoint.gguf> --mlx-runtime dwarfstar` |
 | **Gateway** | One model list for Ollama, LM Studio, Jan, and other local servers | `afm --gateway` |
 
 Model IDs without an organization default to `mlx-community`, so `Qwen3-0.6B-4bit` and `mlx-community/Qwen3-0.6B-4bit` both work.

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -905,7 +905,13 @@ struct MlxCommand: ParsableCommand {
         let requested = mlxRuntime.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard requested != MLXRuntimeBackend.mlx.rawValue else { return model }
         let localPath = localModelPath(model)
-        guard !FileManager.default.fileExists(atPath: localPath), model.contains("/") else {
+        let obviousLocalPrefixes = ["/", "~/", "./", "../"]
+        let looksLocal = obviousLocalPrefixes.contains { model.hasPrefix($0) }
+        let repositoryComponents = model.split(separator: "/", omittingEmptySubsequences: false)
+        let looksLikeRepositoryID = !looksLocal
+            && repositoryComponents.count == 2
+            && repositoryComponents.allSatisfy { !$0.isEmpty }
+        guard !FileManager.default.fileExists(atPath: localPath), looksLikeRepositoryID else {
             if ggufFile != nil {
                 throw ValidationError("--gguf-file requires a Hugging Face repository ID")
             }

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -231,6 +231,7 @@ struct MlxCommand: ParsableCommand {
           --kv-bits: Quantize KV cache (4 or 8 bits) to reduce memory
           --prefill-step-size: Prompt tokens per GPU pass (default: 1024)
           --mlx-runtime: Runtime backend: auto, mlx, or dwarfstar (default: auto)
+          --gguf-file: Exact GGUF path inside a Hugging Face repository; otherwise AFM selects the largest model artifact that fits memory
           --enable-prefix-caching / --no-enable-prefix-caching: KV cache reuse across requests
           --mtp: Enable MTP self-speculative decoding for compatible Qwen3.6 models
           --mtp-depth: MTP draft depth compatibility setting
@@ -254,7 +255,7 @@ struct MlxCommand: ParsableCommand {
           --openclaw-config: Print OpenClaw provider config JSON and exit
           --help-json: Print machine-readable JSON capability card for AI agents and exit
         sampling_parameters: [temperature, top_p, top_k, min_p, presence_penalty, repetition_penalty, seed, max_tokens, logprobs, top_logprobs]
-        features: [streaming-sse, tool-calling, think-reasoning-extraction, stop-sequences, json-mode, json-schema, prompt-caching, vlm-image-input, kv-cache-quantization, grammar-constrained-decoding, openclaw-integration]
+        features: [streaming-sse, tool-calling, think-reasoning-extraction, stop-sequences, json-mode, json-schema, prompt-caching, vlm-image-input, kv-cache-quantization, grammar-constrained-decoding, huggingface-gguf-resolution, openclaw-integration]
         api_compatibility: OpenAI Chat Completions API (https://platform.openai.com/docs/api-reference/chat/create)
         extra_request_fields:
           top_k: int (not in OpenAI spec)
@@ -407,6 +408,8 @@ struct MlxCommand: ParsableCommand {
     var mlxKernels: String = "native"
     @Option(name: .long, help: "Runtime backend: auto, mlx, or dwarfstar. auto selects vanilla DwarfStar for compatible DeepSeek V4 GGUF metadata; directory checkpoints use MLX.")
     var mlxRuntime: String = "auto"
+    @Option(name: .customLong("gguf-file"), help: "Exact GGUF path inside a Hugging Face repository. By default AFM selects the largest model GGUF that fits memory and excludes speculative support files.")
+    var ggufFile: String?
     @Option(name: .long, help: "Pre-warm MLX kernels on startup for faster first response/TTFT (y/n, default: y)")
     var prewarm: String = "y"
     @Flag(name: .long, help: "Trust remote code (compatibility)")
@@ -645,13 +648,14 @@ struct MlxCommand: ParsableCommand {
             throw ExitCode.failure
         }
 
-        let runtimeBackend = try resolveRuntimeBackend(model: rawModel)
+        let resolvedModel = try resolveRemoteDwarfStarModelIfNeeded(rawModel)
+        let runtimeBackend = try resolveRuntimeBackend(model: resolvedModel)
         if runtimeBackend != .dwarfstar, dsparkSupportPath != nil {
             throw ValidationError("--dspark-support requires --mlx-runtime dwarfstar or a DwarfStar executor checkpoint")
         }
         if runtimeBackend == .dwarfstar {
             try runDwarfStar(
-                checkpointPath: localModelPath(rawModel),
+                checkpointPath: localModelPath(resolvedModel),
                 modelStore: modelStore,
                 chatTemplateKwargs: parsedKwargs,
                 forceDisableThinking: noThink,
@@ -686,7 +690,7 @@ struct MlxCommand: ParsableCommand {
             defaultGuidedJsonSchema: defaultGuidedJsonSchema
         )
         let runtime = AFMMLXRuntime(
-            modelID: rawModel,
+            modelID: resolvedModel,
             configuration: runtimeConfiguration,
             resolver: resolver
         )
@@ -895,6 +899,51 @@ struct MlxCommand: ParsableCommand {
             print("[Runtime] Selected DwarfStar for compatible raw GGUF.")
         }
         return .dwarfstar
+    }
+
+    private func resolveRemoteDwarfStarModelIfNeeded(_ model: String) throws -> String {
+        let requested = mlxRuntime.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard requested != MLXRuntimeBackend.mlx.rawValue else { return model }
+        let localPath = localModelPath(model)
+        guard !FileManager.default.fileExists(atPath: localPath), model.contains("/") else {
+            if ggufFile != nil {
+                throw ValidationError("--gguf-file requires a Hugging Face repository ID")
+            }
+            return model
+        }
+
+        let group = DispatchGroup()
+        let result = SendableBox<Result<URL, Error>?>(nil)
+        group.enter()
+        Task.detached {
+            do {
+                let resolver = AFMDwarfStarHubResolver()
+                result.value = .success(try await resolver.resolve(
+                    repositoryID: model,
+                    requestedPath: ggufFile))
+            } catch {
+                result.value = .failure(error)
+            }
+            group.leave()
+        }
+        group.wait()
+
+        switch result.value {
+        case .success(let url):
+            print("[Runtime] Hugging Face GGUF resolved: \(model) -> \(url.lastPathComponent)")
+            return url.path
+        case .failure(let error as AFMDwarfStarHubSelectionError):
+            if requested == MLXRuntimeBackend.auto.rawValue,
+               case .noModelGGUF = error,
+               ggufFile == nil {
+                return model
+            }
+            throw error
+        case .failure(let error):
+            throw error
+        case .none:
+            throw ValidationError("Hugging Face GGUF resolution ended without a result")
+        }
     }
 
     private func localModelPath(_ model: String) -> String {

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarHubResolver.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarHubResolver.swift
@@ -1,0 +1,148 @@
+import Foundation
+import HuggingFace
+
+public struct AFMDwarfStarHubArtifact: Equatable, Sendable {
+    public enum Role: Equatable, Sendable {
+        case model
+        case speculativeSupport
+    }
+
+    public let path: String
+    public let size: Int64?
+    public let role: Role
+
+    public init(path: String, size: Int64?) {
+        self.path = path
+        self.size = size
+        self.role = Self.classify(path: path)
+    }
+
+    private static func classify(path: String) -> Role {
+        let name = URL(fileURLWithPath: path).lastPathComponent.lowercased()
+        return name.contains("dspark") || name.contains("speculator") || name.contains("draft")
+            ? .speculativeSupport
+            : .model
+    }
+}
+
+public enum AFMDwarfStarHubSelectionError: LocalizedError, Equatable {
+    case invalidRepositoryID(String)
+    case noModelGGUF(String)
+    case requestedFileNotFound(String)
+    case modelExceedsMemoryBudget(path: String, size: Int64, budget: Int64)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRepositoryID(let id):
+            return "Invalid Hugging Face repository ID: \(id)"
+        case .noModelGGUF(let id):
+            return "Repository \(id) does not contain a DwarfStar model GGUF."
+        case .requestedFileNotFound(let path):
+            return "Requested GGUF file was not found in the repository: \(path)"
+        case .modelExceedsMemoryBudget(let path, let size, let budget):
+            return "GGUF \(path) is \(Self.bytes(size)), exceeding the \(Self.bytes(budget)) memory budget. Use --gguf-file to select it explicitly."
+        }
+    }
+
+    private static func bytes(_ value: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: value, countStyle: .binary)
+    }
+}
+
+public enum AFMDwarfStarHubSelector {
+    public static func selectModel(
+        from artifacts: [AFMDwarfStarHubArtifact],
+        repositoryID: String,
+        requestedPath: String? = nil,
+        physicalMemory: UInt64 = ProcessInfo.processInfo.physicalMemory,
+        memoryFraction: Double = 0.80
+    ) throws -> AFMDwarfStarHubArtifact {
+        let candidates = artifacts.filter {
+            $0.role == .model && $0.path.lowercased().hasSuffix(".gguf")
+        }
+        guard !candidates.isEmpty else {
+            throw AFMDwarfStarHubSelectionError.noModelGGUF(repositoryID)
+        }
+
+        if let requestedPath {
+            guard let exact = candidates.first(where: { $0.path == requestedPath }) else {
+                throw AFMDwarfStarHubSelectionError.requestedFileNotFound(requestedPath)
+            }
+            return exact
+        }
+
+        let fraction = min(max(memoryFraction, 0.1), 1.0)
+        let budget = Int64(min(Double(Int64.max), Double(physicalMemory) * fraction))
+        let fitting = candidates.filter { artifact in
+            guard let size = artifact.size else { return true }
+            return size <= budget
+        }
+        guard !fitting.isEmpty else {
+            let smallest = candidates.min { ($0.size ?? .max) < ($1.size ?? .max) }!
+            throw AFMDwarfStarHubSelectionError.modelExceedsMemoryBudget(
+                path: smallest.path,
+                size: smallest.size ?? .max,
+                budget: budget)
+        }
+
+        // Prefer the highest-fidelity artifact that fits. Unknown sizes sort
+        // last so a repository with complete metadata remains deterministic.
+        return fitting.sorted {
+            switch ($0.size, $1.size) {
+            case let (lhs?, rhs?) where lhs != rhs: return lhs > rhs
+            case (_?, nil): return true
+            case (nil, _?): return false
+            default: return $0.path.localizedStandardCompare($1.path) == .orderedAscending
+            }
+        }.first!
+    }
+}
+
+public struct AFMDwarfStarHubResolver: Sendable {
+    private let cacheDirectory: URL
+
+    public init(cacheDirectory: URL = Self.defaultCacheDirectory()) {
+        self.cacheDirectory = cacheDirectory
+    }
+
+    public func resolve(
+        repositoryID: String,
+        requestedPath: String? = nil,
+        progress: (@MainActor @Sendable (Progress) -> Void)? = nil
+    ) async throws -> URL {
+        guard let repo = HuggingFace.Repo.ID(rawValue: repositoryID) else {
+            throw AFMDwarfStarHubSelectionError.invalidRepositoryID(repositoryID)
+        }
+        let client = HuggingFace.HubClient(cache: HubCache(cacheDirectory: cacheDirectory))
+        let entries = try await client.listFiles(in: repo).filter {
+            $0.type == .file && $0.path.lowercased().hasSuffix(".gguf")
+        }
+        let artifact = try AFMDwarfStarHubSelector.selectModel(
+            from: entries.map {
+                AFMDwarfStarHubArtifact(path: $0.path, size: $0.size.map(Int64.init))
+            },
+            repositoryID: repositoryID,
+            requestedPath: requestedPath)
+        let snapshot = try await client.downloadSnapshot(
+            of: repo,
+            matching: [artifact.path],
+            maxConcurrentDownloads: 1,
+            progressHandler: progress)
+        return snapshot.appendingPathComponent(artifact.path)
+    }
+
+    public static func defaultCacheDirectory() -> URL {
+        let environment = ProcessInfo.processInfo.environment
+        if let value = environment["HF_HUB_CACHE"] ?? environment["HUGGINGFACE_HUB_CACHE"],
+           !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return URL(fileURLWithPath: NSString(string: value).expandingTildeInPath)
+        }
+        if let value = environment["HF_HOME"],
+           !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return URL(fileURLWithPath: NSString(string: value).expandingTildeInPath)
+                .appendingPathComponent("hub")
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache/huggingface/hub")
+    }
+}

--- a/Tests/AFMKitDwarfStarTests/AFMDwarfStarHubResolverTests.swift
+++ b/Tests/AFMKitDwarfStarTests/AFMDwarfStarHubResolverTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import AFMKitDwarfStar
+
+final class AFMDwarfStarHubResolverTests: XCTestCase {
+    func testSelectorExcludesDSparkSupportArtifact() throws {
+        let selected = try AFMDwarfStarHubSelector.selectModel(
+            from: [
+                .init(path: "DeepSeek-DSpark.gguf", size: 6_000),
+                .init(path: "DeepSeek-main.gguf", size: 150_000)
+            ],
+            repositoryID: "owner/model",
+            physicalMemory: 1_000_000)
+
+        XCTAssertEqual(selected.path, "DeepSeek-main.gguf")
+    }
+
+    func testSelectorChoosesLargestModelThatFitsMemoryBudget() throws {
+        let selected = try AFMDwarfStarHubSelector.selectModel(
+            from: [
+                .init(path: "q2.gguf", size: 20),
+                .init(path: "q4.gguf", size: 70),
+                .init(path: "q8.gguf", size: 95)
+            ],
+            repositoryID: "owner/model",
+            physicalMemory: 100,
+            memoryFraction: 0.8)
+
+        XCTAssertEqual(selected.path, "q4.gguf")
+    }
+
+    func testExplicitFileOverridesMemorySelection() throws {
+        let selected = try AFMDwarfStarHubSelector.selectModel(
+            from: [
+                .init(path: "small.gguf", size: 20),
+                .init(path: "large.gguf", size: 95)
+            ],
+            repositoryID: "owner/model",
+            requestedPath: "large.gguf",
+            physicalMemory: 100)
+
+        XCTAssertEqual(selected.path, "large.gguf")
+    }
+
+    func testSelectorRejectsRepositoryWithOnlySupportGGUF() {
+        XCTAssertThrowsError(try AFMDwarfStarHubSelector.selectModel(
+            from: [.init(path: "dspark-support.gguf", size: 10)],
+            repositoryID: "owner/model")) { error in
+                XCTAssertEqual(
+                    error as? AFMDwarfStarHubSelectionError,
+                    .noModelGGUF("owner/model"))
+            }
+    }
+}

--- a/docs/dwarfstar-runtime.md
+++ b/docs/dwarfstar-runtime.md
@@ -15,6 +15,21 @@ The DwarfStar runtime accepts a local native GGUF file whose
 selects DwarfStar for that file without relying on its filename. Directory-based
 MLX or AFM safetensor checkpoints remain on the MLX runtime.
 
+AFM also accepts a Hugging Face repository ID directly. AFMKit lists the
+repository GGUF artifacts, excludes DSpark/speculator support files from target
+model selection, downloads only the selected model, and then performs the same
+metadata-based runtime detection:
+
+```bash
+afm mlx -m scouzi1966/DeepSeek-V4-Flash-0731-DwarfStar-GGUF -w
+```
+
+When a repository contains multiple target checkpoints, AFM selects the largest
+one that fits within 80% of physical memory. Use `--gguf-file <repo/path.gguf>`
+to make the selection explicit. The existing Hugging Face cache environment
+variables (`HF_HUB_CACHE`, `HUGGINGFACE_HUB_CACHE`, and `HF_HOME`) control the
+download location.
+
 AFM does not project safetensor shards into DwarfStar's address space. Supporting
 that representation would require changing DwarfStar's loader internals and is
 outside the dependency boundary. Convert or obtain a DwarfStar-compatible GGUF


### PR DESCRIPTION
Closes #170.

- resolve Hugging Face GGUF repositories through AFMKitDwarfStar
- exclude speculative support artifacts and select the largest model fitting memory
- support explicit `--gguf-file` selection
- preserve metadata-based DwarfStar runtime detection
- document the one-command workflow

Validation:
- `Scripts/swiftpm-reliable.sh test -c release --filter AFMDwarfStarHubResolverTests`
- `Scripts/swiftpm-reliable.sh build -c release --product afm`
- human and JSON CLI help discovery checks

## Summary by Sourcery

Resolve DwarfStar GGUF checkpoints from Hugging Face repositories, automatically selecting an appropriate model artifact, while exposing explicit GGUF file selection through the CLI and documenting the new workflow.

New Features:
- Allow AFM to resolve and download DwarfStar GGUF models directly from Hugging Face repositories, including automatic selection of a suitable checkpoint.
- Add CLI support for explicitly selecting a specific GGUF file within a Hugging Face repository via the --gguf-file option.

Enhancements:
- Integrate the swift-huggingface client into AFMKitDwarfStar for repository browsing and snapshot downloads.
- Extend runtime resolution to transparently handle remote DwarfStar GGUF repositories while preserving metadata-based backend detection.
- Advertise Hugging Face GGUF resolution capability in CLI JSON help and user-facing documentation, including an updated one-command DwarfStar workflow.

Build:
- Add HuggingFace package dependency to AFMKitDwarfStar for Hugging Face Hub integration.

Documentation:
- Update DwarfStar runtime documentation and README to describe direct Hugging Face repository usage, automatic GGUF selection, and cache environment variables.

Tests:
- Add unit tests for DwarfStar Hub selection logic, covering speculative artifact exclusion, memory-based model choice, explicit file selection, and error handling when no valid model GGUF exists.