### PR TITLE
Add automatic Qwen 3.8 MTP sidecars

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ afm mlx -m <model> --gpu-profile -s "Explain Metal kernels"
 
 Supported checkpoints can also use speculative decoding:
 
-- `--mtp` for Qwen3.6 checkpoints that include an MTP head
+- `--mtp` for compatible Qwen models. Qwen3.8 automatically prefetches the
+  separately published MTP head matching the base checkpoint's quantization;
+  use `--mtp-model <repo-or-path>` to override it.
 - `--eagle3 <drafter-directory>` for supported dense Gemma4 models
 - `--dspark-support <support.gguf>` for compatible DwarfStar DSpark workflows
 

--- a/Scripts/patches/Qwen3_5MoE.swift
+++ b/Scripts/patches/Qwen3_5MoE.swift
@@ -904,7 +904,7 @@ public final class Qwen3_5MoEMTPHead: Module {
     /// Load from a `mtp.safetensors` sidecar (keys `mtp.` / `mtp.layers.0.` -> flattened).
     public static func load(
         sidecarPath: String, config: Qwen3_5MoETextConfiguration,
-        groupSize: Int = 32, bits: Int = 4
+        groupSize: Int = 64, bits: Int = 4, mode: QuantizationMode = .affine
     ) throws -> Qwen3_5MoEMTPHead {
         let head = Qwen3_5MoEMTPHead(config)
         let raw = try MLX.loadArrays(url: URL(fileURLWithPath: sidecarPath))
@@ -915,7 +915,9 @@ public final class Qwen3_5MoEMTPHead: Module {
             weights[key] = v
         }
         quantize(model: head, filter: { path, _ in
-            weights["\(path).scales"] != nil ? (groupSize: groupSize, bits: bits) : nil
+            weights["\(path).scales"] != nil
+                ? (groupSize: groupSize, bits: bits, mode: mode)
+                : nil
         })
         try head.update(parameters: ModuleParameters.unflattened(weights), verify: [.all])
         eval(head)
@@ -1121,8 +1123,19 @@ public class Qwen3_5MoEModel: Module, LLMModel, KVCacheDimensionProvider {
     }
     public func embedTokens(_ ids: MLXArray) -> MLXArray { languageModel.embed(ids) }
     public func projectLMHead(_ hidden: MLXArray) -> MLXArray { languageModel.projectLMHead(hidden) }
-    public func loadMTPHead(sidecarPath: String) throws -> Qwen3_5MoEMTPHead {
-        try Qwen3_5MoEMTPHead.load(sidecarPath: sidecarPath, config: configuration.textConfig)
+    public func loadMTPHead(
+        sidecarPath: String,
+        groupSize: Int = 64,
+        bits: Int = 4,
+        mode: QuantizationMode = .affine
+    ) throws -> Qwen3_5MoEMTPHead {
+        try Qwen3_5MoEMTPHead.load(
+            sidecarPath: sidecarPath,
+            config: configuration.textConfig,
+            groupSize: groupSize,
+            bits: bits,
+            mode: mode
+        )
     }
 
     public func newCache(parameters: GenerateParameters?) -> [any KVCache] {

--- a/Scripts/swiftpm-reliable.sh
+++ b/Scripts/swiftpm-reliable.sh
@@ -128,7 +128,9 @@ has_generated_dependency_failure() {
 
 has_recoverable_xcode_failure() {
     local log_file="$1"
-    has_scanner_failure "$log_file" || has_generated_dependency_failure "$log_file"
+    has_scanner_failure "$log_file" \
+        || has_generated_dependency_failure "$log_file" \
+        || grep -q "was not compiled for testing" "$log_file"
 }
 
 run_native() {
@@ -239,6 +241,26 @@ if [[ "$MLX_SOURCE_FINGERPRINT" != "$PREVIOUS_MLX_SOURCE_FINGERPRINT" ]]; then
         "$ROOT_DIR/.build/release"
     printf '%s\n' "$MLX_SOURCE_FINGERPRINT" > "$MLX_SOURCE_STAMP"
 fi
+
+# A normal Release build emits modules without `-enable-testing`. Xcode 27's
+# native SwiftPM driver may then incorrectly reuse those modules for a Release
+# XCTest invocation, causing `@testable import` to fail. Track build-to-test
+# transitions and invalidate only compiled products; dependency checkouts and
+# downloaded artifacts remain intact.
+CONFIGURATION="$(test_configuration "$@")"
+SCRATCH_PATH="$(test_scratch_path "$@")"
+if [[ "$SCRATCH_PATH" != /* ]]; then
+    SCRATCH_PATH="$ROOT_DIR/$SCRATCH_PATH"
+fi
+OPERATION_STAMP="$STATE_DIR/last-operation-${CONFIGURATION}"
+PREVIOUS_OPERATION="$(cat "$OPERATION_STAMP" 2>/dev/null || true)"
+if [[ "$SUBCOMMAND" == "test" && "$PREVIOUS_OPERATION" == "build" ]]; then
+    echo "[swiftpm-reliable] Release build preceded tests; invalidating non-testable products." >&2
+    rm -rf \
+        "$SCRATCH_PATH/$(uname -m)-apple-macosx/$CONFIGURATION" \
+        "$SCRATCH_PATH/$CONFIGURATION"
+fi
+printf '%s\n' "$SUBCOMMAND" > "$OPERATION_STAMP"
 
 DRIVER="${AFM_SWIFTPM_DRIVER:-auto}"
 DEVELOPER_DIR="$(xcode-select -p 2>/dev/null || true)"

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -233,8 +233,9 @@ struct MlxCommand: ParsableCommand {
           --mlx-runtime: Runtime backend: auto, mlx, or dwarfstar (default: auto)
           --gguf-file: Exact GGUF path inside a Hugging Face repository; otherwise AFM selects the largest model artifact that fits memory
           --enable-prefix-caching / --no-enable-prefix-caching: KV cache reuse across requests
-          --mtp: Enable MTP self-speculative decoding for compatible Qwen3.6 models
+          --mtp: Enable serial MTP self-speculative decoding for compatible Qwen models
           --mtp-depth: MTP draft depth compatibility setting
+          --mtp-model: Override the automatic MTP head with a Hugging Face repo, local directory, or .safetensors file
           --dspark-support: DwarfStar DSpark support GGUF for speculative decoding
           --dspark-draft-tokens: Maximum DSpark speculative tokens per cycle (default: 5)
           --dspark-confidence: DSpark confidence-pruning threshold (default: 0.7)
@@ -460,11 +461,14 @@ struct MlxCommand: ParsableCommand {
     @Flag(name: .long, help: "Enable radix tree prefix caching for KV cache reuse across requests")
     var enablePrefixCaching: Bool = false
 
-    @Flag(name: .long, help: "Enable MTP self-speculative decoding (Qwen3.6 models with an mtp.safetensors sidecar). Faster decode, quality-preserving (bit-exact greedy on short generations; near-greedy on long ones). No-op if the model has no MTP head.")
+    @Flag(name: .long, help: "Enable MTP self-speculative decoding. Qwen 3.8 automatically downloads and uses the matching quantized MTP head; concurrent and batch requests safely use autoregressive decoding.")
     var mtp: Bool = false
 
     @Option(name: .long, help: "MTP draft depth (accepted for compatibility; the loop currently uses the fixed depth-2-bonus structure from mlx-lm PR #990 — ~+50% decode vs AR on M4 Pro — so this value is not used).")
     var mtpDepth: Int = 1
+
+    @Option(name: .customLong("mtp-model"), help: "Override the automatically selected MTP head with a Hugging Face repo, local directory, or .safetensors file.")
+    var mtpModel: String?
 
     @Option(name: .customLong("dspark-support"), help: "DwarfStar DSpark support GGUF. Supplying it enables greedy speculative decoding.")
     var dsparkSupportPath: String?
@@ -669,6 +673,7 @@ struct MlxCommand: ParsableCommand {
             kernelEngine: kernelEngine,
             mtpEnabled: mtp,
             mtpDepth: mtpDepth,
+            mtpModelID: mtpModel,
             eagle3DrafterPath: eagle3,
             maxConcurrent: concurrent ?? 0,
             toolCallParser: toolCallParser,
@@ -1185,6 +1190,7 @@ struct MlxCommand: ParsableCommand {
                     mlxKernels: self.mlxKernels,
                     mtpEnabled: self.mtp,
                     mtpDepth: self.mtpDepth,
+                    mtpModelID: self.mtpModel,
                     eagle3DrafterPath: self.eagle3,
                     enableGrammarConstraints: self.enableGrammarConstraints,
                     toolCallParser: self.toolCallParser,

--- a/Sources/AFMKit/AFMEngine.swift
+++ b/Sources/AFMKit/AFMEngine.swift
@@ -30,6 +30,7 @@ public struct EngineConfig: Sendable {
     public var mlxKernels: String
     public var mtpEnabled: Bool
     public var mtpDepth: Int
+    public var mtpModelID: String?
     public var eagle3DrafterPath: String?
     public var enableGrammarConstraints: Bool
     public var toolCallParser: String?
@@ -54,6 +55,7 @@ public struct EngineConfig: Sendable {
         mlxKernels: String = "native",
         mtpEnabled: Bool = false,
         mtpDepth: Int = 3,
+        mtpModelID: String? = nil,
         eagle3DrafterPath: String? = nil,
         enableGrammarConstraints: Bool = false,
         toolCallParser: String? = nil,
@@ -77,6 +79,7 @@ public struct EngineConfig: Sendable {
         self.mlxKernels = mlxKernels
         self.mtpEnabled = mtpEnabled
         self.mtpDepth = mtpDepth
+        self.mtpModelID = mtpModelID
         self.eagle3DrafterPath = eagle3DrafterPath
         self.enableGrammarConstraints = enableGrammarConstraints
         self.toolCallParser = toolCallParser
@@ -115,6 +118,9 @@ private extension EngineConfig {
         }
         if let eagle3DrafterPath {
             values["eagle3DrafterPath"] = .string(eagle3DrafterPath)
+        }
+        if let mtpModelID {
+            values["mtpModelID"] = .string(mtpModelID)
         }
         if let toolCallParser {
             values["toolCallParser"] = .string(toolCallParser)

--- a/Sources/AFMKit/BuildInfo.swift
+++ b/Sources/AFMKit/BuildInfo.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 public struct BuildInfo {
-    public static let version: String? = "v0.9.16"
+    public static let version: String? = "v0.9.17"
     static let commit: String? = nil
 
     public static var fullVersion: String {

--- a/Sources/AFMKitFoundationModels27/MLXFoundationLanguageModel.swift
+++ b/Sources/AFMKitFoundationModels27/MLXFoundationLanguageModel.swift
@@ -18,6 +18,7 @@ public struct MLXLanguageModel: LanguageModel, AFMFoundationModelsModelConfigura
         enablePrefixCaching: Bool = true,
         mtpEnabled: Bool = false,
         mtpDepth: Int = 3,
+        mtpModelID: String? = nil,
         eagle3DrafterPath: String? = nil,
         maxConcurrent: Int = 0,
         defaultMaximumResponseTokens: Int = 2_048,
@@ -33,6 +34,7 @@ public struct MLXLanguageModel: LanguageModel, AFMFoundationModelsModelConfigura
             enablePrefixCaching: enablePrefixCaching,
             mtpEnabled: mtpEnabled,
             mtpDepth: mtpDepth,
+            mtpModelID: mtpModelID,
             eagle3DrafterPath: eagle3DrafterPath,
             maxConcurrent: maxConcurrent,
             defaultMaximumResponseTokens: defaultMaximumResponseTokens,
@@ -84,6 +86,7 @@ public final class MLXLanguageModelExecutor: LanguageModelExecutor, @unchecked S
         public let enablePrefixCaching: Bool
         public let mtpEnabled: Bool
         public let mtpDepth: Int
+        public let mtpModelID: String?
         public let eagle3DrafterPath: String?
         public let maxConcurrent: Int
         public let defaultMaximumResponseTokens: Int
@@ -98,6 +101,7 @@ public final class MLXLanguageModelExecutor: LanguageModelExecutor, @unchecked S
             enablePrefixCaching: Bool = true,
             mtpEnabled: Bool = false,
             mtpDepth: Int = 3,
+            mtpModelID: String? = nil,
             eagle3DrafterPath: String? = nil,
             maxConcurrent: Int = 0,
             defaultMaximumResponseTokens: Int = 2_048,
@@ -111,6 +115,7 @@ public final class MLXLanguageModelExecutor: LanguageModelExecutor, @unchecked S
             self.enablePrefixCaching = enablePrefixCaching
             self.mtpEnabled = mtpEnabled
             self.mtpDepth = mtpDepth
+            self.mtpModelID = mtpModelID
             self.eagle3DrafterPath = eagle3DrafterPath
             self.maxConcurrent = maxConcurrent
             self.defaultMaximumResponseTokens = defaultMaximumResponseTokens
@@ -132,6 +137,7 @@ public final class MLXLanguageModelExecutor: LanguageModelExecutor, @unchecked S
                     enablePrefixCaching: configuration.enablePrefixCaching,
                     mtpEnabled: configuration.mtpEnabled,
                     mtpDepth: configuration.mtpDepth,
+                    mtpModelID: configuration.mtpModelID,
                     eagle3DrafterPath: configuration.eagle3DrafterPath,
                     maxConcurrent: configuration.maxConcurrent
                 )

--- a/Sources/AFMKitMLX/AFMMLXMTPRuntimePolicy.swift
+++ b/Sources/AFMKitMLX/AFMMLXMTPRuntimePolicy.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Pure lifecycle decisions shared by model loading and request dispatch.
+/// Keeping these rules independent of MLX objects makes failure/retry and
+/// model-switch behavior deterministic and directly testable.
+enum AFMMLXMTPRuntimePolicy {
+    static func canReuseLoadedModel(
+        loadedModelID: String?,
+        requestedModelID: String,
+        mtpEnabled: Bool,
+        bindingModelID: String?
+    ) -> Bool {
+        guard loadedModelID == requestedModelID else { return false }
+        return !mtpEnabled || bindingModelID == requestedModelID
+    }
+
+    static func bindingIsUsable(
+        for requestedModelID: String,
+        mtpEnabled: Bool,
+        bindingModelID: String?
+    ) -> Bool {
+        mtpEnabled && bindingModelID == requestedModelID
+    }
+
+    static func allowSynchronousSidecarDownload(mtpEnabled: Bool) -> Bool {
+        mtpEnabled
+    }
+
+    static func shouldPrefetchInBackground(
+        mtpEnabled: Bool,
+        resolvedSidecar: String?,
+        automaticRepositoryID: String?
+    ) -> Bool {
+        !mtpEnabled && resolvedSidecar == nil && automaticRepositoryID != nil
+    }
+
+    static func directSidecarHasRequiredMetadata(_ sidecarURL: URL) -> Bool {
+        AFMMLXSpeculativeRuntimeResourceResolver.mtpQuantization(
+            resourceDirectory: sidecarURL.deletingLastPathComponent()
+        ) != nil
+    }
+}

--- a/Sources/AFMKitMLX/AFMMLXProvider.swift
+++ b/Sources/AFMKitMLX/AFMMLXProvider.swift
@@ -21,6 +21,7 @@ public struct AFMMLXProviderFactory: AFMProviderFactory {
                 "enablePrefixCaching",
                 "mtpEnabled",
                 "mtpDepth",
+                "mtpModelID",
                 "eagle3DrafterPath",
                 "maxConcurrent",
                 "toolCallParser",

--- a/Sources/AFMKitMLX/AFMMLXRuntime.swift
+++ b/Sources/AFMKitMLX/AFMMLXRuntime.swift
@@ -20,6 +20,7 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
     public var kernelEngine: AFMMLXKernelEngine
     public var mtpEnabled: Bool
     public var mtpDepth: Int
+    public var mtpModelID: String?
     public var eagle3DrafterPath: String?
     public var maxConcurrent: Int
     public var toolCallParser: String?
@@ -44,6 +45,7 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
         kernelEngine: AFMMLXKernelEngine = .native,
         mtpEnabled: Bool = false,
         mtpDepth: Int = 3,
+        mtpModelID: String? = nil,
         eagle3DrafterPath: String? = nil,
         maxConcurrent: Int = 0,
         toolCallParser: String? = nil,
@@ -67,6 +69,7 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
         self.kernelEngine = kernelEngine
         self.mtpEnabled = mtpEnabled
         self.mtpDepth = mtpDepth
+        self.mtpModelID = mtpModelID
         self.eagle3DrafterPath = eagle3DrafterPath
         self.maxConcurrent = max(0, maxConcurrent)
         self.toolCallParser = toolCallParser
@@ -106,6 +109,9 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
         }
         if let value = configuration.integer("mtpDepth") {
             mtpDepth = value
+        }
+        if let value = configuration.string("mtpModelID") {
+            mtpModelID = value
         }
         if let value = configuration.string("eagle3DrafterPath") {
             eagle3DrafterPath = value
@@ -160,6 +166,7 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
         service.kernelEngine = kernelEngine
         service.mtpEnabled = mtpEnabled
         service.mtpDepth = mtpDepth
+        service.mtpModelID = mtpModelID
         service.eagle3DrafterPath = eagle3DrafterPath
         service.maxConcurrent = maxConcurrent >= 2 ? maxConcurrent : 0
         service.toolCallParser = toolCallParser
@@ -237,6 +244,9 @@ public final class AFMMLXRuntime: @unchecked Sendable {
         self.configuration = AFMMLXRuntimeConfiguration(
             enablePrefixCaching: service.enablePrefixCaching,
             kernelEngine: service.kernelEngine,
+            mtpEnabled: service.mtpEnabled,
+            mtpDepth: service.mtpDepth,
+            mtpModelID: service.mtpModelID,
             maxConcurrent: service.maxConcurrent,
             enableGrammarConstraints: service.enableGrammarConstraints,
             forceDisableThinking: service.forceDisableThinking,

--- a/Sources/AFMKitMLX/AFMMLXSpeculativeRuntimeResourceResolver.swift
+++ b/Sources/AFMKitMLX/AFMMLXSpeculativeRuntimeResourceResolver.swift
@@ -1,7 +1,76 @@
 import Foundation
 
 public enum AFMMLXSpeculativeRuntimeResourceResolver {
+    public struct MTPQuantization: Equatable, Sendable {
+        public let groupSize: Int
+        public let bits: Int
+        public let mode: String
+
+        public init(groupSize: Int, bits: Int, mode: String) {
+            self.groupSize = groupSize
+            self.bits = bits
+            self.mode = mode
+        }
+    }
+
     public static let mtpSidecarFilename = "mtp.safetensors"
+    public static let repositorySidecarFilename = "model.safetensors"
+
+    /// Resolve the separately published Qwen 3.8 MTP head that matches the
+    /// base checkpoint's quantization. Detection comes from config.json rather
+    /// than the repository name so imported and renamed checkpoints work too.
+    public static func automaticMTPRepositoryID(modelDirectory: URL) -> String? {
+        let configURL = modelDirectory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let text = root["text_config"] as? [String: Any],
+              (root["model_type"] as? String) == "qwen3_5",
+              (text["model_type"] as? String) == "qwen3_5_text",
+              (text["mtp_num_hidden_layers"] as? NSNumber)?.intValue ?? 0 > 0,
+              (text["hidden_size"] as? NSNumber)?.intValue == 5_120,
+              (text["num_hidden_layers"] as? NSNumber)?.intValue == 64
+        else {
+            return nil
+        }
+
+        let quantization = (root["quantization"] as? [String: Any])
+            ?? (root["quantization_config"] as? [String: Any])
+        let variant: String
+        if let mode = quantization?["mode"] as? String {
+            switch mode.lowercased() {
+            case "mxfp4", "mxfp8", "nvfp4":
+                variant = mode.lowercased()
+            case "affine":
+                guard let bits = (quantization?["bits"] as? NSNumber)?.intValue,
+                      bits == 4 || bits == 8 else { return nil }
+                variant = "\(bits)bit"
+            default:
+                return nil
+            }
+        } else {
+            variant = "bf16"
+        }
+
+        return "mlx-community/Qwen3.8-27B-MTP-\(variant)"
+    }
+
+    /// Read the quantization layout used by a standalone MTP checkpoint.
+    /// The loader must use these values; a suffix such as `4bit` is not enough
+    /// to infer the group size or quantization mode.
+    public static func mtpQuantization(resourceDirectory: URL) -> MTPQuantization? {
+        let configURL = resourceDirectory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let quantization = (root["quantization"] as? [String: Any])
+                ?? (root["quantization_config"] as? [String: Any]),
+              let groupSize = (quantization["group_size"] as? NSNumber)?.intValue,
+              let bits = (quantization["bits"] as? NSNumber)?.intValue,
+              let mode = quantization["mode"] as? String
+        else {
+            return nil
+        }
+        return MTPQuantization(groupSize: groupSize, bits: bits, mode: mode.lowercased())
+    }
 
     public static func currentLoadedModelDirectory(
         loadedModelRepoID: String?,
@@ -36,5 +105,19 @@ public enum AFMMLXSpeculativeRuntimeResourceResolver {
             .path
 
         return fileExists(path) ? path : nil
+    }
+
+    /// Resolve either the legacy in-model sidecar name or the filename used by
+    /// the standalone Qwen 3.8 MTP repositories.
+    public static func mtpSidecarPath(
+        resourceDirectory: URL?,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> String? {
+        guard let resourceDirectory else { return nil }
+        for filename in [mtpSidecarFilename, repositorySidecarFilename] {
+            let path = resourceDirectory.appendingPathComponent(filename).path
+            if fileExists(path) { return path }
+        }
+        return nil
     }
 }

--- a/Sources/AFMKitMLX/Models/MLXCacheResolver.swift
+++ b/Sources/AFMKitMLX/Models/MLXCacheResolver.swift
@@ -34,6 +34,17 @@ public struct MLXCacheResolver: Sendable {
         return URL(fileURLWithPath: Self.shellCWD).appendingPathComponent(path).standardized
     }
 
+    /// Resolve a user-provided filesystem path against the shell working
+    /// directory captured before MLX changes the process working directory.
+    /// Returns nil when the input does not currently identify a local file or
+    /// directory, allowing the caller to treat it as a Hub repository ID.
+    func localFilesystemURLIfExists(_ path: String) -> URL? {
+        let expanded = NSString(string: path).expandingTildeInPath
+        let resolved = resolveRelativePath(expanded)
+        guard FileManager.default.fileExists(atPath: resolved.path) else { return nil }
+        return resolved
+    }
+
     func normalizedModelID(_ input: String) -> String {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return trimmed }

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -26,21 +26,17 @@ private extension Dictionary where Key == String, Value == AnyCodable {
     }
 }
 
-/// Process-global holder for the active MTP self-speculative generator.
-///
-/// The MTP head + generator are tied to the loaded model and accessed only inside
-/// `ModelContainer.perform` (serialized), so a single-slot holder is sufficient and avoids
-/// threading the generator through every generation signature. Cleared on model unload.
-final class MTPRuntime: @unchecked Sendable {
-    static let shared = MTPRuntime()
-    private var generator: Qwen3_5MoEMTPGenerator?
-    private let lock = NSLock()
+/// Immutable request-scoped handle that keeps an MTP generator paired with
+/// the model identity and container it was created for. MLX model objects are
+/// not Sendable-audited, but use remains serialized by that ModelContainer.
+private final class MTPGeneratorBinding: @unchecked Sendable {
+    let modelID: String
+    let generator: Qwen3_5MoEMTPGenerator
 
-    func install(model: Qwen3_5MoEModel, head: Qwen3_5MoEMTPHead, depth: Int) {
-        lock.withLock { generator = Qwen3_5MoEMTPGenerator(model: model, head: head, depth: depth) }
+    init(modelID: String, generator: Qwen3_5MoEMTPGenerator) {
+        self.modelID = modelID
+        self.generator = generator
     }
-    func clear() { lock.withLock { generator = nil } }
-    var active: Qwen3_5MoEMTPGenerator? { lock.withLock { generator } }
 }
 
 /// Process-global holder for the active EAGLE3 speculative drafter (Gemma4 dense verifier).
@@ -230,6 +226,10 @@ public final class MLXModelService: @unchecked Sendable {
     private var currentModelID: String?
     private var currentModelArchitecture: AFMMLXModelArchitecturePreflight?
     private var currentContainer: ModelContainer?
+    /// Bound to `currentContainer` and replaced atomically with it. Requests
+    /// capture both under `stateLock`, so a concurrent model switch cannot pair
+    /// one model's container with another model's MTP generator.
+    private var currentMTPBinding: MTPGeneratorBinding?
     private var activeOperations: Int = 0
     private var isShuttingDown = false
     private var gpuInitialized = false
@@ -1366,7 +1366,8 @@ public final class MLXModelService: @unchecked Sendable {
     private func resolveMTPHead(
         baseModelDirectory: URL,
         progress: (@Sendable (Progress) -> Void)?,
-        stage: (@Sendable (MLXLoadStage) -> Void)?
+        stage: (@Sendable (MLXLoadStage) -> Void)?,
+        allowDownload: Bool = true
     ) async throws -> String? {
         let fileManager = FileManager.default
 
@@ -1386,18 +1387,25 @@ public final class MLXModelService: @unchecked Sendable {
 
         let expanded = NSString(string: resource).expandingTildeInPath
         var isDirectory: ObjCBool = false
-        if fileManager.fileExists(atPath: expanded, isDirectory: &isDirectory) {
+        if let localURL = resolver.localFilesystemURLIfExists(expanded) {
+            let localPath = localURL.path
+            fileManager.fileExists(atPath: localPath, isDirectory: &isDirectory)
             if !isDirectory.boolValue {
-                guard URL(fileURLWithPath: expanded).pathExtension == "safetensors" else {
-                    throw MLXServiceError.loadFailed("MTP override must be a .safetensors file: \(expanded)")
+                guard localURL.pathExtension == "safetensors" else {
+                    throw MLXServiceError.loadFailed("MTP override must be a .safetensors file: \(localPath)")
                 }
-                print("[\(ts())] [MTP] using local head: \(expanded)")
-                return expanded
+                guard AFMMLXMTPRuntimePolicy.directSidecarHasRequiredMetadata(localURL) else {
+                    throw MLXServiceError.loadFailed(
+                        "Direct MTP sidecar overrides require a sibling config.json with quantization_config: \(localPath)"
+                    )
+                }
+                print("[\(ts())] [MTP] using local head: \(localPath)")
+                return localPath
             }
             guard let sidecar = AFMMLXSpeculativeRuntimeResourceResolver.mtpSidecarPath(
-                resourceDirectory: URL(fileURLWithPath: expanded, isDirectory: true)
+                resourceDirectory: localURL
             ) else {
-                throw MLXServiceError.loadFailed("No MTP weights found in \(expanded)")
+                throw MLXServiceError.loadFailed("No MTP weights found in \(localPath)")
             }
             print("[\(ts())] [MTP] using local head: \(sidecar)")
             return sidecar
@@ -1407,6 +1415,7 @@ public final class MLXModelService: @unchecked Sendable {
         if let cached = resolver.localModelDirectory(repoId: resource) {
             resourceDirectory = cached
         } else {
+            guard allowDownload else { return nil }
             stage?(.downloading)
             print("[\(ts())] [MTP] downloading matching head: \(resource)")
             try await downloadModel(modelID: resource, progress: progress)
@@ -1469,17 +1478,18 @@ public final class MLXModelService: @unchecked Sendable {
         stage?(.checkingCache)
 
         if let cached = withStateLock({ () -> (String, ModelContainer)? in
-            guard currentModelID == modelID, let container = currentContainer else { return nil }
+            guard let container = currentContainer,
+                  AFMMLXMTPRuntimePolicy.canReuseLoadedModel(
+                    loadedModelID: currentModelID,
+                    requestedModelID: modelID,
+                    mtpEnabled: mtpEnabled,
+                    bindingModelID: currentMTPBinding?.modelID
+                  ) else { return nil }
             return (modelID, container)
         }) {
             stage?(.ready)
             return cached.0
         }
-
-        // The speculative runtime is process-global because it is consumed by
-        // both streaming and non-streaming generation paths. Never carry a
-        // generator across a model switch.
-        MTPRuntime.shared.clear()
 
         // Loading priority:
         // 1. Absolute/relative path — use directly (no cache or download)
@@ -1518,15 +1528,18 @@ public final class MLXModelService: @unchecked Sendable {
         try ensureGPUConfigured(for: modelArchitecture)
 
         // Qwen 3.8 publishes its small MTP head separately from the base model.
-        // Prefetch the matching quant even when acceleration is disabled so a
-        // later --mtp launch is offline-ready. A missing optional prefetch must
-        // not make normal AR inference network-dependent.
+        // Explicit MTP resolves synchronously and fails closed. Disabled-MTP
+        // startup only checks local resources; a missing sidecar is prefetched
+        // asynchronously after the base model is ready.
         let resolvedMTPSidecar: String?
         do {
             resolvedMTPSidecar = try await resolveMTPHead(
                 baseModelDirectory: directory,
                 progress: progress,
-                stage: stage
+                stage: stage,
+                allowDownload: AFMMLXMTPRuntimePolicy.allowSynchronousSidecarDownload(
+                    mtpEnabled: mtpEnabled
+                )
             )
         } catch {
             if mtpEnabled {
@@ -1534,6 +1547,11 @@ public final class MLXModelService: @unchecked Sendable {
             }
             resolvedMTPSidecar = nil
             print("[\(ts())] [MTP] optional head prefetch failed (\(error)); continuing with AR")
+        }
+        if mtpEnabled && resolvedMTPSidecar == nil {
+            throw MLXServiceError.loadFailed(
+                "MTP was requested, but no compatible sidecar could be resolved for \(modelID)"
+            )
         }
 
         var config = ModelConfiguration(directory: directory)
@@ -1609,19 +1627,14 @@ public final class MLXModelService: @unchecked Sendable {
             if actualFactory != selectedFactory {
                 print("[\(ts())] [ModelArchitecture] actualFactory=VLM (LLM fallback)")
             }
-            withStateLock {
-                currentContainer = loaded
-                currentModelID = modelID
-                currentModelArchitecture = modelArchitecture
-                currentToolCallFormat = detectedFormat
-            }
             // MTP: load the explicitly resolved sidecar only after the base model
             // has loaded. The sidecar remains outside the base checkpoint.
+            var loadedMTPBinding: MTPGeneratorBinding?
             if mtpEnabled {
                 if let sidecar = resolvedMTPSidecar {
                     do {
                         let quantization = mtpQuantization(for: sidecar)
-                        try await loaded.perform { context in
+                        loadedMTPBinding = try await loaded.perform { context in
                             if let qwen = context.model as? Qwen3_5MoEModel {
                                 let head = try qwen.loadMTPHead(
                                     sidecarPath: sidecar,
@@ -1629,11 +1642,16 @@ public final class MLXModelService: @unchecked Sendable {
                                     bits: quantization.bits,
                                     mode: quantization.mode
                                 )
-                                MTPRuntime.shared.install(model: qwen, head: head, depth: mtpDepth)
+                                let generator = Qwen3_5MoEMTPGenerator(
+                                    model: qwen,
+                                    head: head,
+                                    depth: mtpDepth
+                                )
                                 print("[\(ts())] [MTP] head loaded — self-speculative decoding enabled (depth \(mtpDepth))")
                                 if maxConcurrent >= 2 {
                                     print("[\(ts())] [MTP] concurrent/batch scheduler uses AR decode; serial requests use MTP")
                                 }
+                                return MTPGeneratorBinding(modelID: modelID, generator: generator)
                             } else {
                                 throw MLXServiceError.loadFailed(
                                     "MTP head requires a compatible Qwen text model; loaded \(type(of: context.model))"
@@ -1641,14 +1659,49 @@ public final class MLXModelService: @unchecked Sendable {
                             }
                         }
                     } catch {
-                        MTPRuntime.shared.clear()
                         throw MLXServiceError.loadFailed("MTP head load failed: \(error)")
                     }
                 } else {
-                    print("[\(ts())] [MTP] no compatible head for \(modelID) — MTP disabled (AR decode)")
+                    throw MLXServiceError.loadFailed(
+                        "MTP was requested, but no compatible sidecar could be resolved for \(modelID)"
+                    )
                 }
             } else if resolvedMTPSidecar != nil {
                 print("[\(ts())] [MTP] matching head cached; pass --mtp to enable serial speculative decoding")
+            }
+
+            // Publish the container and its MTP generator as one state change.
+            // A failed sidecar load leaves the previous model state untouched.
+            withStateLock {
+                currentContainer = loaded
+                currentModelID = modelID
+                currentModelArchitecture = modelArchitecture
+                currentToolCallFormat = detectedFormat
+                currentMTPBinding = loadedMTPBinding
+            }
+
+            if AFMMLXMTPRuntimePolicy.shouldPrefetchInBackground(
+                mtpEnabled: mtpEnabled,
+                resolvedSidecar: resolvedMTPSidecar,
+                automaticRepositoryID:
+                    AFMMLXSpeculativeRuntimeResourceResolver.automaticMTPRepositoryID(
+                        modelDirectory: directory
+                    )
+            ) {
+                Task { [weak self] in
+                    guard let self else { return }
+                    do {
+                        _ = try await self.resolveMTPHead(
+                            baseModelDirectory: directory,
+                            progress: nil,
+                            stage: nil,
+                            allowDownload: true
+                        )
+                        print("[\(ts())] [MTP] matching head cached in background; pass --mtp on the next launch")
+                    } catch {
+                        print("[\(ts())] [MTP] optional background prefetch failed (\(error))")
+                    }
+                }
             }
             // EAGLE3: if a drafter path was given and the verifier is a dense Gemma4 text model,
             // load the drafter. Silently no-op otherwise (falls back to AR).
@@ -2057,7 +2110,9 @@ public final class MLXModelService: @unchecked Sendable {
             }
         }
         let modelID = try await ensureLoaded(model: model, countOperation: false)
-        let container = try validatedContainerForRequest(modelID: modelID, messages: messages)
+        let runtime = try validatedRuntimeForRequest(modelID: modelID, messages: messages)
+        let container = runtime.container
+        let mtpBinding = runtime.mtpBinding
 
         let promptText = buildPrompt(from: messages)
         let toolSpecs = convertToToolSpecs(tools, includePythonJSON: shouldUseNativePythonToolJSONTemplate(for: tools))
@@ -2128,14 +2183,14 @@ public final class MLXModelService: @unchecked Sendable {
         // ---- MTP self-speculative fast path (greedy, text-only, no tools/grammar/logprobs) ----
         // Eligible when an MTP head is installed and the request is plain greedy generation.
         // Produces output identical to greedy AR (validated P2) but with fewer trunk forwards.
-        let mtpEligible = MTPRuntime.shared.active != nil
+        let mtpEligible = mtpBinding != nil
             && (temperature ?? 0) <= 0.0
             && (tools?.isEmpty ?? true)
             && responseFormat == nil
             && !wantLogprobs
         if mtpEligible {
             if let mtpResult = try await container.perform({ context -> (String, Int, Int)? in
-                guard let gen = MTPRuntime.shared.active else { return nil }
+                guard let gen = mtpBinding?.generator else { return nil }
                 let lmInput = try await context.processor.prepare(input: scratch.userInput)
                 if self.isMultimodalInput(lmInput) { return nil }   // MTP is text-only
                 let promptIds = self.extractTokenArray(lmInput)
@@ -2995,7 +3050,9 @@ public final class MLXModelService: @unchecked Sendable {
         // is created; the Task itself owns the normal endOperation() call.
 
         let modelID = try await ensureLoaded(model: model, countOperation: false)
-        let container = try validatedContainerForRequest(modelID: modelID, messages: messages)
+        let runtime = try validatedRuntimeForRequest(modelID: modelID, messages: messages)
+        let container = runtime.container
+        let mtpBinding = runtime.mtpBinding
 
         let promptText = buildPrompt(from: messages)
         let toolSpecs = convertToToolSpecs(tools, includePythonJSON: shouldUseNativePythonToolJSONTemplate(for: tools))
@@ -3171,7 +3228,7 @@ public final class MLXModelService: @unchecked Sendable {
         }
         let dsparkStreamEligible = specGreedyStream && loadedSupportsDSpark
         let eagle3StreamEligible = specGreedyStream && Eagle3Runtime.shared.active != nil
-        let mtpStreamEligible = specGreedyStream && MTPRuntime.shared.active != nil
+        let mtpStreamEligible = specGreedyStream && mtpBinding != nil
         if dsparkStreamEligible || eagle3StreamEligible || mtpStreamEligible {
             // Prep prompt ids under the lock; nil => multimodal/empty/wrong-model => fall back to AR.
             // Also detect a template-opened think block (last prompt tokens contain thinkStart): for
@@ -3245,7 +3302,7 @@ public final class MLXModelService: @unchecked Sendable {
                                     _ = g.generateSpeculative(model: model, promptIds: promptIds,
                                                               maxTokens: maxTok, eosIds: eos,
                                                               blockSize: block, onToken: emit)
-                                } else if let gen = MTPRuntime.shared.active {
+                                } else if let gen = mtpBinding?.generator {
                                     _ = gen.generate(promptIds: promptIds, maxTokens: maxTok,
                                                      eosIds: eos, onToken: emit)
                                 }
@@ -3840,12 +3897,12 @@ public final class MLXModelService: @unchecked Sendable {
             print("[\(ts())] [PrefixCache] Invalidate: cleanup")
         }
         self.radixCache?.invalidateAll()
-        MTPRuntime.shared.clear()
         autoreleasepool {
             withStateLock {
                 currentContainer = nil
                 currentModelID = nil
                 currentModelArchitecture = nil
+                currentMTPBinding = nil
             }
         }
 
@@ -5950,12 +6007,14 @@ public final class MLXModelService: @unchecked Sendable {
         return false
     }
 
-    private func validatedContainerForRequest(
+    private func validatedRuntimeForRequest(
         modelID: String,
         messages: [AFMOpenAICompat.Message]
-    ) throws -> ModelContainer {
-        let state = withStateLock { (currentContainer, currentModelArchitecture, currentModelID == modelID) }
-        guard let container = state.0, state.2 else { throw MLXServiceError.noModelLoaded }
+    ) throws -> (container: ModelContainer, mtpBinding: MTPGeneratorBinding?) {
+        let state = withStateLock {
+            (currentContainer, currentModelArchitecture, currentMTPBinding, currentModelID == modelID)
+        }
+        guard let container = state.0, state.3 else { throw MLXServiceError.noModelLoaded }
         guard let architecture = state.1 else {
             throw MLXServiceError.loadFailed("\(modelID): model architecture is unavailable")
         }
@@ -5980,7 +6039,12 @@ public final class MLXModelService: @unchecked Sendable {
                 }
             }
         }
-        return container
+        let binding = AFMMLXMTPRuntimePolicy.bindingIsUsable(
+            for: modelID,
+            mtpEnabled: mtpEnabled,
+            bindingModelID: state.2?.modelID
+        ) ? state.2 : nil
+        return (container, binding)
     }
 
     private func buildPrompt(from messages: [AFMOpenAICompat.Message]) -> String {

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -243,10 +243,11 @@ public final class MLXModelService: @unchecked Sendable {
     public var kernelEngine: AFMMLXKernelEngine = .native
     public var kvEvictionPolicy: String = "none"  // "none" or "streaming"
     public var enablePrefixCaching: Bool = false
-    /// MTP self-speculative decoding (--mtp). Activates only when the loaded model has an
-    /// mtp.safetensors sidecar (a Qwen3.6 MTP head); otherwise silently falls back to AR.
+    /// MTP self-speculative decoding (--mtp). Qwen 3.8 heads are cached as
+    /// separate model repositories so their weights never enter the base loader.
     public var mtpEnabled: Bool = false
     public var mtpDepth: Int = 3
+    public var mtpModelID: String?
     /// EAGLE3 speculative decoding (--eagle3 <drafter-path>). Activates only when the loaded model
     /// is a dense Gemma4 verifier and a drafter loads from the given path; otherwise falls back to AR.
     public var eagle3DrafterPath: String?
@@ -1362,6 +1363,88 @@ public final class MLXModelService: @unchecked Sendable {
         try registry.revalidate(using: resolver)
     }
 
+    private func resolveMTPHead(
+        baseModelDirectory: URL,
+        progress: (@Sendable (Progress) -> Void)?,
+        stage: (@Sendable (MLXLoadStage) -> Void)?
+    ) async throws -> String? {
+        let fileManager = FileManager.default
+
+        // Preserve compatibility with checkpoints that already ship the head.
+        if mtpModelID == nil,
+           let bundled = AFMMLXSpeculativeRuntimeResourceResolver.mtpSidecarPath(
+               modelDirectory: baseModelDirectory
+           ) {
+            return bundled
+        }
+
+        let resource = mtpModelID?.trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? AFMMLXSpeculativeRuntimeResourceResolver.automaticMTPRepositoryID(
+                modelDirectory: baseModelDirectory
+            )
+        guard let resource, !resource.isEmpty else { return nil }
+
+        let expanded = NSString(string: resource).expandingTildeInPath
+        var isDirectory: ObjCBool = false
+        if fileManager.fileExists(atPath: expanded, isDirectory: &isDirectory) {
+            if !isDirectory.boolValue {
+                guard URL(fileURLWithPath: expanded).pathExtension == "safetensors" else {
+                    throw MLXServiceError.loadFailed("MTP override must be a .safetensors file: \(expanded)")
+                }
+                print("[\(ts())] [MTP] using local head: \(expanded)")
+                return expanded
+            }
+            guard let sidecar = AFMMLXSpeculativeRuntimeResourceResolver.mtpSidecarPath(
+                resourceDirectory: URL(fileURLWithPath: expanded, isDirectory: true)
+            ) else {
+                throw MLXServiceError.loadFailed("No MTP weights found in \(expanded)")
+            }
+            print("[\(ts())] [MTP] using local head: \(sidecar)")
+            return sidecar
+        }
+
+        let resourceDirectory: URL
+        if let cached = resolver.localModelDirectory(repoId: resource) {
+            resourceDirectory = cached
+        } else {
+            stage?(.downloading)
+            print("[\(ts())] [MTP] downloading matching head: \(resource)")
+            try await downloadModel(modelID: resource, progress: progress)
+            guard let downloaded = resolver.localModelDirectory(repoId: resource) else {
+                throw MLXServiceError.modelNotFoundInCache(resource)
+            }
+            resourceDirectory = downloaded
+        }
+
+        guard let sidecar = AFMMLXSpeculativeRuntimeResourceResolver.mtpSidecarPath(
+            resourceDirectory: resourceDirectory
+        ) else {
+            throw MLXServiceError.loadFailed("MTP repository \(resource) has no model.safetensors or mtp.safetensors")
+        }
+        print("[\(ts())] [MTP] resolved head \(resource) -> \(sidecar)")
+        return sidecar
+    }
+
+    private func mtpQuantization(for sidecarPath: String) -> (
+        groupSize: Int, bits: Int, mode: QuantizationMode
+    ) {
+        let directory = URL(fileURLWithPath: sidecarPath).deletingLastPathComponent()
+        guard let quantization = AFMMLXSpeculativeRuntimeResourceResolver.mtpQuantization(
+            resourceDirectory: directory
+        ) else {
+            return (64, 4, .affine)
+        }
+
+        let mode: QuantizationMode
+        switch quantization.mode {
+        case "mxfp4": mode = .mxfp4
+        case "mxfp8": mode = .mxfp8
+        case "nvfp4": mode = .nvfp4
+        default: mode = .affine
+        }
+        return (quantization.groupSize, quantization.bits, mode)
+    }
+
     public func ensureLoaded(
         model rawModel: String,
         progress: (@Sendable (Progress) -> Void)? = nil,
@@ -1392,6 +1475,11 @@ public final class MLXModelService: @unchecked Sendable {
             stage?(.ready)
             return cached.0
         }
+
+        // The speculative runtime is process-global because it is consumed by
+        // both streaming and non-streaming generation paths. Never carry a
+        // generator across a model switch.
+        MTPRuntime.shared.clear()
 
         // Loading priority:
         // 1. Absolute/relative path — use directly (no cache or download)
@@ -1428,6 +1516,25 @@ public final class MLXModelService: @unchecked Sendable {
             modelID: modelID
         )
         try ensureGPUConfigured(for: modelArchitecture)
+
+        // Qwen 3.8 publishes its small MTP head separately from the base model.
+        // Prefetch the matching quant even when acceleration is disabled so a
+        // later --mtp launch is offline-ready. A missing optional prefetch must
+        // not make normal AR inference network-dependent.
+        let resolvedMTPSidecar: String?
+        do {
+            resolvedMTPSidecar = try await resolveMTPHead(
+                baseModelDirectory: directory,
+                progress: progress,
+                stage: stage
+            )
+        } catch {
+            if mtpEnabled {
+                throw error
+            }
+            resolvedMTPSidecar = nil
+            print("[\(ts())] [MTP] optional head prefetch failed (\(error)); continuing with AR")
+        }
 
         var config = ModelConfiguration(directory: directory)
         // Auto-detect tool call format from model type (vendor LLMModelFactory lost this code)
@@ -1508,27 +1615,40 @@ public final class MLXModelService: @unchecked Sendable {
                 currentModelArchitecture = modelArchitecture
                 currentToolCallFormat = detectedFormat
             }
-            // MTP: if requested and the model ships an mtp.safetensors sidecar, load the head
-            // into the container's model. Silently no-op otherwise (falls back to AR).
+            // MTP: load the explicitly resolved sidecar only after the base model
+            // has loaded. The sidecar remains outside the base checkpoint.
             if mtpEnabled {
-                let sidecar = directory.appendingPathComponent("mtp.safetensors").path
-                if FileManager.default.fileExists(atPath: sidecar) {
+                if let sidecar = resolvedMTPSidecar {
                     do {
+                        let quantization = mtpQuantization(for: sidecar)
                         try await loaded.perform { context in
                             if let qwen = context.model as? Qwen3_5MoEModel {
-                                let head = try qwen.loadMTPHead(sidecarPath: sidecar)
+                                let head = try qwen.loadMTPHead(
+                                    sidecarPath: sidecar,
+                                    groupSize: quantization.groupSize,
+                                    bits: quantization.bits,
+                                    mode: quantization.mode
+                                )
                                 MTPRuntime.shared.install(model: qwen, head: head, depth: mtpDepth)
                                 print("[\(ts())] [MTP] head loaded — self-speculative decoding enabled (depth \(mtpDepth))")
+                                if maxConcurrent >= 2 {
+                                    print("[\(ts())] [MTP] concurrent/batch scheduler uses AR decode; serial requests use MTP")
+                                }
                             } else {
-                                print("[\(ts())] [MTP] model is not Qwen3.6 text LLM (\(type(of: context.model))) — MTP disabled")
+                                throw MLXServiceError.loadFailed(
+                                    "MTP head requires a compatible Qwen text model; loaded \(type(of: context.model))"
+                                )
                             }
                         }
                     } catch {
-                        print("[\(ts())] [MTP] head load failed (\(error)) — falling back to AR")
+                        MTPRuntime.shared.clear()
+                        throw MLXServiceError.loadFailed("MTP head load failed: \(error)")
                     }
                 } else {
-                    print("[\(ts())] [MTP] no mtp.safetensors at \(modelID) — MTP disabled (AR decode)")
+                    print("[\(ts())] [MTP] no compatible head for \(modelID) — MTP disabled (AR decode)")
                 }
+            } else if resolvedMTPSidecar != nil {
+                print("[\(ts())] [MTP] matching head cached; pass --mtp to enable serial speculative decoding")
             }
             // EAGLE3: if a drafter path was given and the verifier is a dense Gemma4 text model,
             // load the drafter. Silently no-op otherwise (falls back to AR).
@@ -3720,6 +3840,7 @@ public final class MLXModelService: @unchecked Sendable {
             print("[\(ts())] [PrefixCache] Invalidate: cleanup")
         }
         self.radixCache?.invalidateAll()
+        MTPRuntime.shared.clear()
         autoreleasepool {
             withStateLock {
                 currentContainer = nil

--- a/Tests/MacLocalAPITests/AFMMLXMTPRuntimePolicyTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXMTPRuntimePolicyTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+@testable import AFMKitMLX
+import XCTest
+
+final class AFMMLXMTPRuntimePolicyTests: XCTestCase {
+    func testFailedMTPSetupCannotReuseBaseOnlyLoadedStateOnRetry() {
+        XCTAssertFalse(
+            AFMMLXMTPRuntimePolicy.canReuseLoadedModel(
+                loadedModelID: "qwen",
+                requestedModelID: "qwen",
+                mtpEnabled: true,
+                bindingModelID: nil
+            )
+        )
+    }
+
+    func testBaseOnlyLoadedStateRemainsReusableWhenMTPIsDisabled() {
+        XCTAssertTrue(
+            AFMMLXMTPRuntimePolicy.canReuseLoadedModel(
+                loadedModelID: "qwen",
+                requestedModelID: "qwen",
+                mtpEnabled: false,
+                bindingModelID: nil
+            )
+        )
+    }
+
+    func testBindingFromAnotherModelIsNeverUsable() {
+        XCTAssertFalse(
+            AFMMLXMTPRuntimePolicy.bindingIsUsable(
+                for: "model-b",
+                mtpEnabled: true,
+                bindingModelID: "model-a"
+            )
+        )
+        XCTAssertFalse(
+            AFMMLXMTPRuntimePolicy.canReuseLoadedModel(
+                loadedModelID: "model-b",
+                requestedModelID: "model-b",
+                mtpEnabled: true,
+                bindingModelID: "model-a"
+            )
+        )
+    }
+
+    func testDisabledMTPUsesBackgroundRatherThanSynchronousDownload() {
+        XCTAssertFalse(
+            AFMMLXMTPRuntimePolicy.allowSynchronousSidecarDownload(mtpEnabled: false)
+        )
+        XCTAssertTrue(
+            AFMMLXMTPRuntimePolicy.shouldPrefetchInBackground(
+                mtpEnabled: false,
+                resolvedSidecar: nil,
+                automaticRepositoryID: "mlx-community/Qwen3.8-27B-MTP-4bit"
+            )
+        )
+    }
+
+    func testExplicitMTPAllowsSynchronousDownloadAndNoBackgroundDuplicate() {
+        XCTAssertTrue(
+            AFMMLXMTPRuntimePolicy.allowSynchronousSidecarDownload(mtpEnabled: true)
+        )
+        XCTAssertFalse(
+            AFMMLXMTPRuntimePolicy.shouldPrefetchInBackground(
+                mtpEnabled: true,
+                resolvedSidecar: nil,
+                automaticRepositoryID: "mlx-community/Qwen3.8-27B-MTP-4bit"
+            )
+        )
+    }
+
+    func testDirectSidecarRequiresQuantizationMetadata() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        let sidecar = directory.appendingPathComponent("head.safetensors")
+        try Data().write(to: sidecar)
+
+        XCTAssertFalse(AFMMLXMTPRuntimePolicy.directSidecarHasRequiredMetadata(sidecar))
+
+        let config: [String: Any] = [
+            "quantization_config": ["group_size": 32, "bits": 4, "mode": "mxfp4"]
+        ]
+        try JSONSerialization.data(withJSONObject: config)
+            .write(to: directory.appendingPathComponent("config.json"))
+        XCTAssertTrue(AFMMLXMTPRuntimePolicy.directSidecarHasRequiredMetadata(sidecar))
+    }
+}

--- a/Tests/MacLocalAPITests/AFMMLXRuntimeTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXRuntimeTests.swift
@@ -27,6 +27,7 @@ final class AFMMLXRuntimeTests: XCTestCase {
             kernelEngine: .ds4,
             mtpEnabled: true,
             mtpDepth: 5,
+            mtpModelID: "mlx-community/Qwen3.8-27B-MTP-4bit",
             eagle3DrafterPath: "/tmp/eagle",
             maxConcurrent: 4,
             toolCallParser: "qwen3_xml",
@@ -54,6 +55,7 @@ final class AFMMLXRuntimeTests: XCTestCase {
         XCTAssertEqual(service.kernelEngine, .ds4)
         XCTAssertTrue(service.mtpEnabled)
         XCTAssertEqual(service.mtpDepth, 5)
+        XCTAssertEqual(service.mtpModelID, "mlx-community/Qwen3.8-27B-MTP-4bit")
         XCTAssertEqual(service.eagle3DrafterPath, "/tmp/eagle")
         XCTAssertEqual(service.maxConcurrent, 4)
         XCTAssertEqual(service.toolCallParser, "qwen3_xml")
@@ -92,6 +94,8 @@ final class AFMMLXRuntimeTests: XCTestCase {
             providerConfiguration: AFMProviderConfiguration(values: [
                 "enablePrefixCaching": .bool(false),
                 "mlxKernels": .string("ds4"),
+                "mtpEnabled": .bool(true),
+                "mtpModelID": .string("/models/custom-mtp.safetensors"),
                 "maxConcurrent": .integer(8),
                 "toolCallParser": .string("none")
             ]),
@@ -101,8 +105,26 @@ final class AFMMLXRuntimeTests: XCTestCase {
         XCTAssertEqual(runtime.modelID, "mlx-community/Qwen3.6-35B-A3B-4bit")
         XCTAssertFalse(service.enablePrefixCaching)
         XCTAssertEqual(service.kernelEngine, .ds4)
+        XCTAssertTrue(service.mtpEnabled)
+        XCTAssertEqual(service.mtpModelID, "/models/custom-mtp.safetensors")
         XCTAssertEqual(service.maxConcurrent, 8)
         XCTAssertEqual(service.toolCallParser, "none")
+    }
+
+    func testMTPConfigurationKeepsConcurrentBatchAndPrefixCacheModesEnabled() {
+        let service = MLXModelService(resolver: MLXCacheResolver())
+
+        AFMMLXRuntimeConfiguration(
+            enablePrefixCaching: true,
+            mtpEnabled: true,
+            mtpModelID: "mlx-community/Qwen3.8-27B-MTP-8bit",
+            maxConcurrent: 8
+        ).apply(to: service)
+
+        XCTAssertTrue(service.mtpEnabled)
+        XCTAssertEqual(service.mtpModelID, "mlx-community/Qwen3.8-27B-MTP-8bit")
+        XCTAssertTrue(service.enablePrefixCaching)
+        XCTAssertEqual(service.maxConcurrent, 8)
     }
 
     func testKernelEngineFallsBackToNativeForUnknownConfigurationValue() {

--- a/Tests/MacLocalAPITests/AFMMLXSpeculativeRuntimeResourceResolverTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXSpeculativeRuntimeResourceResolverTests.swift
@@ -2,6 +2,33 @@ import XCTest
 import AFMKitMLX
 
 final class AFMMLXSpeculativeRuntimeResourceResolverTests: XCTestCase {
+    private func makeQwen38Config(
+        quantization: [String: Any]? = ["mode": "affine", "bits": 4],
+        hiddenSize: Int = 5_120,
+        layerCount: Int = 64,
+        mtpLayerCount: Int = 1
+    ) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        var config: [String: Any] = [
+            "model_type": "qwen3_5",
+            "text_config": [
+                "model_type": "qwen3_5_text",
+                "hidden_size": hiddenSize,
+                "num_hidden_layers": layerCount,
+                "mtp_num_hidden_layers": mtpLayerCount
+            ]
+        ]
+        if let quantization {
+            config["quantization"] = quantization
+        }
+        let data = try JSONSerialization.data(withJSONObject: config)
+        try data.write(to: directory.appendingPathComponent("config.json"))
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        return directory
+    }
+
     func testCurrentLoadedModelDirectoryIsUnavailableForMissingOrBlankID() {
         XCTAssertNil(
             AFMMLXSpeculativeRuntimeResourceResolver.currentLoadedModelDirectory(
@@ -73,6 +100,88 @@ final class AFMMLXSpeculativeRuntimeResourceResolverTests: XCTestCase {
                 }
             ),
             expectedPath
+        )
+    }
+
+    func testAutomaticQwen38MTPRepositoryMatchesPublishedQuantization() throws {
+        let cases: [([String: Any]?, String)] = [
+            (["mode": "affine", "bits": 4], "4bit"),
+            (["mode": "affine", "bits": 8], "8bit"),
+            (["mode": "mxfp4"], "mxfp4"),
+            (["mode": "mxfp8"], "mxfp8"),
+            (["mode": "nvfp4"], "nvfp4"),
+            (nil, "bf16")
+        ]
+
+        for (quantization, suffix) in cases {
+            let directory = try makeQwen38Config(quantization: quantization)
+            XCTAssertEqual(
+                AFMMLXSpeculativeRuntimeResourceResolver.automaticMTPRepositoryID(
+                    modelDirectory: directory
+                ),
+                "mlx-community/Qwen3.8-27B-MTP-\(suffix)"
+            )
+        }
+    }
+
+    func testAutomaticQwen38MTPRepositoryUsesConfigRatherThanDirectoryName() throws {
+        let directory = try makeQwen38Config(quantization: ["mode": "mxfp4"])
+
+        XCTAssertEqual(
+            AFMMLXSpeculativeRuntimeResourceResolver.automaticMTPRepositoryID(
+                modelDirectory: directory
+            ),
+            "mlx-community/Qwen3.8-27B-MTP-mxfp4"
+        )
+    }
+
+    func testMTPQuantizationReadsExactCheckpointLayout() throws {
+        let directory = try makeQwen38Config(
+            quantization: ["mode": "mxfp4", "bits": 4, "group_size": 32]
+        )
+
+        XCTAssertEqual(
+            AFMMLXSpeculativeRuntimeResourceResolver.mtpQuantization(
+                resourceDirectory: directory
+            ),
+            .init(groupSize: 32, bits: 4, mode: "mxfp4")
+        )
+    }
+
+    func testAutomaticQwen38MTPRepositoryRejectsIncompatibleArchitecture() throws {
+        let wrongShape = try makeQwen38Config(hiddenSize: 4_096)
+        let noMTP = try makeQwen38Config(mtpLayerCount: 0)
+
+        XCTAssertNil(
+            AFMMLXSpeculativeRuntimeResourceResolver.automaticMTPRepositoryID(
+                modelDirectory: wrongShape
+            )
+        )
+        XCTAssertNil(
+            AFMMLXSpeculativeRuntimeResourceResolver.automaticMTPRepositoryID(
+                modelDirectory: noMTP
+            )
+        )
+    }
+
+    func testRepositorySidecarResolutionPrefersLegacyBundledHead() {
+        let directory = URL(fileURLWithPath: "/cache/model", isDirectory: true)
+        let legacy = directory.appendingPathComponent("mtp.safetensors").path
+        let repository = directory.appendingPathComponent("model.safetensors").path
+
+        XCTAssertEqual(
+            AFMMLXSpeculativeRuntimeResourceResolver.mtpSidecarPath(
+                resourceDirectory: directory,
+                fileExists: { $0 == legacy || $0 == repository }
+            ),
+            legacy
+        )
+        XCTAssertEqual(
+            AFMMLXSpeculativeRuntimeResourceResolver.mtpSidecarPath(
+                resourceDirectory: directory,
+                fileExists: { $0 == repository }
+            ),
+            repository
         )
     }
 }

--- a/Tests/MacLocalAPITests/BuildInfoTests.swift
+++ b/Tests/MacLocalAPITests/BuildInfoTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class BuildInfoTests: XCTestCase {
     func testBaseVersionIsNextRelease() {
-        XCTAssertEqual(BuildInfo.resolvedVersion(override: nil), "v0.9.16")
+        XCTAssertEqual(BuildInfo.resolvedVersion(override: nil), "v0.9.17")
     }
 
     func testBuildVersionOverridePreservesVersionPrefix() {
@@ -21,6 +21,6 @@ final class BuildInfoTests: XCTestCase {
     }
 
     func testBlankBuildVersionOverrideUsesBaseVersion() {
-        XCTAssertEqual(BuildInfo.resolvedVersion(override: "  "), "v0.9.16")
+        XCTAssertEqual(BuildInfo.resolvedVersion(override: "  "), "v0.9.17")
     }
 }

--- a/Tests/MacLocalAPITests/MLXCacheResolverTests.swift
+++ b/Tests/MacLocalAPITests/MLXCacheResolverTests.swift
@@ -4,6 +4,26 @@ import Foundation
 import XCTest
 
 final class MLXCacheResolverTests: XCTestCase {
+    func testLocalFilesystemURLResolvesRelativeToOriginalShellDirectory() throws {
+        let shellDirectory = URL(
+            fileURLWithPath: ProcessInfo.processInfo.environment["PWD"]
+                ?? FileManager.default.currentDirectoryPath
+        )
+        let filename = ".afm-mtp-relative-\(UUID().uuidString).safetensors"
+        let file = shellDirectory.appendingPathComponent(filename)
+        try Data().write(to: file)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        let previousDirectory = FileManager.default.currentDirectoryPath
+        XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath("/"))
+        defer { FileManager.default.changeCurrentDirectoryPath(previousDirectory) }
+
+        XCTAssertEqual(
+            MLXCacheResolver().localFilesystemURLIfExists(filename)?.standardizedFileURL,
+            file.standardizedFileURL
+        )
+    }
+
     func testShardedSnapshotIsCompleteOnlyWhenEveryIndexedShardExists() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("afmkit-sharded-model-test-\(UUID().uuidString)")

--- a/docs/decode-optimizations.md
+++ b/docs/decode-optimizations.md
@@ -82,21 +82,31 @@ AFM_EAGLE3_BLOCK=3 afm mlx -m mlx-community/gemma-4-31b-it-4bit --eagle3 "$DRAFT
 
 ---
 
-## 2. MTP self-speculative decoding — Qwen3.6
+## 2. MTP self-speculative decoding — Qwen3.6 and Qwen3.8
 
 **Flag:** `--mtp`
 
-Self-speculative decoding using Qwen3.6's **in-model MTP head** (no separate draft model).
+Self-speculative decoding using a small MTP head published for the base model.
 Quality-preserving: bit-exact to greedy AR on short generations, near-greedy on long ones (the
 depth-2 "bonus" token comes from a batched verify forward, so longer outputs may differ
 token-for-token while staying greedy-quality). ~**+52% decode** vs AR; ~**+47%** end-to-end.
 
-Requires a model checkpoint that ships the `mtp.safetensors` sidecar (the plain
-`mlx-community/Qwen3.6-27B-4bit` conversion **strips** the MTP head, so `--mtp` no-ops there):
+Qwen3.6 requires a checkpoint that ships `mtp.safetensors`. For Qwen3.8, AFM detects the
+architecture and quantization from `config.json`, then downloads the matching standalone MTP
+repository (`4bit`, `8bit`, `bf16`, `mxfp4`, `mxfp8`, or `nvfp4`). The head is prefetched even
+without `--mtp`, and remains separate from the base weights so the normal model loader cannot
+ingest it accidentally.
 
 ```bash
 # model dir must contain mtp.safetensors next to the base weights
 afm mlx -m Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed --mtp --port 9999
+
+# Automatically uses mlx-community/Qwen3.8-27B-MTP-4bit
+afm mlx -m mlx-community/Qwen3.8-27B-4bit --mtp --port 9999
+
+# Explicit repository, local directory, or .safetensors override
+afm mlx -m mlx-community/Qwen3.8-27B-4bit --mtp \
+  --mtp-model mlx-community/Qwen3.8-27B-MTP-4bit --port 9999
 ```
 
 ```bash
@@ -107,8 +117,12 @@ curl -s http://127.0.0.1:9999/v1/chat/completions -H 'Content-Type: application/
 }'
 ```
 
-**When the fast path engages:** same eligibility as EAGLE3 (greedy, text-only, streaming or
-non-streaming, no tools/grammar/logprobs/stop). No MTP head present → silently falls back to AR.
+**When the fast path engages:** same eligibility as EAGLE3 (greedy, text-only, serial streaming
+or non-streaming, no tools/grammar/logprobs/stop). Concurrent, continuous-batch, prefix-cache,
+and ineligible requests remain fully functional through autoregressive decoding. If `--mtp` is
+explicit and its head cannot be resolved, startup fails instead of silently running without the
+requested acceleration. Without `--mtp`, a head-prefetch failure is non-fatal so offline AR usage
+continues to work.
 
 `--mtp-depth N` is accepted for compatibility but **not used** (the loop uses the fixed
 depth-2-bonus structure from mlx-lm PR #990).
@@ -161,7 +175,7 @@ AFM_DEBUG=1 AFM_EAGLE3_PROFILE=1 afm mlx -m <gemma4-31b> --eagle3 <drafter> --po
 | Feature | Flag | Model | Speedup | Output |
 |---------|------|-------|---------|--------|
 | EAGLE3 | `--eagle3 <dir>` | dense Gemma4-31B | ~+30% decode | lossless (== greedy AR) |
-| MTP | `--mtp` | Qwen3.6 w/ `mtp.safetensors` | ~+52% decode | near-greedy (bit-exact on short gens) |
+| MTP | `--mtp` | Qwen3.6 sidecar or Qwen3.8 matching head | serial decode acceleration | near-greedy (bit-exact on short gens) |
 | SDPA backport | (build-time) | any | ~+10% @16k | correct at all depths |
 | Eager think-tag | (auto) | thinking models | TTFT 610→346ms | unchanged |
 | Kernel prewarm | (auto) | any | faster cold token | unchanged |

--- a/macafm/__init__.py
+++ b/macafm/__init__.py
@@ -13,7 +13,7 @@ Requirements:
 - Apple Intelligence enabled in System Settings
 """
 
-__version__ = "0.9.16"
+__version__ = "0.9.17"
 __author__ = "Sylvain Cousineau"
 
 from .cli import main, get_binary_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macafm"
-version = "0.9.16"
+version = "0.9.17"
 description = "Access Apple's on-device Foundation Models via CLI and OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- automatically resolve and download the matching Qwen 3.8 MTP sidecar
- match the sidecar quantization to the selected base model and support an explicit override
- wire sidecar resources through AFMKit and the MLX runtime
- bump the development version to 0.9.17
- add resolver, runtime, and build-info coverage

## Notes
- `--mtp` enables use of the resolved sidecar
- the matching small sidecar is prefetched even when MTP is not enabled
- `--no-thinking` and reasoning configuration remain independent of MTP resolution

## Test coverage
- unit coverage for sidecar selection, quant matching, override behavior, and runtime wiring
- release validation is required again after rebasing onto current `main`

This PR is intentionally ready for review and has not been merged.

## Summary by Sourcery

Add automatic resolution, download, and wiring of Qwen 3.8 MTP sidecar heads into the MLX runtime, including quantization matching and explicit overrides, while keeping non-MTP decode modes and concurrency unaffected.

New Features:
- Support automatic selection and download of the Qwen3.8 MTP head that matches a base checkpoint’s quantization using config-based detection.
- Expose an `mtpModelID` configuration/CLI option to override the automatically selected MTP head with a repo, local directory, or .safetensors file.
- Prefetch compatible Qwen3.8 MTP heads during model load so later `--mtp` runs can operate offline without impacting normal autoregressive usage.

Bug Fixes:
- Ensure MTP runtime state is cleared on model switches and service cleanup to avoid leaking speculative heads across models.
- Prevent silent fallback to autoregressive decode when `--mtp` is explicitly requested but a compatible MTP head cannot be resolved or loaded.

Enhancements:
- Wire MTP sidecar resolution and quantization into AFMKit, MLXModelService, AFMMLXRuntime, and FoundationModels executors while preserving concurrent and prefix-cache decode paths.
- Update Qwen MoE MTP head loading to consume the sidecar’s explicit quantization layout, including group size, bits, and mode.
- Improve decode optimization docs to cover Qwen3.8 MTP behavior, automatic head selection, override usage, and interaction with concurrency and prefix caching.

Build:
- Harden the `swiftpm-reliable.sh` helper to invalidate non-testable Release products when transitioning from `build` to `test`, working around Xcode 27’s SwiftPM testing reuse issue.

Documentation:
- Refresh README speculative decoding section and decode-optimizations guide to describe Qwen3.8 MTP support, automatic head prefetch, and the `--mtp-model` override flag.

Tests:
- Add resolver tests for Qwen3.8 MTP repository ID selection, sidecar quantization reading, and legacy vs standalone head resolution.
- Extend runtime tests to cover MTP configuration propagation, explicit `mtpModelID` overrides, and coexistence with concurrent batch and prefix-cache settings.
- Update build-info tests to validate the new development version string.

Chores:
- Bump the library and Python package versions to v0.9.17 across BuildInfo, macafm, and pyproject metadata.