### PR TITLE
Align nightly version reporting across installers

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,7 +89,10 @@ jobs:
         # Set release tag for unique naming
         RELEASE_TAG="nightly-${BUILD_DATE}-${SHORT_SHA}"
         echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
-        VERSION="0.9.5-next.${SHORT_SHA}.${BUILD_DATE}"
+        BASE_VERSION=$(Scripts/nightly-version.sh --field base)
+        VERSION=$(Scripts/nightly-version.sh \
+          --base-version "$BASE_VERSION" --date "$BUILD_DATE" --sha "$SHORT_SHA" \
+          --field canonical)
         echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
         echo "PREV_SHA=${PREV_SHA:-first build}" >> "$GITHUB_ENV"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,10 @@ Preserve bulky release-validation output without burdening clones by attaching o
 
 Verify the archive with `shasum -a 256` and `tar -tzf`, check existing assets with `gh release view v<VERSION> --repo scouzi1966/maclocal-api --json assets`, upload with `gh release upload v<VERSION> /tmp/afm-v<VERSION>-test-reports.tar.gz --repo scouzi1966/maclocal-api`, and verify the live asset afterward. Keep reports and archives untracked. Release assets are optional downloads and do not enter clones, source archives, Homebrew installs, or pip installs. Use Actions artifacts only for temporary output; use a separate reports repository with GitHub Pages when permanent browser-rendered HTML is required.
 
+## Nightly Version Contract
+
+Resolve nightly identifiers with `Scripts/nightly-version.sh`; do not assemble them independently in release scripts. Homebrew and every installed `afm --version` must report the canonical `v<base>-next.<YYYYMMDD>.<sha>` value. Python distribution metadata uses the equivalent PEP 440 form `<base>.dev<YYYYMMDD>+<sha>`, because the canonical display value is not a valid Python package version. `Scripts/build-nightly-wheel.sh` must smoke-test the bundled command and fail unless its runtime version exactly matches the canonical Homebrew version.
+
 ## Commit & Pull Request Guidelines
 Recent history favors short, imperative subjects such as `Fix prefix cache save path` or `Add unit test tier`. Prefer `Add`, `Fix`, `Update`, or `Restore`, and keep the subject focused on user-visible behavior. PRs should describe the problem, the approach, and validation performed; link the issue when applicable and include screenshots only for WebUI or report-facing changes.
 

--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -65,9 +65,9 @@ cleanup() {
     else
         rm -f setup.py
     fi
+    rm -rf macafm_next.egg-info
     if [ -d "$METADATA_BACKUP/macafm_next.egg-info" ]; then
-        mkdir -p macafm_next.egg-info
-        cp -R "$METADATA_BACKUP/macafm_next.egg-info/." macafm_next.egg-info/
+        cp -R "$METADATA_BACKUP/macafm_next.egg-info" macafm_next.egg-info
     fi
     rm -rf macafm_next/bin macafm_next/share "$WHEEL_SMOKE" "$METADATA_BACKUP"
 }

--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -227,7 +227,7 @@ rm -rf "$WHEEL_SMOKE"
 echo "[INFO] Verified wheel metadata version: $ACTUAL_PYTHON_VERSION"
 echo "[INFO] Verified wheel runtime version: $ACTUAL_VERSION"
 if ! unzip -Z1 "$WHL" | grep -E \
-    '^macafm_next/bin/MacLocalAPI_AFMKit\.bundle/(Evals/|Contents/Resources/Evals/)comprehensive\.json$' \
+    '(^|/)macafm_next/bin/MacLocalAPI_AFMKit\.bundle/(Evals/|Contents/Resources/Evals/)comprehensive\.json$' \
     >/dev/null; then
     echo "[ERROR] Wheel is missing the bundled comprehensive evaluation suite"
     exit 1

--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -44,19 +44,23 @@ fi
 echo "[INFO] Nightly display version: ${BUILD_VERSION}"
 echo "[INFO] Nightly Python version: ${PYTHON_VERSION}"
 
-METADATA_BACKUP="$REPO_ROOT/.build/afm-next-wheel-metadata"
-rm -rf "$METADATA_BACKUP"
-mkdir -p "$METADATA_BACKUP"
+mkdir -p "$REPO_ROOT/.build"
+METADATA_BACKUP=$(mktemp -d "$REPO_ROOT/.build/afm-next-wheel-metadata.XXXXXX")
 cp macafm_next/__init__.py "$METADATA_BACKUP/__init__.py"
 cp pyproject-next.toml "$METADATA_BACKUP/pyproject-next.toml"
 cp pyproject.toml "$METADATA_BACKUP/pyproject.toml"
