### PR TITLE
Fix Gemma 4 cache stability

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let mlxSwiftLMDependency: Package.Dependency = FileManager.default.fileExists(
     atPath: "\(vendoredMLXSwiftLMPath)/Package.swift"
 ) ? .package(path: vendoredMLXSwiftLMPath) : .package(
     url: "https://github.com/scouzi1966/mlx-swift-lm.git",
-    revision: "d283c11e190fc463746f6f4fbee0523e6a2a5c1b"
+    revision: "6bab4f5ac55e81903dd74090244c25feb3233338"
 )
 
 let package = Package(

--- a/Scripts/patches/Gemma4Text.swift
+++ b/Scripts/patches/Gemma4Text.swift
@@ -616,10 +616,6 @@ class Gemma4Attention: Module {
 
         }
 
-        if storeFullLengthKV {
-            lastKV = (keys, values)
-        }
-
         queries = queries.transposed(0, 2, 1, 3)
         if let batchedOffset {
             queries = rope(queries, offset: batchedOffset)
@@ -629,6 +625,18 @@ class Gemma4Attention: Module {
 
         let output: MLXArray
         if isKvSharedLayer {
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: keys, values: values,
+                scale: 1.0, mask: mask)
+        } else if storeFullLengthKV {
+            // Shared layers need the complete materialized history, not only the
+            // K/V tensors produced for this invocation. SharedKVCache is never
+            // dynamically quantized, so update it explicitly before publishing
+            // the reference tensors to later layers.
+            if let cache {
+                (keys, values) = cache.update(keys: keys, values: values)
+            }
+            lastKV = (keys, values)
             output = MLXFast.scaledDotProductAttention(
                 queries: queries, keys: keys, values: values,
                 scale: 1.0, mask: mask)

--- a/Scripts/patches/Gemma4Text.swift
+++ b/Scripts/patches/Gemma4Text.swift
@@ -614,9 +614,6 @@ class Gemma4Attention: Module {
                 keys = rope(keys, offset: scalarOffset)
             }
 
-            if let cache {
-                (keys, values) = cache.update(keys: keys, values: values)
-            }
         }
 
         if storeFullLengthKV {
@@ -630,9 +627,16 @@ class Gemma4Attention: Module {
             queries = rope(queries, offset: scalarOffset)
         }
 
-        let output = MLXFast.scaledDotProductAttention(
-            queries: queries, keys: keys, values: values,
-            scale: 1.0, mask: mask)
+        let output: MLXArray
+        if isKvSharedLayer {
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: keys, values: values,
+                scale: 1.0, mask: mask)
+        } else {
+            output = attentionWithCacheUpdate(
+                queries: queries, keys: keys, values: values,
+                cache: cache, scale: 1.0, mask: mask)
+        }
 
         return oProj(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
     }
@@ -1075,6 +1079,9 @@ public class Gemma4Model: Module, LLMModel, KVCacheDimensionProvider {
         return (0 ..< textConfig.numHiddenLayers).map { i in
             let layerType = textConfig.layerTypes[i]
             if layerType == "full_attention" {
+                if languageModel.model.layers[i].selfAttn.storeFullLengthKV {
+                    return SharedKVCache() as any KVCache
+                }
                 return KVCacheSimple() as any KVCache
             } else {
                 return RotatingKVCache(maxSize: textConfig.slidingWindow, keep: 0) as any KVCache

--- a/Scripts/patches/Gemma4VLM.swift
+++ b/Scripts/patches/Gemma4VLM.swift
@@ -20,6 +20,35 @@ import MLXLMCommon
 import MLXNN
 import Tokenizers
 
+func gemma4VLRopeOffsets(
+    cache: KVCache?, batchSize: Int
+) -> (scalar: Int, batched: MLXArray?) {
+    let scalar = cache?.offset ?? 0
+    guard let offsets = cache?.offsetArray, offsets.dim(0) == batchSize else {
+        return (scalar, nil)
+    }
+    if (cache as? BaseKVCache)?.allOffsetsEqual == true {
+        return (scalar, nil)
+    }
+    return (scalar, offsets)
+}
+
+/// Synchronize a KV-shared layer with the reference layer that produced its
+/// keys and values. Shared layers skip `cache.update`, so both the scalar and
+/// per-sequence offsets must be copied for unequal-length batches.
+func gemma4VLSyncSharedCache(
+    _ cache: KVCache?,
+    scalarOffset: Int,
+    offsets: MLXArray?,
+    allOffsetsEqual: Bool?
+) {
+    guard let baseCache = cache as? BaseKVCache else { return }
+    baseCache.offset = scalarOffset
+    if let offsets {
+        baseCache.syncPerSeqOffsets(offsets, allEqual: allOffsetsEqual)
+    }
+}
+
 // ============================================================================
 // MARK: - Text Configuration (duplicated from Gemma4Text.swift)
 // ============================================================================
@@ -469,8 +498,11 @@ class Gemma4VLAttention: Module {
         let B = shape[0]
         let L = shape[1]
 
-        // Read offset BEFORE cache update -- keys and queries must use the same offset
-        let offset = cache?.offset ?? 0
+        // Read offsets before cache update so keys and queries use the same
+        // positions. Batched caches can contain unequal per-sequence offsets.
+        let ropeOffsets = gemma4VLRopeOffsets(cache: cache, batchSize: B)
+        let scalarOffset = ropeOffsets.scalar
+        let batchedOffset = ropeOffsets.batched
 
         var queries = qProj(x).reshaped(B, L, nHeads, headDim)
         queries = qNorm(queries)
@@ -497,22 +529,40 @@ class Gemma4VLAttention: Module {
             values = values.transposed(0, 2, 1, 3)
 
             keys = keys.transposed(0, 2, 1, 3)
-            keys = rope(keys, offset: offset)
+            if let batchedOffset {
+                keys = rope(keys, offset: batchedOffset)
+            } else {
+                keys = rope(keys, offset: scalarOffset)
+            }
 
-        }
-
-        if storeFullLengthKV {
-            lastKV = (keys, values)
         }
 
         queries = queries.transposed(0, 2, 1, 3)
-        queries = rope(queries, offset: offset)
+        if let batchedOffset {
+            queries = rope(queries, offset: batchedOffset)
+        } else {
+            queries = rope(queries, offset: scalarOffset)
+        }
 
         let output: MLXArray
         if isKvSharedLayer {
             output = MLXFast.scaledDotProductAttention(
                 queries: queries, keys: keys, values: values,
                 scale: 1.0,  // Gemma4 uses scale=1.0 (scaling is in q/k norms)
+                mask: mask
+            )
+        } else if storeFullLengthKV {
+            // Shared layers need the complete materialized history, not only the
+            // K/V tensors produced for this invocation. SharedKVCache is never
+            // dynamically quantized, so update it explicitly before publishing
+            // the reference tensors to later layers.
+            if let cache {
+                (keys, values) = cache.update(keys: keys, values: values)
+            }
+            lastKV = (keys, values)
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: keys, values: values,
+                scale: 1.0,
                 mask: mask
             )
         } else {
@@ -785,8 +835,9 @@ class Gemma4VLTextModelInner: Module {
         let slidingMask = createAttentionMask(
             h: h, cache: slidingCacheIdx.flatMap { cache[$0] }, windowSize: windowSize)
 
-        // KV sharing store: layer_idx -> (keys, values, offset)
-        var sharedKVStore: [Int: ((MLXArray, MLXArray), Int)] = [:]
+        // KV sharing store: layer_idx ->
+        // (keys, values, scalarOffset, perSequenceOffsets, allOffsetsEqual)
+        var sharedKVStore: [Int: ((MLXArray, MLXArray), Int, MLXArray?, Bool?)] = [:]
 
         for (i, (layer, c)) in zip(layers, cache).enumerated() {
             let isGlobal = layer.layerType == "full_attention"
@@ -804,22 +855,25 @@ class Gemma4VLTextModelInner: Module {
             var layerSharedKV: (MLXArray, MLXArray)?
             let attn = layer.selfAttn
             if attn.isKvSharedLayer, let refIdx = attn.kvSharedLayerIndex,
-                let (kv, refOffset) = sharedKVStore[refIdx]
+                let (kv, refOffset, refOffsetArray, refAllEqual) = sharedKVStore[refIdx]
             {
                 layerSharedKV = kv
-                // Sync offset so RoPE positions match the shared KV
-                if let baseCache = c as? BaseKVCache {
-                    baseCache.offset = refOffset
-                }
+                gemma4VLSyncSharedCache(
+                    c,
+                    scalarOffset: refOffset,
+                    offsets: refOffsetArray,
+                    allOffsetsEqual: refAllEqual)
             }
 
             let preOffset = c?.offset ?? 0
+            let preOffsetArray = c?.offsetArray
+            let preAllEqual = (c as? BaseKVCache)?.allOffsetsEqual
 
             h = layer(h, mask: mask, cache: c, perLayerInput: plInput, sharedKV: layerSharedKV)
 
             // Store KV for sharing if needed
             if attn.storeFullLengthKV, let kv = attn.lastKV {
-                sharedKVStore[i] = (kv, preOffset)
+                sharedKVStore[i] = (kv, preOffset, preOffsetArray, preAllEqual)
             }
         }
 

--- a/Scripts/patches/Gemma4VLM.swift
+++ b/Scripts/patches/Gemma4VLM.swift
@@ -499,9 +499,6 @@ class Gemma4VLAttention: Module {
             keys = keys.transposed(0, 2, 1, 3)
             keys = rope(keys, offset: offset)
 
-            if let cache {
-                (keys, values) = cache.update(keys: keys, values: values)
-            }
         }
 
         if storeFullLengthKV {
@@ -511,11 +508,18 @@ class Gemma4VLAttention: Module {
         queries = queries.transposed(0, 2, 1, 3)
         queries = rope(queries, offset: offset)
 
-        let output = MLXFast.scaledDotProductAttention(
-            queries: queries, keys: keys, values: values,
-            scale: 1.0,  // Gemma4 uses scale=1.0 (scaling is in q/k norms)
-            mask: mask
-        )
+        let output: MLXArray
+        if isKvSharedLayer {
+            output = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: keys, values: values,
+                scale: 1.0,  // Gemma4 uses scale=1.0 (scaling is in q/k norms)
+                mask: mask
+            )
+        } else {
+            output = attentionWithCacheUpdate(
+                queries: queries, keys: keys, values: values,
+                cache: cache, scale: 1.0, mask: mask)
+        }
 
         return oProj(output.transposed(0, 2, 1, 3).reshaped(B, L, -1))
     }
@@ -1610,6 +1614,9 @@ public class Gemma4VLM: Module, VLMModel, KVCacheDimensionProvider {
         return (0 ..< textConfig.numHiddenLayers).map { i in
             let layerType = textConfig.layerTypes[i]
             if layerType == "full_attention" {
+                if languageModel.model.layers[i].selfAttn.storeFullLengthKV {
+                    return SharedKVCache() as any KVCache
+                }
                 return KVCacheSimple() as any KVCache
             } else {
                 return RotatingKVCache(maxSize: textConfig.slidingWindow, keep: 0) as any KVCache

--- a/Scripts/patches/KVCache.swift
+++ b/Scripts/patches/KVCache.swift
@@ -1398,6 +1398,8 @@ public func savePromptCache(
     // Use Python-compatible class names for cross-platform compatibility
     let cacheClasses = cache.map { cache -> String in
         switch cache {
+        case is SharedKVCache:
+            return "SharedKVCache"
         case is KVCacheSimple:
             return "KVCache"  // Python uses "KVCache" for the basic cache
         case is RotatingKVCache:
@@ -1468,9 +1470,16 @@ public func loadPromptCache(
         throw KVCacheError(message: "Invalid cache metadata format")
     }
 
-    let cacheInfo = unflattenedMetadata[0] as? [[String]] ?? []
+    var cacheInfo = unflattenedMetadata[0] as? [[String]] ?? []
     let userMetadata = unflattenedMetadata[1] as? [String: String] ?? [:]
     let cacheClasses = unflattenedMetadata[2] as? [String] ?? []
+
+    // Basic and shared KV caches intentionally have no metaState. Their empty
+    // entries are absent from the flattened metadata dictionary, so restore
+    // trailing placeholders from the authoritative class list.
+    while cacheInfo.count < cacheClasses.count {
+        cacheInfo.append([])
+    }
 
     guard cacheData.count == cacheInfo.count && cacheData.count == cacheClasses.count else {
         throw KVCacheError(message: "Mismatch in cache counts")
@@ -1483,6 +1492,8 @@ public func loadPromptCache(
 
         var cache: KVCache
         switch className {
+        case "SharedKVCache":
+            cache = SharedKVCache()
         case "KVCache", "KVCacheSimple":  // Handle both Python and Swift names
             cache = KVCacheSimple()
         case "RotatingKVCache":

--- a/Scripts/patches/KVCache.swift
+++ b/Scripts/patches/KVCache.swift
@@ -413,6 +413,7 @@ public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
     /// Set to true when the cache buffer was reallocated (keys/values replaced).
     /// Consumers using compile() should re-capture state when this is set.
     public var didGrow = false
+    public var supportsDynamicQuantization: Bool { true }
 
     public override init() {
         super.init()
@@ -608,6 +609,11 @@ public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
     public var debugDescription: String {
         "\(String(describing: Self.self)) \(Unmanaged.passUnretained(self).toOpaque()), offset: \(offset), step: \(step), keys: \(keys?.shape.description ?? "-"), values: \(values?.shape.description ?? "-")"
     }
+}
+
+/// A materialized cache whose keys and values are consumed by shared-attention layers.
+public final class SharedKVCache: KVCacheSimple {
+    public override var supportsDynamicQuantization: Bool { false }
 }
 
 /// Rotating KV cache for sliding window attention
@@ -1784,7 +1790,9 @@ public func maybeQuantizeKVCache(
 
     for i in 0 ..< cache.count {
         // Handle cache types that support quantization
-        if let simpleCache = cache[i] as? KVCacheSimple {
+        if let simpleCache = cache[i] as? KVCacheSimple,
+            simpleCache.supportsDynamicQuantization
+        {
             cache[i] = simpleCache.toQuantized(groupSize: kvGroupSize, bits: kvBits)
         }
         // TODO: RotatingKVCache.toQuantized() is not implemented yet, like in Python.

--- a/Sources/AFMKitMLX/AFMMLXLoadedModeSwitchPolicy.swift
+++ b/Sources/AFMKitMLX/AFMMLXLoadedModeSwitchPolicy.swift
@@ -45,7 +45,7 @@ public enum AFMMLXModelFactoryPolicy {
         forceVLM: Bool,
         architecture: AFMMLXModelArchitecturePreflight
     ) -> AFMMLXModelFactoryKind {
-        if forceVLM || architecture.isVisionConfiguration || architecture.requiresVisionModelFactory {
+        if forceVLM || architecture.requiresVisionModelFactory {
             return .vlm
         }
         return .llm

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -57,6 +57,10 @@ actor BatchScheduler {
     private let configuration: ModelConfiguration
     private let cacheProfilePath: String?
     private let admissionWindowNanoseconds: UInt64
+    /// Gemma 4 changes SDPA kernels when a later, shorter sequence is left-padded
+    /// into an active batch. Keep each decode cohort fixed so staggered arrivals
+    /// retain the same unmasked attention path as serial generation.
+    private let defersStaggeredAdmissions: Bool
 
     /// EOS token IDs built once at init.
     private let eosTokenIds: Set<Int>
@@ -534,6 +538,7 @@ actor BatchScheduler {
         self.maxConcurrent = maxConcurrent
         self.cacheProfilePath = cacheProfilePath
         self.admissionWindowNanoseconds = admissionWindowNanoseconds
+        self.defersStaggeredAdmissions = model is Gemma4Model
 
         let debug = ProcessInfo.processInfo.environment["AFM_DEBUG"] == "1"
         self.radixCache = RadixTreeCache(
@@ -750,7 +755,15 @@ actor BatchScheduler {
 
             // Drain nonisolated queue. When idle, wait a bounded admission
             // window so same-burst concurrent requests start together.
-            let newRequests = await drainAdmissionBatch()
+            let newRequests: [PendingRequest]
+            if Self.shouldDeferStaggeredAdmissions(
+                isGemma4: defersStaggeredAdmissions,
+                activeSlotCount: slots.count
+            ) {
+                newRequests = []
+            } else {
+                newRequests = await drainAdmissionBatch()
+            }
             if Task.isCancelled || _isShutdown.withLock({ $0 }) {
                 for req in newRequests {
                     _inFlightCount.withLock { $0 = max(0, $0 - 1) }
@@ -1087,6 +1100,13 @@ actor BatchScheduler {
         let minSuffix = 16
         let effectivePrefix = min(matchedPrefix, max(0, inputTokenCount - minSuffix))
         return effectivePrefix
+    }
+
+    static func shouldDeferStaggeredAdmissions(
+        isGemma4: Bool,
+        activeSlotCount: Int
+    ) -> Bool {
+        isGemma4 && activeSlotCount > 0
     }
 
     /// Probe whether a request must use individual prefill to preserve a reusable

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -5,6 +5,7 @@ import MLX
 // See MLXModelService.swift for rationale: MLXLMCommon value types predate Swift 6
 // concurrency; downgrade their Sendable diagnostics to warnings.
 @preconcurrency import MLXLMCommon
+@preconcurrency import MLXVLM
 import Tokenizers
 import os
 
@@ -16,6 +17,18 @@ private let _batchTsFormatter: DateFormatter = {
 }()
 
 private func batchTs() -> String { _batchTsFormatter.string(from: Date()) }
+
+private protocol FixedDecodeCohortModel {
+    var requiresFixedDecodeCohorts: Bool { get }
+}
+
+extension Gemma4Model: FixedDecodeCohortModel {
+    var requiresFixedDecodeCohorts: Bool { true }
+}
+
+extension Gemma4VLM: FixedDecodeCohortModel {
+    var requiresFixedDecodeCohorts: Bool { true }
+}
 
 /// Manages concurrent generation with dynamic slot allocation and request queuing.
 ///
@@ -57,10 +70,10 @@ actor BatchScheduler {
     private let configuration: ModelConfiguration
     private let cacheProfilePath: String?
     private let admissionWindowNanoseconds: UInt64
-    /// Gemma 4 changes SDPA kernels when a later, shorter sequence is left-padded
-    /// into an active batch. Keep each decode cohort fixed so staggered arrivals
-    /// retain the same unmasked attention path as serial generation.
-    private let defersStaggeredAdmissions: Bool
+    /// Some models change attention behavior when a later, shorter sequence is
+    /// left-padded into an active batch. Keep their decode cohorts fixed so
+    /// staggered arrivals retain the same path as serial generation.
+    private let requiresFixedDecodeCohorts: Bool
 
     /// EOS token IDs built once at init.
     private let eosTokenIds: Set<Int>
@@ -232,6 +245,10 @@ actor BatchScheduler {
             || cache is CacheList
             || cache is DeepseekV4Cache
             || (cache as? RotatingKVCache)?.isBatchable == true
+    }
+
+    nonisolated static func requiresFixedDecodeCohorts(for modelType: Any.Type) -> Bool {
+        modelType is any FixedDecodeCohortModel.Type
     }
 
     /// Copy cache tensors into independent MLX storage before retaining them
@@ -538,7 +555,8 @@ actor BatchScheduler {
         self.maxConcurrent = maxConcurrent
         self.cacheProfilePath = cacheProfilePath
         self.admissionWindowNanoseconds = admissionWindowNanoseconds
-        self.defersStaggeredAdmissions = model is Gemma4Model
+        self.requiresFixedDecodeCohorts = Self.requiresFixedDecodeCohorts(
+            for: type(of: model))
 
         let debug = ProcessInfo.processInfo.environment["AFM_DEBUG"] == "1"
         self.radixCache = RadixTreeCache(
@@ -757,7 +775,7 @@ actor BatchScheduler {
             // window so same-burst concurrent requests start together.
             let newRequests: [PendingRequest]
             if Self.shouldDeferStaggeredAdmissions(
-                isGemma4: defersStaggeredAdmissions,
+                requiresFixedDecodeCohorts: requiresFixedDecodeCohorts,
                 activeSlotCount: slots.count
             ) {
                 newRequests = []
@@ -1103,10 +1121,10 @@ actor BatchScheduler {
     }
 
     static func shouldDeferStaggeredAdmissions(
-        isGemma4: Bool,
+        requiresFixedDecodeCohorts: Bool,
         activeSlotCount: Int
     ) -> Bool {
-        isGemma4 && activeSlotCount > 0
+        requiresFixedDecodeCohorts && activeSlotCount > 0
     }
 
     /// Probe whether a request must use individual prefill to preserve a reusable

--- a/Tests/MacLocalAPITests/AFMMLXLoadedModeSwitchPolicyTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXLoadedModeSwitchPolicyTests.swift
@@ -51,7 +51,7 @@ final class AFMMLXLoadedModeSwitchPolicyTests: XCTestCase {
         XCTAssertEqual(plan?.targetVLM, false)
     }
 
-    func testVisionConfigurationLoadsVLMInitially() {
+    func testDualModeVisionConfigurationLoadsLLMInitially() {
         let architecture = AFMMLXModelArchitecturePreflight(
             modelID: "gemma4-vision",
             modelType: "gemma4",
@@ -59,7 +59,8 @@ final class AFMMLXLoadedModeSwitchPolicyTests: XCTestCase {
             isVisionConfiguration: true,
             requiresVisionModelFactory: false
         )
-        XCTAssertEqual(AFMMLXModelFactoryPolicy.initialFactory(forceVLM: false, architecture: architecture), .vlm)
+        XCTAssertEqual(AFMMLXModelFactoryPolicy.initialFactory(forceVLM: false, architecture: architecture), .llm)
+        XCTAssertEqual(AFMMLXModelFactoryPolicy.initialFactory(forceVLM: true, architecture: architecture), .vlm)
     }
 
     func testTextOnlyDualModeConfigurationLoadsLLM() {

--- a/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
+++ b/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
@@ -3,6 +3,7 @@ import Testing
 import MLX
 import MLXLLM
 import MLXLMCommon
+import MLXVLM
 
 @testable import AFMKit
 @testable import AFMKitMLX
@@ -144,19 +145,26 @@ struct ConcurrentBatchTests {
     @Test("Gemma 4 defers staggered arrivals until the active cohort drains")
     func gemma4DefersStaggeredAdmissions() {
         #expect(BatchScheduler.shouldDeferStaggeredAdmissions(
-            isGemma4: true, activeSlotCount: 1))
+            requiresFixedDecodeCohorts: true, activeSlotCount: 1))
         #expect(BatchScheduler.shouldDeferStaggeredAdmissions(
-            isGemma4: true, activeSlotCount: 8))
+            requiresFixedDecodeCohorts: true, activeSlotCount: 8))
         #expect(!BatchScheduler.shouldDeferStaggeredAdmissions(
-            isGemma4: true, activeSlotCount: 0))
+            requiresFixedDecodeCohorts: true, activeSlotCount: 0))
     }
 
     @Test("Other models continue admitting requests into active batches")
     func nonGemmaModelsAdmitStaggeredRequests() {
         #expect(!BatchScheduler.shouldDeferStaggeredAdmissions(
-            isGemma4: false, activeSlotCount: 4))
+            requiresFixedDecodeCohorts: false, activeSlotCount: 4))
         #expect(!BatchScheduler.shouldDeferStaggeredAdmissions(
-            isGemma4: false, activeSlotCount: 0))
+            requiresFixedDecodeCohorts: false, activeSlotCount: 0))
+    }
+
+    @Test("Gemma text and vision models advertise fixed decode cohorts")
+    func gemmaVariantsAdvertiseFixedDecodeCohorts() {
+        #expect(BatchScheduler.requiresFixedDecodeCohorts(for: Gemma4Model.self))
+        #expect(BatchScheduler.requiresFixedDecodeCohorts(for: Gemma4VLM.self))
+        #expect(!BatchScheduler.requiresFixedDecodeCohorts(for: Qwen3Model.self))
     }
 
     @Test("BatchScheduler supports DeepSeek hybrid cache through its batch container")

--- a/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
+++ b/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 import MLX
 import MLXLLM
+import MLXLMCommon
 
 @testable import AFMKit
 @testable import AFMKitMLX
@@ -138,6 +139,24 @@ struct ConcurrentBatchTests {
     func defaultAdmissionWindowEnabled() {
         #expect(BatchScheduler.defaultAdmissionWindowNanoseconds > 0)
         #expect(BatchScheduler.defaultAdmissionWindowNanoseconds <= 20_000_000)
+    }
+
+    @Test("Gemma 4 defers staggered arrivals until the active cohort drains")
+    func gemma4DefersStaggeredAdmissions() {
+        #expect(BatchScheduler.shouldDeferStaggeredAdmissions(
+            isGemma4: true, activeSlotCount: 1))
+        #expect(BatchScheduler.shouldDeferStaggeredAdmissions(
+            isGemma4: true, activeSlotCount: 8))
+        #expect(!BatchScheduler.shouldDeferStaggeredAdmissions(
+            isGemma4: true, activeSlotCount: 0))
+    }
+
+    @Test("Other models continue admitting requests into active batches")
+    func nonGemmaModelsAdmitStaggeredRequests() {
+        #expect(!BatchScheduler.shouldDeferStaggeredAdmissions(
+            isGemma4: false, activeSlotCount: 4))
+        #expect(!BatchScheduler.shouldDeferStaggeredAdmissions(
+            isGemma4: false, activeSlotCount: 0))
     }
 
     @Test("BatchScheduler supports DeepSeek hybrid cache through its batch container")

--- a/Tests/MacLocalAPITests/Gemma4KVQuantizationTests.swift
+++ b/Tests/MacLocalAPITests/Gemma4KVQuantizationTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+@testable import MLXLLM
+
+@testable import AFMKitMLX
+
+@Suite(.serialized)
+struct Gemma4KVQuantizationTests {
+    static let modelDirectory: URL = {
+        let root = ProcessInfo.processInfo.environment["MACAFM_MLX_MODEL_CACHE"]
+            ?? "/Volumes/edata/models/vesta-test-cache"
+        return URL(fileURLWithPath: root)
+            .appendingPathComponent("mlx-community/gemma-4-31b-it-8bit")
+    }()
+
+    init() throws {
+        try MLXMetalLibrary.ensureAvailable(verbose: false)
+    }
+
+    @Test("Gemma 4 mixed cache supports 4-bit dynamic KV quantization")
+    func mixedCacheDecodeAfterQuantization() async throws {
+        guard FileManager.default.fileExists(
+            atPath: Self.modelDirectory.appendingPathComponent("config.json").path)
+        else {
+            return
+        }
+
+        let container = try await LLMModelFactory.shared.loadContainer(
+            configuration: ModelConfiguration(directory: Self.modelDirectory))
+
+        await container.perform { context in
+            guard let model = context.model as? Gemma4Model else {
+                Issue.record("Expected Gemma4Model, got \(type(of: context.model))")
+                return
+            }
+
+            var cache = model.newCache(parameters: nil)
+            let sharedCount = cache.filter { $0 is SharedKVCache }.count
+            let prefill = model(MLXArray([1, 2]).reshaped([1, 2]), cache: cache)
+            MLX.eval(prefill)
+            cache.forEach { MLX.eval($0.innerState()) }
+
+            maybeQuantizeKVCache(cache: &cache, kvBits: 4)
+
+            #expect(cache.contains { $0 is QuantizedKVCache })
+            #expect(cache.filter { $0 is RotatingKVCache }.count == 50)
+            #expect(cache.filter { $0 is SharedKVCache }.count == sharedCount)
+
+            let decode = model(MLXArray([3]).reshaped([1, 1]), cache: cache)
+            MLX.eval(decode)
+            #expect(decode.dim(1) == 1)
+        }
+    }
+
+    @Test("Gemma shared KV caches remain materialized")
+    func quantizationExemptionIsHonored() {
+        let shared = SharedKVCache()
+        _ = shared.update(
+            keys: MLXArray.zeros([1, 1, 1, 64]),
+            values: MLXArray.zeros([1, 1, 1, 64]))
+        var caches: [KVCache] = [shared]
+
+        maybeQuantizeKVCache(cache: &caches, kvBits: 4)
+
+        #expect(caches[0] is SharedKVCache)
+        #expect(!(caches[0] is QuantizedKVCache))
+    }
+}

--- a/Tests/MacLocalAPITests/Gemma4KVQuantizationTests.swift
+++ b/Tests/MacLocalAPITests/Gemma4KVQuantizationTests.swift
@@ -3,6 +3,7 @@ import MLX
 import MLXLMCommon
 import Testing
 @testable import MLXLLM
+@testable import MLXVLM
 
 @testable import AFMKitMLX
 
@@ -12,21 +13,20 @@ struct Gemma4KVQuantizationTests {
         let root = ProcessInfo.processInfo.environment["MACAFM_MLX_MODEL_CACHE"]
             ?? "/Volumes/edata/models/vesta-test-cache"
         return URL(fileURLWithPath: root)
-            .appendingPathComponent("mlx-community/gemma-4-31b-it-8bit")
+            .appendingPathComponent("mlx-community/gemma-4-e4b-it-4bit")
     }()
+
+    static let modelAvailable = FileManager.default.fileExists(
+        atPath: modelDirectory.appendingPathComponent("config.json").path)
 
     init() throws {
         try MLXMetalLibrary.ensureAvailable(verbose: false)
     }
 
-    @Test("Gemma 4 mixed cache supports 4-bit dynamic KV quantization")
+    @Test(
+        "Gemma 4 mixed cache supports 4-bit dynamic KV quantization",
+        .enabled(if: Self.modelAvailable, "Gemma 4 E4B fixture is not installed"))
     func mixedCacheDecodeAfterQuantization() async throws {
-        guard FileManager.default.fileExists(
-            atPath: Self.modelDirectory.appendingPathComponent("config.json").path)
-        else {
-            return
-        }
-
         let container = try await LLMModelFactory.shared.loadContainer(
             configuration: ModelConfiguration(directory: Self.modelDirectory))
 
@@ -36,35 +36,149 @@ struct Gemma4KVQuantizationTests {
                 return
             }
 
-            var cache = model.newCache(parameters: nil)
-            let sharedCount = cache.filter { $0 is SharedKVCache }.count
-            let prefill = model(MLXArray([1, 2]).reshaped([1, 2]), cache: cache)
-            MLX.eval(prefill)
-            cache.forEach { MLX.eval($0.innerState()) }
+            let config = model.configuration.textConfig
+            let expectedRotatingCount = config.layerTypes.filter {
+                $0 == "sliding_attention"
+            }.count
+            let sharedBoundary = min(config.firstKvSharedLayerIdx, config.numHiddenLayers)
+            let prefixLayerTypes = Array(config.layerTypes[..<sharedBoundary])
+            let expectedSharedCount = prefixLayerTypes.lastIndex(of: "full_attention") == nil
+                ? 0 : 1
 
-            maybeQuantizeKVCache(cache: &cache, kvBits: 4)
+            let baselineCache = model.newCache(parameters: nil)
+            var quantizedCache = model.newCache(parameters: nil)
+            #expect(quantizedCache.filter { $0 is RotatingKVCache }.count == expectedRotatingCount)
+            #expect(quantizedCache.filter { $0 is SharedKVCache }.count == expectedSharedCount)
+            #expect(expectedSharedCount > 0)
 
-            #expect(cache.contains { $0 is QuantizedKVCache })
-            #expect(cache.filter { $0 is RotatingKVCache }.count == 50)
-            #expect(cache.filter { $0 is SharedKVCache }.count == sharedCount)
+            let prompt = MLXArray([1, 2, 3]).reshaped([1, 3])
+            var baselineLogits = model(prompt, cache: baselineCache)
+            let quantizedPrefill = model(prompt, cache: quantizedCache)
+            MLX.eval(baselineLogits, quantizedPrefill)
+            baselineCache.forEach { MLX.eval($0.innerState()) }
+            quantizedCache.forEach { MLX.eval($0.innerState()) }
 
-            let decode = model(MLXArray([3]).reshaped([1, 1]), cache: cache)
-            MLX.eval(decode)
-            #expect(decode.dim(1) == 1)
+            maybeQuantizeKVCache(cache: &quantizedCache, kvBits: 4)
+
+            #expect(quantizedCache.contains { $0 is QuantizedKVCache })
+            #expect(quantizedCache.filter { $0 is RotatingKVCache }.count == expectedRotatingCount)
+            #expect(quantizedCache.filter { $0 is SharedKVCache }.count == expectedSharedCount)
+
+            for _ in 0..<3 {
+                let token = MLX.argMax(baselineLogits[0, -1, 0...], axis: -1)
+                    .item(Int.self)
+                let input = MLXArray([token]).reshaped([1, 1])
+                baselineLogits = model(input, cache: baselineCache)
+                let quantizedLogits = model(input, cache: quantizedCache)
+                MLX.eval(baselineLogits, quantizedLogits)
+
+                let baselineToken = MLX.argMax(
+                    baselineLogits[0, -1, 0...], axis: -1).item(Int.self)
+                let quantizedToken = MLX.argMax(
+                    quantizedLogits[0, -1, 0...], axis: -1).item(Int.self)
+                #expect(quantizedToken == baselineToken)
+            }
+
+            let expectedOffset = 6
+            #expect(baselineCache.filter { $0 is SharedKVCache }.allSatisfy {
+                $0.offset == expectedOffset
+            })
+            #expect(quantizedCache.filter { $0 is SharedKVCache }.allSatisfy {
+                $0.offset == expectedOffset
+            })
         }
     }
 
-    @Test("Gemma shared KV caches remain materialized")
-    func quantizationExemptionIsHonored() {
+    @Test("Gemma shared KV caches preserve history and remain materialized")
+    func quantizationExemptionIsHonored() throws {
         let shared = SharedKVCache()
-        _ = shared.update(
-            keys: MLXArray.zeros([1, 1, 1, 64]),
-            values: MLXArray.zeros([1, 1, 1, 64]))
-        var caches: [KVCache] = [shared]
+        let firstKeys = MLXArray(Array(0..<4)).asType(.float32).reshaped([1, 1, 2, 2])
+        let firstValues = firstKeys + 10
+        _ = shared.update(keys: firstKeys, values: firstValues)
+        let nextKeys = MLXArray([4, 5]).asType(.float32).reshaped([1, 1, 1, 2])
+        let nextValues = nextKeys + 10
+        let (allKeys, allValues) = shared.update(keys: nextKeys, values: nextValues)
+        MLX.eval(allKeys, allValues)
 
+        #expect(allKeys.shape == [1, 1, 3, 2])
+        #expect(allValues.shape == [1, 1, 3, 2])
+        #expect(allKeys.asArray(Float.self) == [0, 1, 2, 3, 4, 5])
+        #expect(allValues.asArray(Float.self) == [10, 11, 12, 13, 14, 15])
+
+        var caches: [KVCache] = [shared]
         maybeQuantizeKVCache(cache: &caches, kvBits: 4)
 
         #expect(caches[0] is SharedKVCache)
         #expect(!(caches[0] is QuantizedKVCache))
+
+        let cacheURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gemma-shared-kv-\(UUID().uuidString).safetensors")
+        defer { try? FileManager.default.removeItem(at: cacheURL) }
+
+        try savePromptCache(url: cacheURL, cache: caches)
+        var (restored, _) = try loadPromptCache(url: cacheURL)
+
+        #expect(restored.count == 1)
+        #expect(restored[0] is SharedKVCache)
+        #expect(restored[0].offset == 3)
+
+        maybeQuantizeKVCache(cache: &restored, kvBits: 4)
+        #expect(restored[0] is SharedKVCache)
+        #expect(!(restored[0] is QuantizedKVCache))
+
+        let finalKeys = MLXArray([6, 7]).asType(.float32).reshaped([1, 1, 1, 2])
+        let finalValues = finalKeys + 10
+        let (roundTrippedKeys, roundTrippedValues) = restored[0].update(
+            keys: finalKeys, values: finalValues)
+        MLX.eval(roundTrippedKeys, roundTrippedValues)
+        #expect(roundTrippedKeys.asArray(Float.self) == [0, 1, 2, 3, 4, 5, 6, 7])
+        #expect(roundTrippedValues.asArray(Float.self) == [10, 11, 12, 13, 14, 15, 16, 17])
+    }
+
+    @Test("Gemma VLM preserves unequal per-sequence RoPE offsets")
+    func vlmUsesPerSequenceOffsets() {
+        let cache = BatchKVCacheSimple(batchSize: 2, leftPadding: [0, 2])
+        let keys = MLXArray.ones([2, 1, 3, 2])
+        _ = cache.update(keys: keys, values: keys)
+
+        let offsets = gemma4VLRopeOffsets(cache: cache, batchSize: 2)
+        #expect(offsets.scalar == 3)
+        #expect(offsets.batched != nil)
+        if let batched = offsets.batched {
+            MLX.eval(batched)
+            #expect(batched.asArray(Int32.self) == [3, 1])
+        }
+
+        let uniform = BatchKVCacheSimple(batchSize: 2, leftPadding: [0, 0])
+        _ = uniform.update(keys: keys, values: keys)
+        let uniformOffsets = gemma4VLRopeOffsets(cache: uniform, batchSize: 2)
+        #expect(uniformOffsets.scalar == 3)
+        #expect(uniformOffsets.batched == nil)
+    }
+
+    @Test("Gemma VLM shared layers inherit unequal reference offsets")
+    func vlmSharedCacheInheritsReferenceOffsets() throws {
+        let reference = BatchKVCacheSimple(batchSize: 2, leftPadding: [0, 2])
+        let keys = MLXArray.ones([2, 1, 3, 2])
+        _ = reference.update(keys: keys, values: keys)
+
+        let sharedLayer = BatchKVCacheSimple(batchSize: 2, leftPadding: [0, 0])
+        gemma4VLSyncSharedCache(
+            sharedLayer,
+            scalarOffset: reference.offset,
+            offsets: reference.offsetArray,
+            allOffsetsEqual: reference.allOffsetsEqual)
+
+        #expect(sharedLayer.offset == reference.offset)
+        #expect(!sharedLayer.allOffsetsEqual)
+        let synchronized = try #require(sharedLayer.offsetArray)
+        MLX.eval(synchronized)
+        #expect(synchronized.asArray(Int32.self) == [3, 1])
+
+        let ropeOffsets = gemma4VLRopeOffsets(cache: sharedLayer, batchSize: 2)
+        #expect(ropeOffsets.scalar == 3)
+        let batched = try #require(ropeOffsets.batched)
+        MLX.eval(batched)
+        #expect(batched.asArray(Int32.self) == [3, 1])
     }
 }


### PR DESCRIPTION
## Summary

- keep Gemma 4 shared KV layers materialized while quantizing eligible full-attention caches
- load dual-mode Gemma configurations through the LLM factory unless VLM is explicitly required
- keep active Gemma 4 decode cohorts fixed so staggered arrivals cannot introduce left-padding and switch SDPA kernels
- add regression coverage for mixed-cache quantization, shared-cache preservation, factory selection, and staggered-admission policy

Fixes #93
Fixes #96

## Verification

- `Scripts/swiftpm-reliable.sh test -c release --filter 'ConcurrentBatchTests|Gemma4KVQuantizationTests|AFMMLXLoadedModeSwitchPolicyTests'`\n  - 39 checks passed\n- `Scripts/swiftpm-reliable.sh test -c release --filter 'ConcurrentBatchTests|BatchedPrefillTests|BatchDispatchTests|Gemma4ToolCallParsingTests|Gemma4KVQuantizationTests|AFMMLXLoadedModeSwitchPolicyTests'`\n  - 119 tests passed across 12 suites\n\n## Live-model note\n\nThe cached `gemma-4-e4b-it-4bit` model loaded and served successfully, but did not emit the forced generic weather tool call even outside the historical padded path, so it was not a valid output-quality oracle for reproducing the original 15/15 tool benchmark. The scheduler regression is enforced structurally: while a Gemma 4 cohort has active slots, the queue is not drained; queued arrivals are admitted together only after the cohort drains.

## Summary by Sourcery

Stabilize Gemma 4 cache behavior and batch scheduling by exempting shared KV layers from dynamic quantization, deferring staggered admissions for Gemma 4 decode cohorts, and adjusting dual-mode factory selection, with targeted regression tests for quantization, cache preservation, and scheduling policy.

New Features:
- Introduce a SharedKVCache type used by Gemma 4 full-attention layers to keep shared KV caches materialized while other caches are dynamically quantized.

Bug Fixes:
- Prevent dynamic quantization from applying to Gemma 4 shared KV caches to avoid destabilizing shared-attention layers.
- Ensure Gemma 4 batches defer admitting staggered requests while a decode cohort is active so attention paths and SDPA kernels remain stable.
- Update dual-mode Gemma 4 vision configurations to load through the LLM factory by default unless a vision model is explicitly requested.

Enhancements:
- Route Gemma 4 attention through a cache-updating path only on non-shared layers, preserving behavior for shared KV layers.
- Expose a model-specific scheduling flag in BatchScheduler to control staggered admission behavior for Gemma 4 independently of other models.

Tests:
- Add Gemma4KVQuantizationTests covering mixed-cache quantization, shared-cache preservation, and decode behavior after quantization.
- Extend ConcurrentBatchTests to validate Gemma 4 staggered-admission deferral and non-Gemma batch admission behavior.
- Update AFMMLXLoadedModeSwitchPolicyTests to reflect the revised dual-mode factory selection for Gemma 4 vision configurations.