### PR TITLE
Remove README maintainer note

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 
 ## What's new
 
-Release infographics are collected here newest first. Select an infographic to open the full release notes.
-
 ### [AFM v0.9.16](https://github.com/scouzi1966/maclocal-api/releases/tag/v0.9.16)
 
 [![AFM v0.9.16 — four new models, official developer logos, and two installation paths](assets/afm-0.9.16-models-deep-dive-social-v6.png)](https://github.com/scouzi1966/maclocal-api/releases/tag/v0.9.16)


### PR DESCRIPTION
## What changed

Removed the editorial note beneath the README’s **What’s new** heading.

## Why

The README is user-facing documentation. The note described how the section is maintained instead of presenting useful release content.

## Impact

Readers now move directly from **What’s new** to the latest release and infographic. No release content or links were changed.

## Validation

- `git diff --check`
- Confirmed the commit changes only `README.md` and removes only the two-line note.

## Summary by Sourcery

Documentation:
- Remove the editorial maintainer note from the README "What's new" section so users see release content immediately.