-cp -R macafm_next.egg-info "$METADATA_BACKUP/macafm_next.egg-info"
+if [ -d macafm_next.egg-info ]; then
+    cp -R macafm_next.egg-info "$METADATA_BACKUP/macafm_next.egg-info"
+fi
 
 cleanup() {
     cp "$METADATA_BACKUP/__init__.py" macafm_next/__init__.py 2>/dev/null || true
     cp "$METADATA_BACKUP/pyproject-next.toml" pyproject-next.toml 2>/dev/null || true
     cp "$METADATA_BACKUP/pyproject.toml" pyproject.toml 2>/dev/null || true
-    cp -R "$METADATA_BACKUP/macafm_next.egg-info/." macafm_next.egg-info/ 2>/dev/null || true
+    if [ -d "$METADATA_BACKUP/macafm_next.egg-info" ]; then
+        mkdir -p macafm_next.egg-info
+        cp -R "$METADATA_BACKUP/macafm_next.egg-info/." macafm_next.egg-info/
+    fi
     rm -rf macafm_next/bin macafm_next/share "$WHEEL_SMOKE" "$METADATA_BACKUP"
 }
 WHEEL_SMOKE=""
@@ -134,9 +138,7 @@ unzip -p "$WHL" macafm_next/share/webui/index.html.gz > "$WHEEL_WEBUI"
 "$REPO_ROOT/Scripts/verify-webui.sh" "$WHEEL_WEBUI"
 rm -f "$WHEEL_WEBUI"
 
-WHEEL_SMOKE="$REPO_ROOT/.build/afm-next-wheel-smoke"
-rm -rf "$WHEEL_SMOKE"
-mkdir -p "$WHEEL_SMOKE"
+WHEEL_SMOKE=$(mktemp -d "$REPO_ROOT/.build/afm-next-wheel-smoke.XXXXXX")
 unzip -q "$WHL" -d "$WHEEL_SMOKE"
 WHEEL_METADATA=$(find "$WHEEL_SMOKE" -path '*.dist-info/METADATA' -print -quit)
 ACTUAL_PYTHON_VERSION=$(awk '/^Version: / { print $2; exit }' "$WHEEL_METADATA")

--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -144,7 +144,8 @@ if [ "$ACTUAL_PYTHON_VERSION" != "$PYTHON_VERSION" ]; then
     echo "[ERROR] Wheel metadata reports '$ACTUAL_PYTHON_VERSION'; expected '$PYTHON_VERSION'"
     exit 1
 fi
-ACTUAL_VERSION=$(AFM_BUILD_VERSION="v-invalid-host-override" PYTHONPATH="$WHEEL_SMOKE" \
+ACTUAL_VERSION=$(cd "$WHEEL_SMOKE" && \
+    AFM_BUILD_VERSION="v-invalid-host-override" PYTHONPATH="$WHEEL_SMOKE" \
     python3 -c 'from macafm_next.cli import main; main()' --version)
 EXPECTED_VERSION="v${BUILD_VERSION#v}"
 if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then

--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -6,7 +6,7 @@
 #   ./Scripts/build-nightly-wheel.sh [--version BASE_VERSION]
 #       [--build-version CANONICAL_VERSION] [--python-version PEP440_VERSION]
 #
-# The wheel is written to dist/macafm_next-VERSION-py3-none-macosx_14_0_arm64.whl
+# The wheel is written to dist/macafm_next-VERSION-py3-none-macosx_26_0_arm64.whl
 # Python metadata uses a PEP 440 dev version while the bundled command reports
 # the canonical Homebrew/nightly display version.
 #
@@ -49,6 +49,9 @@ METADATA_BACKUP=$(mktemp -d "$REPO_ROOT/.build/afm-next-wheel-metadata.XXXXXX")
 cp macafm_next/__init__.py "$METADATA_BACKUP/__init__.py"
 cp pyproject-next.toml "$METADATA_BACKUP/pyproject-next.toml"
 cp pyproject.toml "$METADATA_BACKUP/pyproject.toml"
+if [ -f setup.py ]; then
+    cp setup.py "$METADATA_BACKUP/setup.py"
+fi
 if [ -d macafm_next.egg-info ]; then
     cp -R macafm_next.egg-info "$METADATA_BACKUP/macafm_next.egg-info"
 fi
@@ -57,6 +60,11 @@ cleanup() {
     cp "$METADATA_BACKUP/__init__.py" macafm_next/__init__.py 2>/dev/null || true
     cp "$METADATA_BACKUP/pyproject-next.toml" pyproject-next.toml 2>/dev/null || true
     cp "$METADATA_BACKUP/pyproject.toml" pyproject.toml 2>/dev/null || true
+    if [ -f "$METADATA_BACKUP/setup.py" ]; then
+        cp "$METADATA_BACKUP/setup.py" setup.py 2>/dev/null || true
+    else
+        rm -f setup.py
+    fi
     if [ -d "$METADATA_BACKUP/macafm_next.egg-info" ]; then
         mkdir -p macafm_next.egg-info
         cp -R "$METADATA_BACKUP/macafm_next.egg-info/." macafm_next.egg-info/
@@ -112,9 +120,30 @@ echo "[INFO] Included webui"
 # Use pyproject-next.toml by temporarily swapping it in.
 cp pyproject-next.toml pyproject.toml
 
+# The package embeds a macOS arm64 executable and Metal resources. Setuptools
+# otherwise classifies the declarative Python wrapper as a pure, cross-platform
+# wheel (`py3-none-any`), allowing pip to install an unusable payload elsewhere.
+cat > setup.py <<'PY'
+from setuptools import setup
+from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
+
+
+class AFMBinaryWheel(_bdist_wheel):
+    def finalize_options(self):
+        super().finalize_options()
+        self.root_is_pure = False
+
+    def get_tag(self):
+        _, _, platform = super().get_tag()
+        return "py3", "none", platform
+
+
+setup(cmdclass={"bdist_wheel": AFMBinaryWheel})
+PY
+
 echo "[INFO] Building wheel..."
 rm -rf dist/macafm_next-*
-uv build --wheel 2>&1
+_PYTHON_HOST_PLATFORM=macosx-26.0-arm64 uv build --wheel 2>&1
 
 # ---------- clean staged assets ----------
 rm -rf macafm_next/bin macafm_next/share
@@ -126,6 +155,13 @@ if [ -z "$WHL" ]; then
     echo "[ERROR] No wheel found in dist/"
     exit 1
 fi
+case "$(basename "$WHL")" in
+    *-py3-none-macosx_26_0_arm64.whl) ;;
+    *)
+        echo "[ERROR] Wheel is not restricted to macOS 26 arm64: $WHL"
+        exit 1
+        ;;
+esac
 WHL_SIZE=$(du -m "$WHL" | cut -f1)
 echo "[INFO] Wheel: $WHL (${WHL_SIZE}MB)"
 if [ "$WHL_SIZE" -lt 1 ]; then
