### PR TITLE
Reuse Nemotron recurrent prefix checkpoints

### DIFF
--- a/Scripts/feature-mlx-concurrent-batch/README.md
+++ b/Scripts/feature-mlx-concurrent-batch/README.md
@@ -81,6 +81,20 @@ python3 validate_mixed_workload.py 1 4          # specific batch sizes
 python3 validate_mixed_workload.py --label "overlap-v2" 1 2 4 8
 ```
 
+For a bounded Release acceptance run, cap generation and assert that the widest
+batch materially improves aggregate throughput without starving short requests:
+
+```bash
+AFM_MIXED_MAX_TOKENS=512 \
+AFM_MIXED_ASSERT=1 \
+AFM_MIXED_MIN_AGGREGATE_SCALE=1.20 \
+AFM_MIXED_MAX_SHORT_TTFT_S=15 \
+python3 validate_mixed_workload.py --label "release-acceptance" 1 8
+```
+
+Aggregate throughput uses total completion tokens divided by complete workload
+wall time. This keeps sequential `B=1` and concurrent results comparable.
+
 ### `validate_multiturn_prefix.py`
 
 Multi-turn prefix cache validation. Simulates concurrent users with shared long system prompts (~350 tok each), 3-turn conversations, and 2 long-decode requests. Measures cached_tokens, pp, tg, TTFT, and prefix cache hit rates.

--- a/Scripts/feature-mlx-concurrent-batch/validate_mixed_workload.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_mixed_workload.py
@@ -14,6 +14,10 @@ import asyncio, aiohttp, json, time, sys, subprocess, threading, os
 URL = os.environ.get("AFM_CHAT_COMPLETIONS_URL", "http://localhost:9999/v1/chat/completions")
 MODEL = os.environ.get("AFM_MODEL", "mlx-community/Qwen3.5-35B-A3B-4bit")
 REQUEST_TIMEOUT_S = int(os.environ.get("AFM_REQUEST_TIMEOUT_S", "1200"))
+MAX_TOKENS_CAP = int(os.environ.get("AFM_MIXED_MAX_TOKENS", "0"))
+ASSERT_ACCEPTANCE = os.environ.get("AFM_MIXED_ASSERT", "0") == "1"
+MIN_AGGREGATE_SCALE = float(os.environ.get("AFM_MIXED_MIN_AGGREGATE_SCALE", "1.20"))
+MAX_SHORT_TTFT_S = float(os.environ.get("AFM_MIXED_MAX_SHORT_TTFT_S", "15"))
 
 # --- Short-answer tests (long prompts, expect brief response) ---
 SHORT_ANSWER_TESTS = [
@@ -207,6 +211,8 @@ class MactopSampler:
 
 async def send_request(session, prompt, max_tokens=4096):
     """Send streaming request, return full stats dict from server."""
+    if MAX_TOKENS_CAP > 0:
+        max_tokens = min(max_tokens, MAX_TOKENS_CAP)
     payload = {
         "model": MODEL,
         "messages": [{"role": "user", "content": prompt}],
@@ -282,6 +288,7 @@ async def run_batch(batch_size, tests):
     failed = 0
     results = []
 
+    workload_start = time.monotonic()
     timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT_S + 30, sock_read=REQUEST_TIMEOUT_S)
     async with aiohttp.ClientSession(timeout=timeout) as session:
         for batch_start in range(0, len(tests), batch_size):
@@ -303,24 +310,28 @@ async def run_batch(batch_size, tests):
                 r = outcome
                 min_tok = test.get("min_tokens", 0)
                 check = check_response(r["text"], test["expected"], min_tok)
+                r["name"] = name
+                r["kind"] = "long" if min_tok > 0 else "short"
 
                 if check["is_garbage"]:
                     failed += 1
                     print(f"  FAIL  {name}: GARBAGE")
-                    results.append({"name": name, "status": "GARBAGE"})
+                    r["status"] = "GARBAGE"
+                    results.append(r)
                 elif check["too_short"]:
                     failed += 1
                     print(f"  FAIL  {name}: TOO SHORT ({r['completion_tokens']} tok)")
-                    results.append({"name": name, "status": "TOO_SHORT"})
+                    r["status"] = "TOO_SHORT"
+                    results.append(r)
                 elif not check["all_found"]:
                     failed += 1
                     print(f"  FAIL  {name}: missing {check['missing']}")
-                    results.append({"name": name, "status": "MISSING", "missing": check["missing"]})
+                    r["status"] = "MISSING"
+                    r["missing"] = check["missing"]
+                    results.append(r)
                 else:
                     passed += 1
-                    r["name"] = name
                     r["status"] = "OK"
-                    r["kind"] = "long" if min_tok > 0 else "short"
                     results.append(r)
 
                     pp = r["pp_tok_s"]
@@ -331,7 +342,7 @@ async def run_batch(batch_size, tests):
                           f"tg={ct:4d} tok {tg:6.1f} t/s  "
                           f"TTFT={r['ttft']:.2f}s  wall={r['wall_s']:.1f}s")
 
-    return passed, failed, results
+    return passed, failed, results, time.monotonic() - workload_start
 
 
 # ─── main ─────────────────────────────────────────────────────────────────────
@@ -362,45 +373,46 @@ async def main():
         gpu = MactopSampler()
         gpu.start()
 
-        p, f, results = await run_batch(bs, all_tests)
+        p, f, results, workload_wall = await run_batch(bs, all_tests)
         total_passed += p
         total_failed += f
 
         gpu.stop()
         gpu_stats = gpu.summary()
 
-        ok_results = [r for r in results if r.get("status") == "OK"]
-        long_ok = [r for r in ok_results if r.get("kind") == "long"]
-        short_ok = [r for r in ok_results if r.get("kind") == "short"]
+        completed_results = [r for r in results if r.get("completion_tokens") is not None]
+        long_completed = [r for r in completed_results if r.get("kind") == "long"]
+        short_completed = [r for r in completed_results if r.get("kind") == "short"]
 
         # Per-request summary
-        if ok_results:
-            total_prompt = sum(r["prompt_tokens"] for r in ok_results)
-            total_completion = sum(r["completion_tokens"] for r in ok_results)
+        if completed_results:
+            total_prompt = sum(r["prompt_tokens"] for r in completed_results)
+            total_completion = sum(r["completion_tokens"] for r in completed_results)
             total_all = total_prompt + total_completion
-            avg_pp = sum(r["pp_tok_s"] for r in ok_results) / len(ok_results)
-            avg_tg = sum(r["tg_tok_s"] for r in ok_results) / len(ok_results)
-            avg_ttft = sum(r["ttft"] for r in ok_results) / len(ok_results)
-            max_wall = max(r["wall_s"] for r in ok_results)
-            agg_tg = total_completion / max_wall if max_wall > 0 else 0
+            avg_pp = sum(r["pp_tok_s"] for r in completed_results) / len(completed_results)
+            avg_tg = sum(r["tg_tok_s"] for r in completed_results) / len(completed_results)
+            avg_ttft = sum(r["ttft"] for r in completed_results) / len(completed_results)
+            max_wall = max(r["wall_s"] for r in completed_results)
+            agg_tg = total_completion / workload_wall if workload_wall > 0 else 0
 
             print(f"  {'─'*96}")
             print(f"  Totals: {total_prompt} prompt + {total_completion} completion = {total_all} tokens")
             print(f"  Avg pp: {avg_pp:.1f} tok/s   Avg tg (per-req): {avg_tg:.1f} tok/s   "
-                  f"Agg tg: {agg_tg:.1f} tok/s   Avg TTFT: {avg_ttft:.2f}s")
+                  f"Agg tg: {agg_tg:.1f} tok/s   Avg TTFT: {avg_ttft:.2f}s   "
+                  f"Workload wall: {workload_wall:.1f}s")
 
-            if long_ok:
-                l_pp = sum(r["pp_tok_s"] for r in long_ok) / len(long_ok)
-                l_tg = sum(r["tg_tok_s"] for r in long_ok) / len(long_ok)
-                l_ct = sum(r["completion_tokens"] for r in long_ok)
-                l_ttft = sum(r["ttft"] for r in long_ok) / len(long_ok)
+            if long_completed:
+                l_pp = sum(r["pp_tok_s"] for r in long_completed) / len(long_completed)
+                l_tg = sum(r["tg_tok_s"] for r in long_completed) / len(long_completed)
+                l_ct = sum(r["completion_tokens"] for r in long_completed)
+                l_ttft = sum(r["ttft"] for r in long_completed) / len(long_completed)
                 print(f"  Long-decode: {l_ct} tok, avg pp={l_pp:.1f} tg={l_tg:.1f} tok/s, TTFT={l_ttft:.2f}s")
 
-            if short_ok:
-                s_pp = sum(r["pp_tok_s"] for r in short_ok) / len(short_ok)
-                s_tg = sum(r["tg_tok_s"] for r in short_ok) / len(short_ok)
-                s_ct = sum(r["completion_tokens"] for r in short_ok)
-                s_ttft = sum(r["ttft"] for r in short_ok) / len(short_ok)
+            if short_completed:
+                s_pp = sum(r["pp_tok_s"] for r in short_completed) / len(short_completed)
+                s_tg = sum(r["tg_tok_s"] for r in short_completed) / len(short_completed)
+                s_ct = sum(r["completion_tokens"] for r in short_completed)
+                s_ttft = sum(r["ttft"] for r in short_completed) / len(short_completed)
                 print(f"  Short-answer: {s_ct} tok, avg pp={s_pp:.1f} tg={s_tg:.1f} tok/s, TTFT={s_ttft:.2f}s")
 
         if gpu_stats and gpu_stats["n_samples"] > 0:
@@ -414,8 +426,8 @@ async def main():
         print(f"{'='*100}")
 
         all_batch_results[bs] = {
-            "passed": p, "failed": f, "results": ok_results,
-            "gpu": gpu_stats,
+            "passed": p, "failed": f, "results": completed_results,
+            "gpu": gpu_stats, "workload_wall_s": workload_wall,
         }
         await asyncio.sleep(1)
 
@@ -447,7 +459,8 @@ async def main():
         avg_tg = sum(r["tg_tok_s"] for r in ok) / len(ok)
         avg_ttft = sum(r["ttft"] for r in ok) / len(ok)
         max_wall = max(r["wall_s"] for r in ok)
-        agg_tg = total_compl / max_wall if max_wall > 0 else 0
+        workload_wall = br["workload_wall_s"]
+        agg_tg = total_compl / workload_wall if workload_wall > 0 else 0
         g = br.get("gpu") or {}
 
         gpu_pct = f"{g.get('gpu_pct', 0):.0f}%" if g else "—"
@@ -467,6 +480,42 @@ async def main():
         print(f"  ({total_failed} failures: model answer mismatches, not code bugs)")
     print(f"{'='*120}")
 
+    acceptance_failed = False
+    if ASSERT_ACCEPTANCE:
+        baseline = all_batch_results.get(1)
+        widest_size = max(batch_sizes)
+        widest = all_batch_results.get(widest_size)
+        if not baseline or not widest or not baseline["results"] or not widest["results"]:
+            print("  ACCEPTANCE FAIL: B=1 and widest requested batch must both complete")
+            acceptance_failed = True
+        else:
+            def aggregate(result):
+                tokens = sum(r["completion_tokens"] for r in result["results"])
+                return tokens / result["workload_wall_s"]
+
+            baseline_aggregate = aggregate(baseline)
+            widest_aggregate = aggregate(widest)
+            scale = widest_aggregate / baseline_aggregate if baseline_aggregate > 0 else 0
+            widest_short = [r for r in widest["results"] if r.get("kind") == "short"]
+            max_short_ttft = max((r["ttft"] for r in widest_short), default=float("inf"))
+            throughput_ok = scale >= MIN_AGGREGATE_SCALE
+            fairness_ok = max_short_ttft <= MAX_SHORT_TTFT_S
+            print(
+                f"  ACCEPTANCE: aggregate scale={scale:.2f}x "
+                f"(minimum {MIN_AGGREGATE_SCALE:.2f}x), "
+                f"max short TTFT={max_short_ttft:.2f}s "
+                f"(maximum {MAX_SHORT_TTFT_S:.2f}s)"
+            )
+            if not throughput_ok:
+                print("  ACCEPTANCE FAIL: aggregate decode did not scale materially")
+            if not fairness_ok:
+                print("  ACCEPTANCE FAIL: short requests were starved")
+            acceptance_failed = not throughput_ok or not fairness_ok
+
+    # Acceptance mode is a scheduler-performance gate. Semantic answer checks
+    # remain visible in the report but are covered by the uncapped quality run.
+    if ASSERT_ACCEPTANCE:
+        return 1 if acceptance_failed else 0
     return 1 if total_failed else 0
 
 

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -216,6 +216,15 @@ actor BatchScheduler {
         }
     }
 
+    /// Hybrid recurrent state cannot be trimmed to an arbitrary token offset.
+    /// Capture it one token before the prompt boundary, then replay that token
+    /// after restore to recover the same next-token logits.
+    nonisolated static func requiresReplayBoundarySnapshot(_ cache: [KVCache]) -> Bool {
+        cache.contains {
+            $0 is ArraysCache || $0 is CacheList || $0 is DeepseekV4Cache
+        }
+    }
+
     /// Whether a per-request cache can be promoted into the scheduler's dense
     /// batch cache representation. Hybrid caches carry model-specific state and
     /// must provide their own batch implementation before entering this path.
@@ -232,6 +241,30 @@ actor BatchScheduler {
     /// otherwise alias mutable rotating-cache buffers.
     nonisolated static func snapshotCacheState(_ state: [MLXArray]) -> [MLXArray] {
         state.map { $0 * 1 }
+    }
+
+    /// Select bounded exact recurrent-state boundaries across a prefill. These
+    /// checkpoints let a later divergent request restore the closest captured
+    /// prefix without pretending recurrent state can be trimmed.
+    nonisolated static func recurrentCheckpointBoundaries(
+        restoredPrefix: Int,
+        finalBoundary: Int,
+        minimumStride: Int = 256,
+        maximumCheckpoints: Int = 8
+    ) -> [Int] {
+        guard finalBoundary > restoredPrefix,
+              minimumStride > 0,
+              maximumCheckpoints > 0
+        else { return [] }
+        let span = finalBoundary - restoredPrefix
+        let stride = max(minimumStride, (span + maximumCheckpoints - 1) / maximumCheckpoints)
+        var boundaries: [Int] = []
+        var boundary = restoredPrefix + stride
+        while boundary < finalBoundary && boundaries.count < maximumCheckpoints {
+            boundaries.append(boundary)
+            boundary += stride
+        }
+        return boundaries
     }
 
     private func unsafeExactReplaySuffix() -> Int? {
@@ -766,7 +799,10 @@ actor BatchScheduler {
 
                     for req in accepted {
                         let isMultimodal = req.input.image != nil || req.input.video != nil
-                        if isMultimodal || hasReusableCachedPrefix(for: req) {
+                        let recurrentCache = radixCache != nil
+                            && Self.requiresReplayBoundarySnapshot(
+                                model.newCache(parameters: req.parameters))
+                        if isMultimodal || recurrentCache || hasReusableCachedPrefix(for: req) {
                             individual.append(req)
                         } else {
                             batchEligible.append(req)
@@ -1063,13 +1099,14 @@ actor BatchScheduler {
         let inputTokens = req.input.text.tokens.reshaped(-1).asArray(Int.self)
         guard !inputTokens.isEmpty else { return false }
 
-        let match = radix.findPrefixMatch(inputTokens)
-        guard match.prefixLen > 0, match.layerStates != nil else { return false }
-
         let cache = model.newCache(parameters: req.parameters)
         let recurrent = cache.contains {
             $0 is ArraysCache || $0 is CacheList || $0 is DeepseekV4Cache
         }
+        let match = recurrent
+            ? radix.findExactBoundaryMatch(inputTokens)
+            : radix.findPrefixMatch(inputTokens)
+        guard match.prefixLen > 0, match.layerStates != nil else { return false }
         return Self.effectiveCachedPrefixLength(
             matchedPrefix: match.prefixLen,
             inputTokenCount: inputTokens.count,
@@ -1100,7 +1137,12 @@ actor BatchScheduler {
         // Prefix cache: restore KV state if available
         if !isMultimodal, let radix = radixCache {
             let tLookup0 = Date.timeIntervalSinceReferenceDate
-            let match = radix.findPrefixMatch(inputTokens)
+            let recurrent = cache.contains {
+                $0 is ArraysCache || $0 is CacheList || $0 is DeepseekV4Cache
+            }
+            let match = recurrent
+                ? radix.findExactBoundaryMatch(inputTokens)
+                : radix.findPrefixMatch(inputTokens)
             let prefixLen = match.prefixLen
             let layerStates = match.layerStates
             let layerMetaStates = match.layerMetaStates
@@ -1110,9 +1152,6 @@ actor BatchScheduler {
             // Inlined hasRecurrentLayers(cache): an actor-isolated call would make
             // the compiler treat the non-Sendable `cache` as "sent", conflicting
             // with its later in-actor uses. Inlining keeps it in one region.
-            let recurrent = cache.contains {
-                $0 is ArraysCache || $0 is CacheList || $0 is DeepseekV4Cache
-            }
             let effectivePrefix = Self.effectiveCachedPrefixLength(
                 matchedPrefix: prefixLen,
                 inputTokenCount: inputTokens.count,
@@ -1173,25 +1212,50 @@ actor BatchScheduler {
         let logitSampler = req.parameters.sampler()
         logitProcessor?.prompt(generateInput.text.tokens)
 
-        // DeepSeek's compressor/indexer state is not safely rewindable from a
-        // longer descendant snapshot. Persist the exact prompt-minus-one
-        // boundary instead: restore that state later and evaluate the final
-        // prompt token to reproduce the original next-token logits.
-        let hasDeepseekCache = cache.contains { $0 is DeepseekV4Cache }
-        let shouldCaptureDeepseekBoundary = radixCache != nil
-            && hasDeepseekCache
+        // Hybrid recurrent state (DeepSeek compressor/indexer, Mamba, and
+        // GatedDeltaNet) is not safely rewindable from a longer snapshot.
+        // Persist the exact prompt-minus-one boundary instead: restore that
+        // state later and evaluate the final prompt token to reproduce the
+        // original next-token logits.
+        let shouldCaptureReplayBoundary = radixCache != nil
+            && Self.requiresReplayBoundarySnapshot(cache)
             && !inputTokens.isEmpty
         var prefixCacheTokens: [Int]? = nil
         var prefixCacheStates: [[MLXArray]]? = nil
         var prefixCacheMetaStates: [[String]]? = nil
         let suffixTokens = generateInput.text.tokens.reshaped(-1).asArray(Int.self)
         let result: LMOutput
-        if shouldCaptureDeepseekBoundary, let finalToken = suffixTokens.last {
+        if shouldCaptureReplayBoundary, let finalToken = suffixTokens.last {
             var recurrentState: LMOutput.State? = nil
-            if suffixTokens.count > 1 {
-                let leading = LMInput.Text(
-                    tokens: MLXArray(Array(suffixTokens.dropLast()))[.newAxis])
-                recurrentState = model(leading, cache: cache, state: nil).state
+            let leadingTokens = Array(suffixTokens.dropLast())
+            let finalBoundary = inputTokens.count - 1
+            let checkpoints = Self.recurrentCheckpointBoundaries(
+                restoredPrefix: cachedTokens,
+                finalBoundary: finalBoundary
+            )
+            var consumed = 0
+            for boundary in checkpoints + [finalBoundary] {
+                let targetConsumed = boundary - cachedTokens
+                guard targetConsumed > consumed else { continue }
+                let chunk = Array(leadingTokens[consumed..<targetConsumed])
+                recurrentState = model(
+                    LMInput.Text(tokens: MLXArray(chunk)[.newAxis]),
+                    cache: cache,
+                    state: recurrentState
+                ).state
+                consumed = targetConsumed
+
+                if boundary < finalBoundary, let radix = radixCache {
+                    let states = cache.map { Self.snapshotCacheState($0.state) }
+                    MLX.eval(states.flatMap { $0 })
+                    radix.insert(
+                        tokens: Array(inputTokens.prefix(boundary)),
+                        layerStates: states,
+                        layerMetaStates: cache.map { $0.metaState }
+                    )
+                    DebugLogger.log(
+                        "[BatchScheduler] Recurrent prefix checkpoint: \(boundary) tokens")
+                }
             }
             let states = cache.map { layerCache in
                 // `contiguous` may return the original storage when the source

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -210,12 +210,6 @@ actor BatchScheduler {
     /// Total tokens generated across all slots (for periodic cache clearing).
     private var totalTokensGenerated = 0
 
-    private func hasRecurrentLayers(_ cache: [KVCache]) -> Bool {
-        cache.contains {
-            $0 is ArraysCache || $0 is CacheList || $0 is DeepseekV4Cache
-        }
-    }
-
     /// Hybrid recurrent state cannot be trimmed to an arbitrary token offset.
     /// Capture it one token before the prompt boundary, then replay that token
     /// after restore to recover the same next-token logits.
@@ -799,10 +793,13 @@ actor BatchScheduler {
 
                     for req in accepted {
                         let isMultimodal = req.input.image != nil || req.input.video != nil
+                        let requestCache = model.newCache(parameters: req.parameters)
                         let recurrentCache = radixCache != nil
-                            && Self.requiresReplayBoundarySnapshot(
-                                model.newCache(parameters: req.parameters))
-                        if isMultimodal || recurrentCache || hasReusableCachedPrefix(for: req) {
+                            && Self.requiresReplayBoundarySnapshot(requestCache)
+                        if isMultimodal
+                            || recurrentCache
+                            || hasReusableCachedPrefix(for: req, cache: requestCache)
+                        {
                             individual.append(req)
                         } else {
                             batchEligible.append(req)
@@ -1094,15 +1091,15 @@ actor BatchScheduler {
 
     /// Probe whether a request must use individual prefill to preserve a reusable
     /// radix entry. This is called only from the actor's serialized generation loop.
-    private func hasReusableCachedPrefix(for req: PendingRequest) -> Bool {
+    private func hasReusableCachedPrefix(
+        for req: PendingRequest,
+        cache: [KVCache]
+    ) -> Bool {
         guard let radix = radixCache else { return false }
         let inputTokens = req.input.text.tokens.reshaped(-1).asArray(Int.self)
         guard !inputTokens.isEmpty else { return false }
 
-        let cache = model.newCache(parameters: req.parameters)
-        let recurrent = cache.contains {
-            $0 is ArraysCache || $0 is CacheList || $0 is DeepseekV4Cache
-        }
+        let recurrent = Self.requiresReplayBoundarySnapshot(cache)
         let match = recurrent
             ? radix.findExactBoundaryMatch(inputTokens)
             : radix.findPrefixMatch(inputTokens)
@@ -1137,9 +1134,7 @@ actor BatchScheduler {
         // Prefix cache: restore KV state if available
         if !isMultimodal, let radix = radixCache {
             let tLookup0 = Date.timeIntervalSinceReferenceDate
-            let recurrent = cache.contains {
-                $0 is ArraysCache || $0 is CacheList || $0 is DeepseekV4Cache
-            }
+            let recurrent = Self.requiresReplayBoundarySnapshot(cache)
             let match = recurrent
                 ? radix.findExactBoundaryMatch(inputTokens)
                 : radix.findPrefixMatch(inputTokens)
@@ -1227,7 +1222,10 @@ actor BatchScheduler {
         let result: LMOutput
         if shouldCaptureReplayBoundary, let finalToken = suffixTokens.last {
             var recurrentState: LMOutput.State? = nil
-            let leadingTokens = Array(suffixTokens.dropLast())
+            // `generateInput` was sliced at `cachedTokens` on restore, so this
+            // array contains only the uncached suffix before the final replay
+            // token. The consumed offsets below are relative to that suffix.
+            let uncachedLeadingTokens = Array(suffixTokens.dropLast())
             let finalBoundary = inputTokens.count - 1
             let checkpoints = Self.recurrentCheckpointBoundaries(
                 restoredPrefix: cachedTokens,
@@ -1237,7 +1235,7 @@ actor BatchScheduler {
             for boundary in checkpoints + [finalBoundary] {
                 let targetConsumed = boundary - cachedTokens
                 guard targetConsumed > consumed else { continue }
-                let chunk = Array(leadingTokens[consumed..<targetConsumed])
+                let chunk = Array(uncachedLeadingTokens[consumed..<targetConsumed])
                 recurrentState = model(
                     LMInput.Text(tokens: MLXArray(chunk)[.newAxis]),
                     cache: cache,

--- a/Sources/AFMKitMLX/Models/RadixTreeCache.swift
+++ b/Sources/AFMKitMLX/Models/RadixTreeCache.swift
@@ -166,6 +166,51 @@ final class RadixTreeCache: @unchecked Sendable {
         )
     }
 
+    /// Return the deepest cached state whose capture boundary is fully contained
+    /// in `tokens`. Unlike `findPrefixMatch`, this never borrows a longer
+    /// descendant entry. Recurrent caches cannot be trimmed, so they must restore
+    /// state captured at an exact token boundary.
+    func findExactBoundaryMatch(_ tokens: [Int]) -> RadixPrefixMatch {
+        var node = root
+        var matched = 0
+        var lastCachedEntry: KVCacheEntry?
+        var lastCachedLen = 0
+
+        while matched < tokens.count {
+            guard let child = node.children[tokens[matched]] else { break }
+            let edge = child.edgeTokens
+            var edgePos = 0
+            while edgePos < edge.count && matched < tokens.count {
+                guard tokens[matched] == edge[edgePos] else { break }
+                edgePos += 1
+                matched += 1
+            }
+
+            guard edgePos == edge.count else { break }
+            node = child
+            if let entry = node.cacheEntry {
+                lastCachedEntry = entry
+                lastCachedLen = matched
+            }
+        }
+
+        guard let cached = lastCachedEntry else {
+            return RadixPrefixMatch(
+                prefixLen: 0,
+                sourceTokenCount: nil,
+                layerStates: nil,
+                layerMetaStates: nil
+            )
+        }
+        cached.touch()
+        return RadixPrefixMatch(
+            prefixLen: lastCachedLen,
+            sourceTokenCount: cached.tokens.count,
+            layerStates: cached.layerStates,
+            layerMetaStates: cached.layerMetaStates
+        )
+    }
+
     /// Insert a cached prefix into the tree.
     /// layerStates: per-layer KV cache state (from cache[i].state).
     func insert(tokens: [Int], layerStates: [[MLXArray]], layerMetaStates: [[String]] = []) {

--- a/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
+++ b/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
@@ -268,6 +268,34 @@ struct ConcurrentBatchTests {
         ) == 58)
     }
 
+    @Test("BatchScheduler snapshots generic recurrent caches at a replay boundary")
+    func genericRecurrentBoundarySnapshot() {
+        #expect(BatchScheduler.requiresReplayBoundarySnapshot([
+            MambaCache(), KVCacheSimple()
+        ]))
+        #expect(!BatchScheduler.requiresReplayBoundarySnapshot([
+            KVCacheSimple(), KVCacheSimple()
+        ]))
+    }
+
+    @Test("BatchScheduler bounds recurrent prefix checkpoints")
+    func recurrentCheckpointSelection() {
+        #expect(BatchScheduler.recurrentCheckpointBoundaries(
+            restoredPrefix: 0,
+            finalBoundary: 870
+        ) == [256, 512, 768])
+        let long = BatchScheduler.recurrentCheckpointBoundaries(
+            restoredPrefix: 0,
+            finalBoundary: 32_767
+        )
+        #expect(long.count == 7)
+        #expect(long.last! < 32_767)
+        #expect(BatchScheduler.recurrentCheckpointBoundaries(
+            restoredPrefix: 768,
+            finalBoundary: 870
+        ).isEmpty)
+    }
+
     @Test("BatchScheduler cache snapshot owns independent MLX storage")
     func cacheSnapshotOwnsIndependentStorage() {
         let backing = MLXArray([Int32(10), Int32(20), Int32(30), Int32(40)])

--- a/Tests/MacLocalAPITests/RadixTreeCacheTests.swift
+++ b/Tests/MacLocalAPITests/RadixTreeCacheTests.swift
@@ -21,6 +21,29 @@ struct RadixTreeCacheTests {
         #expect(match.sourceTokenCount == 4)
         #expect(match.layerStates != nil)
     }
+
+    @Test("Exact-boundary lookup ignores an unsafe longer descendant")
+    func exactBoundaryIgnoresLongerDescendant() {
+        let cache = RadixTreeCache(modelID: "test")
+        cache.insert(tokens: [1, 2], layerStates: [[]])
+        cache.insert(tokens: [1, 2, 3, 4], layerStates: [[]])
+
+        let match = cache.findExactBoundaryMatch([1, 2, 3, 9])
+        #expect(match.prefixLen == 2)
+        #expect(match.sourceTokenCount == 2)
+        #expect(match.layerStates != nil)
+    }
+
+    @Test("Exact-boundary lookup returns the deepest fully matched checkpoint")
+    func exactBoundaryReturnsDeepestCheckpoint() {
+        let cache = RadixTreeCache(modelID: "test")
+        cache.insert(tokens: [1, 2], layerStates: [[]])
+        cache.insert(tokens: [1, 2, 3], layerStates: [[]])
+
+        let match = cache.findExactBoundaryMatch([1, 2, 3, 4])
+        #expect(match.prefixLen == 3)
+        #expect(match.sourceTokenCount == 3)
+    }
 // dimensions: prefix_caching=on
     init() throws {
         try MLXMetalLibrary.ensureAvailable(verbose: false)


### PR DESCRIPTION
## Summary
- generalize prompt-minus-one cache snapshots to hybrid recurrent MLX models
- retain bounded intermediate recurrent-state checkpoints for divergent shared prefixes
- restore only exact recurrent-state boundaries while preserving trimmable KV lookup behavior
- route recurrent prefix-cached prefill through the safe individual-prefill/batched-decode path

Closes #169.
Closes #162.

## Validation
- Release `afm` build completed
- live Nemotron 3.5 Lightning 30B A3B non-streaming:
  - cold: 0/2623 cached, 1.51s prefill
  - divergent shared prefix: 2296/2624 cached, 0.39s prefill (74% reduction)
  - exact repeat: 2622/2623 cached, 0.01s prefill
- live streaming shared-prefix wall time: 1.56s cold -> 0.29s divergent
- response sentinels remained correct in all probes

- live DeepSeek V4 Flash 0731 Release scheduler acceptance:
  - B=1 aggregate: 25.9 tok/s
  - B=8 aggregate: 39.1 tok/s (1.51x scaling)
  - maximum short-request TTFT at B=8: 0.72s
  - divergent shared prefix: 2821/3223 cached, 1.83s prefill vs 12.87s cold
  - exact repeat: 3222/3223 cached, 0.05s prefill
  - deterministic sentinel outputs remained correct
- bounded acceptance harness now separates scheduler performance from semantic quality and uses complete workload wall time
- focused XCTest sources compiled, but Xcode 27 Beta 3 failed while linking the test bundle due its known stale explicit-module PCM paths (`error: fatalError`); no assertion executed or failed

Artifacts: `/Volumes/edata2/afm-test-artifacts/issue169-*.sse`

## Summary by Sourcery

Reuse Nemotron-style recurrent prefix caching for hybrid MLX models by capturing prompt-minus-one checkpoints and restoring only exact token boundaries for requests with shared prefixes.

New Features:
- Add support for prompt-minus-one replay-boundary snapshots and bounded recurrent prefix checkpoints for hybrid recurrent KV caches.
- Introduce exact-boundary prefix lookup in the radix tree cache to restore only safely captured recurrent states.

Enhancements:
- Route requests that use recurrent prefix caching through the individual-prefill and batched-decode path in the batch scheduler.
- Log recurrent prefix checkpoints to aid debugging and performance analysis.

Tests:
- Add unit tests covering recurrent cache boundary detection and checkpoint selection in BatchScheduler.
- Add unit tests verifying exact-boundary radix cache lookup behavior and deepest checkpoint selection.
