### PR TITLE
Remove v0.9.16 infographic from main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@
 
 [![AFM v0.9.17 — four new models with standard and MTP Qwen launch commands](assets/afm-0.9.17-models-deep-dive-social-v8-mtp.png)](https://github.com/scouzi1966/maclocal-api/releases/tag/v0.9.17)
 
-### [AFM v0.9.16](https://github.com/scouzi1966/maclocal-api/releases/tag/v0.9.16)
-
-[![AFM v0.9.16 — four new models with copy-ready run commands](assets/afm-0.9.16-models-deep-dive-social-v7-command-strips.png)](https://github.com/scouzi1966/maclocal-api/releases/tag/v0.9.16)
-
 AFM turns an Apple Silicon Mac into a private, OpenAI-compatible AI server. Run Hugging Face MLX models or Apple’s on-device Foundation Model, then connect the clients and SDKs you already use.
 
 - Native Swift executable—no Python runtime for serving


### PR DESCRIPTION
Removes the v0.9.16 infographic block from the main README now that v0.9.17 is current. The v0.9.16 image asset and GitHub release remain unchanged.

## Summary by Sourcery

Documentation:
- Update the main README to only highlight the v0.9.17 release infographic and remove the outdated v0.9.16 block.