@@ -134,20 +170,32 @@ if [ "$WHL_SIZE" -lt 1 ]; then
 fi
 
 WHEEL_WEBUI="$REPO_ROOT/.build/afm-next-wheel-webui.html.gz"
-unzip -p "$WHL" macafm_next/share/webui/index.html.gz > "$WHEEL_WEBUI"
+WHEEL_WEBUI_ENTRY=$(unzip -Z1 "$WHL" \
+    | awk '/(^|\/)macafm_next\/share\/webui\/index.html.gz$/ { print; exit }')
+if [ -z "$WHEEL_WEBUI_ENTRY" ]; then
+    echo "[ERROR] Wheel does not contain the required WebUI"
+    exit 1
+fi
+unzip -p "$WHL" "$WHEEL_WEBUI_ENTRY" > "$WHEEL_WEBUI"
 "$REPO_ROOT/Scripts/verify-webui.sh" "$WHEEL_WEBUI"
 rm -f "$WHEEL_WEBUI"
 
 WHEEL_SMOKE=$(mktemp -d "$REPO_ROOT/.build/afm-next-wheel-smoke.XXXXXX")
-unzip -q "$WHL" -d "$WHEEL_SMOKE"
-WHEEL_METADATA=$(find "$WHEEL_SMOKE" -path '*.dist-info/METADATA' -print -quit)
+python3 -m pip install --quiet --no-deps --no-compile \
+    --target "$WHEEL_SMOKE/site" "$WHL"
+WHEEL_METADATA=$(find "$WHEEL_SMOKE/site" -path '*.dist-info/METADATA' -print -quit)
 ACTUAL_PYTHON_VERSION=$(awk '/^Version: / { print $2; exit }' "$WHEEL_METADATA")
 if [ "$ACTUAL_PYTHON_VERSION" != "$PYTHON_VERSION" ]; then
     echo "[ERROR] Wheel metadata reports '$ACTUAL_PYTHON_VERSION'; expected '$PYTHON_VERSION'"
     exit 1
 fi
