### PR TITLE
Add Qwen3.8 FP8 MLX routing

### DIFF
--- a/Sources/AFMKitMLX/AFMMLXModelArchitecture.swift
+++ b/Sources/AFMKitMLX/AFMMLXModelArchitecture.swift
@@ -371,7 +371,9 @@ public enum AFMMLXModelArchitecture {
         "qwen3.5-",
         "qwen3.5_",
         "qwen3.6-",
-        "qwen3.6_"
+        "qwen3.6_",
+        "qwen3.8-",
+        "qwen3.8_"
     ]
 
     public static let visionNamePatterns: [String] = [

--- a/Sources/AFMKitMLX/AFMMLXModelCatalog.swift
+++ b/Sources/AFMKitMLX/AFMMLXModelCatalog.swift
@@ -7,17 +7,20 @@ import MLXVLM
 public struct AFMMLXGenerationPreset: Hashable, Sendable {
     public var temperature: Double?
     public var topP: Double?
+    public var topK: Int?
     public var repetitionPenalty: Double?
     public var maxTokens: Int?
 
     public init(
         temperature: Double? = nil,
         topP: Double? = nil,
+        topK: Int? = nil,
         repetitionPenalty: Double? = nil,
         maxTokens: Int? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
+        self.topK = topK
         self.repetitionPenalty = repetitionPenalty
         self.maxTokens = maxTokens
     }
@@ -25,16 +28,19 @@ public struct AFMMLXGenerationPreset: Hashable, Sendable {
     public static func generationConfigPreset(_ json: [String: Any]) -> AFMMLXGenerationPreset? {
         let temperature = doubleValue(json["temperature"])
         let topP = doubleValue(json["top_p"])
+        let topK = intValue(json["top_k"])
         let repetitionPenalty = doubleValue(json["repetition_penalty"])
         let maxTokens = intValue(json["max_new_tokens"])
 
-        guard temperature != nil || topP != nil || repetitionPenalty != nil || maxTokens != nil else {
+        guard temperature != nil || topP != nil || topK != nil
+            || repetitionPenalty != nil || maxTokens != nil else {
             return nil
         }
 
         return AFMMLXGenerationPreset(
             temperature: temperature,
             topP: topP,
+            topK: topK,
             repetitionPenalty: repetitionPenalty,
             maxTokens: maxTokens
         )
@@ -211,6 +217,7 @@ public struct AFMMLXCuratedModel: Hashable, Identifiable, Sendable {
         ]
         metadata["temperature"] = generationPreset.temperature.map { .number($0) }
         metadata["topP"] = generationPreset.topP.map { .number($0) }
+        metadata["topK"] = generationPreset.topK.map { .integer($0) }
         metadata["repetitionPenalty"] = generationPreset.repetitionPenalty.map { .number($0) }
         metadata["maxTokens"] = generationPreset.maxTokens.map { .integer($0) }
 
@@ -355,13 +362,15 @@ public enum AFMMLXModelCatalog {
             repoID: "mlx-community/Qwen3.8-27B-4bit",
             temperature: 1.0,
             topP: 0.95,
+            topK: 20,
             maxTokens: 32768
         ),
         visionModel(
-            displayName: "Qwen3.8-27B-MXFP8",
+            displayName: "Qwen3.8-27B-mxfp8",
             repoID: "mlx-community/Qwen3.8-27B-mxfp8",
             temperature: 1.0,
             topP: 0.95,
+            topK: 20,
             maxTokens: 32768
         ),
         visionModel(
@@ -475,6 +484,7 @@ public enum AFMMLXModelCatalog {
         repoID: String,
         temperature: Double = 0.7,
         topP: Double = 0.8,
+        topK: Int? = nil,
         maxTokens: Int
     ) -> AFMMLXCuratedModel {
         AFMMLXCuratedModel(
@@ -485,6 +495,7 @@ public enum AFMMLXModelCatalog {
             generationPreset: AFMMLXGenerationPreset(
                 temperature: temperature,
                 topP: topP,
+                topK: topK,
                 repetitionPenalty: nil,
                 maxTokens: maxTokens
             )

--- a/Sources/AFMKitMLX/AFMMLXModelCatalog.swift
+++ b/Sources/AFMKitMLX/AFMMLXModelCatalog.swift
@@ -351,6 +351,20 @@ public enum AFMMLXModelCatalog {
             maxTokens: 32768
         ),
         visionModel(
+            displayName: "Qwen3.8-27B-4bit",
+            repoID: "mlx-community/Qwen3.8-27B-4bit",
+            temperature: 1.0,
+            topP: 0.95,
+            maxTokens: 32768
+        ),
+        visionModel(
+            displayName: "Qwen3.8-27B-MXFP8",
+            repoID: "mlx-community/Qwen3.8-27B-mxfp8",
+            temperature: 1.0,
+            topP: 0.95,
+            maxTokens: 32768
+        ),
+        visionModel(
             displayName: "Gemma-4-26B-A4B-it-4bit",
             repoID: "mlx-community/gemma-4-26b-a4b-it-4bit",
             temperature: 1.0,
@@ -419,6 +433,7 @@ public enum AFMMLXModelCatalog {
              "mlx-community/gemma-4-e2b-it-4bit",
              "mlx-community/gemma-4-e4b-it-4bit",
              "mlx-community/Qwen3.6-27B-4bit",
+             "mlx-community/Qwen3.8-27B-4bit",
              "mlx-community/gemma-4-26b-a4b-it-4bit",
              "mlx-community/gemma-4-31b-it-4bit":
             return VLMRegistry.qwen3VL4BInstruct4Bit
@@ -426,7 +441,8 @@ public enum AFMMLXModelCatalog {
              "mlx-community/Qwen3-VL-8B-Instruct-8bit",
              "mlx-community/Qwen3-VL-8B-Instruct-bf16",
              "mlx-community/gemma-4-31b-it-8bit",
-             "mlx-community/Qwen3.6-35B-A3B-8bit":
+             "mlx-community/Qwen3.6-35B-A3B-8bit",
+             "mlx-community/Qwen3.8-27B-mxfp8":
             return VLMRegistry.qwen3VL4BInstruct8Bit
         default:
             return nil

--- a/Tests/MacLocalAPITests/AFMMLXModelArchitectureTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXModelArchitectureTests.swift
@@ -205,28 +205,7 @@ final class AFMMLXModelArchitectureTests: XCTestCase {
     }
 
     func testQwen38PublishedConfigurationUsesExistingQwen35MultimodalArchitecture() throws {
-        let config: [String: Any] = [
-            "model_type": "qwen3_5",
-            "architectures": ["Qwen3_5ForConditionalGeneration"],
-            "image_token_id": 248056,
-            "text_config": [
-                "model_type": "qwen3_5_text",
-                "num_hidden_layers": 64,
-                "hidden_size": 5120,
-                "full_attention_interval": 4,
-                "mtp_num_hidden_layers": 1,
-            ],
-            "vision_config": [
-                "model_type": "qwen3_5",
-                "depth": 27,
-                "hidden_size": 1152,
-            ],
-            "quantization": [
-                "group_size": 32,
-                "bits": 8,
-                "mode": "mxfp8",
-            ],
-        ]
+        let config = Qwen38PublishedConfigFixture.mxfp8
 
         let preflight = try AFMMLXModelArchitecture.preflightConfiguration(
             config,
@@ -236,53 +215,18 @@ final class AFMMLXModelArchitectureTests: XCTestCase {
         XCTAssertEqual(preflight.modelType, "qwen3_5")
         XCTAssertEqual(preflight.canonicalModelType, "qwen3_5")
         XCTAssertTrue(preflight.isVisionConfiguration)
-        XCTAssertTrue(preflight.requiresVisionModelFactory)
+        XCTAssertFalse(preflight.requiresVisionModelFactory)
+        XCTAssertEqual(
+            AFMMLXModelFactoryPolicy.initialFactory(forceVLM: false, architecture: preflight),
+            .llm
+        )
+        XCTAssertTrue(AFMMLXRequestMediaPolicy.supports(.image, architecture: preflight))
+        XCTAssertTrue(AFMMLXRequestMediaPolicy.supports(.video, architecture: preflight))
         XCTAssertTrue(AFMMLXModelArchitecture.isDualModeConfiguration(config))
     }
 
     func testQwen38PublishedConfigurationDecodesWithQwen35VLMFactoryConfiguration() throws {
-        let config: [String: Any] = [
-            "model_type": "qwen3_5",
-            "image_token_id": 248056,
-            "video_token_id": 248057,
-            "vision_start_token_id": 248053,
-            "vision_end_token_id": 248054,
-            "text_config": [
-                "model_type": "qwen3_5_text",
-                "hidden_size": 5120,
-                "num_hidden_layers": 64,
-                "intermediate_size": 17408,
-                "num_attention_heads": 24,
-                "num_key_value_heads": 4,
-                "head_dim": 256,
-                "linear_num_value_heads": 48,
-                "linear_num_key_heads": 16,
-                "linear_key_head_dim": 128,
-                "linear_value_head_dim": 128,
-                "linear_conv_kernel_dim": 4,
-                "vocab_size": 248320,
-                "full_attention_interval": 4,
-                "max_position_embeddings": 262144,
-                "rope_parameters": [
-                    "partial_rotary_factor": 0.25,
-                    "rope_theta": 10_000_000,
-                ],
-            ],
-            "vision_config": [
-                "model_type": "qwen3_5",
-                "depth": 27,
-                "hidden_size": 1152,
-                "intermediate_size": 4304,
-                "out_hidden_size": 5120,
-                "num_heads": 16,
-                "patch_size": 16,
-                "spatial_merge_size": 2,
-                "temporal_patch_size": 2,
-                "num_position_embeddings": 2304,
-            ],
-        ]
-
-        let data = try JSONSerialization.data(withJSONObject: config)
+        let data = try JSONSerialization.data(withJSONObject: Qwen38PublishedConfigFixture.mxfp8)
         XCTAssertNoThrow(try JSONDecoder().decode(Qwen3_5MoEVLConfiguration.self, from: data))
     }
 

--- a/Tests/MacLocalAPITests/AFMMLXModelArchitectureTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXModelArchitectureTests.swift
@@ -1,4 +1,6 @@
+import Foundation
 import XCTest
+import MLXVLM
 @testable import AFMKitMLX
 
 final class AFMMLXModelArchitectureTests: XCTestCase {
@@ -202,6 +204,88 @@ final class AFMMLXModelArchitectureTests: XCTestCase {
         XCTAssertTrue(preflight.requiresVisionModelFactory)
     }
 
+    func testQwen38PublishedConfigurationUsesExistingQwen35MultimodalArchitecture() throws {
+        let config: [String: Any] = [
+            "model_type": "qwen3_5",
+            "architectures": ["Qwen3_5ForConditionalGeneration"],
+            "image_token_id": 248056,
+            "text_config": [
+                "model_type": "qwen3_5_text",
+                "num_hidden_layers": 64,
+                "hidden_size": 5120,
+                "full_attention_interval": 4,
+                "mtp_num_hidden_layers": 1,
+            ],
+            "vision_config": [
+                "model_type": "qwen3_5",
+                "depth": 27,
+                "hidden_size": 1152,
+            ],
+            "quantization": [
+                "group_size": 32,
+                "bits": 8,
+                "mode": "mxfp8",
+            ],
+        ]
+
+        let preflight = try AFMMLXModelArchitecture.preflightConfiguration(
+            config,
+            modelID: "mlx-community/Qwen3.8-27B-mxfp8"
+        )
+
+        XCTAssertEqual(preflight.modelType, "qwen3_5")
+        XCTAssertEqual(preflight.canonicalModelType, "qwen3_5")
+        XCTAssertTrue(preflight.isVisionConfiguration)
+        XCTAssertTrue(preflight.requiresVisionModelFactory)
+        XCTAssertTrue(AFMMLXModelArchitecture.isDualModeConfiguration(config))
+    }
+
+    func testQwen38PublishedConfigurationDecodesWithQwen35VLMFactoryConfiguration() throws {
+        let config: [String: Any] = [
+            "model_type": "qwen3_5",
+            "image_token_id": 248056,
+            "video_token_id": 248057,
+            "vision_start_token_id": 248053,
+            "vision_end_token_id": 248054,
+            "text_config": [
+                "model_type": "qwen3_5_text",
+                "hidden_size": 5120,
+                "num_hidden_layers": 64,
+                "intermediate_size": 17408,
+                "num_attention_heads": 24,
+                "num_key_value_heads": 4,
+                "head_dim": 256,
+                "linear_num_value_heads": 48,
+                "linear_num_key_heads": 16,
+                "linear_key_head_dim": 128,
+                "linear_value_head_dim": 128,
+                "linear_conv_kernel_dim": 4,
+                "vocab_size": 248320,
+                "full_attention_interval": 4,
+                "max_position_embeddings": 262144,
+                "rope_parameters": [
+                    "partial_rotary_factor": 0.25,
+                    "rope_theta": 10_000_000,
+                ],
+            ],
+            "vision_config": [
+                "model_type": "qwen3_5",
+                "depth": 27,
+                "hidden_size": 1152,
+                "intermediate_size": 4304,
+                "out_hidden_size": 5120,
+                "num_heads": 16,
+                "patch_size": 16,
+                "spatial_merge_size": 2,
+                "temporal_patch_size": 2,
+                "num_position_embeddings": 2304,
+            ],
+        ]
+
+        let data = try JSONSerialization.data(withJSONObject: config)
+        XCTAssertNoThrow(try JSONDecoder().decode(Qwen3_5MoEVLConfiguration.self, from: data))
+    }
+
     func testDeepseekV40731PreflightUsesLanguageModelFactory() throws {
         let preflight = try AFMMLXModelArchitecture.preflightConfiguration(
             [
@@ -382,6 +466,7 @@ final class AFMMLXModelArchitectureTests: XCTestCase {
         XCTAssertFalse(AFMMLXModelArchitecture.matchesSupportedNamePattern("example/random-model"))
 
         XCTAssertTrue(AFMMLXModelArchitecture.looksLikeDualMode("mlx-community/Qwen3.5-35B-A3B-4bit"))
+        XCTAssertTrue(AFMMLXModelArchitecture.looksLikeDualMode("Qwen/Qwen3.8-27B-FP8"))
         XCTAssertFalse(AFMMLXModelArchitecture.looksLikeDualMode("mlx-community/Qwen3-VL-4B-Instruct"))
 
         XCTAssertTrue(AFMMLXModelArchitecture.looksLikeVisionModel("mlx-community/paligemma-3b"))

--- a/Tests/MacLocalAPITests/AFMMLXModelCatalogTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXModelCatalogTests.swift
@@ -24,6 +24,8 @@ final class AFMMLXModelCatalogTests: XCTestCase {
                 "mlx-community/Qwen3-VL-8B-Instruct-8bit",
                 "mlx-community/Qwen3-VL-8B-Instruct-bf16",
                 "mlx-community/Qwen3.6-27B-4bit",
+                "mlx-community/Qwen3.8-27B-4bit",
+                "mlx-community/Qwen3.8-27B-mxfp8",
                 "mlx-community/gemma-4-26b-a4b-it-4bit",
                 "mlx-community/gemma-4-31b-it-4bit",
                 "mlx-community/gemma-4-31b-it-8bit",
@@ -67,6 +69,22 @@ final class AFMMLXModelCatalogTests: XCTestCase {
         XCTAssertEqual(vision.generationPreset.temperature, 0.7)
         XCTAssertEqual(vision.generationPreset.topP, 0.8)
         XCTAssertEqual(vision.generationPreset.maxTokens, 32768)
+
+        let qwen38 = try XCTUnwrap(
+            AFMMLXModelCatalog.model(for: "mlx-community/Qwen3.8-27B-4bit")
+        )
+        XCTAssertTrue(qwen38.isVisionModel)
+        XCTAssertEqual(qwen38.generationPreset.temperature, 1.0)
+        XCTAssertEqual(qwen38.generationPreset.topP, 0.95)
+        XCTAssertEqual(qwen38.generationPreset.maxTokens, 32768)
+
+        let qwen38MXFP8 = try XCTUnwrap(
+            AFMMLXModelCatalog.model(for: "mlx-community/Qwen3.8-27B-mxfp8")
+        )
+        XCTAssertTrue(qwen38MXFP8.isVisionModel)
+        XCTAssertEqual(qwen38MXFP8.generationPreset.temperature, 1.0)
+        XCTAssertEqual(qwen38MXFP8.generationPreset.topP, 0.95)
+        XCTAssertEqual(qwen38MXFP8.generationPreset.maxTokens, 32768)
     }
 
     func testGenerationConfigPresetReadsKnownSamplingKeys() throws {

--- a/Tests/MacLocalAPITests/AFMMLXModelCatalogTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXModelCatalogTests.swift
@@ -76,6 +76,7 @@ final class AFMMLXModelCatalogTests: XCTestCase {
         XCTAssertTrue(qwen38.isVisionModel)
         XCTAssertEqual(qwen38.generationPreset.temperature, 1.0)
         XCTAssertEqual(qwen38.generationPreset.topP, 0.95)
+        XCTAssertEqual(qwen38.generationPreset.topK, 20)
         XCTAssertEqual(qwen38.generationPreset.maxTokens, 32768)
 
         let qwen38MXFP8 = try XCTUnwrap(
@@ -84,6 +85,7 @@ final class AFMMLXModelCatalogTests: XCTestCase {
         XCTAssertTrue(qwen38MXFP8.isVisionModel)
         XCTAssertEqual(qwen38MXFP8.generationPreset.temperature, 1.0)
         XCTAssertEqual(qwen38MXFP8.generationPreset.topP, 0.95)
+        XCTAssertEqual(qwen38MXFP8.generationPreset.topK, 20)
         XCTAssertEqual(qwen38MXFP8.generationPreset.maxTokens, 32768)
     }
 
@@ -91,6 +93,7 @@ final class AFMMLXModelCatalogTests: XCTestCase {
         let preset = try XCTUnwrap(AFMMLXGenerationPreset.generationConfigPreset([
             "temperature": 0.2,
             "top_p": 1,
+            "top_k": 20,
             "repetition_penalty": 1.05,
             "max_new_tokens": 4096,
             "ignored": "value",
@@ -98,6 +101,7 @@ final class AFMMLXModelCatalogTests: XCTestCase {
 
         XCTAssertEqual(preset.temperature, 0.2)
         XCTAssertEqual(preset.topP, 1.0)
+        XCTAssertEqual(preset.topK, 20)
         XCTAssertEqual(preset.repetitionPenalty, 1.05)
         XCTAssertEqual(preset.maxTokens, 4096)
     }
@@ -118,6 +122,7 @@ final class AFMMLXModelCatalogTests: XCTestCase {
         let data = try JSONSerialization.data(withJSONObject: [
             "temperature": 0.4,
             "top_p": 0.9,
+            "top_k": 17,
             "max_new_tokens": 128,
         ])
         try data.write(to: directory.appendingPathComponent("generation_config.json"))
@@ -125,6 +130,7 @@ final class AFMMLXModelCatalogTests: XCTestCase {
         let preset = try XCTUnwrap(AFMMLXGenerationPreset.generationConfigPreset(in: directory))
         XCTAssertEqual(preset.temperature, 0.4)
         XCTAssertEqual(preset.topP, 0.9)
+        XCTAssertEqual(preset.topK, 17)
         XCTAssertNil(preset.repetitionPenalty)
         XCTAssertEqual(preset.maxTokens, 128)
     }
@@ -142,6 +148,7 @@ final class AFMMLXModelCatalogTests: XCTestCase {
         try JSONSerialization.data(withJSONObject: [
             "temperature": 0.25,
             "top_p": 0.9,
+            "top_k": 20,
             "enable_thinking": true,
         ]).write(to: directory.appendingPathComponent("generation_config.json"))
         try JSONSerialization.data(withJSONObject: [
@@ -157,6 +164,7 @@ final class AFMMLXModelCatalogTests: XCTestCase {
         XCTAssertEqual(metadata.contextWindow, 65_536)
         XCTAssertEqual(metadata.generationPreset?.temperature, 0.25)
         XCTAssertEqual(metadata.generationPreset?.topP, 0.9)
+        XCTAssertEqual(metadata.generationPreset?.topK, 20)
         XCTAssertTrue(metadata.hasImplicitReasoning)
         XCTAssertTrue(metadata.supportsThinkingToggle)
     }

--- a/Tests/MacLocalAPITests/AFMMLXSpeculativeDecodingTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXSpeculativeDecodingTests.swift
@@ -256,11 +256,7 @@ final class AFMMLXSpeculativeDecodingTests: XCTestCase {
 
     func testSpeculativeModelCompatibilityAcceptsQwen38PublishedQwen35Config() {
         let compatibility = AFMMLXSpeculativeModelCompatibility.evaluate(
-            config: [
-                "model_type": "qwen3_5",
-                "architectures": ["Qwen3_5ForConditionalGeneration"],
-                "text_config": ["model_type": "qwen3_5_text"],
-            ],
+            config: Qwen38PublishedConfigFixture.mxfp8,
             hasMTPSidecar: true
         )
 

--- a/Tests/MacLocalAPITests/AFMMLXSpeculativeDecodingTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXSpeculativeDecodingTests.swift
@@ -254,6 +254,20 @@ final class AFMMLXSpeculativeDecodingTests: XCTestCase {
         XCTAssertFalse(missingSidecar.mtpCompatible)
     }
 
+    func testSpeculativeModelCompatibilityAcceptsQwen38PublishedQwen35Config() {
+        let compatibility = AFMMLXSpeculativeModelCompatibility.evaluate(
+            config: [
+                "model_type": "qwen3_5",
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "text_config": ["model_type": "qwen3_5_text"],
+            ],
+            hasMTPSidecar: true
+        )
+
+        XCTAssertTrue(compatibility.mtpCompatible)
+        XCTAssertFalse(compatibility.denseGemma4Verifier)
+    }
+
     func testSpeculativeModelCompatibilityDetectsDenseGemma4Verifier() {
         let dense = AFMMLXSpeculativeModelCompatibility.evaluate(
             config: [

--- a/Tests/MacLocalAPITests/Qwen38PublishedConfigFixture.swift
+++ b/Tests/MacLocalAPITests/Qwen38PublishedConfigFixture.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+enum Qwen38PublishedConfigFixture {
+    static var mxfp8: [String: Any] { [
+        "model_type": "qwen3_5",
+        "architectures": ["Qwen3_5ForConditionalGeneration"],
+        "image_token_id": 248056,
+        "video_token_id": 248057,
+        "vision_start_token_id": 248053,
+        "vision_end_token_id": 248054,
+        "text_config": [
+            "model_type": "qwen3_5_text",
+            "hidden_size": 5120,
+            "num_hidden_layers": 64,
+            "intermediate_size": 17408,
+            "num_attention_heads": 24,
+            "num_key_value_heads": 4,
+            "head_dim": 256,
+            "linear_num_value_heads": 48,
+            "linear_num_key_heads": 16,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "linear_conv_kernel_dim": 4,
+            "vocab_size": 248320,
+            "full_attention_interval": 4,
+            "max_position_embeddings": 262144,
+            "mtp_num_hidden_layers": 1,
+            "rope_parameters": [
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 10_000_000,
+            ],
+        ],
+        "vision_config": [
+            "model_type": "qwen3_5",
+            "depth": 27,
+            "hidden_size": 1152,
+            "intermediate_size": 4304,
+            "out_hidden_size": 5120,
+            "num_heads": 16,
+            "patch_size": 16,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2,
+            "num_position_embeddings": 2304,
+        ],
+        "quantization": [
+            "group_size": 32,
+            "bits": 8,
+            "mode": "mxfp8",
+        ],
+    ] }
+}

--- a/docs/qwen3.8-27b-fp8-implementation-log.md
+++ b/docs/qwen3.8-27b-fp8-implementation-log.md
@@ -1,0 +1,182 @@
+# Qwen3.8-27B-FP8 Implementation Log
+
+Date: 2026-08-14
+Branch: `codex/qwen3.8-27b-fp8`
+Lock status: source-only edits completed under active test lock; no build, test, model load, download, conversion, or upload executed.
+
+## Scope handled
+
+- Reviewed AFM's current Qwen architecture support and MLX loader constraints.
+- Inspected the exact official FP8 config and the authoritative MLX conversions.
+- Confirmed Qwen3.8 retains the existing `qwen3_5` model contract implemented by AFM.
+- Added only pre-download name routing plus deterministic config-backed tests.
+- Documented why the raw Transformers FP8 checkpoint is not the AFM runtime artifact.
+
+## Architecture findings
+
+### Authoritative evidence inspected
+
+- Requested checkpoint: [`Qwen/Qwen3.8-27B-FP8`](https://huggingface.co/Qwen/Qwen3.8-27B-FP8)
+  - Inspected revision: `017b9c7af6b5689d5dd426a76e0bc077eb5ca20a`
+- Official base checkpoint: [`Qwen/Qwen3.8-27B`](https://huggingface.co/Qwen/Qwen3.8-27B)
+- Authoritative MLX conversions:
+  - [`mlx-community/Qwen3.8-27B-4bit`](https://huggingface.co/mlx-community/Qwen3.8-27B-4bit)
+    - Inspected revision: `3e6447f082e89cc7f0bc6e5441afd38dfce760ff`
+  - [`mlx-community/Qwen3.8-27B-mxfp8`](https://huggingface.co/mlx-community/Qwen3.8-27B-mxfp8)
+    - Inspected revision: `d48d163bcdf24acaf656474854ab88ea17d65bd1`
+  - [`mlx-community/Qwen3.8-27B-bf16`](https://huggingface.co/mlx-community/Qwen3.8-27B-bf16)
+- Comparison baseline: `Qwen/Qwen3.6-27B`
+- Current AFM implementation:
+  - `Scripts/patches/Qwen3_5MoE.swift`
+  - `Scripts/patches/Qwen3VL.swift`
+  - `Scripts/patches/LLMModelFactory.swift`
+  - `Scripts/patches/VLMModelFactory.swift`
+
+### Exact published architecture
+
+- `Qwen/Qwen3.8-27B-FP8` publishes `architectures: ["Qwen3_5ForConditionalGeneration"]`.
+- Its top-level `model_type` is `qwen3_5`; the text tower is `qwen3_5_text`.
+- It is multimodal: top-level config includes `text_config`, `vision_config`, and `image_token_id`.
+- The text tower matches the public Qwen3.6-27B shape already implemented in AFM:
+  - GatedDeltaNet / full-attention interleave
+  - 64 layers
+  - 5120 hidden size
+  - 24 Q heads / 4 KV heads in full attention
+  - 16 QK heads / 48 V heads in linear attention
+  - 48 linear-attention layers and 16 full-attention layers
+  - 262144 context
+- The official FP8 checkpoint includes one MTP layer and an `mtp.safetensors` sidecar.
+- Its Transformers FP8 scheme is E4M3, dynamically scaled, with a 128x128 weight block.
+- The authoritative MLX 4-bit artifact was converted from `Qwen/Qwen3.8-27B` with `mlx-vlm` 0.6.8 and includes both language and vision weights. It is not a byte-for-byte conversion of the separate Transformers FP8 repository.
+
+### Prompt, reasoning, and tool contract
+
+- The published `chat_template.jinja` defaults `enable_thinking` to true.
+- `enable_thinking=false` emits an empty `<think>\n\n</think>` section before the answer.
+- Tool calls use the Qwen XML function format already selected by AFM for `qwen3_5`:
+  `<tool_call><function=name><parameter=name>value</parameter></function></tool_call>`.
+- The published generation defaults are `temperature: 1.0`, `top_k: 20`, and `top_p: 0.95`.
+
+### AFM consequence
+
+- Qwen3.8 routes through AFM's existing `Qwen3_5MoE` / `Qwen3VL` support. It does not require a new `qwen3_8` Swift architecture or model-factory registration.
+- The source changes deliberately do not invent `qwen3_8` config aliases. Compatibility is established from the published config, not inferred from the repository name.
+
+## Public artifact status
+
+### `Qwen/Qwen3.8-27B-FP8`
+
+- The exact repository is public and its config, tokenizer metadata, safetensors index, and MTP sidecar metadata are inspectable.
+- The repo is a Transformers FP8 artifact, not an MLX-formatted artifact.
+
+### MLX equivalent
+
+- Suitable authoritative artifacts exist. The primary Release validation target is `mlx-community/Qwen3.8-27B-4bit` because it uses AFM's established affine 4-bit path and preserves the multimodal checkpoint.
+- `mlx-community/Qwen3.8-27B-mxfp8` is the closer numeric analogue to FP8 and is the secondary validation target for MLX block-scaled 8-bit coverage.
+- Both publish the same `qwen3_5` / `Qwen3_5ForConditionalGeneration` architecture and preserve the language and vision towers.
+- Their safetensors indexes expose the 64-layer `language_model.model.layers.*` namespace and all 27 `vision_tower.blocks.*` groups. Neither index contains MTP tensors.
+
+## FP8 viability
+
+- Direct loading of the raw Hugging Face Transformers FP8 repo is **not the supported AFM MLX path**.
+- AFM's loader expects MLX-formatted checkpoints and optional MLX quantization metadata.
+- The raw Qwen FP8 repos publish Transformers-style `quantization_config` (`quant_method: "fp8"`, `fmt: "e4m3"`), which is not the same as an MLX snapshot.
+- AFM's special packed-weight inference in `Scripts/patches/Load.swift` is targeted at MLX block-scaled tensor layouts (`mxfp4` / `mxfp8`) after weight loading, not generic Transformers FP8 repos.
+
+## Source changes made
+
+### Pre-download compatibility
+
+- `Sources/AFMKitMLX/AFMMLXModelArchitecture.swift`
+  - Added `qwen3.8-` / `qwen3.8_` to dual-mode repo-name heuristics.
+  - Rationale: the exact official and MLX repositories are now verified as multimodal `qwen3_5` checkpoints, so the pre-config UI heuristic can route their names consistently with Qwen3.5/Qwen3.6.
+
+- `Sources/AFMKitMLX/AFMMLXModelCatalog.swift`
+  - Added `mlx-community/Qwen3.8-27B-4bit` as the primary curated text+vision checkpoint.
+  - Added `mlx-community/Qwen3.8-27B-mxfp8` as the closer FP8-format comparison checkpoint.
+  - Uses the published generation defaults (`temperature: 1.0`, `top_p: 0.95`) and a conservative 32768-token catalog limit pending long-context Release validation.
+
+### Deterministic tests
+
+- `Tests/MacLocalAPITests/AFMMLXModelArchitectureTests.swift`
+  - Added the repo-name heuristic assertion.
+  - Added a config-backed preflight test using the published Qwen3.8 model type, architecture, text/vision layout, and MLX MXFP8 metadata.
+  - Added direct `Qwen3_5MoEVLConfiguration` decoding coverage using the published dense text and vision dimensions.
+
+- `Tests/MacLocalAPITests/AFMMLXSpeculativeDecodingTests.swift`
+  - Added MTP compatibility coverage using the actual published `qwen3_5` / `Qwen3_5ForConditionalGeneration` contract.
+
+- `Tests/MacLocalAPITests/AFMMLXModelCatalogTests.swift`
+  - Added catalog ordering, text+vision capability, generation preset, and runtime-configuration coverage for the authoritative 4-bit artifact.
+
+## Deferred conversion plan
+
+No custom conversion or `scouzi1966` upload is required because authoritative `mlx-community` artifacts already exist.
+
+### Proposed target repo
+
+- Proposed only as a fallback if the authoritative artifacts prove defective: `scouzi1966/Qwen3.8-27B-4bit`
+
+If a VLM-preserving MLX conversion is produced and kept public:
+
+- `scouzi1966/Qwen3.8-27B-4bit`
+- optional sidecar sibling if MTP extraction is needed later:
+  - `scouzi1966/Qwen3.8-27B-MTPLX`
+
+### Locked-out procedure to run later
+
+1. Capture the source:
+   - `config.json`
+   - `tokenizer_config.json`
+   - `generation_config.json`
+   - `model.safetensors.index.json`
+2. Treat the source as multimodal and use the VLM conversion path rather than text-only `mlx-lm`.
+3. Preserve the 27-layer vision tower, 64-layer text tower, tokenizer/processor metadata, and MTP sidecar separately.
+4. Preserve source provenance in the destination model card and commit notes.
+5. Re-run AFM preflight and release validation against the converted MLX snapshot, not the raw FP8 repo.
+
+### Release-only validation commands to run after unlock
+
+These are intentionally not executed under the lock.
+
+```bash
+git branch --show-current
+```
+
+```bash
+Scripts/swiftpm-reliable.sh test -c release --filter AFMMLXModelArchitectureTests
+```
+
+```bash
+Scripts/swiftpm-reliable.sh test -c release --filter AFMMLXSpeculativeDecodingTests
+```
+
+Primary model validation after unlock:
+
+```bash
+MACAFM_MLX_MODEL_CACHE=/Volumes/edata/models/vesta-test-cache \
+./.build/release/afm mlx -m mlx-community/Qwen3.8-27B-4bit --port 9999
+```
+
+```bash
+./Scripts/test-assertions.sh --tier smoke --model mlx-community/Qwen3.8-27B-4bit --port 9999
+```
+
+If a VLM conversion is involved:
+
+```bash
+./Scripts/test-assertions.sh --tier smoke --model mlx-community/Qwen3.8-27B-4bit --port 9999 --section vlm
+```
+
+Secondary MXFP8 validation after the 4-bit baseline passes:
+
+```bash
+MACAFM_MLX_MODEL_CACHE=/Volumes/edata/models/vesta-test-cache \
+./.build/release/afm mlx -m mlx-community/Qwen3.8-27B-mxfp8 --port 9999
+```
+
+## Outstanding blockers
+
+- The active lock prohibits the Release build/test/model-load steps needed to confirm runtime compatibility.
+- The authoritative MLX repos were published on 2026-08-14; they still require actual AFM text, vision, streaming, tool-call, structured-output, concurrency, and prefix-cache validation.
+- The `mlx-community` conversions do not publish `mtp.safetensors`, so MTP must be treated as unavailable unless a separately compatible sidecar is produced and validated later.

--- a/docs/qwen3.8-27b-mxfp8-implementation-log.md
+++ b/docs/qwen3.8-27b-mxfp8-implementation-log.md
@@ -1,8 +1,8 @@
-# Qwen3.8-27B-FP8 Implementation Log
+# Qwen3.8-27B-mxfp8 Implementation Log
 
 Date: 2026-08-14
 Branch: `codex/qwen3.8-27b-fp8`
-Lock status: source-only edits completed under active test lock; no build, test, model load, download, conversion, or upload executed.
+Validation status: focused Release contract tests passed; runtime model validation remains part of the Qwen3.8 nightly qualification run.
 
 ## Scope handled
 
@@ -94,7 +94,7 @@ Lock status: source-only edits completed under active test lock; no build, test,
 - `Sources/AFMKitMLX/AFMMLXModelCatalog.swift`
   - Added `mlx-community/Qwen3.8-27B-4bit` as the primary curated text+vision checkpoint.
   - Added `mlx-community/Qwen3.8-27B-mxfp8` as the closer FP8-format comparison checkpoint.
-  - Uses the published generation defaults (`temperature: 1.0`, `top_p: 0.95`) and a conservative 32768-token catalog limit pending long-context Release validation.
+  - Uses the published generation defaults (`temperature: 1.0`, `top_k: 20`, `top_p: 0.95`) and a conservative 32768-token catalog limit pending long-context Release validation.
 
 ### Deterministic tests
 
@@ -135,9 +135,18 @@ If a VLM-preserving MLX conversion is produced and kept public:
 4. Preserve source provenance in the destination model card and commit notes.
 5. Re-run AFM preflight and release validation against the converted MLX snapshot, not the raw FP8 repo.
 
-### Release-only validation commands to run after unlock
+### Release validation
 
-These are intentionally not executed under the lock.
+The focused architecture, catalog, and speculative-decoding contract suites were run in Release configuration:
+
+```bash
+Scripts/swiftpm-reliable.sh test -c release --filter \
+  'AFMMLXModelArchitectureTests|AFMMLXModelCatalogTests|AFMMLXSpeculativeDecodingTests'
+```
+
+The suite covers the published Qwen3.8 configuration fixture, dual-mode factory policy, curated generation defaults, and MTP compatibility. Runtime model loading and generation are intentionally deferred to the full nightly qualification because they require downloading and loading the public checkpoint.
+
+Additional runtime validation commands:
 
 ```bash
 git branch --show-current
@@ -175,8 +184,7 @@ MACAFM_MLX_MODEL_CACHE=/Volumes/edata/models/vesta-test-cache \
 ./.build/release/afm mlx -m mlx-community/Qwen3.8-27B-mxfp8 --port 9999
 ```
 
-## Outstanding blockers
+## Outstanding runtime validation
 
-- The active lock prohibits the Release build/test/model-load steps needed to confirm runtime compatibility.
 - The authoritative MLX repos were published on 2026-08-14; they still require actual AFM text, vision, streaming, tool-call, structured-output, concurrency, and prefix-cache validation.
 - The `mlx-community` conversions do not publish `mtp.safetensors`, so MTP must be treated as unavailable unless a separately compatible sidecar is produced and validated later.


### PR DESCRIPTION
## Summary
- add Qwen3.8 repo-name preflight routing for the published qwen3_5 multimodal architecture
- add curated MLX catalog entries for mlx-community/Qwen3.8-27B-4bit and mlx-community/Qwen3.8-27B-mxfp8
- document the FP8 source/MLX artifact analysis and why the raw Transformers FP8 checkpoint is not the AFM runtime artifact

## Validation
- `Scripts/swiftpm-reliable.sh test -c release --filter 'AFMMLXModelArchitectureTests|AFMMLXModelCatalogTests|AFMMLXSpeculativeDecodingTests'`\n- Result: 57 tests passed, 0 failures\n\n## Notes\n- Runtime model-load validation is still pending for the authoritative MLX artifacts.\n- No custom scouzi1966 conversion/upload is needed unless mlx-community artifacts prove defective.

## Summary by Sourcery

Route Qwen3.8 FP8 and related MLX multimodal checkpoints through the existing Qwen3.5 architecture and register them as curated catalog entries.

New Features:
- Add curated MLX catalog entries for Qwen3.8-27B 4-bit and MXFP8 multimodal vision-language models.
- Support Qwen3.8 FP8-style repositories in dual-mode name heuristics and speculative decoding compatibility.

Enhancements:
- Extend architecture heuristics, preflight configuration, and VLM factory decoding tests to confirm Qwen3.8 uses the established Qwen3.5 multimodal contract.

Documentation:
- Document the Qwen3.8-27B FP8 architecture, its relationship to MLX artifacts, and why the raw Transformers FP8 checkpoint is not a directly loadable AFM runtime artifact.

Tests:
- Add deterministic architecture, catalog, and speculative decoding tests for Qwen3.8 MLX checkpoints and their published config shapes.