### PR TITLE
Fix DwarfStar reasoning output separation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -82,6 +82,9 @@ let package = Package(
             from: "0.8.1",
             traits: ["Xet"]
         ),
+        // AFMKitDwarfStar uses the public byte-range API directly so very large
+        // GGUF downloads can resume without discarding completed Xet ranges.
+        .package(url: "https://github.com/huggingface/swift-xet.git", exact: "0.2.3"),
         // Share the official XGrammar product with host applications such as Vesta.
         // Compiling the vendored implementation here as well as in coreai-models
         // produces duplicate native symbols when both libraries are linked.
@@ -165,7 +168,8 @@ let package = Package(
             dependencies: [
                 "AFMKitCore",
                 "CDwarfStar",
-                .product(name: "HuggingFace", package: "swift-huggingface")
+                .product(name: "HuggingFace", package: "swift-huggingface"),
+                .product(name: "Xet", package: "swift-xet")
             ],
             resources: [
                 // DS4 compiles these include-style fragments at runtime. Keep the

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -864,7 +864,9 @@ struct MlxCommand: ParsableCommand {
         guard requested != .mlx else { return .mlx }
 
         let path = localModelPath(model)
-        let modelURL = URL(fileURLWithPath: path)
+        // Hugging Face snapshots expose model files as symlinks into blobs.
+        // Classify the resolved target so a cached GGUF is not mistaken for MLX.
+        let modelURL = URL(fileURLWithPath: path).resolvingSymlinksInPath()
         let resourceValues = try? modelURL.resourceValues(
             forKeys: [.isDirectoryKey, .isRegularFileKey])
         guard resourceValues?.isDirectory != true else {

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -920,13 +920,18 @@ struct MlxCommand: ParsableCommand {
 
         let group = DispatchGroup()
         let result = SendableBox<Result<URL, Error>?>(nil)
+        let loadReporter = MLXLoadReporter(
+            modelID: model,
+            loadingLabel: "Resolving remote DwarfStar model")
+        loadReporter.start()
         group.enter()
         Task.detached {
             do {
                 let resolver = AFMDwarfStarHubResolver()
                 result.value = .success(try await resolver.resolve(
                     repositoryID: model,
-                    requestedPath: ggufFile))
+                    requestedPath: ggufFile,
+                    progress: { loadReporter.updateDownload($0) }))
             } catch {
                 result.value = .failure(error)
             }
@@ -936,18 +941,23 @@ struct MlxCommand: ParsableCommand {
 
         switch result.value {
         case .success(let url):
+            loadReporter.finish(success: true)
             print("[Runtime] Hugging Face GGUF resolved: \(model) -> \(url.lastPathComponent)")
             return url.path
         case .failure(let error as AFMDwarfStarHubSelectionError):
             if requested == MLXRuntimeBackend.auto.rawValue,
                case .noModelGGUF = error,
                ggufFile == nil {
+                loadReporter.finish(success: true)
                 return model
             }
+            loadReporter.finish(success: false, errorMessage: error.localizedDescription)
             throw error
         case .failure(let error):
+            loadReporter.finish(success: false, errorMessage: error.localizedDescription)
             throw error
         case .none:
+            loadReporter.finish(success: false, errorMessage: "resolver returned no result")
             throw ValidationError("Hugging Face GGUF resolution ended without a result")
         }
     }
@@ -2099,6 +2109,7 @@ private final class MLXLoadReporter: @unchecked Sendable {
     nonisolated(unsafe) private static weak var activeReporter: MLXLoadReporter?
 
     private let modelID: String
+    private let loadingLabel: String
     private let lock = NSLock()
     private var stage: MLXLoadStage = .checkingCache
     private var downloadFraction: Double?
@@ -2109,6 +2120,7 @@ private final class MLXLoadReporter: @unchecked Sendable {
     private var downloadCurrentFiles: [String] = []
     private var downloadCompletedFiles: Int?
     private var downloadTotalFiles: Int?
+    private var downloadCurrentTransports: [String] = []
     private var lastDownloadSample: (date: Date, completed: Int64)?
     private var timer: DispatchSourceTimer?
     private var spinnerIndex: Int = 0
@@ -2117,8 +2129,9 @@ private final class MLXLoadReporter: @unchecked Sendable {
 
     private let spinnerFrames = ["|", "/", "-", "\\"]
 
-    init(modelID: String) {
+    init(modelID: String, loadingLabel: String = "Loading MLX model") {
         self.modelID = modelID
+        self.loadingLabel = loadingLabel
     }
 
     func start() {
@@ -2127,7 +2140,7 @@ private final class MLXLoadReporter: @unchecked Sendable {
         Self.reporterLock.unlock()
 
         startedAt = Date()
-        print("Loading MLX model: \(modelID)")
+        print("\(loadingLabel): \(modelID)")
 
         let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .utility))
         timer.schedule(deadline: .now(), repeating: .milliseconds(200))
@@ -2150,6 +2163,7 @@ private final class MLXLoadReporter: @unchecked Sendable {
         downloadCurrentFiles = progress.userInfo[AFMDownloadProgressUserInfo.currentFiles] as? [String] ?? []
         downloadCompletedFiles = progress.userInfo[AFMDownloadProgressUserInfo.completedFiles] as? Int
         downloadTotalFiles = progress.userInfo[AFMDownloadProgressUserInfo.totalFiles] as? Int
+        downloadCurrentTransports = progress.userInfo[AFMDownloadProgressUserInfo.currentTransports] as? [String] ?? []
         if let previous = lastDownloadSample {
             let elapsed = now.timeIntervalSince(previous.date)
             let delta = completed - previous.completed
@@ -2183,6 +2197,7 @@ private final class MLXLoadReporter: @unchecked Sendable {
             downloadCurrentFiles = []
             downloadCompletedFiles = nil
             downloadTotalFiles = nil
+            downloadCurrentTransports = []
             lastDownloadSample = nil
         }
         lock.unlock()
@@ -2243,6 +2258,7 @@ private final class MLXLoadReporter: @unchecked Sendable {
         let currentFiles = self.downloadCurrentFiles
         let completedFiles = self.downloadCompletedFiles
         let totalFiles = self.downloadTotalFiles
+        let currentTransports = self.downloadCurrentTransports
         spinnerIndex = (spinnerIndex + 1) % spinnerFrames.count
         let spinner = spinnerFrames[spinnerIndex]
         let elapsed = Date().timeIntervalSince(startedAt)
@@ -2278,7 +2294,8 @@ private final class MLXLoadReporter: @unchecked Sendable {
                 line += " | \(first)"
                 if currentFiles.count > 1 { line += " (+\(currentFiles.count - 1))" }
             }
-            line += " | transport auto"
+            let transports = Array(Set(currentTransports)).sorted()
+            line += " | transport \(transports.isEmpty ? "auto" : transports.joined(separator: "+"))"
         }
         fputs(Self.terminalSafeLine(line, clearExisting: true), stdout)
         fflush(stdout)

--- a/Sources/AFMKit/BuildInfo.swift
+++ b/Sources/AFMKit/BuildInfo.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 public struct BuildInfo {
-    public static let version: String? = "v0.9.15"
+    public static let version: String? = "v0.9.16"
     static let commit: String? = nil
 
     public static var fullVersion: String {

--- a/Sources/AFMKitCore/AFMDownloadProgress.swift
+++ b/Sources/AFMKitCore/AFMDownloadProgress.swift
@@ -1,25 +1,21 @@
 import Foundation
 import os
 
-/// AFM metadata attached to Hugging Face snapshot `Progress` instances.
-///
-/// The official Hub API reports aggregate bytes. AFM augments that progress
-/// with the public repository manifest so terminal clients can also identify
-/// active files without replacing the Hub's Xet/LFS transport or cache logic.
+/// Provider-neutral metadata attached to aggregate model download progress.
 public enum AFMDownloadProgressUserInfo {
     public static let currentFiles = ProgressUserInfoKey("com.maclocal.afm.download.current-files")
     public static let completedFiles = ProgressUserInfoKey("com.maclocal.afm.download.completed-files")
     public static let totalFiles = ProgressUserInfoKey("com.maclocal.afm.download.total-files")
     public static let currentTransports = ProgressUserInfoKey("com.maclocal.afm.download.current-transports")
 
-    struct File: @unchecked Sendable {
-        let path: String
-        let expectedBytes: Int64
-        let destination: URL?
-        let progress: Progress
-        let transport: OSAllocatedUnfairLock<String>
+    public struct File: @unchecked Sendable {
+        public let path: String
+        public let expectedBytes: Int64
+        public let destination: URL?
+        public let progress: Progress
+        private let transport: OSAllocatedUnfairLock<String>
 
-        init(
+        public init(
             path: String,
             expectedBytes: Int64,
             destination: URL?,
@@ -33,52 +29,42 @@ public enum AFMDownloadProgressUserInfo {
             self.transport = OSAllocatedUnfairLock(initialState: transport)
         }
 
-        func setTransport(_ value: String) {
+        public func setTransport(_ value: String) {
             transport.withLock { $0 = value }
         }
 
-        var currentTransport: String {
+        public var currentTransport: String {
             transport.withLock { $0 }
         }
     }
 
-    static func enrich(_ progress: Progress, files: [File]) {
+    public static func enrich(_ progress: Progress, files: [File]) {
         guard !files.isEmpty else { return }
         var completed = 0
         var completedBytes: Int64 = 0
         var activePairs: [(path: String, transport: String)] = []
         var firstPendingPair: (path: String, transport: String)?
         for file in files {
-            let path = file.path
             let child = file.progress
-            let transport = file.currentTransport
             if let destination = file.destination,
                let attributes = try? FileManager.default.attributesOfItem(atPath: destination.path),
                let size = (attributes[.size] as? NSNumber)?.int64Value,
                size > child.completedUnitCount {
                 child.completedUnitCount = min(size, file.expectedBytes)
             }
-            if child.totalUnitCount > 0,
-               child.completedUnitCount >= child.totalUnitCount {
+            if child.totalUnitCount > 0, child.completedUnitCount >= child.totalUnitCount {
                 completed += 1
             } else {
-                if firstPendingPair == nil {
-                    firstPendingPair = (path, transport)
-                }
-                if child.completedUnitCount > 0 {
-                    activePairs.append((path, transport))
-                }
+                let pair = (file.path, file.currentTransport)
+                if firstPendingPair == nil { firstPendingPair = pair }
+                if child.completedUnitCount > 0 { activePairs.append(pair) }
             }
             completedBytes += min(child.completedUnitCount, file.expectedBytes)
         }
-        if activePairs.isEmpty, let firstPendingPair {
-            activePairs = [firstPendingPair]
-        }
-        let active = activePairs.map(\.path)
-        let activeTransports = activePairs.map(\.transport)
+        if activePairs.isEmpty, let firstPendingPair { activePairs = [firstPendingPair] }
         progress.completedUnitCount = min(completedBytes, progress.totalUnitCount)
-        progress.setUserInfoObject(active, forKey: currentFiles)
-        progress.setUserInfoObject(activeTransports, forKey: currentTransports)
+        progress.setUserInfoObject(activePairs.map(\.path), forKey: currentFiles)
+        progress.setUserInfoObject(activePairs.map(\.transport), forKey: currentTransports)
         progress.setUserInfoObject(completed, forKey: completedFiles)
         progress.setUserInfoObject(files.count, forKey: totalFiles)
     }

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarCheckpoint.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarCheckpoint.swift
@@ -77,7 +77,7 @@ public struct AFMDwarfStarCheckpointCatalog: Sendable {
     /// Reads the model architecture from GGUF metadata without loading tensor
     /// data. This is the runtime auto-selection signal; filenames are ignored.
     public static func ggufArchitecture(at url: URL) -> String? {
-        try? GGUFMetadataReader(url: url).architecture()
+        try? GGUFMetadataReader(url: url.resolvingSymlinksInPath()).architecture()
     }
 
     public static func isDwarfStarCompatibleGGUF(at url: URL) -> Bool {

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarHubResolver.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarHubResolver.swift
@@ -134,50 +134,130 @@ public struct AFMDwarfStarHubResolver: Sendable {
         let expectedBytes = max(Int64(entry.size ?? 1), 1)
         let blobKey = Self.hubBlobKey(repo: repo, revision: revision, entry: entry)
         let destination = try cache.blobPath(repo: repo, kind: .model, etag: blobKey)
-        let aggregate = Progress(totalUnitCount: expectedBytes)
+        let partial = try cache.incompleteBlobPath(repo: repo, kind: .model, etag: blobKey)
+        let segment = partial.appendingPathExtension("xet-segment")
+        print("Download destination: \(cacheDirectory.path)")
+        try FileManager.default.createDirectory(at: partial.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let token = try await TokenProvider.environment.getToken()
+        let listedSHA256 = entry.oid.flatMap(Self.normalizedSHA256)
+        let xetMetadata: AFMDwarfStarXetMetadata
+        do {
+            xetMetadata = try await AFMDwarfStarResumableDownload.fetchXetMetadata(
+                repositoryID: repositoryID,
+                revision: revision,
+                path: entry.path,
+                expectedBytes: expectedBytes,
+                token: token)
+        } catch {
+            print("Hugging Face Xet metadata unavailable: \(AFMDwarfStarResumableDownload.detailedError(error)); using cache-local LFS")
+            xetMetadata = AFMDwarfStarXetMetadata(
+                fileID: nil,
+                expectedBytes: expectedBytes,
+                expectedSHA256: listedSHA256)
+        }
+        let aggregate = Progress(totalUnitCount: xetMetadata.expectedBytes)
         let file = AFMDownloadProgressUserInfo.File(
             path: entry.path,
-            expectedBytes: expectedBytes,
-            destination: destination,
-            progress: Progress(totalUnitCount: expectedBytes),
+            expectedBytes: xetMetadata.expectedBytes,
+            destination: nil,
+            progress: Progress(totalUnitCount: xetMetadata.expectedBytes),
             transport: "xet")
         let monitor = Task {
             while !Task.isCancelled {
+                let persisted = AFMDwarfStarResumableDownload.fileSize(partial)
+                let activeSegment = AFMDwarfStarResumableDownload.fileSize(segment)
+                file.progress.completedUnitCount = min(
+                    persisted + activeSegment,
+                    xetMetadata.expectedBytes)
                 AFMDownloadProgressUserInfo.enrich(aggregate, files: [file])
                 progress?(aggregate)
                 try? await Task.sleep(for: .milliseconds(100))
             }
         }
         defer { monitor.cancel() }
-
-        print("Download destination: \(cacheDirectory.path)")
-        try FileManager.default.createDirectory(
-            at: destination.deletingLastPathComponent(),
-            withIntermediateDirectories: true)
-        do {
-            print("Hugging Face transport selected: xet file=\(entry.path)")
-            _ = try await client.downloadFile(
-                entry,
-                from: repo,
-                to: destination,
-                revision: revision,
-                progress: file.progress,
-                transport: .xet)
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch {
-            guard !Task.isCancelled else { throw CancellationError() }
-            file.setTransport("xet-fallback-lfs")
-            print("Hugging Face transport fallback: xet failed for \(entry.path): \(error.localizedDescription); retrying with lfs")
-            try? FileManager.default.removeItem(at: destination)
-            _ = try await client.downloadFile(
-                entry,
-                from: repo,
-                to: destination,
-                revision: revision,
-                progress: file.progress,
-                transport: .lfs)
+        try AFMDwarfStarResumableDownload.adoptSegment(
+            segment,
+            as: partial,
+            expectedBytes: xetMetadata.expectedBytes)
+        var offset = min(
+            AFMDwarfStarResumableDownload.fileSize(partial),
+            xetMetadata.expectedBytes)
+        file.progress.completedUnitCount = offset
+        if offset > 0 {
+            print("Resuming cached partial: \(ByteCountFormatter.string(fromByteCount: offset, countStyle: .file)) / \(ByteCountFormatter.string(fromByteCount: xetMetadata.expectedBytes, countStyle: .file))")
         }
+
+        let maximumXetAttempts = 4
+        var lastXetError: Error?
+        if xetMetadata.fileID != nil {
+            for attempt in 1 ... maximumXetAttempts where offset < xetMetadata.expectedBytes {
+                try? FileManager.default.removeItem(at: segment)
+                file.setTransport(attempt == 1 ? "xet" : "xet-retry-\(attempt)")
+                print("Hugging Face transport selected: xet file=\(entry.path) offset=\(offset) attempt=\(attempt)/\(maximumXetAttempts)")
+                do {
+                    try await AFMDwarfStarResumableDownload.downloadXetRange(
+                        metadata: xetMetadata,
+                        repositoryID: repositoryID,
+                        revision: revision,
+                        offset: offset,
+                        segmentURL: segment,
+                        token: token)
+                    try AFMDwarfStarResumableDownload.adoptSegment(
+                        segment,
+                        as: partial,
+                        expectedBytes: xetMetadata.expectedBytes)
+                    offset = AFMDwarfStarResumableDownload.fileSize(partial)
+                    file.progress.completedUnitCount = offset
+                    lastXetError = nil
+                } catch is CancellationError {
+                    try? AFMDwarfStarResumableDownload.adoptSegment(
+                        segment,
+                        as: partial,
+                        expectedBytes: xetMetadata.expectedBytes)
+                    throw CancellationError()
+                } catch {
+                    guard !Task.isCancelled else { throw CancellationError() }
+                    try? AFMDwarfStarResumableDownload.adoptSegment(
+                        segment,
+                        as: partial,
+                        expectedBytes: xetMetadata.expectedBytes)
+                    offset = AFMDwarfStarResumableDownload.fileSize(partial)
+                    file.progress.completedUnitCount = offset
+                    lastXetError = error
+                    let detail = AFMDwarfStarResumableDownload.detailedError(error)
+                    if attempt < maximumXetAttempts {
+                        let delay = min(1 << (attempt - 1), 8)
+                        print("Xet interrupted at \(offset)/\(xetMetadata.expectedBytes) bytes: \(detail); retrying in \(delay)s")
+                        try await Task.sleep(for: .seconds(delay))
+                    }
+                }
+            }
+        } else {
+            lastXetError = AFMDwarfStarDownloadError.missingXetMetadata(entry.path)
+        }
+
+        if offset < xetMetadata.expectedBytes {
+            file.setTransport("xet-fallback-lfs")
+            let detail = lastXetError.map(AFMDwarfStarResumableDownload.detailedError) ?? "unknown Xet failure"
+            print("Hugging Face transport fallback: Xet exhausted at \(offset)/\(xetMetadata.expectedBytes) bytes: \(detail); continuing with cache-local LFS")
+            try await AFMDwarfStarResumableDownload.downloadLFSRange(
+                repositoryID: repositoryID,
+                revision: revision,
+                path: entry.path,
+                destination: partial,
+                offset: offset,
+                expectedBytes: xetMetadata.expectedBytes,
+                token: token,
+                progress: { completed in file.progress.completedUnitCount = completed })
+        }
+
+        file.setTransport("verifying-sha256")
+        print("Verifying downloaded file size and SHA-256 before publication")
+        try AFMDwarfStarResumableDownload.publish(
+            partial: partial,
+            blob: destination,
+            expectedBytes: xetMetadata.expectedBytes,
+            expectedSHA256: xetMetadata.expectedSHA256)
         try await cache.storeFile(
             at: destination,
             repo: repo,
@@ -186,7 +266,7 @@ public struct AFMDwarfStarHubResolver: Sendable {
             filename: entry.path,
             etag: blobKey,
             ref: "main")
-        file.progress.completedUnitCount = expectedBytes
+        file.progress.completedUnitCount = xetMetadata.expectedBytes
         AFMDownloadProgressUserInfo.enrich(aggregate, files: [file])
         progress?(aggregate)
         let snapshot = try cache.snapshotPath(repo: repo, kind: .model, commitHash: revision)
@@ -202,6 +282,12 @@ public struct AFMDwarfStarHubResolver: Sendable {
         return SHA256.hash(data: Data(identity.utf8))
             .map { String(format: "%02x", $0) }
             .joined()
+    }
+
+    private static func normalizedSHA256(_ value: String) -> String? {
+        let value = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard value.count == 64, value.allSatisfy(\.isHexDigit) else { return nil }
+        return value
     }
 
     public static func defaultCacheDirectory() -> URL {

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarHubResolver.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarHubResolver.swift
@@ -132,6 +132,13 @@ public struct AFMDwarfStarHubResolver: Sendable {
         }
 
         let expectedBytes = max(Int64(entry.size ?? 1), 1)
+        let snapshot = try cache.snapshotPath(repo: repo, kind: .model, commitHash: revision)
+        let cachedArtifact = snapshot.appendingPathComponent(entry.path)
+        let cachedTarget = cachedArtifact.resolvingSymlinksInPath()
+        if AFMDwarfStarResumableDownload.fileSize(cachedTarget) == expectedBytes {
+            print("Using cached DwarfStar model: \(cachedArtifact.path)")
+            return cachedArtifact
+        }
         let blobKey = Self.hubBlobKey(repo: repo, revision: revision, entry: entry)
         let destination = try cache.blobPath(repo: repo, kind: .model, etag: blobKey)
         let partial = try cache.incompleteBlobPath(repo: repo, kind: .model, etag: blobKey)
@@ -269,7 +276,6 @@ public struct AFMDwarfStarHubResolver: Sendable {
         file.progress.completedUnitCount = xetMetadata.expectedBytes
         AFMDownloadProgressUserInfo.enrich(aggregate, files: [file])
         progress?(aggregate)
-        let snapshot = try cache.snapshotPath(repo: repo, kind: .model, commitHash: revision)
         return snapshot.appendingPathComponent(entry.path)
     }
 

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarHubResolver.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarHubResolver.swift
@@ -1,4 +1,6 @@
 import Foundation
+import CryptoKit
+import AFMKitCore
 import HuggingFace
 
 public struct AFMDwarfStarHubArtifact: Equatable, Sendable {
@@ -108,13 +110,15 @@ public struct AFMDwarfStarHubResolver: Sendable {
     public func resolve(
         repositoryID: String,
         requestedPath: String? = nil,
-        progress: (@MainActor @Sendable (Progress) -> Void)? = nil
+        progress: (@Sendable (Progress) -> Void)? = nil
     ) async throws -> URL {
         guard let repo = HuggingFace.Repo.ID(rawValue: repositoryID) else {
             throw AFMDwarfStarHubSelectionError.invalidRepositoryID(repositoryID)
         }
-        let client = HuggingFace.HubClient(cache: HubCache(cacheDirectory: cacheDirectory))
-        let entries = try await client.listFiles(in: repo).filter {
+        let cache = HubCache(cacheDirectory: cacheDirectory)
+        let client = HuggingFace.HubClient(cache: cache)
+        let revision = try await client.getModel(repo).sha ?? "main"
+        let entries = try await client.listFiles(in: repo, revision: revision).filter {
             $0.type == .file && $0.path.lowercased().hasSuffix(".gguf")
         }
         let artifact = try AFMDwarfStarHubSelector.selectModel(
@@ -123,12 +127,81 @@ public struct AFMDwarfStarHubResolver: Sendable {
             },
             repositoryID: repositoryID,
             requestedPath: requestedPath)
-        let snapshot = try await client.downloadSnapshot(
-            of: repo,
-            matching: [artifact.path],
-            maxConcurrentDownloads: 1,
-            progressHandler: progress)
-        return snapshot.appendingPathComponent(artifact.path)
+        guard let entry = entries.first(where: { $0.path == artifact.path }) else {
+            throw AFMDwarfStarHubSelectionError.requestedFileNotFound(artifact.path)
+        }
+
+        let expectedBytes = max(Int64(entry.size ?? 1), 1)
+        let blobKey = Self.hubBlobKey(repo: repo, revision: revision, entry: entry)
+        let destination = try cache.blobPath(repo: repo, kind: .model, etag: blobKey)
+        let aggregate = Progress(totalUnitCount: expectedBytes)
+        let file = AFMDownloadProgressUserInfo.File(
+            path: entry.path,
+            expectedBytes: expectedBytes,
+            destination: destination,
+            progress: Progress(totalUnitCount: expectedBytes),
+            transport: "xet")
+        let monitor = Task {
+            while !Task.isCancelled {
+                AFMDownloadProgressUserInfo.enrich(aggregate, files: [file])
+                progress?(aggregate)
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+        }
+        defer { monitor.cancel() }
+
+        print("Download destination: \(cacheDirectory.path)")
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        do {
+            print("Hugging Face transport selected: xet file=\(entry.path)")
+            _ = try await client.downloadFile(
+                entry,
+                from: repo,
+                to: destination,
+                revision: revision,
+                progress: file.progress,
+                transport: .xet)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            guard !Task.isCancelled else { throw CancellationError() }
+            file.setTransport("xet-fallback-lfs")
+            print("Hugging Face transport fallback: xet failed for \(entry.path): \(error.localizedDescription); retrying with lfs")
+            try? FileManager.default.removeItem(at: destination)
+            _ = try await client.downloadFile(
+                entry,
+                from: repo,
+                to: destination,
+                revision: revision,
+                progress: file.progress,
+                transport: .lfs)
+        }
+        try await cache.storeFile(
+            at: destination,
+            repo: repo,
+            kind: .model,
+            revision: revision,
+            filename: entry.path,
+            etag: blobKey,
+            ref: "main")
+        file.progress.completedUnitCount = expectedBytes
+        AFMDownloadProgressUserInfo.enrich(aggregate, files: [file])
+        progress?(aggregate)
+        let snapshot = try cache.snapshotPath(repo: repo, kind: .model, commitHash: revision)
+        return snapshot.appendingPathComponent(entry.path)
+    }
+
+    private static func hubBlobKey(
+        repo: HuggingFace.Repo.ID,
+        revision: String,
+        entry: Git.TreeEntry
+    ) -> String {
+        let identity = "\(repo.description)|\(revision)|\(entry.path)|\(entry.oid ?? "")"
+        return SHA256.hash(data: Data(identity.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 
     public static func defaultCacheDirectory() -> URL {

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarResumableDownload.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarResumableDownload.swift
@@ -1,0 +1,356 @@
+import Foundation
+import CryptoKit
+import HuggingFace
+import Xet
+
+struct AFMDwarfStarXetMetadata: Sendable {
+    let fileID: String?
+    let expectedBytes: Int64
+    let expectedSHA256: String?
+}
+
+enum AFMDwarfStarDownloadError: LocalizedError {
+    case missingXetMetadata(String)
+    case invalidResponse(String)
+    case rangeNotHonored(expectedOffset: Int64, statusCode: Int)
+    case incompleteDownload(expected: Int64, actual: Int64)
+    case checksumMismatch(expected: String, actual: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingXetMetadata(let path):
+            return "Hugging Face did not return Xet metadata for \(path)."
+        case .invalidResponse(let detail):
+            return "Invalid Hugging Face response: \(detail)"
+        case .rangeNotHonored(let offset, let status):
+            return "LFS fallback did not honor byte offset \(offset) (HTTP \(status)); the partial Xet download was preserved."
+        case .incompleteDownload(let expected, let actual):
+            return "Downloaded file size is \(actual) bytes; expected \(expected) bytes. The partial download was preserved."
+        case .checksumMismatch(let expected, let actual):
+            return "Downloaded file SHA-256 is \(actual); expected \(expected). The partial download was preserved."
+        }
+    }
+}
+
+enum AFMDwarfStarResumableDownload {
+    static func fetchXetMetadata(
+        repositoryID: String,
+        revision: String,
+        path: String,
+        expectedBytes: Int64,
+        token: String?
+    ) async throws -> AFMDwarfStarXetMetadata {
+        let url = try resolveURL(repositoryID: repositoryID, revision: revision, path: path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "HEAD"
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
+        let delegate = NoRedirectDelegate()
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw AFMDwarfStarDownloadError.invalidResponse("HEAD did not return HTTP metadata")
+        }
+        guard (200 ... 399).contains(http.statusCode) else {
+            throw AFMDwarfStarDownloadError.invalidResponse("HEAD returned HTTP \(http.statusCode)")
+        }
+        let xetHash = http.value(forHTTPHeaderField: "X-Xet-Hash")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let fileID = xetHash.flatMap { value -> String? in
+            value.count == 64 && value.allSatisfy(\.isHexDigit) ? value : nil
+        }
+        let linkedSize = http.value(forHTTPHeaderField: "X-Linked-Size").flatMap(Int64.init)
+        let linkedEtag = normalizeSHA256(http.value(forHTTPHeaderField: "X-Linked-Etag"))
+        return AFMDwarfStarXetMetadata(
+            fileID: fileID,
+            expectedBytes: linkedSize ?? expectedBytes,
+            expectedSHA256: linkedEtag)
+    }
+
+    static func downloadXetRange(
+        metadata: AFMDwarfStarXetMetadata,
+        repositoryID: String,
+        revision: String,
+        offset: Int64,
+        segmentURL: URL,
+        token: String?
+    ) async throws {
+        guard offset < metadata.expectedBytes else { return }
+        guard let fileID = metadata.fileID else {
+            throw AFMDwarfStarDownloadError.missingXetMetadata(repositoryID)
+        }
+        guard let refreshURL = URL(
+            string: "https://huggingface.co/api/models/\(repositoryID)/xet-read-token/\(revision)"
+        ) else {
+            throw AFMDwarfStarDownloadError.invalidResponse("invalid Xet refresh URL")
+        }
+        var configuration = XetDownloader.Configuration.default
+        configuration.readTimeout = 600
+        configuration.idleTimeout = 300
+        configuration.enableMultipath = false
+        _ = try await Xet.withDownloader(
+            refreshURL: refreshURL,
+            hubToken: token,
+            configuration: configuration
+        ) { downloader in
+            try await downloader.download(
+                fileID,
+                byteRange: UInt64(offset)..<UInt64(metadata.expectedBytes),
+                to: segmentURL)
+        }
+    }
+
+    static func downloadLFSRange(
+        repositoryID: String,
+        revision: String,
+        path: String,
+        destination: URL,
+        offset: Int64,
+        expectedBytes: Int64,
+        token: String?,
+        progress: @escaping @Sendable (Int64) -> Void
+    ) async throws {
+        let url = try resolveURL(repositoryID: repositoryID, revision: revision, path: path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        if offset > 0 { request.setValue("bytes=\(offset)-", forHTTPHeaderField: "Range") }
+        if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
+        let delegate = CacheLocalDataDelegate(
+            destination: destination,
+            offset: offset,
+            expectedBytes: expectedBytes,
+            progress: progress)
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+        try await delegate.run(request: request, session: session)
+    }
+
+    static func appendSegment(_ segment: URL, to partial: URL, expectedBytes: Int64) throws {
+        guard FileManager.default.fileExists(atPath: segment.path) else { return }
+        let partialSize = fileSize(partial)
+        let remaining = max(expectedBytes - partialSize, 0)
+        let segmentSize = fileSize(segment)
+        guard segmentSize <= remaining else {
+            throw AFMDwarfStarDownloadError.incompleteDownload(
+                expected: expectedBytes,
+                actual: partialSize + segmentSize)
+        }
+        if !FileManager.default.fileExists(atPath: partial.path) {
+            FileManager.default.createFile(atPath: partial.path, contents: nil)
+        }
+        let input = try FileHandle(forReadingFrom: segment)
+        let output = try FileHandle(forWritingTo: partial)
+        defer {
+            try? input.close()
+            try? output.close()
+        }
+        try output.seekToEnd()
+        while let data = try input.read(upToCount: 8 * 1024 * 1024), !data.isEmpty {
+            try output.write(contentsOf: data)
+        }
+        try FileManager.default.removeItem(at: segment)
+    }
+
+    static func adoptSegment(_ segment: URL, as partial: URL, expectedBytes: Int64) throws {
+        guard FileManager.default.fileExists(atPath: segment.path) else { return }
+        if fileSize(partial) == 0 {
+            if FileManager.default.fileExists(atPath: partial.path) {
+                try FileManager.default.removeItem(at: partial)
+            }
+            guard fileSize(segment) <= expectedBytes else {
+                throw AFMDwarfStarDownloadError.incompleteDownload(
+                    expected: expectedBytes,
+                    actual: fileSize(segment))
+            }
+            try FileManager.default.moveItem(at: segment, to: partial)
+        } else {
+            try appendSegment(segment, to: partial, expectedBytes: expectedBytes)
+        }
+    }
+
+    static func publish(
+        partial: URL,
+        blob: URL,
+        expectedBytes: Int64,
+        expectedSHA256: String?
+    ) throws {
+        let actual = fileSize(partial)
+        guard actual == expectedBytes else {
+            throw AFMDwarfStarDownloadError.incompleteDownload(expected: expectedBytes, actual: actual)
+        }
+        if let expectedSHA256 {
+            let actualSHA256 = try sha256(partial)
+            guard actualSHA256 == expectedSHA256 else {
+                throw AFMDwarfStarDownloadError.checksumMismatch(
+                    expected: expectedSHA256,
+                    actual: actualSHA256)
+            }
+        }
+        if FileManager.default.fileExists(atPath: blob.path) {
+            _ = try FileManager.default.replaceItemAt(blob, withItemAt: partial)
+        } else {
+            try FileManager.default.moveItem(at: partial, to: blob)
+        }
+    }
+
+    static func fileSize(_ url: URL) -> Int64 {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let size = attributes[.size] as? NSNumber else { return 0 }
+        return size.int64Value
+    }
+
+    static func sha256(_ url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while let data = try handle.read(upToCount: 8 * 1024 * 1024), !data.isEmpty {
+            hasher.update(data: data)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func detailedError(_ error: Error) -> String {
+        var parts = [String(reflecting: error)]
+        var current = error as NSError
+        var seen = Set<ObjectIdentifier>()
+        while let underlying = current.userInfo[NSUnderlyingErrorKey] as? NSError,
+              seen.insert(ObjectIdentifier(underlying)).inserted {
+            parts.append(String(reflecting: underlying))
+            current = underlying
+        }
+        return parts.joined(separator: " <- ")
+    }
+
+    private static func resolveURL(repositoryID: String, revision: String, path: String) throws -> URL {
+        guard let base = URL(string: "https://huggingface.co") else {
+            throw AFMDwarfStarDownloadError.invalidResponse("invalid Hugging Face base URL")
+        }
+        return path.split(separator: "/").reduce(
+            base.appendingPathComponent(repositoryID)
+                .appendingPathComponent("resolve")
+                .appendingPathComponent(revision)
+        ) { $0.appendingPathComponent(String($1)) }
+    }
+
+    private static func normalizeSHA256(_ value: String?) -> String? {
+        guard var value else { return nil }
+        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasPrefix("W/") { value.removeFirst(2) }
+        value = value.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+        guard value.count == 64, value.allSatisfy(\.isHexDigit) else { return nil }
+        return value.lowercased()
+    }
+}
+
+private final class NoRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}
+
+private final class CacheLocalDataDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    private let destination: URL
+    private let offset: Int64
+    private let expectedBytes: Int64
+    private let progress: @Sendable (Int64) -> Void
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var handle: FileHandle?
+    private var received: Int64 = 0
+    private var responseError: Error?
+
+    init(
+        destination: URL,
+        offset: Int64,
+        expectedBytes: Int64,
+        progress: @escaping @Sendable (Int64) -> Void
+    ) {
+        self.destination = destination
+        self.offset = offset
+        self.expectedBytes = expectedBytes
+        self.progress = progress
+    }
+
+    func run(request: URLRequest, session: URLSession) async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                lock.withLock { self.continuation = continuation }
+                session.dataTask(with: request).resume()
+            }
+        } onCancel: {
+            session.invalidateAndCancel()
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let http = response as? HTTPURLResponse else {
+            responseError = AFMDwarfStarDownloadError.invalidResponse("GET did not return HTTP metadata")
+            completionHandler(.cancel)
+            return
+        }
+        guard (200 ... 299).contains(http.statusCode) else {
+            responseError = AFMDwarfStarDownloadError.invalidResponse("GET returned HTTP \(http.statusCode)")
+            completionHandler(.cancel)
+            return
+        }
+        guard offset == 0 || http.statusCode == 206 else {
+            responseError = AFMDwarfStarDownloadError.rangeNotHonored(
+                expectedOffset: offset,
+                statusCode: http.statusCode)
+            completionHandler(.cancel)
+            return
+        }
+        do {
+            if !FileManager.default.fileExists(atPath: destination.path) {
+                FileManager.default.createFile(atPath: destination.path, contents: nil)
+            }
+            let handle = try FileHandle(forWritingTo: destination)
+            try handle.seekToEnd()
+            self.handle = handle
+            completionHandler(.allow)
+        } catch {
+            responseError = error
+            completionHandler(.cancel)
+        }
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        do {
+            try handle?.write(contentsOf: data)
+            received += Int64(data.count)
+            progress(min(offset + received, expectedBytes))
+        } catch {
+            responseError = error
+            dataTask.cancel()
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        try? handle?.close()
+        handle = nil
+        let result = responseError ?? error
+        let continuation = lock.withLock { () -> CheckedContinuation<Void, Error>? in
+            defer { self.continuation = nil }
+            return self.continuation
+        }
+        if let result { continuation?.resume(throwing: result) }
+        else { continuation?.resume() }
+    }
+}

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarScheduler.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarScheduler.swift
@@ -31,7 +31,14 @@ enum AFMDwarfStarReasoningMode: String, Equatable, Sendable {
     }
 
     var thinkMode: ds4_think_mode {
-        self == .chat ? DS4_THINK_NONE : DS4_THINK_HIGH
+        switch self {
+        case .chat:
+            return DS4_THINK_NONE
+        case .low, .high:
+            return DS4_THINK_HIGH
+        case .max:
+            return DS4_THINK_MAX
+        }
     }
 
     var promptPrefix: String? {
@@ -955,13 +962,15 @@ public actor AFMDwarfStarRuntimeCoordinator {
         let texts = request.messages.map { message in
             (try? AFMDwarfStarToolCodec.textContent(of: message)) ?? "<non-text>"
         }
+        let reasoningMode = AFMDwarfStarReasoningMode.resolve(metadata: request.metadata)
         let tokenIDs: [Int32]
         if let values = prompt.v {
             tokenIDs = (0..<Int(prompt.len)).map { Int32(values[$0]) }
         } else {
             tokenIDs = []
         }
-        let line = "[DwarfStarPrompt] roles=\(roles) texts=\(texts.debugDescription) "
+        let line = "[DwarfStarPrompt] reasoning=\(reasoningMode.rawValue) "
+            + "roles=\(roles) texts=\(texts.debugDescription) "
             + "tokens=\(tokenIDs)\n"
         FileHandle.standardError.write(Data(line.utf8))
     }

--- a/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
+++ b/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
@@ -9,6 +9,7 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
     private let resolver: MLXCacheResolver
     private let fixedModel: AnyAFMModel?
     private let fixedModelID: String?
+    private let fixedServingConfiguration: AFMMLXServingConfiguration
     private let defaultChatTemplateKwargs: [String: AnyCodable]?
     private let forceDisableThinking: Bool
     private let slotLock = NSLock()
@@ -25,6 +26,7 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
         self.resolver = resolver
         fixedModel = nil
         fixedModelID = nil
+        fixedServingConfiguration = .init()
         self.defaultChatTemplateKwargs = defaultChatTemplateKwargs
         self.forceDisableThinking = forceDisableThinking
         fixedMaxConcurrent = 1
@@ -40,6 +42,9 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
         resolver = .init()
         fixedModel = model
         fixedModelID = modelID
+        fixedServingConfiguration = model.descriptor.capabilities.contains(.reasoning)
+            ? .init(thinkStartTag: "<think>", thinkEndTag: "</think>")
+            : .init()
         self.defaultChatTemplateKwargs = defaultChatTemplateKwargs
         self.forceDisableThinking = forceDisableThinking
         if case .integer(let value) = model.descriptor.metadata["maxConcurrent"] {
@@ -51,7 +56,7 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
 
     var maxConcurrent: Int { service?.maxConcurrent ?? fixedMaxConcurrent }
     var servingConfiguration: AFMMLXServingConfiguration {
-        service?.servingConfiguration ?? .init()
+        service?.servingConfiguration ?? fixedServingConfiguration
     }
     var defaultGuidedJsonSchema: ResponseFormat? { service?.defaultGuidedJsonSchema }
 

--- a/Tests/AFMKitDwarfStarTests/AFMDwarfStarHubResolverTests.swift
+++ b/Tests/AFMKitDwarfStarTests/AFMDwarfStarHubResolverTests.swift
@@ -159,4 +159,43 @@ final class AFMDwarfStarHubResolverTests: XCTestCase {
         XCTAssertTrue(detail.contains("download.wrapper"))
         XCTAssertTrue(detail.contains("download.transport"))
     }
+
+    func testDwarfStarDetectionFollowsHuggingFaceSnapshotSymlink() throws {
+        let directory = try temporaryDirectory()
+        let blobs = directory.appendingPathComponent("blobs", isDirectory: true)
+        let snapshot = directory.appendingPathComponent("snapshots/commit", isDirectory: true)
+        try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        let blob = blobs.appendingPathComponent("model-blob")
+        try minimalGGUF(architecture: "deepseek4").write(to: blob)
+        let link = snapshot.appendingPathComponent("model.gguf")
+        try FileManager.default.createSymbolicLink(
+            atPath: link.path,
+            withDestinationPath: "../../blobs/model-blob")
+
+        XCTAssertTrue(AFMDwarfStarCheckpointCatalog.isDwarfStarCompatibleGGUF(at: link))
+        XCTAssertEqual(AFMDwarfStarCheckpointCatalog.ggufArchitecture(at: link), "deepseek4")
+    }
+
+    private func minimalGGUF(architecture: String) -> Data {
+        var data = Data("GGUF".utf8)
+        append(UInt32(3), to: &data)
+        append(UInt64(0), to: &data) // tensor count
+        append(UInt64(1), to: &data) // metadata count
+        appendString("general.architecture", to: &data)
+        append(UInt32(8), to: &data) // GGUF string value
+        appendString(architecture, to: &data)
+        return data
+    }
+
+    private func append<T: FixedWidthInteger>(_ value: T, to data: inout Data) {
+        var value = value.littleEndian
+        withUnsafeBytes(of: &value) { data.append(contentsOf: $0) }
+    }
+
+    private func appendString(_ value: String, to data: inout Data) {
+        let bytes = Data(value.utf8)
+        append(UInt64(bytes.count), to: &data)
+        data.append(bytes)
+    }
 }

--- a/Tests/AFMKitDwarfStarTests/AFMDwarfStarHubResolverTests.swift
+++ b/Tests/AFMKitDwarfStarTests/AFMDwarfStarHubResolverTests.swift
@@ -2,6 +2,14 @@ import XCTest
 @testable import AFMKitDwarfStar
 
 final class AFMDwarfStarHubResolverTests: XCTestCase {
+    private func temporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        return directory
+    }
+
     func testSelectorExcludesDSparkSupportArtifact() throws {
         let selected = try AFMDwarfStarHubSelector.selectModel(
             from: [
@@ -49,5 +57,106 @@ final class AFMDwarfStarHubResolverTests: XCTestCase {
                     error as? AFMDwarfStarHubSelectionError,
                     .noModelGGUF("owner/model"))
             }
+    }
+
+    func testAppendSegmentPreservesAndExtendsPartialDownload() throws {
+        let directory = try temporaryDirectory()
+        let partial = directory.appendingPathComponent("model.incomplete")
+        let segment = directory.appendingPathComponent("model.segment")
+        try Data("first".utf8).write(to: partial)
+        try Data("second".utf8).write(to: segment)
+
+        try AFMDwarfStarResumableDownload.appendSegment(segment, to: partial, expectedBytes: 11)
+
+        XCTAssertEqual(try Data(contentsOf: partial), Data("firstsecond".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: segment.path))
+    }
+
+    func testAdoptSegmentMovesFirstRangeWithoutCopying() throws {
+        let directory = try temporaryDirectory()
+        let partial = directory.appendingPathComponent("model.incomplete")
+        let segment = directory.appendingPathComponent("model.segment")
+        try Data("first-range".utf8).write(to: segment)
+
+        try AFMDwarfStarResumableDownload.adoptSegment(segment, as: partial, expectedBytes: 100)
+
+        XCTAssertEqual(try Data(contentsOf: partial), Data("first-range".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: segment.path))
+    }
+
+    func testAdoptSegmentRecoversRangeLeftByInterruptedProcess() throws {
+        let directory = try temporaryDirectory()
+        let partial = directory.appendingPathComponent("model.incomplete")
+        let segment = directory.appendingPathComponent("model.segment")
+        try Data("first".utf8).write(to: partial)
+        try Data("-recovered".utf8).write(to: segment)
+
+        try AFMDwarfStarResumableDownload.adoptSegment(segment, as: partial, expectedBytes: 100)
+
+        XCTAssertEqual(try Data(contentsOf: partial), Data("first-recovered".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: segment.path))
+    }
+
+    func testPublishRejectsTruncatedDownloadAndPreservesPartial() throws {
+        let directory = try temporaryDirectory()
+        let partial = directory.appendingPathComponent("model.incomplete")
+        let blob = directory.appendingPathComponent("model.gguf")
+        try Data("short".utf8).write(to: partial)
+
+        XCTAssertThrowsError(try AFMDwarfStarResumableDownload.publish(
+            partial: partial,
+            blob: blob,
+            expectedBytes: 100,
+            expectedSHA256: nil))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: partial.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: blob.path))
+    }
+
+    func testPublishRejectsChecksumMismatchAndPreservesPartial() throws {
+        let directory = try temporaryDirectory()
+        let partial = directory.appendingPathComponent("model.incomplete")
+        let blob = directory.appendingPathComponent("model.gguf")
+        try Data("payload".utf8).write(to: partial)
+
+        XCTAssertThrowsError(try AFMDwarfStarResumableDownload.publish(
+            partial: partial,
+            blob: blob,
+            expectedBytes: 7,
+            expectedSHA256: String(repeating: "0", count: 64)))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: partial.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: blob.path))
+    }
+
+    func testPublishAtomicallyMovesVerifiedDownload() throws {
+        let directory = try temporaryDirectory()
+        let partial = directory.appendingPathComponent("model.incomplete")
+        let blob = directory.appendingPathComponent("model.gguf")
+        try Data("payload".utf8).write(to: partial)
+        let digest = try AFMDwarfStarResumableDownload.sha256(partial)
+
+        try AFMDwarfStarResumableDownload.publish(
+            partial: partial,
+            blob: blob,
+            expectedBytes: 7,
+            expectedSHA256: digest)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: partial.path))
+        XCTAssertEqual(try Data(contentsOf: blob), Data("payload".utf8))
+    }
+
+    func testDetailedErrorIncludesUnderlyingFailure() {
+        let underlying = NSError(
+            domain: "download.transport",
+            code: 42,
+            userInfo: [NSLocalizedDescriptionKey: "connection reset"])
+        let wrapper = NSError(
+            domain: "download.wrapper",
+            code: 1,
+            userInfo: [NSUnderlyingErrorKey: underlying])
+
+        let detail = AFMDwarfStarResumableDownload.detailedError(wrapper)
+
+        XCTAssertTrue(detail.contains("download.wrapper"))
+        XCTAssertTrue(detail.contains("download.transport"))
     }
 }

--- a/Tests/AFMKitDwarfStarTests/AFMDwarfStarProviderTests.swift
+++ b/Tests/AFMKitDwarfStarTests/AFMDwarfStarProviderTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AFMKitCore
+import CDwarfStar
 @testable import AFMKitDwarfStar
 
 final class AFMDwarfStarProviderTests: XCTestCase {
@@ -107,6 +108,13 @@ final class AFMDwarfStarProviderTests: XCTestCase {
                 ])
             ]),
             .chat)
+    }
+
+    func testReasoningModesMapToNativeDwarfStarModes() {
+        XCTAssertEqual(AFMDwarfStarReasoningMode.chat.thinkMode, DS4_THINK_NONE)
+        XCTAssertEqual(AFMDwarfStarReasoningMode.low.thinkMode, DS4_THINK_HIGH)
+        XCTAssertEqual(AFMDwarfStarReasoningMode.high.thinkMode, DS4_THINK_HIGH)
+        XCTAssertEqual(AFMDwarfStarReasoningMode.max.thinkMode, DS4_THINK_MAX)
     }
 
     func testSlotPolicyUsesFirstAvailableSlotWithoutPrefixCaching() {

--- a/Tests/MacLocalAPITests/AFMDownloadProgressTests.swift
+++ b/Tests/MacLocalAPITests/AFMDownloadProgressTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import AFMKitMLX
+@testable import AFMKitCore
 
 final class AFMDownloadProgressTests: XCTestCase {
     func testEnrichmentReportsActiveAndCompletedFiles() {

--- a/Tests/MacLocalAPITests/AFMKitMLXReasoningPropagationTests.swift
+++ b/Tests/MacLocalAPITests/AFMKitMLXReasoningPropagationTests.swift
@@ -1,0 +1,142 @@
+@testable import AFMServer
+import AFMKit
+import XCTest
+
+final class AFMKitMLXReasoningPropagationTests: XCTestCase {
+    private actor RequestCapture {
+        private var requests: [AFMRequest] = []
+
+        func append(_ request: AFMRequest) {
+            requests.append(request)
+        }
+
+        func request(at index: Int) -> AFMRequest {
+            requests[index]
+        }
+    }
+
+    private struct CapturingModel: AFMModel {
+        let descriptor = AFMModelDescriptor(
+            providerID: "test.capture",
+            modelID: "capture",
+            displayName: "Capture",
+            capabilities: [.text, .reasoning],
+            metadata: ["maxConcurrent": .integer(1)]
+        )
+        let capture: RequestCapture
+
+        func availability() async -> AFMModelAvailability { .available }
+
+        func load(
+            progress: (@Sendable (Double) -> Void)?
+        ) async throws -> AFMModelDescriptor {
+            descriptor
+        }
+
+        func respond(to request: AFMRequest) async throws -> AFMModelResponse {
+            await capture.append(request)
+            return AFMModelResponse(text: "captured", reasoning: "thought")
+        }
+
+        func streamResponse(
+            to request: AFMRequest
+        ) -> AsyncThrowingStream<AFMGenerationEvent, Error> {
+            AsyncThrowingStream { continuation in
+                continuation.finish()
+            }
+        }
+    }
+
+    func testStartupReasoningDefaultsReachAFMRequestMetadata() async throws {
+        let capture = RequestCapture()
+        let adapter = makeAdapter(
+            capture: capture,
+            defaults: [
+                "enable_thinking": AnyCodable(true),
+                "reasoning_effort": AnyCodable("high"),
+            ]
+        )
+
+        _ = try await generate(adapter: adapter, kwargs: nil)
+
+        let request = await capture.request(at: 0)
+        XCTAssertEqual(
+            request.metadata["chatTemplateKwargs"],
+            .object([
+                "enable_thinking": .bool(true),
+                "reasoning_effort": .string("high"),
+            ])
+        )
+    }
+
+    func testReasoningCapableFixedModelPublishesStructuralTags() async throws {
+        let adapter = makeAdapter(capture: RequestCapture(), defaults: [:])
+
+        let result = try await generate(adapter: adapter, kwargs: nil)
+
+        XCTAssertEqual(adapter.thinkStartTag, "<think>")
+        XCTAssertEqual(adapter.thinkEndTag, "</think>")
+        XCTAssertEqual(result.content, "<think>thought</think>captured")
+    }
+
+    func testRequestReasoningEffortOverridesStartupDefault() async throws {
+        let capture = RequestCapture()
+        let adapter = makeAdapter(
+            capture: capture,
+            defaults: [
+                "enable_thinking": AnyCodable(true),
+                "reasoning_effort": AnyCodable("low"),
+            ]
+        )
+
+        _ = try await generate(
+            adapter: adapter,
+            kwargs: ["reasoning_effort": AnyCodable("max")]
+        )
+
+        let request = await capture.request(at: 0)
+        XCTAssertEqual(
+            request.metadata["chatTemplateKwargs"],
+            .object([
+                "enable_thinking": .bool(true),
+                "reasoning_effort": .string("max"),
+            ])
+        )
+    }
+
+    private func makeAdapter(
+        capture: RequestCapture,
+        defaults: [String: AnyCodable]
+    ) -> AFMKitMLXChatServingAdapter {
+        AFMKitMLXChatServingAdapter(
+            model: AnyAFMModel(CapturingModel(capture: capture)),
+            modelID: "capture",
+            defaultChatTemplateKwargs: defaults
+        )
+    }
+
+    private func generate(
+        adapter: AFMKitMLXChatServingAdapter,
+        kwargs: [String: AnyCodable]?
+    ) async throws -> AFMMLXChatGenerationResult {
+        try await adapter.generate(
+            model: "capture",
+            messages: [Message(role: "user", content: "hello")],
+            temperature: nil,
+            maxTokens: 8,
+            topP: nil,
+            repetitionPenalty: nil,
+            topK: nil,
+            minP: nil,
+            presencePenalty: nil,
+            seed: nil,
+            logprobs: nil,
+            topLogprobs: nil,
+            tools: nil,
+            parallelToolCalls: nil,
+            stop: nil,
+            responseFormat: nil,
+            chatTemplateKwargs: kwargs
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- preserve DwarfStar reasoning as structured reasoning output instead of leaking it into answer content
- propagate fixed-provider reasoning delimiters through the OpenAI adapter
- map max effort to the native DwarfStar maximum mode
- add reasoning propagation and mode mapping tests

## Validation
- Release focused reasoning/streaming suite: 60 tests, 0 failures
- live non-streaming DwarfStar request: separate reasoning_content and content verified

## Summary by Sourcery

Improve DwarfStar reasoning propagation and model downloading resilience, and expose provider-neutral download progress metadata.

New Features:
- Support resumable GGUF downloads for DwarfStar models using Hugging Face Xet with LFS fallback and SHA-256 verification.
- Expose provider-neutral download progress metadata, including active transports, for terminal load reporting.
- Automatically publish structural reasoning tags for reasoning-capable fixed MLX models through the serving configuration.

Enhancements:
- Resolve and classify GGUF model files via symlink targets to avoid misidentifying cached GGUFs as MLX models.
- Extend DwarfStar reasoning mode mapping to include a native maximum-effort mode and log the resolved reasoning mode in prompts.
- Improve MLX load reporting with custom loading labels and visualization of active download transports.

Build:
- Add swift-xet as a dependency for large GGUF byte-range downloads and update the package version to v0.9.16.

Tests:
- Add tests covering resumable download behavior, SHA-256 verification, and detailed error reporting for DwarfStar GGUF downloads.
- Add tests for GGUF symlink resolution and DwarfStar compatibility detection.
- Add tests ensuring reasoning defaults and request overrides propagate into AFMRequest metadata and reasoning is structurally separated in OpenAI-style responses.
- Add tests verifying DwarfStar reasoning modes map correctly to native think modes.