-ACTUAL_VERSION=$(cd "$WHEEL_SMOKE" && \
-    AFM_BUILD_VERSION="v-invalid-host-override" PYTHONPATH="$WHEEL_SMOKE" \
+WHEEL_DESCRIPTOR=$(find "$WHEEL_SMOKE/site" -path '*.dist-info/WHEEL' -print -quit)
+if ! grep -Fxq 'Root-Is-Purelib: false' "$WHEEL_DESCRIPTOR"; then
+    echo "[ERROR] Wheel metadata still marks the native payload as pure"
+    exit 1
+fi
+ACTUAL_VERSION=$(cd "$WHEEL_SMOKE/site" && \
+    AFM_BUILD_VERSION="v-invalid-host-override" PYTHONPATH="$WHEEL_SMOKE/site" \
     python3 -c 'from macafm_next.cli import main; main()' --version)
 EXPECTED_VERSION="v${BUILD_VERSION#v}"
 if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then

--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -4,9 +4,11 @@
 #
 # Usage:
 #   ./Scripts/build-nightly-wheel.sh [--version BASE_VERSION]
+#       [--build-version CANONICAL_VERSION] [--python-version PEP440_VERSION]
 #
 # The wheel is written to dist/macafm_next-VERSION-py3-none-macosx_14_0_arm64.whl
-# VERSION defaults to <BuildInfo version>.dev<YYYYMMDD> (PEP 440 dev release).
+# Python metadata uses a PEP 440 dev version while the bundled command reports
+# the canonical Homebrew/nightly display version.
 #
 set -euo pipefail
 
@@ -15,9 +17,13 @@ cd "$REPO_ROOT"
 
 # ---------- parse args ----------
 BASE_VERSION=""
+BUILD_VERSION=""
+PYTHON_VERSION=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --version) BASE_VERSION="$2"; shift 2 ;;
+        --build-version) BUILD_VERSION="$2"; shift 2 ;;
+        --python-version) PYTHON_VERSION="$2"; shift 2 ;;
         *) echo "Unknown arg: $1"; exit 1 ;;
     esac
 done
@@ -27,9 +33,34 @@ if [ -z "$BASE_VERSION" ]; then
     BASE_VERSION=$(grep 'static let version' Sources/AFMKit/BuildInfo.swift \
         | sed 's/.*"\(.*\)".*/\1/' | sed 's/^v//')
 fi
-DATE=$(date -u +%Y%m%d)
-DEV_VERSION="${BASE_VERSION}.dev${DATE}"
-echo "[INFO] Nightly wheel version: ${DEV_VERSION}"
+if [ -z "$BUILD_VERSION" ]; then
+    BUILD_VERSION=$("$REPO_ROOT/Scripts/nightly-version.sh" \
+        --base-version "$BASE_VERSION" --field canonical)
+fi
+if [ -z "$PYTHON_VERSION" ]; then
+    PYTHON_VERSION=$("$REPO_ROOT/Scripts/nightly-version.sh" \
+        --base-version "$BASE_VERSION" --field python)
+fi
+echo "[INFO] Nightly display version: ${BUILD_VERSION}"
+echo "[INFO] Nightly Python version: ${PYTHON_VERSION}"
+
+METADATA_BACKUP="$REPO_ROOT/.build/afm-next-wheel-metadata"
+rm -rf "$METADATA_BACKUP"
+mkdir -p "$METADATA_BACKUP"
+cp macafm_next/__init__.py "$METADATA_BACKUP/__init__.py"
+cp pyproject-next.toml "$METADATA_BACKUP/pyproject-next.toml"
+cp pyproject.toml "$METADATA_BACKUP/pyproject.toml"
+cp -R macafm_next.egg-info "$METADATA_BACKUP/macafm_next.egg-info"
+
+cleanup() {
+    cp "$METADATA_BACKUP/__init__.py" macafm_next/__init__.py 2>/dev/null || true
+    cp "$METADATA_BACKUP/pyproject-next.toml" pyproject-next.toml 2>/dev/null || true
+    cp "$METADATA_BACKUP/pyproject.toml" pyproject.toml 2>/dev/null || true
+    cp -R "$METADATA_BACKUP/macafm_next.egg-info/." macafm_next.egg-info/ 2>/dev/null || true
+    rm -rf macafm_next/bin macafm_next/share "$WHEEL_SMOKE" "$METADATA_BACKUP"
+}
+WHEEL_SMOKE=""
+trap cleanup EXIT
 
 # ---------- locate binary ----------
 BIN=".build/arm64-apple-macosx/release/afm"
@@ -47,8 +78,9 @@ fi
 "$REPO_ROOT/Scripts/check-macos26-compatibility.sh" "$BIN" "$METALLIB"
 
 # ---------- set version in package files ----------
-sed -i '' "s/^__version__ = .*/__version__ = \"${DEV_VERSION}\"/" macafm_next/__init__.py
-sed -i '' "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject-next.toml
+sed -i '' "s/^__version__ = .*/__version__ = \"${PYTHON_VERSION}\"/" macafm_next/__init__.py
+sed -i '' "s/^__build_version__ = .*/__build_version__ = \"${BUILD_VERSION}\"/" macafm_next/__init__.py
+sed -i '' "s/^version = .*/version = \"${PYTHON_VERSION}\"/" pyproject-next.toml
 
 # ---------- stage assets ----------
 echo "[INFO] Staging assets into macafm_next/"
@@ -73,16 +105,12 @@ cp Resources/webui/index.html.gz macafm_next/share/webui/
 echo "[INFO] Included webui"
 
 # ---------- build wheel ----------
-# Use pyproject-next.toml by temporarily swapping it in
-cp pyproject.toml pyproject.toml.bak
+# Use pyproject-next.toml by temporarily swapping it in.
 cp pyproject-next.toml pyproject.toml
 
 echo "[INFO] Building wheel..."
 rm -rf dist/macafm_next-*
 uv build --wheel 2>&1
-
-# Restore original pyproject.toml
-mv pyproject.toml.bak pyproject.toml
 
 # ---------- clean staged assets ----------
 rm -rf macafm_next/bin macafm_next/share
@@ -105,5 +133,26 @@ WHEEL_WEBUI="$REPO_ROOT/.build/afm-next-wheel-webui.html.gz"
 unzip -p "$WHL" macafm_next/share/webui/index.html.gz > "$WHEEL_WEBUI"
 "$REPO_ROOT/Scripts/verify-webui.sh" "$WHEEL_WEBUI"
 rm -f "$WHEEL_WEBUI"
+
+WHEEL_SMOKE="$REPO_ROOT/.build/afm-next-wheel-smoke"
+rm -rf "$WHEEL_SMOKE"
+mkdir -p "$WHEEL_SMOKE"
+unzip -q "$WHL" -d "$WHEEL_SMOKE"
+WHEEL_METADATA=$(find "$WHEEL_SMOKE" -path '*.dist-info/METADATA' -print -quit)
+ACTUAL_PYTHON_VERSION=$(awk '/^Version: / { print $2; exit }' "$WHEEL_METADATA")
+if [ "$ACTUAL_PYTHON_VERSION" != "$PYTHON_VERSION" ]; then
+    echo "[ERROR] Wheel metadata reports '$ACTUAL_PYTHON_VERSION'; expected '$PYTHON_VERSION'"
+    exit 1
+fi
+ACTUAL_VERSION=$(AFM_BUILD_VERSION="v-invalid-host-override" PYTHONPATH="$WHEEL_SMOKE" \
+    python3 -c 'from macafm_next.cli import main; main()' --version)
+EXPECTED_VERSION="v${BUILD_VERSION#v}"
+if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+    echo "[ERROR] Wheel reports '$ACTUAL_VERSION'; expected '$EXPECTED_VERSION'"
+    exit 1
+fi
+rm -rf "$WHEEL_SMOKE"
+echo "[INFO] Verified wheel metadata version: $ACTUAL_PYTHON_VERSION"
+echo "[INFO] Verified wheel runtime version: $ACTUAL_VERSION"
 
 echo "[INFO] Done. Wheel ready: $WHL"

--- a/Scripts/nightly-version.sh
+++ b/Scripts/nightly-version.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Resolve all identifiers for one AFM nightly from a single input tuple.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BASE_VERSION=""
+BUILD_DATE="$(date -u +%Y%m%d)"
+SHORT_SHA="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
+FIELD="canonical"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base-version) BASE_VERSION="$2"; shift 2 ;;
+        --date) BUILD_DATE="$2"; shift 2 ;;
+        --sha) SHORT_SHA="$2"; shift 2 ;;
+        --field) FIELD="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$BASE_VERSION" ]]; then
+    BASE_VERSION=$(grep 'static let version' "$ROOT_DIR/Sources/AFMKit/BuildInfo.swift" \
+        | sed 's/.*"\(.*\)".*/\1/' | sed 's/^v//')
+fi
+BASE_VERSION="${BASE_VERSION#v}"
+
+if [[ ! "$BASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Invalid base version: $BASE_VERSION" >&2
+    exit 1
+fi
+if [[ ! "$BUILD_DATE" =~ ^[0-9]{8}$ ]]; then
+    echo "Invalid nightly date: $BUILD_DATE" >&2
+    exit 1
+fi
+if [[ ! "$SHORT_SHA" =~ ^[0-9a-fA-F]+$ ]]; then
+    echo "Invalid commit identifier: $SHORT_SHA" >&2
+    exit 1
+fi
+SHORT_SHA=$(printf '%s' "$SHORT_SHA" | tr '[:upper:]' '[:lower:]')
+
+CANONICAL_VERSION="${BASE_VERSION}-next.${BUILD_DATE}.${SHORT_SHA}"
+PYTHON_VERSION="${BASE_VERSION}.dev${BUILD_DATE}+${SHORT_SHA}"
+RELEASE_TAG="nightly-${BUILD_DATE}-${SHORT_SHA}"
+
+case "$FIELD" in
+    base) printf '%s\n' "$BASE_VERSION" ;;
+    canonical) printf '%s\n' "$CANONICAL_VERSION" ;;
+    python) printf '%s\n' "$PYTHON_VERSION" ;;
+    tag) printf '%s\n' "$RELEASE_TAG" ;;
+    env)
+        printf 'AFM_NIGHTLY_BASE_VERSION=%s\n' "$BASE_VERSION"
+        printf 'AFM_NIGHTLY_VERSION=%s\n' "$CANONICAL_VERSION"
+        printf 'AFM_NIGHTLY_PYTHON_VERSION=%s\n' "$PYTHON_VERSION"
+        printf 'AFM_NIGHTLY_TAG=%s\n' "$RELEASE_TAG"
+        ;;
+    *) echo "Unknown field: $FIELD" >&2; exit 1 ;;
+esac

--- a/Scripts/publish-next.sh
+++ b/Scripts/publish-next.sh
@@ -282,7 +282,8 @@ EOF
   --target main \
   --repo "$REPO" \
   "$TARBALL" \
-  "$TARBALL.sha256"
+  "$TARBALL.sha256" \
+  "$NIGHTLY_WHEEL"
 
 log_info "Release uploaded: $RELEASE_TAG"
 
@@ -290,7 +291,19 @@ log_info "Release uploaded: $RELEASE_TAG"
 git tag -f nightly HEAD
 git push origin nightly --force 2>/dev/null || true
 
-# Step 6: Update tap formula
+# Step 6: Publish the already-attached wheel through the PEP 503 index. Do this
+# before updating Homebrew so every advertised installer has a resolvable asset.
+cd "$ROOT_DIR"
+if [ ! -x "$SCRIPT_DIR/update-wheel-index.sh" ]; then
+  log_error "Required update-wheel-index.sh not found"
+  exit 1
+fi
+log_info "Updating the nightly wheel index..."
+"$SCRIPT_DIR/update-wheel-index.sh" "$NIGHTLY_WHEEL" "$RELEASE_TAG" --skip-upload
+
+# Step 7: Update tap formula only after both GitHub assets and the pip index are
+# available. Cross-repository publication cannot be fully atomic, but this
+# ordering avoids exposing a Homebrew release with a missing pip counterpart.
 log_info "Updating tap formula..."
 SHA256=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
 
@@ -307,9 +320,8 @@ if ! grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm-
   exit 1
 fi
 
-# Also emit a pinned versioned formula (afm-next@YYYYMMDD.rb) and prune older nightlies
-# beyond the last 10. This lets users do `brew install scouzi1966/afm/afm-next@20260408`
-# for reproducible installs.
+# Also emit a pinned versioned formula and prune older nightlies beyond the
+# last 10. This lets users install a reproducible dated build.
 cd "$ROOT_DIR"
 if [ -x "$SCRIPT_DIR/generate-tap-versioned.sh" ]; then
   log_info "Generating versioned nightly formula afm-next@${DATE}.rb"
@@ -318,22 +330,13 @@ if [ -x "$SCRIPT_DIR/generate-tap-versioned.sh" ]; then
 fi
 cd "$TAP_DIR"
 
-git add afm-next.rb "afm-next@${VERSION}.rb" 2>/dev/null || true
-# If prune removed older files, stage the deletions too
-git add -u .
+# Stage only the formula family owned by this publisher, including pruned
+# versioned formula deletions. Never absorb unrelated tap worktree changes.
+git add -A -- afm-next.rb ':(glob)afm-next@*.rb'
 git commit -m "afm-next ${VERSION} (${SHORT_SHA}) + pinned afm-next@${DATE}"
 git push
 
 log_info "Tap updated"
-
-# Step 7: Upload the already-validated wheel and update the PEP 503 index
-cd "$ROOT_DIR"
-if [ ! -x "$SCRIPT_DIR/update-wheel-index.sh" ]; then
-  log_error "Required update-wheel-index.sh not found"
-  exit 1
-fi
-log_info "Uploading validated wheel and updating index..."
-"$SCRIPT_DIR/update-wheel-index.sh" "$NIGHTLY_WHEEL" "$RELEASE_TAG"
 
 # Cleanup
 rm -rf "$STAGING"

--- a/Scripts/publish-next.sh
+++ b/Scripts/publish-next.sh
@@ -96,7 +96,12 @@ else
   fi
   BASE_VERSION="${BASE_VERSION:-0.0.0}"
 fi
-VERSION="${BASE_VERSION}-next.${DATE}.${SHORT_SHA}"
+VERSION=$("$SCRIPT_DIR/nightly-version.sh" \
+  --base-version "$BASE_VERSION" --date "$DATE" --sha "$SHORT_SHA" --field canonical)
+PYTHON_VERSION=$("$SCRIPT_DIR/nightly-version.sh" \
+  --base-version "$BASE_VERSION" --date "$DATE" --sha "$SHORT_SHA" --field python)
+RELEASE_TAG=$("$SCRIPT_DIR/nightly-version.sh" \
+  --base-version "$BASE_VERSION" --date "$DATE" --sha "$SHORT_SHA" --field tag)
 
 log_info "Building afm-next"
 log_info "  Commit: ${SHORT_SHA}"
@@ -190,6 +195,24 @@ tar -xOzf "$TARBALL" ./Resources/webui/index.html.gz > "$ARCHIVE_WEBUI"
 "$SCRIPT_DIR/verify-webui.sh" "$ARCHIVE_WEBUI"
 rm -f "$ARCHIVE_WEBUI"
 
+# Build and verify the pip payload before any GitHub or Homebrew publication.
+# The wheel smoke test asserts that its bundled `afm --version` exactly matches
+# the canonical version written to the Homebrew formula.
+if [ ! -x "$SCRIPT_DIR/build-nightly-wheel.sh" ]; then
+  log_error "Required build-nightly-wheel.sh not found"
+  exit 1
+fi
+log_info "Building and validating nightly wheel..."
+"$SCRIPT_DIR/build-nightly-wheel.sh" \
+  --version "$BASE_VERSION" \
+  --build-version "$VERSION" \
+  --python-version "$PYTHON_VERSION"
+NIGHTLY_WHEEL=$(find "$ROOT_DIR/dist" -maxdepth 1 -name 'macafm_next-*.whl' -print -quit)
+if [ -z "$NIGHTLY_WHEEL" ]; then
+  log_error "Validated nightly wheel was not found"
+  exit 1
+fi
+
 # Step 4: Generate changelog
 log_info "Generating changelog..."
 if [ -n "$SINCE_SHA" ]; then
@@ -211,7 +234,6 @@ else
 fi
 
 # Step 5: Upload to GitHub release (unique tag per build, keep history)
-RELEASE_TAG="nightly-${DATE}-${SHORT_SHA}"
 log_info "Creating release: $RELEASE_TAG"
 gh release create "$RELEASE_TAG" \
   --prerelease \
@@ -304,19 +326,14 @@ git push
 
 log_info "Tap updated"
 
-# Step 7: Build nightly wheel and update PEP 503 index
+# Step 7: Upload the already-validated wheel and update the PEP 503 index
 cd "$ROOT_DIR"
-if [ -x "$SCRIPT_DIR/build-nightly-wheel.sh" ]; then
-  log_info "Building nightly wheel..."
-  "$SCRIPT_DIR/build-nightly-wheel.sh" --version "$BASE_VERSION"
-  WHL=$(ls dist/macafm_next-*.whl 2>/dev/null | head -1)
-  if [ -n "$WHL" ] && [ -x "$SCRIPT_DIR/update-wheel-index.sh" ]; then
-    log_info "Uploading wheel and updating index..."
-    "$SCRIPT_DIR/update-wheel-index.sh" "$WHL" "$RELEASE_TAG"
-  fi
-else
-  log_warn "build-nightly-wheel.sh not found, skipping wheel"
+if [ ! -x "$SCRIPT_DIR/update-wheel-index.sh" ]; then
+  log_error "Required update-wheel-index.sh not found"
+  exit 1
 fi
+log_info "Uploading validated wheel and updating index..."
+"$SCRIPT_DIR/update-wheel-index.sh" "$NIGHTLY_WHEEL" "$RELEASE_TAG"
 
 # Cleanup
 rm -rf "$STAGING"

--- a/Scripts/update-wheel-index.sh
+++ b/Scripts/update-wheel-index.sh
@@ -3,7 +3,7 @@
 # Add a new nightly wheel to the PEP 503 simple index and deploy it.
 #
 # Usage:
-#   ./Scripts/update-wheel-index.sh <wheel-file> <release-tag> [--no-deploy]
+#   ./Scripts/update-wheel-index.sh <wheel-file> <release-tag> [--no-deploy] [--skip-upload]
 #
 # Example:
 #   ./Scripts/update-wheel-index.sh dist/macafm_next-0.9.13.dev20260621-py3-none-any.whl nightly-20260621-97e6683
@@ -25,17 +25,19 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 DEPLOY=true
+UPLOAD=true
 POSITIONAL=()
 for arg in "$@"; do
     case "$arg" in
         --no-deploy) DEPLOY=false ;;
+        --skip-upload) UPLOAD=false ;;
         *) POSITIONAL+=("$arg") ;;
     esac
 done
 set -- "${POSITIONAL[@]:-}"
 
 if [ $# -lt 2 ]; then
-    echo "Usage: $0 <wheel-file> <release-tag> [--no-deploy]"
+    echo "Usage: $0 <wheel-file> <release-tag> [--no-deploy] [--skip-upload]"
     exit 1
 fi
 
@@ -61,8 +63,14 @@ if [ ! -f "$WHL_PATH" ]; then
 fi
 
 # ---------- upload wheel to GitHub release ----------
-echo "[INFO] Uploading wheel to release ${RELEASE_TAG}..."
-gh release upload "$RELEASE_TAG" "$WHL_PATH" --repo "$REPO" --clobber
+if [ "$UPLOAD" = true ]; then
+    echo "[INFO] Uploading wheel to release ${RELEASE_TAG}..."
+    gh release upload "$RELEASE_TAG" "$WHL_PATH" --repo "$REPO" --clobber
+else
+    echo "[INFO] Wheel was attached during release creation; skipping duplicate upload"
+    gh release view "$RELEASE_TAG" --repo "$REPO" --json assets \
+        --jq '.assets[].name' | grep -Fxq "$WHL_NAME"
+fi
 
 WHEEL_URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${WHL_NAME}"
 echo "[INFO] Wheel URL: ${WHEEL_URL}"

--- a/macafm_next/__init__.py
+++ b/macafm_next/__init__.py
@@ -10,9 +10,10 @@ Requirements:
 - Apple Intelligence enabled in System Settings
 """
 
-__version__ = "0.9.14.dev0"
+__version__ = "0.9.17.dev0"
+__build_version__ = "0.9.17-next.dev"
 __author__ = "Sylvain Cousineau"
 
 from .cli import main, get_binary_path
 
-__all__ = ["main", "get_binary_path", "__version__"]
+__all__ = ["main", "get_binary_path", "__version__", "__build_version__"]

--- a/macafm_next/cli.py
+++ b/macafm_next/cli.py
@@ -49,7 +49,10 @@ def main():
 
     try:
         environment = os.environ.copy()
-        environment["AFM_BUILD_VERSION"] = f"v{__build_version__.removeprefix('v')}"
+        build_version = __build_version__
+        if build_version.startswith("v"):
+            build_version = build_version[1:]
+        environment["AFM_BUILD_VERSION"] = f"v{build_version}"
         result = subprocess.run([str(binary)] + sys.argv[1:], env=environment)
         sys.exit(result.returncode)
     except KeyboardInterrupt:

--- a/macafm_next/cli.py
+++ b/macafm_next/cli.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from . import __build_version__
+
 
 def get_binary_path() -> Path:
     """Return the path to the afm binary (bundled, Homebrew, or PATH)."""
@@ -46,7 +48,9 @@ def main():
         os.chmod(binary, 0o755)
 
     try:
-        result = subprocess.run([str(binary)] + sys.argv[1:])
+        environment = os.environ.copy()
+        environment["AFM_BUILD_VERSION"] = f"v{__build_version__.removeprefix('v')}"
+        result = subprocess.run([str(binary)] + sys.argv[1:], env=environment)
         sys.exit(result.returncode)
     except KeyboardInterrupt:
         sys.exit(130)

--- a/pyproject-next.toml
+++ b/pyproject-next.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macafm-next"
-version = "0.9.14.dev0"
+version = "0.9.17.dev0"
 description = "Nightly build of AFM — local LLM inference on Apple Silicon via OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- derive Homebrew, GitHub, and pip nightly identifiers from one canonical resolver
- make the pip wrapper report the same canonical `afm --version` as Homebrew
- validate wheel metadata, WebUI, runtime bundles, macOS 26 compatibility, and exact runtime version before publication
- restore temporary package metadata so wheel builds leave the worktree clean
- document the nightly display/PEP 440 version contract for future agents

## Validation
- shell syntax and deterministic resolver checks passed
- real Release wheel built successfully
- wheel metadata: `0.9.17.dev20260816+bc343f6`
- bundled runtime: `v0.9.17-next.20260816.bc343f6`
- WebUI and macOS 26 compatibility checks passed
- packaging left no generated tracked changes

## Summary by Sourcery

Standardize nightly version reporting across installers and validate the packaged runtime before publication.

New Features:
- Add a shared nightly version resolver that generates canonical display, Python package, and release-tag identifiers.
- Publish validated macOS arm64 nightly wheels alongside GitHub releases and the Homebrew distribution.

Bug Fixes:
- Align the pip wrapper's reported runtime version with the canonical Homebrew nightly version.

Enhancements:
- Strengthen nightly release validation for wheel metadata, native wheel targeting, bundled runtime version, WebUI assets, and macOS compatibility.
- Preserve package metadata and avoid leaving generated changes in the worktree after wheel builds.
- Improve release ordering so wheel availability is verified before Homebrew publication and limit tap staging to owned formula files.

CI:
- Use the canonical nightly version resolver in the nightly workflow.

Deployment:
- Coordinate GitHub, pip index, and Homebrew nightly publication around the same version identifiers.

Documentation:
- Document the canonical nightly display version and its PEP 440 package-version contract.