### PR TITLE
Add AFMKit-aware DFlash 2 decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ Supported checkpoints can also use speculative decoding:
   separately published MTP head matching the base checkpoint's quantization;
   use `--mtp-model <repo-or-path>` to override it.
 - `--eagle3 <drafter-directory>` for supported dense Gemma4 models
+- `--dflash2 <repo-or-directory>` for metadata-matched Qwen 3.8 or Muse
+  Glimmer targets. Add `--dflash2-required` to reject ineligible requests
+  instead of falling back to autoregressive decoding.
 - `--dspark-support <support.gguf>` for compatible DwarfStar DSpark workflows
 
 Read [decode optimizations](docs/decode-optimizations.md) before choosing a checkpoint or interpreting benchmark results.

--- a/README.md
+++ b/README.md
@@ -217,8 +217,10 @@ Supported checkpoints can also use speculative decoding:
   use `--mtp-model <repo-or-path>` to override it.
 - `--eagle3 <drafter-directory>` for supported dense Gemma4 models
 - `--dflash2 <repo-or-directory>` for metadata-matched Qwen 3.8 or Muse
-  Glimmer targets. Add `--dflash2-required` to reject ineligible requests
-  instead of falling back to autoregressive decoding.
+  Glimmer targets. The fast path requires an explicit `temperature: 0`; an
+  omitted temperature keeps the normal `0.6` sampling default. Preferred mode
+  falls back to autoregressive decoding for sampling, penalties, prefix cache,
+  concurrency, and batch execution; `--dflash2-required` rejects those cases.
 - `--dspark-support <support.gguf>` for compatible DwarfStar DSpark workflows
 
 Read [decode optimizations](docs/decode-optimizations.md) before choosing a checkpoint or interpreting benchmark results.

--- a/Research/DFlash2/ARCHITECTURE.md
+++ b/Research/DFlash2/ARCHITECTURE.md
@@ -1,0 +1,217 @@
+# DFlash 2 Architecture
+
+## Verified Algorithm Contract
+
+DFlash 2 remains a one-pass block-diffusion drafter. All draft positions are
+predicted in parallel. It adds two independent mechanisms:
+
+1. A selector keeps the top candidates at each position, scores all adjacent
+   predecessor/successor pairs in parallel using a context-gated rank-256
+   bilinear score, then walks the precomputed scores to choose a path. Sampling
+   uses rejection sampling to preserve the target distribution.
+2. A block-local, stateless, dynamic depthwise convolution with two taps mixes
+   each position with its predecessor. The first draft position reads the last
+   verified token. A convolution is placed before and after attention and MLP
+   sublayers in every draft layer.
+
+The article reports the selector and convolution together add about 1.3% to a
+matched five-layer DFlash draft/verify cycle and improve mean acceptance length
+by 21% in its Qwen3.5-4B experiment. Those are upstream measurements, not
+maclocal-api or Apple-Silicon performance claims.
+
+## Released Checkpoint Contracts
+
+Both released repositories contain only `config.json`, one BF16
+`model.safetensors`, a card, and an image. They are auxiliary models, not
+standalone language models.
+
+| Field | Qwen 3.8 drafter | Muse Glimmer drafter |
+| --- | ---: | ---: |
+| `architectures[0]` | `DFlash2DraftModel` | `DFlash2DraftModel` |
+| `model_type` | `qwen3` | `qwen3` |
+| hidden size | 5120 | 6656 |
+| draft layers | 5 | 5 |
+| target layers | 64 | 52 |
+| target feature layers | 5, 19, 33, 47, 61 | 1, 13, 25, 37, 49 |
+| vocabulary | 248320 | 202048 |
+| mask token | 248070 | 201818 |
+| checkpoint block size | 8 | 16 |
+| selector top-k/rank | 16 / 256 | 16 / 256 |
+| convolution kernel/group | 2 / 16 | 2 / 16 |
+| rope theta | 10000000 | 500000 |
+| sliding window | 2048 | 2048 |
+| max positions | 262144 | 131072 |
+| final logit soft cap | absent | 20.0 |
+| output multiplier | absent | 0.19611613513818404 |
+| weight bytes | 3,848,817,896 | 5,544,328,424 |
+| revision inspected | `dedf8df68adf...` | `8336acb8dc9...` |
+
+Each checkpoint has 81 tensors. Shared DFlash 2-specific tensors include:
+
+- `candidate_selector.hidden_projection.weight`: `[256, hidden_size]`
+- predecessor/successor codebooks: `[vocab_size, 256]`
+- `fc.weight`: `[hidden_size, hidden_size * 5]`, fusing five target features
+- for every draft layer and each attention/MLP convolution:
+  - `base_kernel`: `[2, 2, hidden_size]`
+  - `kernel_projection.weight`: `[hidden_size / 4, hidden_size]`
+
+The target configs are not named the same as the draft config. Qwen 3.8's
+published target is a top-level `qwen3_5` conditional-generation model with a
+`qwen3_5_text` stack. Muse is a top-level `muse_glimmer` model with a
+`muse_glimmer_text` stack. Compatibility must therefore compare normalized
+target text metadata and dimensions, not require identical `model_type` values.
+
+The checkpoint block size is not automatically the server's draft-token count.
+The Qwen card describes block size 8 as seven drafted tokens plus a verifier
+token, while one SGLang example passes 8 and vLLM passes 7. oMLX exposes a
+separate runtime block setting and the article recommends 5 for its Qwen demo.
+The runtime API must name and validate these quantities unambiguously.
+
+## Runtime Primitive
+
+DFlash 2 cannot reuse an existing draft primitive in this checkout:
+
+- MTP chains target-specific prediction heads autoregressively and has different
+  cache/rollback state.
+- EAGLE3 uses an autoregressive feature drafter and Gemma-specific runtime.
+- DSpARK is implemented in the DwarfStar GGUF/fixed-schedule runtime and uses a
+  support model, confidence pruning, and a different scheduler.
+- There is no current DFlash implementation.
+
+It can reuse orchestration concepts: auxiliary resource resolution, model load
+progress, serial generation ownership, token callbacks, cancellation, output
+parsers, fallback policy, and telemetry aggregation.
+
+The new AFMKitMLX primitive needs these internal interfaces:
+
+```swift
+struct DFlashDraftDescriptor
+struct DFlashTargetDescriptor
+struct DFlashCompatibilityReport
+struct DFlashCycleTelemetry
+
+protocol DFlashTargetAdapter {
+    func prefillAndCapture(...)
+    func verify(...)
+    func commit(...)
+    func rollback(...)
+}
+
+protocol DFlashDraftRuntime {
+    func draftOnePass(...)
+}
+```
+
+Qwen and Muse adapters may be separate concrete types. Selector, convolution,
+draft attention/MLP, tensor loading, and lossless verification stay inside
+AFMKitMLX or its patched MLX dependency.
+
+## AFMKit Boundary
+
+### Stable, provider-neutral concepts
+
+- A model can support speculative decoding.
+- A caller can disable, prefer, or require speculative decoding.
+- A strategy has a stable identifier, but providers decide which identifiers
+  they implement.
+- A request may fall back before emission for a neutral reason.
+- A cycle proposes and accepts tokens and has draft/verification timing.
+- A completion can summarize proposal count, accepted draft tokens, emitted
+  tokens, cycle count, acceptance length, and phase timing.
+
+### AFMKitCore must not contain
+
+- DFlash 2 config keys, architecture names, tensor names, mask IDs, target layer
+  taps, selector ranks/top-k, convolution parameters, kernels, or model classes.
+- Hugging Face repository IDs or download/cache policy.
+- MLX arrays, caches, model protocols, or scheduling details.
+
+### Proposed AFMKitCore API delta
+
+This is a proposed source-compatible addition; implementing it in a separately
+versioned AFMKit release should include a public API baseline update.
+
+```swift
+public struct AFMSpeculativeStrategyID: RawRepresentable, Hashable, Codable, Sendable {
+    public let rawValue: String
+}
+
+public enum AFMSpeculativeDecodingPolicy: String, Codable, Hashable, Sendable {
+    case disabled
+    case preferred
+    case required
+}
+
+public struct AFMSpeculativeDecodingOptions: Hashable, Codable, Sendable {
+    public var policy: AFMSpeculativeDecodingPolicy
+    public var strategy: AFMSpeculativeStrategyID?
+    public var maximumDraftTokens: Int?
+}
+
+public enum AFMSpeculativeFallbackReason: String, Codable, Hashable, Sendable {
+    case disabled, unavailable, incompatibleModel, incompatibleRequest
+    case concurrency, prefixCache, runtimeFailure
+}
+
+public struct AFMSpeculativeDecodingTelemetry: Hashable, Codable, Sendable {
+    public var strategy: AFMSpeculativeStrategyID
+    public var draftTokens: Int
+    public var acceptedDraftTokens: Int
+    public var emittedTokens: Int
+    public var verificationCycles: Int
+    public var draftDurationSeconds: Double
+    public var verificationDurationSeconds: Double
+    public var totalCycleDurationSeconds: Double
+    public var fallbackReason: AFMSpeculativeFallbackReason?
+}
+```
+
+Add `speculativeDecoding` to `AFMGenerationOptions` only when all providers can
+ignore `.preferred` safely and reject unsupported `.required` consistently.
+Until then, maclocal-api can transport this through `AFMRequest.metadata` and
+emit telemetry through the existing `.metadata` event using versioned keys.
+Adding a new `AFMGenerationEvent` enum case is deferred because exhaustive
+downstream switches would be source-breaking even though the enum is not frozen.
+
+### AFMKitMLX responsibilities
+
+- Config parsing, compatibility reports, runtime strategy selection.
+- DFlash 2 model/tensor implementation and target adapters.
+- Draft/verify loop, cache state, lossless sampling, cancellation checkpoints.
+- Translation from internal cycle records to neutral AFM telemetry.
+
+### maclocal-api server/CLI responsibilities
+
+- Flags, OpenAI extension decoding, startup conflict diagnostics.
+- Hub repository/path resolution, downloads, progress, cache visibility.
+- Request policy, fallback/error mapping, streaming transport.
+- Prometheus/log exposure and benchmark scripts.
+
+## Request and Fallback Semantics
+
+- Startup default: disabled.
+- Explicit startup enable + missing/incompatible drafter: fail startup.
+- Request `disabled`: use normal generation even when a runtime is loaded.
+- Request `preferred`: use DFlash 2 if eligible; otherwise fall back before
+  emitting output and report the reason.
+- Request `required`: reject before generation when ineligible.
+- Runtime failure before output: preferred may fall back once; required errors.
+- Runtime failure after output: error/cancel the request; never restart with AR.
+- Batch/concurrent scheduler: AR fallback for preferred, deterministic conflict
+  for required, until a batch primitive is implemented.
+- Prefix cache: AR fallback for preferred and conflict for required until a
+  complete target+draft snapshot format exists.
+
+## Telemetry Definitions
+
+- `draftTokens`: candidate path tokens proposed to verification; exclude the
+  already verified anchor and verifier bonus token.
+- `acceptedDraftTokens`: proposed tokens accepted from the draft.
+- `emittedTokens`: accepted draft tokens plus target verifier/bonus tokens that
+  become output.
+- `verificationCycles`: target verification passes.
+- `acceptanceLength`: `emittedTokens / verificationCycles`; report as derived
+  floating point, not as accepted draft tokens.
+- Timings use monotonic clocks and synchronize only at existing correctness
+  boundaries. Instrumentation must not add per-token host synchronization.
+

--- a/Research/DFlash2/ARCHITECTURE.md
+++ b/Research/DFlash2/ARCHITECTURE.md
@@ -82,29 +82,31 @@ It can reuse orchestration concepts: auxiliary resource resolution, model load
 progress, serial generation ownership, token callbacks, cancellation, output
 parsers, fallback policy, and telemetry aggregation.
 
-The new AFMKitMLX primitive needs these internal interfaces:
+The implemented vendor/AFMKitMLX primitive uses these internal interfaces:
 
 ```swift
-struct DFlashDraftDescriptor
-struct DFlashTargetDescriptor
-struct DFlashCompatibilityReport
-struct DFlashCycleTelemetry
+struct AFMMLXDFlash2Configuration
+struct AFMMLXSpeculativeTelemetry
 
-protocol DFlashTargetAdapter {
-    func prefillAndCapture(...)
-    func verify(...)
-    func commit(...)
-    func rollback(...)
+protocol DFlash2Target {
+    func dflash2Forward(...)
+    func dflash2CaptureCache(...)
+    func dflash2RestoreCache(...)
 }
 
-protocol DFlashDraftRuntime {
-    func draftOnePass(...)
-}
+final class DFlash2DraftModel
+final class DFlash2Generator
 ```
 
-Qwen and Muse adapters may be separate concrete types. Selector, convolution,
-draft attention/MLP, tensor loading, and lossless verification stay inside
-AFMKitMLX or its patched MLX dependency.
+Qwen and Muse adapters are model extensions in the supported MLX vendor patch.
+Selector, convolution, draft attention/MLP, tensor loading, and lossless greedy
+verification stay inside that patch; orchestration stays in AFMKitMLX.
+
+The current correctness-first generator snapshots target cache state before
+verification, restores it, and replays only the committed verifier token plus
+accepted draft prefix. It recomputes draft context instead of maintaining the
+reference runtime's optimized draft KV cache. This establishes correctness but
+is not evidence of the article's cycle-latency result.
 
 ## AFMKit Boundary
 
@@ -126,7 +128,22 @@ AFMKitMLX or its patched MLX dependency.
 - Hugging Face repository IDs or download/cache policy.
 - MLX arrays, caches, model protocols, or scheduling details.
 
-### Proposed AFMKitCore API delta
+### Implemented source-compatible API delta
+
+- `AFMKit.AFMSpeculativeDecodingConfiguration`: provider-neutral startup mode,
+  drafter resource, maximum draft tokens, and requirement.
+- `AFMOpenAICompat.SpeculativeDecodingOptions`: the same request concepts under
+  `speculative_decoding`.
+- `AFMKitMLX.AFMMLXSpeculativeTelemetry`: provider-neutral counts and phase
+  timing returned by the MLX bridge.
+- `StatsAggregator`/Prometheus: neutral drafted, accepted, cycle, strategy, and
+  phase-time counters.
+
+No source in `AFMKitCore` was changed. The concrete DFlash descriptor, config,
+runtime enum, target adapters, model, and generator remain in AFMKitMLX or the
+patched MLX dependency.
+
+### Proposed future AFMKitCore API delta
 
 This is a proposed source-compatible addition; implementing it in a separately
 versioned AFMKit release should include a public API baseline update.
@@ -177,7 +194,8 @@ downstream switches would be source-breaking even though the enum is not frozen.
 
 - Config parsing, compatibility reports, runtime strategy selection.
 - DFlash 2 model/tensor implementation and target adapters.
-- Draft/verify loop, cache state, lossless sampling, cancellation checkpoints.
+- Draft/verify loop, cache state, lossless greedy verification, and cancellation
+  checkpoints. Distribution-preserving sampling is deferred.
 - Translation from internal cycle records to neutral AFM telemetry.
 
 ### maclocal-api server/CLI responsibilities
@@ -190,12 +208,15 @@ downstream switches would be source-breaking even though the enum is not frozen.
 ## Request and Fallback Semantics
 
 - Startup default: disabled.
-- Explicit startup enable + missing/incompatible drafter: fail startup.
+- Explicit preferred startup + missing/incompatible drafter: log the diagnostic
+  and keep AR available; `--dflash2-required` fails startup.
 - Request `disabled`: use normal generation even when a runtime is loaded.
 - Request `preferred`: use DFlash 2 if eligible; otherwise fall back before
   emitting output and report the reason.
 - Request `required`: reject before generation when ineligible.
-- Runtime failure before output: preferred may fall back once; required errors.
+- Setup or request ineligibility before output: preferred may fall back once;
+  required errors. A generator execution failure is surfaced rather than
+  replayed through AR.
 - Runtime failure after output: error/cancel the request; never restart with AR.
 - Batch/concurrent scheduler: AR fallback for preferred, deterministic conflict
   for required, until a batch primitive is implemented.
@@ -210,8 +231,8 @@ downstream switches would be source-breaking even though the enum is not frozen.
 - `emittedTokens`: accepted draft tokens plus target verifier/bonus tokens that
   become output.
 - `verificationCycles`: target verification passes.
-- `acceptanceLength`: `emittedTokens / verificationCycles`; report as derived
-  floating point, not as accepted draft tokens.
+- `meanAcceptedDraftLength`: `acceptedDraftTokens / verificationCycles`.
+- `meanCommittedTokensPerCycle`: `emittedTokens / verificationCycles`, when an
+  event consumer needs verifier-token-inclusive throughput.
 - Timings use monotonic clocks and synchronize only at existing correctness
   boundaries. Instrumentation must not add per-token host synchronization.
-

--- a/Research/DFlash2/ARCHITECTURE.md
+++ b/Research/DFlash2/ARCHITECTURE.md
@@ -136,8 +136,8 @@ is not evidence of the article's cycle-latency result.
   `speculative_decoding`.
 - `AFMKitMLX.AFMMLXSpeculativeTelemetry`: provider-neutral counts and phase
   timing returned by the MLX bridge.
-- `StatsAggregator`/Prometheus: neutral drafted, accepted, cycle, strategy, and
-  phase-time counters.
+- `StatsAggregator`/Prometheus: neutral drafted, accepted, emitted, cycle,
+  strategy, and phase-time counters.
 
 No source in `AFMKitCore` was changed. The concrete DFlash descriptor, config,
 runtime enum, target adapters, model, and generator remain in AFMKitMLX or the
@@ -185,8 +185,9 @@ public struct AFMSpeculativeDecodingTelemetry: Hashable, Codable, Sendable {
 
 Add `speculativeDecoding` to `AFMGenerationOptions` only when all providers can
 ignore `.preferred` safely and reject unsupported `.required` consistently.
-Until then, maclocal-api can transport this through `AFMRequest.metadata` and
-emit telemetry through the existing `.metadata` event using versioned keys.
+Until then, maclocal-api transports this through `AFMRequest.metadata` and
+emits telemetry through the existing `.metadata` event using the versioned
+`afm.speculative_decoding.v1` key for both non-streaming responses and streams.
 Adding a new `AFMGenerationEvent` enum case is deferred because exhaustive
 downstream switches would be source-breaking even though the enum is not frozen.
 

--- a/Research/DFlash2/DECISION_LOG.md
+++ b/Research/DFlash2/DECISION_LOG.md
@@ -1,0 +1,92 @@
+# DFlash 2 Decision Log
+
+## D001: DFlash 2 is a new runtime primitive
+
+Decision: implement a distinct DFlash 2 draft/verify primitive in AFMKitMLX or
+the supported MLX vendor patch set.
+
+Reason: this checkout has MTP, EAGLE3, and DSpARK but no DFlash. Their model,
+cache, and verification contracts differ. Reusing only orchestration avoids
+misrepresenting one algorithm as another.
+
+## D002: Detection is metadata-first
+
+Decision: recognize DFlash 2 from `architectures`, required `dflash_config`
+fields, and tensor/config validation. Never activate from repository or
+directory names.
+
+Reason: both released drafters declare `model_type=qwen3`, while their targets
+declare different top-level/text model types. Names are especially unreliable
+for imported or renamed checkpoints.
+
+## D003: Opt-in and fail-closed startup
+
+Decision: DFlash 2 remains disabled by default. Explicit startup enablement
+requires a resolved, compatible auxiliary checkpoint and errors otherwise.
+
+Reason: correctness and Apple-Silicon performance are not yet established, and
+silent startup fallback hides deployment mistakes.
+
+## D004: AFMKitCore stays algorithm-neutral
+
+Decision: only provider-neutral speculative policy, capability, fallback, and
+telemetry concepts may enter AFMKitCore. DFlash model/config/kernel details stay
+in AFMKitMLX; server orchestration stays outside AFMKitCore.
+
+Reason: AFMKitCore is dependency-free and shared across providers. DFlash 2 is
+an MLX implementation detail, not a universal provider contract.
+
+## D005: Use existing metadata event before adding an enum case
+
+Decision: initially transport versioned speculative status/telemetry through
+`AFMGenerationEvent.metadata` and response metadata. Propose dedicated public
+types for the next AFMKit API revision, but defer a new event enum case.
+
+Reason: adding an enum case can break exhaustive downstream switches. Versioned
+metadata is already stable and lets the implementation prove the shape first.
+
+## D006: No fallback after output
+
+Decision: preferred mode may fall back only before the first output token/event.
+After emission, runtime failure terminates the request.
+
+Reason: replaying AR generation after partial speculative output can duplicate
+or diverge content, tool-call state, and reasoning channels.
+
+## D007: Prefix cache and batch are gated
+
+Decision: use AR fallback for preferred requests and deterministic rejection for
+required DFlash 2 when prefix restore or concurrent/batch scheduling is active,
+until complete speculative state and row-aligned verification are implemented.
+
+Reason: current caches and batch scheduler are AR-oriented. oMLX also documents
+its DFlash path as single-stream and keeps a separate cache containing draft and
+target state.
+
+## D008: Checkpoint block and draft-token counts remain distinct
+
+Decision: parse checkpoint `block_size` as model metadata and expose a clearly
+named runtime maximum draft-token setting. Validation derives allowed values
+from the implementation contract rather than equating the two fields.
+
+Reason: official examples use inconsistent engine-facing quantities (Qwen
+block 8, seven vLLM draft tokens, SGLang argument 8, oMLX runtime block 5).
+
+## D009: No unmeasured performance claim
+
+Decision: expose neutral counts/timings and retain raw benchmark evidence. Do
+not advertise a speedup until the same-target live matrix passes.
+
+Reason: upstream results use H200/SGLang or a different oMLX implementation;
+they do not establish maclocal-api performance.
+
+## D010: Inaccessible reference dependency is not copied or guessed
+
+Decision: use the public article, configs, tensor headers, oMLX integration, and
+original paper as contracts. Do not recreate undocumented behavior from the
+unavailable `z-lab/dflash-mlx` pin.
+
+Reason: both the final and intermediate DFlash MLX repositories returned 404.
+The oMLX release is still useful behavioral evidence, but not auditable source
+for a production port.
+

--- a/Research/DFlash2/DECISION_LOG.md
+++ b/Research/DFlash2/DECISION_LOG.md
@@ -21,8 +21,9 @@ for imported or renamed checkpoints.
 
 ## D003: Opt-in and fail-closed startup
 
-Decision: DFlash 2 remains disabled by default. Explicit startup enablement
-requires a resolved, compatible auxiliary checkpoint and errors otherwise.
+Decision: DFlash 2 remains disabled by default. Explicit preferred enablement
+falls back to AR before emission with a diagnostic; `required` fails startup or
+the request when the checkpoint/runtime/request is incompatible.
 
 Reason: correctness and Apple-Silicon performance are not yet established, and
 silent startup fallback hides deployment mistakes.
@@ -36,11 +37,11 @@ in AFMKitMLX; server orchestration stays outside AFMKitCore.
 Reason: AFMKitCore is dependency-free and shared across providers. DFlash 2 is
 an MLX implementation detail, not a universal provider contract.
 
-## D005: Use existing metadata event before adding an enum case
+## D005: Keep telemetry structured and neutral before adding an event case
 
-Decision: initially transport versioned speculative status/telemetry through
-`AFMGenerationEvent.metadata` and response metadata. Propose dedicated public
-types for the next AFMKit API revision, but defer a new event enum case.
+Decision: use a neutral AFMKitMLX telemetry value and neutral StatsAggregator /
+Prometheus counters. Propose dedicated AFMKitCore public types for the next API
+revision, but defer a new generation-event enum case.
 
 Reason: adding an enum case can break exhaustive downstream switches. Versioned
 metadata is already stable and lets the implementation prove the shape first.
@@ -80,13 +81,29 @@ not advertise a speedup until the same-target live matrix passes.
 Reason: upstream results use H200/SGLang or a different oMLX implementation;
 they do not establish maclocal-api performance.
 
-## D010: Inaccessible reference dependency is not copied or guessed
+## D010: Audit the signed release artifact when the public pin is unavailable
 
-Decision: use the public article, configs, tensor headers, oMLX integration, and
-original paper as contracts. Do not recreate undocumented behavior from the
-unavailable `z-lab/dflash-mlx` pin.
+Decision: hash-verify and inspect the signed oMLX release DMG read-only. Use its
+bundled Apache-2.0 Python sources as the reference contract; do not alter or
+publish changes to upstream oMLX/MLX repositories.
 
-Reason: both the final and intermediate DFlash MLX repositories returned 404.
-The oMLX release is still useful behavioral evidence, but not auditable source
-for a production port.
+Reason: both repository pins returned 404, but the official release contains
+auditable source and its SHA-256 matches GitHub release metadata.
 
+## D011: Start with correctness-first restore/replay
+
+Decision: snapshot target cache before verification, restore, and replay the
+committed verifier token plus accepted prefix. Defer optimized partial commit,
+draft KV caching, and prefix snapshots.
+
+Reason: this is simple to audit for greedy token equivalence. It may cost more
+than the signed reference and therefore cannot support a performance claim.
+
+## D012: Greedy only until rejection sampling is verified
+
+Decision: DFlash 2 runs only for greedy requests. Preferred sampled requests
+fall back before emission; required sampled requests fail.
+
+Reason: the signed reference implements selector sampling plus target rejection
+sampling. Porting only selector sampling would not preserve the target
+distribution.

--- a/Research/DFlash2/PLAN.md
+++ b/Research/DFlash2/PLAN.md
@@ -1,6 +1,8 @@
 # DFlash 2 Implementation Plan
 
-Status: implementation and compile/unit checkpoint complete; live model matrix pending coordination, 2026-08-19
+Status: takeover audit, corrective implementation, and focused qualification
+complete; bounded official-model smoke tests pass, full live matrix and
+performance qualification remain open, 2026-08-20
 
 ## Objective
 
@@ -22,11 +24,14 @@ Implemented and pushed:
 - `--dflash2`, `--dflash2-block`, and `--dflash2-required` startup controls;
 - provider-neutral AFMKit startup/request contracts and OpenAPI schema;
 - serial streaming/non-streaming service integration and neutral metrics;
+- versioned AFMKit response/stream telemetry, including explicit fallback
+  reasons and proposed/accepted/emitted/cycle/phase totals;
 - reproducible vendor overlay/drift checks and focused losslessness tests.
 
 Deliberately deferred behind deterministic fallback/error policy: sampling,
 explicit string stops, tools/grammar/logprobs, speculative prefix snapshots, and
 concurrent/batched DFlash 2. No heavy live model run or local speed claim has
+been made beyond bounded four/eight-token smoke tests; no local speed claim has
 been made.
 
 ## Current Inventory
@@ -36,22 +41,22 @@ been made.
 | Stable provider contracts | `Sources/AFMKitCore/AFMCoreTypes.swift` | Already has `.speculativeDecoding`, request/response metadata, `.metadata` events, usage, cancellation finish reason |
 | AFMKit facade | `Sources/AFMKit/AFMEngine.swift` | `EngineConfig` has MTP and EAGLE3-specific fields; maps into MLX provider configuration |
 | MLX configuration/lifecycle | `Sources/AFMKitMLX/AFMMLXRuntime.swift` | Applies provider configuration to `MLXModelService`; owns model load and scheduler startup |
-| Speculative policy | `Sources/AFMKitMLX/AFMMLXSpeculativeDecoding.swift` | Modes are off/auto/MTP/EAGLE3; fast path is greedy, text-only, no reasoning/modifiers/stops |
-| Runtime bridge | `Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift` | Runtime enum and execution bridge cover MTP and EAGLE3 only |
-| Main MLX service | `Sources/AFMKitMLX/Models/MLXModelService.swift` | Loads MTP sidecars; installs EAGLE3; has separate streaming/non-streaming speculative paths; batch scheduler uses AR |
+| Speculative policy | `Sources/AFMKitMLX/AFMMLXSpeculativeDecoding.swift` | Off/auto/MTP/EAGLE3/DFlash2 policy; DFlash2 fast path is greedy, serial, text-only, and excludes unsupported modifiers/stops |
+| Runtime bridge | `Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift` | Runtime enum and execution bridge cover MTP, EAGLE3, and DFlash2 |
+| Main MLX service | `Sources/AFMKitMLX/Models/MLXModelService.swift` | Loads MTP/DFlash2 resources; installs EAGLE3; emits DFlash2 telemetry; batch scheduler remains AR |
 | Model resolution/download | `MLXModelService.ensureLoaded`, `downloadModel`, `MLXCacheResolver` | Hub download progress/stages and resumable cache resolution already exist; MTP has an auxiliary-repository resolver |
 | CLI | `Sources/AFMCLI/main.swift` | `--mtp`, `--mtp-model`, `--eagle3`; DSpark is restricted to DwarfStar; startup config flows through `AFMMLXRuntimeConfiguration` |
-| OpenAI request | `Sources/AFMOpenAICompat/OpenAIRequest.swift` | Supports sampling, reasoning, tools, constraints, and template kwargs; no speculative request object yet |
+| OpenAI request | `Sources/AFMOpenAICompat/OpenAIRequest.swift` | Includes provider-neutral `speculative_decoding` mode, requirement, drafter, and draft-limit controls |
 | HTTP execution | `Sources/AFMServer/Controllers/MLXChatCompletionsController.swift` and `AFMLocalClient.swift` | Both streaming and non-streaming call the shared service |
 | Prefix cache | `MLXModelService` and `BatchScheduler` | Serial radix cache and batch cache are AR-oriented; speculative paths currently bypass cache reuse |
 | Batch/concurrency | `BatchScheduler.swift` | Concurrent mode routes through batched AR; existing MTP/EAGLE3 fast paths are serial only |
 | Cancellation | service speculative stream and normal generation tasks | SSE termination cancels the task; token callbacks observe cancellation |
-| Metrics | `Sources/AFMKitMLX/Models/StatsAggregator.swift` | Request/token/timing/cache metrics exist; no neutral speculative counters or phase timings |
+| Metrics | `Sources/AFMKitMLX/Models/StatsAggregator.swift` | Exports neutral drafted, accepted, emitted, cycle, strategy, and phase-time counters |
 | DSpARK | `Sources/AFMKitDwarfStar/*`, `CDwarfStar`, DS4 vendor | Different GGUF/fixed-schedule runtime with its own support model and scheduler; not a reusable DFlash runtime |
 | Vendor workflow | `Scripts/patches`, `Scripts/apply-mlx-patches.sh`, `Scripts/check-mlx-source-selection.sh` | Reproducible source overlays are applied to `vendor/mlx-swift-lm`; URL consumers use a pinned pre-patched fork |
 
-There is no existing DFlash runtime in this checkout. DFlash 2 therefore
-requires a new MLX runtime primitive. It can reuse the general auxiliary-model
+There was no DFlash runtime at the baseline revision. DFlash 2 therefore
+required a new MLX runtime primitive. It reuses the general auxiliary-model
 resolution, request orchestration, cancellation, output parsing, and telemetry
 contracts, but not the MTP, EAGLE3, or DSpARK draft/verify implementation.
 

--- a/Research/DFlash2/PLAN.md
+++ b/Research/DFlash2/PLAN.md
@@ -1,0 +1,132 @@
+# DFlash 2 Implementation Plan
+
+Status: research checkpoint, 2026-08-19
+
+## Objective
+
+Add opt-in DFlash 2 speculative decoding to maclocal-api while preserving the
+existing autoregressive, MTP, EAGLE3, DSpARK, Qwen 3.8, and Muse Glimmer paths.
+The implementation must detect and validate checkpoints from metadata, expose
+deterministic fallback/error behavior, and report provider-neutral speculative
+telemetry without putting DFlash 2 model or kernel details in AFMKitCore.
+
+## Current Inventory
+
+| Concern | Current path | Relevant behavior |
+| --- | --- | --- |
+| Stable provider contracts | `Sources/AFMKitCore/AFMCoreTypes.swift` | Already has `.speculativeDecoding`, request/response metadata, `.metadata` events, usage, cancellation finish reason |
+| AFMKit facade | `Sources/AFMKit/AFMEngine.swift` | `EngineConfig` has MTP and EAGLE3-specific fields; maps into MLX provider configuration |
+| MLX configuration/lifecycle | `Sources/AFMKitMLX/AFMMLXRuntime.swift` | Applies provider configuration to `MLXModelService`; owns model load and scheduler startup |
+| Speculative policy | `Sources/AFMKitMLX/AFMMLXSpeculativeDecoding.swift` | Modes are off/auto/MTP/EAGLE3; fast path is greedy, text-only, no reasoning/modifiers/stops |
+| Runtime bridge | `Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift` | Runtime enum and execution bridge cover MTP and EAGLE3 only |
+| Main MLX service | `Sources/AFMKitMLX/Models/MLXModelService.swift` | Loads MTP sidecars; installs EAGLE3; has separate streaming/non-streaming speculative paths; batch scheduler uses AR |
+| Model resolution/download | `MLXModelService.ensureLoaded`, `downloadModel`, `MLXCacheResolver` | Hub download progress/stages and resumable cache resolution already exist; MTP has an auxiliary-repository resolver |
+| CLI | `Sources/AFMCLI/main.swift` | `--mtp`, `--mtp-model`, `--eagle3`; DSpark is restricted to DwarfStar; startup config flows through `AFMMLXRuntimeConfiguration` |
+| OpenAI request | `Sources/AFMOpenAICompat/OpenAIRequest.swift` | Supports sampling, reasoning, tools, constraints, and template kwargs; no speculative request object yet |
+| HTTP execution | `Sources/AFMServer/Controllers/MLXChatCompletionsController.swift` and `AFMLocalClient.swift` | Both streaming and non-streaming call the shared service |
+| Prefix cache | `MLXModelService` and `BatchScheduler` | Serial radix cache and batch cache are AR-oriented; speculative paths currently bypass cache reuse |
+| Batch/concurrency | `BatchScheduler.swift` | Concurrent mode routes through batched AR; existing MTP/EAGLE3 fast paths are serial only |
+| Cancellation | service speculative stream and normal generation tasks | SSE termination cancels the task; token callbacks observe cancellation |
+| Metrics | `Sources/AFMKitMLX/Models/StatsAggregator.swift` | Request/token/timing/cache metrics exist; no neutral speculative counters or phase timings |
+| DSpARK | `Sources/AFMKitDwarfStar/*`, `CDwarfStar`, DS4 vendor | Different GGUF/fixed-schedule runtime with its own support model and scheduler; not a reusable DFlash runtime |
+| Vendor workflow | `Scripts/patches`, `Scripts/apply-mlx-patches.sh`, `Scripts/check-mlx-source-selection.sh` | Reproducible source overlays are applied to `vendor/mlx-swift-lm`; URL consumers use a pinned pre-patched fork |
+
+There is no existing DFlash runtime in this checkout. DFlash 2 therefore
+requires a new MLX runtime primitive. It can reuse the general auxiliary-model
+resolution, request orchestration, cancellation, output parsing, and telemetry
+contracts, but not the MTP, EAGLE3, or DSpARK draft/verify implementation.
+
+## Implementation Sequence
+
+### 1. Contract and policy layer
+
+- Add a metadata-driven DFlash draft descriptor/parser in AFMKitMLX.
+- Recognize `architectures: ["DFlash2DraftModel"]` exactly for DFlash 2.
+- Preserve legacy DFlash recognition as a separate descriptor version.
+- Validate required config fields and tensor-shape expectations before model load.
+- Match target and drafter by architecture/config dimensions, tokenizer IDs,
+  vocabulary, target layer count, hidden size, context/rope contract, and target
+  feature taps. Repository names are diagnostics only.
+- Keep DFlash 2 opt-in. Explicit mode fails closed; auto/disabled mode never
+  downloads or activates it.
+
+### 2. Stable AFMKit boundary
+
+- Use the existing `AFMModelCapabilities.speculativeDecoding` capability.
+- Add provider-neutral configuration and telemetry types only; do not mention
+  selectors, dynamic convolution, mask IDs, or DFlash tensor layouts in
+  AFMKitCore.
+- Keep concrete checkpoint resolution and model loading in AFMKitMLX.
+- Keep CLI flags, HTTP decoding, download policy, startup diagnostics, and
+  metrics export in maclocal-api layers.
+- See `ARCHITECTURE.md` for proposed API deltas and compatibility strategy.
+
+### 3. MLX runtime
+
+- Add the DFlash 2 draft model, target feature capture adapter, one-pass draft,
+  candidate selector, block-local two-tap dynamic convolution, lossless
+  verification, rollback, and cancellation to the supported MLX vendor patch
+  set or AFMKitMLX as ownership dictates.
+- Use the checkpoint's selector/convolution/block metadata; do not hard-code
+  Qwen/Muse repository names.
+- Implement Qwen 3.8 and Muse target adapters from target architecture metadata.
+- Return a neutral per-cycle record: proposed draft tokens, accepted draft
+  tokens, emitted tokens (including verifier bonus), draft/verify/commit time.
+- Do not silently fall back after any output has been emitted.
+
+### 4. Orchestration
+
+- Add `--dflash2` and `--dflash2-model <repo-or-path>` with an optional validated
+  runtime draft-token limit. Keep the default off.
+- Resolve explicit local paths and Hub repositories with normal progress/stage
+  reporting. Do not infer a drafter repository from the target name.
+- Add OpenAI-compatible extension controls under a structured
+  `speculative_decoding` object. Request-level disable is allowed; enabling or
+  switching auxiliary checkpoints after startup is rejected deterministically.
+- Reject conflicting startup modes (MTP/EAGLE3/DFlash2, DwarfStar/DSpark,
+  incompatible concurrency settings) with actionable diagnostics.
+- Route unsupported request features according to an explicit policy: required
+  DFlash 2 errors before generation; preferred mode falls back before generation
+  and emits a reason.
+
+### 5. Feature integration
+
+- Streaming and non-streaming must share one DFlash 2 token loop and summary.
+- Reasoning and tool parsing remain downstream of token generation, but DFlash 2
+  eligibility must be tested with each mode rather than inheriting the current
+  MTP/EAGLE3 blanket fallback.
+- Prefix caching is disabled for DFlash 2 until a snapshot includes all target
+  and draft state; advertise a neutral fallback reason rather than restoring an
+  AR-only cache.
+- Concurrent/batch requests use the existing AR scheduler until a row-aligned
+  DFlash 2 batch primitive is validated. Explicit required mode must reject this
+  conflict rather than quietly use AR.
+
+### 6. Verification and checkpoints
+
+- Unit tests: descriptor parsing, compatibility, tensor contract, conflicts,
+  request decoding, fallback policy, telemetry aggregation.
+- Contract tests: AFMKit metadata/events, CLI help/config flow, OpenAI JSON,
+  streaming/non-streaming equivalence, cancellation.
+- Vendor tests: clean application, idempotent `--check`, expected upstream hash,
+  compile fixture, and drift failure.
+- Integration tests: tiny synthetic draft/target fixtures where practical.
+- Compile and focused unit tests first. Do not run long Qwen/Muse inference until
+  coordination confirms the AFMKit usability study is not loading Qwen.
+- Run the live matrix in `TEST_MATRIX.md` only after that coordination point.
+- Commit/push separate checkpoints for research, runtime/orchestration, vendor
+  patch, and tests. Never force-push.
+
+## Exit Criteria
+
+- DFlash 2 is off by default and cannot activate from a repository name alone.
+- Released Qwen and Muse draft configs pass strict compatibility validation;
+  intentionally mismatched fixtures fail before allocating model weights.
+- Existing MTP, EAGLE3, DSpARK, normal MLX, Qwen 3.8, and Muse tests pass.
+- Streaming and non-streaming produce target-equivalent output under the
+  documented greedy and seeded-sampling methodology.
+- Telemetry reports counts and timings without a speedup claim.
+- Live performance claims, if any, compare the same target checkpoint,
+  quantization, prompt set, generation parameters, and concurrency on the same
+  machine, with warmups and raw evidence retained.
+

--- a/Research/DFlash2/PLAN.md
+++ b/Research/DFlash2/PLAN.md
@@ -1,8 +1,8 @@
 # DFlash 2 Implementation Plan
 
-Status: takeover audit, corrective implementation, and focused qualification
-complete; bounded official-model smoke tests pass, full live matrix and
-performance qualification remain open, 2026-08-20
+Status: independent-review remediation, focused Release testing, and the
+requested production-path live qualification are complete; the exhaustive live
+matrix and performance qualification remain open, 2026-08-21
 
 ## Objective
 
@@ -24,15 +24,26 @@ Implemented and pushed:
 - `--dflash2`, `--dflash2-block`, and `--dflash2-required` startup controls;
 - provider-neutral AFMKit startup/request contracts and OpenAPI schema;
 - serial streaming/non-streaming service integration and neutral metrics;
+- service/model-bound runtime ownership with retained validated target metadata;
+- explicit-greedy request eligibility that preserves the normal omitted
+  temperature default and gates sampling and non-neutral penalties;
+- complete configured/tokenizer/extra EOS handling without emitting or counting
+  terminal EOS tokens;
+- cancellation propagation without partial-success completion or telemetry;
+- deterministic AR fallback for preferred prefix, concurrent, and batch work,
+  with pre-emission errors for required requests;
 - versioned AFMKit response/stream telemetry, including explicit fallback
   reasons and proposed/accepted/emitted/cycle/phase totals;
+- base prompt/decode timing and token telemetry on the DFlash path;
+- one shared public/production compatibility preflight for target metadata,
+  token IDs, context/RoPE, and safetensor shapes;
 - reproducible vendor overlay/drift checks and focused losslessness tests.
 
-Deliberately deferred behind deterministic fallback/error policy: sampling,
-explicit string stops, tools/grammar/logprobs, speculative prefix snapshots, and
-concurrent/batched DFlash 2. No heavy live model run or local speed claim has
-been made beyond bounded four/eight-token smoke tests; no local speed claim has
-been made.
+Deliberately unsupported behind deterministic fallback/error policy: sampling,
+non-neutral repetition/presence penalties, explicit string stops,
+tools/grammar/logprobs, speculative prefix snapshots, and concurrent/batched
+DFlash 2. Preferred requests use AR and required requests fail before emission.
+No local speed claim has been made.
 
 ## Current Inventory
 
@@ -42,15 +53,15 @@ been made.
 | AFMKit facade | `Sources/AFMKit/AFMEngine.swift` | `EngineConfig` has MTP and EAGLE3-specific fields; maps into MLX provider configuration |
 | MLX configuration/lifecycle | `Sources/AFMKitMLX/AFMMLXRuntime.swift` | Applies provider configuration to `MLXModelService`; owns model load and scheduler startup |
 | Speculative policy | `Sources/AFMKitMLX/AFMMLXSpeculativeDecoding.swift` | Off/auto/MTP/EAGLE3/DFlash2 policy; DFlash2 fast path is greedy, serial, text-only, and excludes unsupported modifiers/stops |
-| Runtime bridge | `Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift` | Runtime enum and execution bridge cover MTP, EAGLE3, and DFlash2 |
-| Main MLX service | `Sources/AFMKitMLX/Models/MLXModelService.swift` | Loads MTP/DFlash2 resources; installs EAGLE3; emits DFlash2 telemetry; batch scheduler remains AR |
+| Runtime bridge | `Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift` | Runtime enum and execution bridge cover MTP, EAGLE3, and DFlash2; public construction uses the production compatibility preflight |
+| Main MLX service | `Sources/AFMKitMLX/Models/MLXModelService.swift` | Owns DFlash2 state per service/model container, loads speculative resources, emits DFlash2 and base telemetry, and keeps the batch scheduler AR |
 | Model resolution/download | `MLXModelService.ensureLoaded`, `downloadModel`, `MLXCacheResolver` | Hub download progress/stages and resumable cache resolution already exist; MTP has an auxiliary-repository resolver |
 | CLI | `Sources/AFMCLI/main.swift` | `--mtp`, `--mtp-model`, `--eagle3`; DSpark is restricted to DwarfStar; startup config flows through `AFMMLXRuntimeConfiguration` |
 | OpenAI request | `Sources/AFMOpenAICompat/OpenAIRequest.swift` | Includes provider-neutral `speculative_decoding` mode, requirement, drafter, and draft-limit controls |
 | HTTP execution | `Sources/AFMServer/Controllers/MLXChatCompletionsController.swift` and `AFMLocalClient.swift` | Both streaming and non-streaming call the shared service |
 | Prefix cache | `MLXModelService` and `BatchScheduler` | Serial radix cache and batch cache are AR-oriented; speculative paths currently bypass cache reuse |
 | Batch/concurrency | `BatchScheduler.swift` | Concurrent mode routes through batched AR; existing MTP/EAGLE3 fast paths are serial only |
-| Cancellation | service speculative stream and normal generation tasks | SSE termination cancels the task; token callbacks observe cancellation |
+| Cancellation | service speculative stream and normal generation tasks | SSE termination cancels the task; DFlash callbacks throw `CancellationError`, and no partial success or speculative totals are committed |
 | Metrics | `Sources/AFMKitMLX/Models/StatsAggregator.swift` | Exports neutral drafted, accepted, emitted, cycle, strategy, and phase-time counters |
 | DSpARK | `Sources/AFMKitDwarfStar/*`, `CDwarfStar`, DS4 vendor | Different GGUF/fixed-schedule runtime with its own support model and scheduler; not a reusable DFlash runtime |
 | Vendor workflow | `Scripts/patches`, `Scripts/apply-mlx-patches.sh`, `Scripts/check-mlx-source-selection.sh` | Reproducible source overlays are applied to `vendor/mlx-swift-lm`; URL consumers use a pinned pre-patched fork |

--- a/Research/DFlash2/PLAN.md
+++ b/Research/DFlash2/PLAN.md
@@ -1,6 +1,6 @@
 # DFlash 2 Implementation Plan
 
-Status: research checkpoint, 2026-08-19
+Status: implementation and compile/unit checkpoint complete; live model matrix pending coordination, 2026-08-19
 
 ## Objective
 
@@ -9,6 +9,25 @@ existing autoregressive, MTP, EAGLE3, DSpARK, Qwen 3.8, and Muse Glimmer paths.
 The implementation must detect and validate checkpoints from metadata, expose
 deterministic fallback/error behavior, and report provider-neutral speculative
 telemetry without putting DFlash 2 model or kernel details in AFMKitCore.
+
+## Implementation Status
+
+Implemented and pushed:
+
+- strict `DFlash2DraftModel` metadata/config and target-shape validation;
+- Qwen 3.8 and Muse Glimmer target hidden-state/cache adapters;
+- one-pass draft, selector, block-local two-tap dynamic convolutions, greedy
+  target verification, rollback/replay, cancellation, and monotonic phase timing;
+- local/Hub drafter resolution with existing download progress;
+- `--dflash2`, `--dflash2-block`, and `--dflash2-required` startup controls;
+- provider-neutral AFMKit startup/request contracts and OpenAPI schema;
+- serial streaming/non-streaming service integration and neutral metrics;
+- reproducible vendor overlay/drift checks and focused losslessness tests.
+
+Deliberately deferred behind deterministic fallback/error policy: sampling,
+explicit string stops, tools/grammar/logprobs, speculative prefix snapshots, and
+concurrent/batched DFlash 2. No heavy live model run or local speed claim has
+been made.
 
 ## Current Inventory
 
@@ -47,8 +66,8 @@ contracts, but not the MTP, EAGLE3, or DSpARK draft/verify implementation.
 - Match target and drafter by architecture/config dimensions, tokenizer IDs,
   vocabulary, target layer count, hidden size, context/rope contract, and target
   feature taps. Repository names are diagnostics only.
-- Keep DFlash 2 opt-in. Explicit mode fails closed; auto/disabled mode never
-  downloads or activates it.
+- Keep DFlash 2 opt-in. Required mode fails closed; preferred mode may fall back
+  before emission; disabled mode never downloads or activates it.
 
 ### 2. Stable AFMKit boundary
 
@@ -76,8 +95,8 @@ contracts, but not the MTP, EAGLE3, or DSpARK draft/verify implementation.
 
 ### 4. Orchestration
 
-- Add `--dflash2` and `--dflash2-model <repo-or-path>` with an optional validated
-  runtime draft-token limit. Keep the default off.
+- Add `--dflash2 <repo-or-path>`, `--dflash2-block`, and
+  `--dflash2-required`. Keep the default off.
 - Resolve explicit local paths and Hub repositories with normal progress/stage
   reporting. Do not infer a drafter repository from the target name.
 - Add OpenAI-compatible extension controls under a structured
@@ -124,9 +143,9 @@ contracts, but not the MTP, EAGLE3, or DSpARK draft/verify implementation.
   intentionally mismatched fixtures fail before allocating model weights.
 - Existing MTP, EAGLE3, DSpARK, normal MLX, Qwen 3.8, and Muse tests pass.
 - Streaming and non-streaming produce target-equivalent output under the
-  documented greedy and seeded-sampling methodology.
+  documented greedy methodology. Seeded sampling remains gated until rejection
+  sampling is ported and distribution-tested.
 - Telemetry reports counts and timings without a speedup claim.
 - Live performance claims, if any, compare the same target checkpoint,
   quantization, prompt set, generation parameters, and concurrency on the same
   machine, with warmups and raw evidence retained.
-

--- a/Research/DFlash2/SOURCES.md
+++ b/Research/DFlash2/SOURCES.md
@@ -1,0 +1,95 @@
+# DFlash 2 Sources
+
+Inspected 2026-08-19. Primary and official sources are listed first.
+
+## Primary Sources
+
+1. [Inco AI, "DFlash 2: Keep Drafting Parallel"](https://inco.ai/blog/dflash2/),
+   published 2026-08-18.
+   - Confirms one-pass parallel drafting remains intact.
+   - Defines the adjacent-candidate selector and block-local stateless two-tap
+     dynamic convolution around every draft attention and MLP sublayer.
+   - Reports upstream acceptance/latency results and links the engine releases.
+   - oMLX example uses a Qwen 4-bit target, DFlash 2 draft quantization,
+     runtime block size 5, and `verify_mode=dflash`.
+
+2. [incoai/Qwen3.8-27B-DFlash2](https://huggingface.co/incoai/Qwen3.8-27B-DFlash2),
+   revision `dedf8df68adfb1afeaf7b7480c0a0243108177b4`.
+   - [config.json](https://huggingface.co/incoai/Qwen3.8-27B-DFlash2/blob/main/config.json)
+   - [model card](https://huggingface.co/incoai/Qwen3.8-27B-DFlash2/blob/main/README.md)
+   - Safetensors header inspected with an HTTP range request; 81 tensors,
+     3,848,817,896-byte payload.
+   - Card declares base model `Qwen/Qwen3.8-27B`, block size 8/seven draft
+     tokens, and lossless greedy/distribution-preserving sampling.
+
+3. [incoai/Muse-Glimmer-30B-DFlash2](https://huggingface.co/incoai/Muse-Glimmer-30B-DFlash2),
+   revision `8336acb8dc9b8bf9c25f12d7785ee6df26703119`.
+   - [config.json](https://huggingface.co/incoai/Muse-Glimmer-30B-DFlash2/blob/main/config.json)
+   - [model card](https://huggingface.co/incoai/Muse-Glimmer-30B-DFlash2/blob/main/README.md)
+   - Safetensors header inspected with an HTTP range request; 81 tensors,
+     5,544,328,424-byte payload.
+   - Card declares base model `meta-models/Muse-Glimmer-30B`, block size
+     16/fifteen draft tokens, and derivation from Meta's assistant drafter.
+
+4. [Qwen/Qwen3.8-27B config](https://huggingface.co/Qwen/Qwen3.8-27B/blob/main/config.json).
+   - Target is top-level `qwen3_5`, text `qwen3_5_text`, hidden size 5120,
+     64 layers, vocabulary 248320, and MTP metadata.
+
+5. [meta-models/Muse-Glimmer-30B config](https://huggingface.co/meta-models/Muse-Glimmer-30B/blob/main/config.json).
+   - Target is top-level `muse_glimmer`, text `muse_glimmer_text`, hidden size
+     6656, 52 layers, vocabulary 202048, soft cap/output multiplier metadata.
+
+6. [Chen, Liang, Liu, "DFlash: Block Diffusion for Flash Speculative Decoding"](https://arxiv.org/abs/2602.06036),
+   arXiv v2, 2026-05-28, accepted at ICML 2026.
+   - Defines original DFlash target feature capture, KV injection, one-pass
+     block drafting, verification, training, and acceptance-length terminology.
+   - Original paper does not define the DFlash 2 selector/convolution additions.
+
+7. [oMLX 0.6.2 DFlash 2 release](https://github.com/z-lab/omlx-fork/releases/tag/0.6.2-dflash2),
+   tag object `009e6e2645ea51d72520a5be05e6f8df7210e2e2`, commit
+   `46225aebee34967d4f4bbb669bf02fc4e2de696a`.
+   - Public oMLX integration adds a runtime block-size setting, passes sampling
+     controls into DFlash, and documents single-stream operation/fallback.
+   - It pins DFlash MLX implementation commit
+     `415cc48d83846cfcd0d5b9da3c83e4f1478acda6`.
+   - The pinned `z-lab/dflash-mlx` repository returned 404 during inspection.
+     The implementation source is therefore unavailable through that pin; no
+     production code will assume undocumented behavior from the binary release.
+   - Release DMG SHA-256 from GitHub metadata:
+     `94f56e14bfa8188d47e187f571bc61244a65010fb23d3601a28a2e22d5e5bd21`.
+
+## Current Repository Sources
+
+- `Sources/AFMKitCore/AFMCoreTypes.swift`
+- `Sources/AFMKit/AFMEngine.swift`
+- `Sources/AFMKitMLX/AFMMLXRuntime.swift`
+- `Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift`
+- `Sources/AFMKitMLX/AFMMLXSpeculativeDecoding.swift`
+- `Sources/AFMKitMLX/AFMMLXSpeculativeRuntimeResourceResolver.swift`
+- `Sources/AFMKitMLX/AFMMLXSpeculativeRuntimeSetupPlanner.swift`
+- `Sources/AFMKitMLX/AFMMLXProvider.swift`
+- `Sources/AFMKitMLX/Models/MLXModelService.swift`
+- `Sources/AFMKitMLX/Models/BatchScheduler.swift`
+- `Sources/AFMKitMLX/Models/StatsAggregator.swift`
+- `Sources/AFMKitDwarfStar/AFMDwarfStarProvider.swift`
+- `Sources/AFMKitDwarfStar/AFMDwarfStarScheduler.swift`
+- `Sources/AFMOpenAICompat/OpenAIRequest.swift`
+- `Sources/AFMServer/Controllers/MLXChatCompletionsController.swift`
+- `Sources/AFMServer/Services/AFMLocalClient.swift`
+- `Sources/AFMCLI/main.swift`
+- `Scripts/apply-mlx-patches.sh`
+- `Scripts/build-mlx-swift-lm-fork.sh`
+- `Scripts/check-mlx-source-selection.sh`
+- existing speculative, MTP, EAGLE3, DSpARK, Qwen 3.8, Muse, streaming,
+  cancellation, prefix-cache, and batch tests under `Tests/MacLocalAPITests`.
+
+## Source Handling Rules
+
+- Repository IDs from model cards are test matrix inputs, never runtime
+  architecture detectors.
+- Blog/release speed numbers are attributed upstream and are not maclocal-api
+  claims.
+- No source changes will be made in oMLX, MLX, or other upstream worktrees.
+- Dependency changes must be represented by maclocal-api patch inputs with an
+  upstream revision/hash guard and clean-application test.
+

--- a/Research/DFlash2/SOURCES.md
+++ b/Research/DFlash2/SOURCES.md
@@ -53,10 +53,15 @@ Inspected 2026-08-19. Primary and official sources are listed first.
    - It pins DFlash MLX implementation commit
      `415cc48d83846cfcd0d5b9da3c83e4f1478acda6`.
    - The pinned `z-lab/dflash-mlx` repository returned 404 during inspection.
-     The implementation source is therefore unavailable through that pin; no
-     production code will assume undocumented behavior from the binary release.
    - Release DMG SHA-256 from GitHub metadata:
      `94f56e14bfa8188d47e187f571bc61244a65010fb23d3601a28a2e22d5e5bd21`.
+   - The release DMG was downloaded to the ignored research build directory,
+     hash-verified, and mounted read-only. Its signed app contains the complete
+     Apache-2.0 `dflash_mlx` Python package, version `0.1.10+omlx.5`.
+   - `model.py`, `draft_backend.py`, and `engine/spec_epoch.py` confirmed exact
+     selector keys, convolution math, staged verifier-token semantics, target
+     feature context, greedy verification, sampling support, cache snapshots,
+     and phase telemetry.
 
 ## Current Repository Sources
 
@@ -78,6 +83,8 @@ Inspected 2026-08-19. Primary and official sources are listed first.
 - `Sources/AFMServer/Services/AFMLocalClient.swift`
 - `Sources/AFMCLI/main.swift`
 - `Scripts/apply-mlx-patches.sh`
+- `Scripts/check-dflash2-vendor-patch.sh`
+- `Scripts/patches/DFlash2.swift`
 - `Scripts/build-mlx-swift-lm-fork.sh`
 - `Scripts/check-mlx-source-selection.sh`
 - existing speculative, MTP, EAGLE3, DSpARK, Qwen 3.8, Muse, streaming,
@@ -92,4 +99,3 @@ Inspected 2026-08-19. Primary and official sources are listed first.
 - No source changes will be made in oMLX, MLX, or other upstream worktrees.
 - Dependency changes must be represented by maclocal-api patch inputs with an
   upstream revision/hash guard and clean-application test.
-

--- a/Research/DFlash2/TEST_MATRIX.md
+++ b/Research/DFlash2/TEST_MATRIX.md
@@ -14,6 +14,15 @@ Run before any large model inference:
 No long Qwen or Muse generation is authorized by this gate. Report readiness
 and coordinate with the AFMKit usability study first.
 
+Current gate result (2026-08-19):
+
+- `swift build --target AFMKitMLX`: pass;
+- `swift build --target AFMCLI`: pass;
+- `swift test --filter AFMMLXDFlash2ConfigurationTests`: 12 pass;
+- `swift test --filter AFMMLXSpeculativeDecodingTests`: 22 pass;
+- `./Scripts/check-dflash2-vendor-patch.sh`: pass;
+- no Qwen/Muse weights downloaded and no heavy inference run.
+
 ## Fixture Matrix
 
 | Area | Cases | Expected result |
@@ -27,6 +36,13 @@ and coordinate with the AFMKit usability study first.
 | Request controls | omitted, disabled, preferred, required, wrong strategy, invalid draft limit | Off default; stable decoding/errors |
 | Fallback timing | unavailable before output; runtime error before output; runtime error after output | Preferred may pre-output fallback only; no replay after output |
 | Telemetry | zero cycles, partial acceptance, full acceptance, cancellation, fallback | Counts and timing definitions remain consistent |
+
+Implemented fixture coverage includes exact released Qwen/Muse metadata,
+name-only rejection, target shape mismatch, provider-neutral startup mapping,
+OpenAI request decoding, nested selector weight keys, greedy target equivalence,
+cancellation, stop/sampling fallback, OpenAPI schema, and existing speculative
+policy regression. Remaining fixture rows should be added before live defaults
+or sampling support changes.
 
 ## Live Target Matrix
 
@@ -52,6 +68,16 @@ and concurrency. Record revisions and hardware.
 | Drafter state | valid local; valid Hub download with progress; missing; incomplete; Qwen/Muse swapped; corrupt tensor shape |
 | Runtime control | startup off; startup on/request omitted; request disabled; preferred; required |
 | Completion | EOS; maximum tokens; stop sequence; cancellation |
+
+Current expected routing:
+
+- Greedy, serial, text-only, no tools/grammar/logprobs/string stops: DFlash 2.
+- Sampling, tools, grammar, logprobs, or string stops: preferred AR fallback;
+  required error before emission.
+- Prefix cache or `--concurrent`: preferred startup fallback to AR; required
+  startup error.
+- Reasoning remains downstream token parsing and must be checked live for both
+  targets before claiming support beyond token-equivalent greedy output.
 
 ## Output Equivalence
 
@@ -88,4 +114,3 @@ Sampling correctness:
    scheduler behavior; an AR-batched result cannot be labeled DFlash 2.
 7. A speedup claim is allowed only from same-machine, same-model evidence in
    this matrix. Upstream H200/oMLX claims remain citations only.
-

--- a/Research/DFlash2/TEST_MATRIX.md
+++ b/Research/DFlash2/TEST_MATRIX.md
@@ -14,14 +14,28 @@ Run before any large model inference:
 No long Qwen or Muse generation is authorized by this gate. Report readiness
 and coordinate with the AFMKit usability study first.
 
-Current gate result (2026-08-19):
+Current gate result (updated 2026-08-20):
 
-- `swift build --target AFMKitMLX`: pass;
-- `swift build --target AFMCLI`: pass;
-- `swift test --filter AFMMLXDFlash2ConfigurationTests`: 12 pass;
-- `swift test --filter AFMMLXSpeculativeDecodingTests`: 22 pass;
-- `./Scripts/check-dflash2-vendor-patch.sh`: pass;
-- no Qwen/Muse weights downloaded and no heavy inference run.
+- `Scripts/swiftpm-reliable.sh build --target AFMKitMLX`: pass;
+- `Scripts/swiftpm-reliable.sh build --target AFMCLI`: pass;
+- `Scripts/swiftpm-reliable.sh test --filter AFMMLXDFlash2ConfigurationTests`:
+  15 pass;
+- `Scripts/swiftpm-reliable.sh test --filter AFMMLXSpeculativeDecodingTests`:
+  22 pass;
+- final focused selection across DFlash2 config, speculative policy/setup,
+  model architecture, AFMKit adapter/provider, stream translation/controller,
+  OpenAPI/metrics, and batch routing: 143 XCTest plus 78 Swift Testing cases
+  pass with zero failures;
+- `Scripts/check-dflash2-vendor-patch.sh`: pass;
+- full patch application plus `--check` from a clean clone of pinned vendor
+  `6bab4f5ac55e81903dd74090244c25feb3233338`: pass with status identical to the
+  working materialized submodule;
+- official Qwen/Muse config snapshots and prior 81-tensor safetensor headers
+  were validated without downloading weight payloads;
+- official Qwen and Muse target/drafter pairs: bounded greedy live smoke pass
+  for request `off`, required non-streaming, required streaming with usage, and
+  nonzero speculative counters, run serially under the shared lock;
+- no full live matrix or local performance run was made.
 
 ## Fixture Matrix
 
@@ -74,8 +88,8 @@ Current expected routing:
 - Greedy, serial, text-only, no tools/grammar/logprobs/string stops: DFlash 2.
 - Sampling, tools, grammar, logprobs, or string stops: preferred AR fallback;
   required error before emission.
-- Prefix cache or `--concurrent`: preferred startup fallback to AR; required
-  startup error.
+- Prefix cache or `--concurrent`: preferred mode uses AR and emits a neutral
+  fallback reason; required mode rejects before generation.
 - Reasoning remains downstream token parsing and must be checked live for both
   targets before claiming support beyond token-equivalent greedy output.
 

--- a/Research/DFlash2/TEST_MATRIX.md
+++ b/Research/DFlash2/TEST_MATRIX.md
@@ -1,0 +1,91 @@
+# DFlash 2 Test Matrix
+
+## Compile and Unit Gate
+
+Run before any large model inference:
+
+1. Patch drift/application checks from a clean pinned vendor revision.
+2. `swift build` for AFMKitCore, AFMKitMLX, AFMKit, AFMServer, and AFMCLI.
+3. Focused DFlash descriptor/config/compatibility/tensor tests.
+4. Existing speculative, MTP, EAGLE3, DSpARK, Qwen 3.8, Muse, streaming,
+   cancellation, prefix-cache, and batch tests.
+5. OpenAI request decode and CLI help-json contract tests.
+
+No long Qwen or Muse generation is authorized by this gate. Report readiness
+and coordinate with the AFMKit usability study first.
+
+## Fixture Matrix
+
+| Area | Cases | Expected result |
+| --- | --- | --- |
+| Architecture detection | DFlash 2 exact architecture; legacy DFlash; MTP; DSpark; arbitrary `*-DFlash2` directory with normal config | Metadata determines type; name-only case is rejected |
+| Required config | Missing selector rank/top-k, conv kernel/group, block size, mask, feature taps | Fails before weight allocation with field-specific error |
+| Shape validation | Selector codebooks, projection, target feature fusion, conv tensors, layer count | Exact expected/actual shape diagnostic |
+| Target pairing | Qwen/Qwen draft; Muse/Muse draft; Qwen/Muse cross-pair; changed vocab/layers/hidden/rope/token IDs | Valid pairs pass; mismatches fail deterministically |
+| Backward compatibility | No drafter, MTP, EAGLE3, DSpARK, legacy DFlash descriptor fixture | Existing selection remains unchanged |
+| Startup conflicts | DFlash2+MTP, DFlash2+EAGLE3, DFlash2+DwarfStar/DSpark, invalid block limit, missing draft | Actionable startup error; no implicit mode choice |
+| Request controls | omitted, disabled, preferred, required, wrong strategy, invalid draft limit | Off default; stable decoding/errors |
+| Fallback timing | unavailable before output; runtime error before output; runtime error after output | Preferred may pre-output fallback only; no replay after output |
+| Telemetry | zero cycles, partial acceptance, full acceptance, cancellation, fallback | Counts and timing definitions remain consistent |
+
+## Live Target Matrix
+
+Targets:
+
+- `mlx-community/Qwen3.8-27B-4bit` with
+  `incoai/Qwen3.8-27B-DFlash2`
+- `mlx-community/Muse-Glimmer-30B-4bit` with
+  `incoai/Muse-Glimmer-30B-DFlash2`
+
+For every row below, run DFlash 2 off and on. Use the same target snapshot,
+prompt bytes, template kwargs, generation settings, maximum tokens, cache state,
+and concurrency. Record revisions and hardware.
+
+| Dimension | Cases |
+| --- | --- |
+| Transport | non-streaming; streaming with usage; streaming client cancellation |
+| Sampling | greedy; seeded model-recommended temperature/top-p/top-k if lossless sampler is implemented |
+| Reasoning | disabled/lowest; Qwen `xhigh`; Muse `high`; explicit request override |
+| Tools | no tools; one tool; parallel tools; multi-turn tool result; malformed partial call cancellation |
+| Prefix cache | disabled; enabled miss; exact repeat; shared-prefix extension |
+| Scheduling | serial; two concurrent requests; configured batch limit; mixed DFlash2 off/on requests |
+| Drafter state | valid local; valid Hub download with progress; missing; incomplete; Qwen/Muse swapped; corrupt tensor shape |
+| Runtime control | startup off; startup on/request omitted; request disabled; preferred; required |
+| Completion | EOS; maximum tokens; stop sequence; cancellation |
+
+## Output Equivalence
+
+Greedy correctness:
+
+- Compare target token IDs, not only decoded text.
+- DFlash 2 and autoregressive output must be identical through EOS or the same
+  maximum-token boundary.
+- Compare extracted reasoning text, visible text, tool calls/arguments, finish
+  reason, and usage semantics after parser translation.
+
+Sampling correctness:
+
+- A single seeded sample is a regression aid, not proof of distributional
+  equivalence.
+- First require the same seed to be reproducible within each mode.
+- Run a fixed prompt/sample suite and compare token-frequency distributions with
+  a declared statistical test and tolerance. Preserve raw outputs.
+- Do not call sampling lossless until rejection-sampling math and empirical
+  distribution checks both pass.
+
+## Performance Methodology
+
+1. Record Mac model, SoC, RAM, macOS, power mode, thermal state, Swift/MLX
+   revisions, target/draft revisions, quantization, and command.
+2. Use one target checkpoint and one prompt set for AR and DFlash 2.
+3. Separate cold download/load, model warmup, prompt processing, draft,
+   verification, commit, and end-to-end measurements.
+4. Run at least three unmeasured warmups and enough measured repetitions to
+   report median, p10/p90, and raw samples.
+5. Report output tok/s, TTFT, inter-token latency, acceptance length, draft
+   tokens, accepted draft tokens, cycles, phase time, peak memory, and errors.
+6. Test concurrency 1 first. Higher concurrency comparisons must use the same
+   scheduler behavior; an AR-batched result cannot be labeled DFlash 2.
+7. A speedup claim is allowed only from same-machine, same-model evidence in
+   this matrix. Upstream H200/oMLX claims remain citations only.
+

--- a/Research/DFlash2/TEST_MATRIX.md
+++ b/Research/DFlash2/TEST_MATRIX.md
@@ -14,14 +14,20 @@ Run before any large model inference:
 No long Qwen or Muse generation is authorized by this gate. Report readiness
 and coordinate with the AFMKit usability study first.
 
-Current gate result (updated 2026-08-20):
+Current gate result (updated 2026-08-21):
 
 - `Scripts/swiftpm-reliable.sh build --target AFMKitMLX`: pass;
 - `Scripts/swiftpm-reliable.sh build --target AFMCLI`: pass;
 - `Scripts/swiftpm-reliable.sh test --filter AFMMLXDFlash2ConfigurationTests`:
-  15 pass;
+  23 pass;
+- `Scripts/swiftpm-reliable.sh test --filter BatchCompletionsControllerTests`:
+  17 pass;
+- `Scripts/swiftpm-reliable.sh test --filter TokenizeAndOpenAPITests`:
+  11 pass;
 - `Scripts/swiftpm-reliable.sh test --filter AFMMLXSpeculativeDecodingTests`:
   22 pass;
+- focused Release selection across DFlash2 configuration, batch routing, and
+  streaming cancellation: 58 XCTest cases pass with zero failures;
 - final focused selection across DFlash2 config, speculative policy/setup,
   model architecture, AFMKit adapter/provider, stream translation/controller,
   OpenAPI/metrics, and batch routing: 143 XCTest plus 78 Swift Testing cases
@@ -35,7 +41,22 @@ Current gate result (updated 2026-08-20):
 - official Qwen and Muse target/drafter pairs: bounded greedy live smoke pass
   for request `off`, required non-streaming, required streaming with usage, and
   nonzero speculative counters, run serially under the shared lock;
-- no full live matrix or local performance run was made.
+- review-remediation Qwen production-path qualification: omitted temperature
+  and non-neutral penalties use AR for preferred and reject required requests;
+  explicit greedy required generation reports normal token/timing telemetry;
+  reasoning remains separated from visible content; partial SSE cancellation
+  preserves observed output, emits `cancelled` without stop/usage, stops
+  speculative work, and leaves the server healthy;
+- Qwen prefix-cache qualification: preferred uses AR, required rejects with
+  `prefix_cache`, and speculative cycles remain zero;
+- Muse batch qualification: two preferred rows complete through AR, a required
+  row emits `batch.error` with reason `batch`, and speculative cycles remain
+  zero;
+- complete Release attempts run the 437-case Swift Testing portion cleanly but
+  the XCTest process terminates with signal 11 in the unrelated macOS 27
+  Foundation Models request-adapter test under Xcode 27 beta 3; focused DFlash2
+  Release coverage is clean and the crash report is retained;
+- no AI judge, full live matrix, or local performance run was made.
 
 ## Fixture Matrix
 
@@ -47,16 +68,19 @@ Current gate result (updated 2026-08-20):
 | Target pairing | Qwen/Qwen draft; Muse/Muse draft; Qwen/Muse cross-pair; changed vocab/layers/hidden/rope/token IDs | Valid pairs pass; mismatches fail deterministically |
 | Backward compatibility | No drafter, MTP, EAGLE3, DSpARK, legacy DFlash descriptor fixture | Existing selection remains unchanged |
 | Startup conflicts | DFlash2+MTP, DFlash2+EAGLE3, DFlash2+DwarfStar/DSpark, invalid block limit, missing draft | Actionable startup error; no implicit mode choice |
-| Request controls | omitted, disabled, preferred, required, wrong strategy, invalid draft limit | Off default; stable decoding/errors |
+| Request controls | omitted/nil temperature, disabled, preferred, required, sampling modifiers, penalties, wrong strategy, invalid draft limit | Normal defaults preserved; stable AR fallback or pre-emission errors |
 | Fallback timing | unavailable before output; runtime error before output; runtime error after output | Preferred may pre-output fallback only; no replay after output |
-| Telemetry | zero cycles, partial acceptance, full acceptance, cancellation, fallback | Counts and timing definitions remain consistent |
+| Telemetry | zero cycles, partial acceptance, full acceptance, cancellation, fallback, base timing/usage | Counts and timing definitions remain consistent; cancellation commits no partial success |
 
 Implemented fixture coverage includes exact released Qwen/Muse metadata,
-name-only rejection, target shape mismatch, provider-neutral startup mapping,
-OpenAI request decoding, nested selector weight keys, greedy target equivalence,
-cancellation, stop/sampling fallback, OpenAPI schema, and existing speculative
-policy regression. Remaining fixture rows should be added before live defaults
-or sampling support changes.
+name-only rejection, full metadata/tensor preflight, target shape mismatch,
+provider-neutral startup mapping, independent service/model ownership, OpenAI
+request decoding, nested selector weight keys, greedy target equivalence,
+complete EOS handling, cancellation propagation, nonstreaming reasoning
+boundaries, omitted-temperature and penalty policy, prefix/concurrency/batch
+fallback reasons, base/speculative telemetry, OpenAPI schema, and existing
+speculative policy regression. Runtime-error-after-emission and broader feature
+combinations remain matrix work before expanding supported modes.
 
 ## Live Target Matrix
 
@@ -90,8 +114,9 @@ Current expected routing:
   required error before emission.
 - Prefix cache or `--concurrent`: preferred mode uses AR and emits a neutral
   fallback reason; required mode rejects before generation.
-- Reasoning remains downstream token parsing and must be checked live for both
-  targets before claiming support beyond token-equivalent greedy output.
+- Reasoning remains downstream token parsing. Qwen prompt-opened reasoning and
+  the bounded Muse reasoning/content comparison pass; broader reasoning levels
+  remain part of the exhaustive matrix.
 
 ## Output Equivalence
 

--- a/Research/DFlash2/TRACE.md
+++ b/Research/DFlash2/TRACE.md
@@ -1,0 +1,136 @@
+# DFlash 2 Research Trace
+
+Date: 2026-08-19
+
+## Workspace Verification
+
+```text
+pwd
+git status --short --branch
+git rev-parse HEAD
+git rev-parse origin/main
+git branch --show-current
+```
+
+Finding: worktree is
+`/Volumes/edata/dev/git/CODEX/vesta-mac/Worktrees/maclocal-api-dflash2`, clean on
+`codex/dflash2-afmkit-20260819`; `HEAD` and `origin/main` were both
+`224125f684881017b2c79f7c4cd457cf4e701061` before research edits.
+
+## Primary Source Commands
+
+```text
+curl -L https://inco.ai/blog/dflash2/ | textutil -convert txt -stdin -stdout
+curl -L https://huggingface.co/incoai/Qwen3.8-27B-DFlash2/raw/main/config.json
+curl -L https://huggingface.co/incoai/Muse-Glimmer-30B-DFlash2/raw/main/config.json
+curl -L https://huggingface.co/api/models/<repo>
+curl -L -I https://huggingface.co/<repo>/resolve/main/model.safetensors
+curl -L -r 0-1048575 https://huggingface.co/<repo>/resolve/main/model.safetensors
+curl -L 'https://export.arxiv.org/api/query?id_list=2602.06036'
+curl -L https://arxiv.org/html/2602.06036 | textutil -convert txt -stdin -stdout
+curl -L https://api.github.com/repos/z-lab/omlx-fork/releases/tags/0.6.2-dflash2
+curl -L https://api.github.com/repos/z-lab/omlx-fork/git/ref/tags/0.6.2-dflash2
+```
+
+Findings:
+
+- Article publication date is 2026-08-18.
+- DFlash 2 keeps one-pass parallel drafting.
+- Selector: top 16, rank 256, parallel adjacent-pair scoring, sequential walk
+  only over already computed scores, lossless rejection sampling.
+- Convolution: two-tap dynamic depthwise, block-local/stateless, before and
+  after attention/MLP, first position reads last verified token.
+- Qwen config block size 8; Muse block size 16; both five draft layers.
+- Qwen weight payload 3,848,817,896 bytes; Muse 5,544,328,424 bytes.
+- Safetensors headers were decoded from range responses without downloading
+  model payloads. Both have 81 tensors and expected selector/conv weights.
+- Original DFlash paper inspected at arXiv v2 (2026-05-28).
+- oMLX release tag resolves to commit
+  `46225aebee34967d4f4bbb669bf02fc4e2de696a`.
+
+## Reference Runtime Inspection
+
+```text
+curl -L 'https://api.github.com/repos/z-lab/omlx-fork/git/trees/<commit>?recursive=1'
+curl -L https://raw.githubusercontent.com/z-lab/omlx-fork/<commit>/pyproject.toml
+curl -L https://raw.githubusercontent.com/z-lab/omlx-fork/<commit>/omlx/engine/dflash.py
+curl -L https://api.github.com/repos/z-lab/omlx-fork/commits/8cf8e75b591f
+curl -L https://api.github.com/repos/z-lab/omlx-fork/commits/1fca1d105445
+git ls-remote https://github.com/z-lab/dflash-mlx.git <pin>
+git ls-remote https://github.com/jianc99/dflash-mlx.git <intermediate-pin>
+```
+
+Findings:
+
+- oMLX adds `dflash_block_size` and forwards temperature/top-p/top-k plus the
+  runtime block setting to DFlash.
+- Its UI states DFlash/DFlash2 is single-stream.
+- Long-context/unsupported flows use a separate AR batched/VLM fallback.
+- Its DFlash prefix cache is separate because snapshots include draft model
+  state and target hidden chunks.
+- Final dependency pin is
+  `z-lab/dflash-mlx@415cc48d83846cfcd0d5b9da3c83e4f1478acda6`.
+
+Failure: the final and intermediate DFlash MLX dependency repositories returned
+GitHub 404 / `Repository not found`. Rejected approach: do not guess or copy an
+undocumented implementation from the release binary. Continue from auditable
+primary model/config/tensor contracts and existing Swift model primitives.
+
+## Current Repository Inspection
+
+```text
+rg --files
+rg -n -i 'dflash|dspark|speculat|draft_model|mtp' Sources Tests Scripts
+nl -ba Sources/AFMKitCore/AFMCoreTypes.swift
+nl -ba Sources/AFMKit/AFMEngine.swift
+nl -ba Sources/AFMKitMLX/AFMMLXRuntime.swift
+nl -ba Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift
+nl -ba Sources/AFMKitMLX/AFMMLXSpeculativeDecoding.swift
+nl -ba Sources/AFMKitMLX/AFMMLXSpeculativeRuntimeResourceResolver.swift
+nl -ba Sources/AFMKitMLX/Models/MLXModelService.swift
+nl -ba Sources/AFMKitMLX/Models/BatchScheduler.swift
+nl -ba Sources/AFMKitMLX/Models/StatsAggregator.swift
+nl -ba Sources/AFMOpenAICompat/OpenAIRequest.swift
+nl -ba Sources/AFMCLI/main.swift
+nl -ba Scripts/apply-mlx-patches.sh
+git submodule status
+```
+
+Findings:
+
+- No DFlash runtime exists in the checkout.
+- AFMKitCore already has neutral speculative capability and metadata channels.
+- AFMKitMLX has MTP/EAGLE3 policy and runtime enums, while the main service also
+  has DSpARK, MTP, and EAGLE3 fast paths.
+- Speculative fast paths are serial; concurrent scheduler uses AR.
+- Current MTP/EAGLE3 eligibility is greedy/text/no modifiers/no stops; reasoning
+  is parsed downstream but policy currently excludes reasoning output in the
+  AFMMLX abstraction.
+- Hub model download progress/stages and an auxiliary MTP resolver are reusable.
+- OpenAI request schema has no speculative extension.
+- Metrics lack draft/accepted/cycle/phase counters.
+- Vendor submodules are uninitialized in this worktree. `Package.swift` falls
+  back to pinned pre-patched `scouzi1966/mlx-swift-lm` revision
+  `6bab4f5ac55e81903dd74090244c25feb3233338` when absent.
+
+## Rejected Approaches
+
+- Repository-name matching: conflicts with renamed/imported models and the
+  released config types.
+- Treating DFlash 2 as MTP/EAGLE3/DSpARK: incompatible algorithm/cache/runtime.
+- Adding DFlash tensor details to AFMKitCore: violates dependency and ownership
+  boundaries.
+- Silent fallback after explicit startup enable or after token emission: hides
+  configuration errors and risks divergent duplicate output.
+- Enabling prefix restore or batching before full speculative-state support:
+  current cache/scheduler contracts are insufficient.
+- Repeating upstream speed claims as local results: no same-model local evidence.
+
+## Exact Performance Methodology
+
+The live methodology is normative in `TEST_MATRIX.md`. Raw run records must
+include command, git revision, target/draft Hub revisions, config hash, hardware,
+OS/power/thermal state, warmups, prompt bytes, seed/sampling, cache state,
+concurrency, token outputs, acceptance/cycle counters, timings, and memory.
+Compare AR and DFlash 2 only with the same target checkpoint and request matrix.
+

--- a/Research/DFlash2/TRACE.md
+++ b/Research/DFlash2/TRACE.md
@@ -1,6 +1,6 @@
 # DFlash 2 Research Trace
 
-Date: 2026-08-19
+Date: 2026-08-19, takeover audit updated 2026-08-20
 
 ## Workspace Verification
 
@@ -201,7 +201,97 @@ d15cd5d Integrate opt-in DFlash 2 runtime
 a07a795 Use monotonic DFlash 2 phase timings
 75f9bb0 Expose DFlash 2 request policy to tests
 158e3f5 Test DFlash 2 contracts and losslessness
+5bdd5e8 Record DFlash 2 implementation evidence
+6b28dc8 Complete DFlash2 runtime compatibility checks
 ```
+
+## 2026-08-20 Takeover Audit
+
+The eight implementation commits through `5bdd5e8` did not fully satisfy the
+released-checkpoint or AFMKit execution contracts. The corrective checkpoint
+`6b28dc8` addressed the following production gaps:
+
+- released Qwen and Muse configs place `rope_theta` under `rope_parameters`;
+  the original parser required a top-level value and rejected both drafters;
+- compatibility checks now cover architecture, target dimensions, tokenizer
+  IDs, context/RoPE, target layers/taps, sliding-window metadata, and the exact
+  81-tensor shape contract before MLX reads the weight payload;
+- draft attention now follows released `layer_types` and `sliding_window`
+  metadata instead of using unrestricted causal attention;
+- AFMKit HTTP execution now forwards request speculative controls through the
+  adapter and provider rather than dropping preferred/required/off semantics;
+- request-level `off` overrides a loaded required-by-default runtime, while
+  request-level required DFlash2 cannot be consumed by MTP, EAGLE3, or the
+  concurrent AR scheduler;
+- DFlash2 is selected ahead of other speculative runtimes when explicitly
+  requested, and request-time drafter switching is rejected.
+
+The follow-up working checkpoint adds versioned
+`afm.speculative_decoding.v1` metadata to AFMKit responses and stream events,
+preserves it through the HTTP adapter, reports explicit pre-emission fallback
+reasons, and exports emitted-token totals alongside draft/accept/cycle/timing
+metrics. It also makes runtime draft limits fail closed instead of silently
+clamping values above the loaded checkpoint limit.
+
+Official config snapshots were retained under
+`.build/qualification/dflash2-official-configs-20260820` with these SHA-256
+values:
+
+```text
+873e3556509b0da06e29654ba00d4944888d4b5e8a33afde25f7eb27d321e980  qwen-draft-config.json
+14b65a0ee06517060a6bbd979bb1a8ff54e7b304b1a1f01d54344b88b8285e85  qwen-target-config.json
+cb684d6f688a22619a63ea1debe7d30c139c195bf3141fd86a763763ab34b5d9  muse-draft-config.json
+c7f48468db2ef9c3de4cb912be24ecc9fbed36d83f3b8386a0b224ee7ba876ca  muse-target-config.json
+```
+
+### Vendor materialization proof
+
+A clean local clone was created at
+`.build/qualification/dflash2-vendor-clean-6b28dc8`, reset to pinned vendor
+commit `6bab4f5ac55e81903dd74090244c25feb3233338`, then processed with the normal
+`Scripts/apply-mlx-patches.sh` workflow. Application and `--check` both passed,
+and `Scripts/patches/DFlash2.swift` was byte-identical to the clean clone's
+materialized `Libraries/MLXLMCommon/DFlash2.swift`.
+
+The clean clone and working vendor submodule produced the same status: modified
+`NemotronH.swift`, `Qwen3_5MoE.swift`, `ToolCallFormat.swift`, and
+`VLMModelFactory.swift`; new `DFlash2.swift`, `ATEMToolCallParser.swift`,
+`ToolCallFormat.swift.original`, `MuseGlimmer.swift`,
+`VLMModelFactory.swift.original`, and `Package.swift.original`. The dirty
+`vendor/mlx-swift-lm` state is therefore expected materialized patch output,
+not an unrecorded dependency edit. No dependency repository was pushed.
+
+After the static gate passed, both official draft payloads were downloaded to
+`/Volumes/edata2/models/huggingface-cache` and tested serially under the shared
+`.agent-live-test-lock`. Each run acquired the lock with atomic `mkdir`, wrote
+the owner record, installed a cleanup trap, and released the lock before the
+next model started. No live suite overlapped another agent's Release run.
+
+Retained artifacts are under
+`.build/qualification/dflash2-final-20260820`:
+
+- Qwen target revision `3e6447f082e89cc7f0bc6e5441afd38dfce760ff`
+  with draft revision `dedf8df68adfb1afeaf7b7480c0a0243108177b4`;
+- Muse target revision `3e7677d7a40d348a3daba263a2b1c0aa41910710`
+  with draft revision `8336acb8dc9b8bf9c25f12d7785ee6df26703119`;
+- both started with `--dflash2-block 5 --dflash2-required`;
+- request-level `off` and required non-streaming output matched for the same
+  greedy prompt on both pairs, comparing visible plus reasoning channels;
+- required streaming completed with usage and `[DONE]` for both pairs;
+- Qwen totals after prewarm plus two required requests were 11 drafted, 5
+  accepted, 8 emitted, and 3 cycles; Muse totals were 21 drafted, 12 accepted,
+  20 emitted, and 7 cycles.
+
+The CLI defaults to a four-token prewarm, and that work intentionally appears
+in process-lifetime Prometheus counters. A separate Qwen debug probe captured
+baseline prewarm totals of 3 drafted, 3 accepted, 4 emitted, and 1 cycle; the
+single subsequent request added 3 drafted, 1 accepted, 2 emitted, and 1 cycle.
+This ruled out telemetry double counting.
+
+These are bounded smoke results, not the full matrix. Long generation,
+reasoning-level comparisons, tools, cancellation, memory limits, statistical
+sampling, prefix snapshots, batch verification, and performance remain
+unqualified on the released checkpoints.
 
 ## Exact Performance Methodology
 

--- a/Research/DFlash2/TRACE.md
+++ b/Research/DFlash2/TRACE.md
@@ -288,10 +288,101 @@ baseline prewarm totals of 3 drafted, 3 accepted, 4 emitted, and 1 cycle; the
 single subsequent request added 3 drafted, 1 accepted, 2 emitted, and 1 cycle.
 This ruled out telemetry double counting.
 
-These are bounded smoke results, not the full matrix. Long generation,
-reasoning-level comparisons, tools, cancellation, memory limits, statistical
-sampling, prefix snapshots, batch verification, and performance remain
-unqualified on the released checkpoints.
+At that checkpoint these were bounded smoke results, not the full matrix. Long
+generation, reasoning-level comparisons, tools, cancellation, memory limits,
+statistical sampling, prefix snapshots, batch verification, and performance
+were still unqualified on the released checkpoints.
+
+## 2026-08-20 to 2026-08-21 Independent Review Remediation
+
+The independent review of PR #196 identified ten release blockers. Checkpoints
+`3b9b7c0`, `6135f0c`, `cf7c0bc`, and `24c6ce9` close them as follows:
+
+1. DFlash2 eligibility now treats omitted temperature as the normal sampling
+   default (`0.6`), accepts only explicit greedy temperature, and gates top-p,
+   top-k, min-p, repetition, and presence modifiers. Preferred uses AR;
+   required fails before emission.
+2. DFlash2 builds one EOS set from configured, tokenizer, and extra token IDs.
+   The shared generator checks EOS before callback/append, so secondary
+   terminators are neither exposed nor counted in streaming or nonstreaming.
+3. Request mode `off` and explicit DFlash2 preferred/required govern DFlash2,
+   DSpARK, MTP, and EAGLE3 selection rather than only the DFlash fast-path flag.
+4. Process-global DFlash2 state was removed. Each `MLXModelService` owns runtime
+   state keyed to its service instance, model ID, drafter, loaded container, and
+   validated target metadata.
+5. Vendor callbacks and AFMKit provider/service paths propagate
+   `CancellationError`. Partial output is not converted to a successful stop,
+   usage completion, or speculative metric commit.
+6. Nonstreaming DFlash2 seeds the response parser from the prompt-opened
+   reasoning boundary, keeping private reasoning in `reasoning_content`.
+7. DFlash2 now publishes prompt/completion token counts and prompt/decode
+   timings through the normal response and process metrics paths.
+8. Both batch controllers force preferred work to deterministic AR and reject
+   required DFlash2 as a pre-emission batch conflict; Muse is not run as serial
+   DFlash inside the batch endpoint.
+9. Public `AFMMLXRuntimeAdapter` construction uses the same compatibility
+   preflight as production, covering target metadata bytes, architecture,
+   context/RoPE/token IDs, feature taps, block limit, and safetensor shapes.
+10. Service-level regressions cover nil temperature, independent sampling
+    controls and penalties (including nil companion fields), secondary EOS,
+    partial cancellation, prompt-opened reasoning, independent service scopes,
+    prefix/concurrency/batch reasons, forced-AR batch behavior, and base plus
+    speculative telemetry.
+
+The patch definition in `Scripts/patches/DFlash2.swift` remains the source of
+truth. `Scripts/check-dflash2-vendor-patch.sh` passes, and the dirty
+`vendor/mlx-swift-lm` submodule remains expected materialized output from the
+repository patch workflow described above. No dependency repository was
+pushed.
+
+Focused validation after the review fixes:
+
+```text
+Debug AFMMLXDFlash2ConfigurationTests: 23/23 pass
+Debug BatchCompletionsControllerTests: 17/17 pass
+Debug TokenizeAndOpenAPITests: 11/11 pass
+Release DFlash2 + batch + stream cancellation selection: 58/58 pass
+Scripts/check-dflash2-vendor-patch.sh: pass
+git diff --check: pass
+```
+
+Two complete Release attempts reached 437/437 passing Swift Testing cases, but
+the XCTest process terminated with signal 11 in
+`MLXFoundationLanguageModelTests.testGenerationConfigDisablesThinkingByDefaultForReasoningModels`.
+Repeated crash reports locate the fault in
+`AFMFoundationModelsRequestAdapter.generationConfig` under macOS 27.0 and
+Xcode 27 beta 3. Isolated empty- and nonempty-metadata tests reproduce the
+same unrelated compiler/framework code-generation fault. Experimental guards
+were removed; no unrelated workaround is included in this branch. Logs are in
+`.build/qualification/dflash2-review-fixes-20260820`.
+
+Production-path qualification used Release `afm` binaries built from `cf7c0bc`
+for the Qwen sampling/reasoning/cancellation run and `24c6ce9` for the Qwen
+prefix and Muse batch runs. It used the same released Qwen/Muse snapshots listed
+above, atomic shared lock acquisition, an owner record, and trap-based cleanup.
+No run overlapped another agent's live or Release suite. Evidence is retained
+under `.build/qualification/dflash2-review-fixes-20260820/live`:
+
+- `qwen-final/summary.json`: preferred omitted-temperature and penalty requests
+  returned 200 through AR; required variants returned 400; explicit greedy
+  required generation returned content and nonzero normal usage/timings;
+  reasoning was split into nonempty `reasoning_content` and visible `content`
+  without leaked think tags;
+- the Qwen SSE cancellation probe cancelled only after a nonempty partial token,
+  returned `finish_reason=cancelled` without stop or usage, held speculative
+  cycles at 22 after cancellation, and passed a subsequent health check;
+- `qwen-prefix/summary.json`: preferred prefix-cache conflict used AR, required
+  returned 400 with `prefix_cache`, and speculative cycles stayed zero;
+- `muse-batch/summary.json`: two preferred batch rows completed through AR, the
+  required row emitted `batch.error` with stable reason `batch`, and speculative
+  cycles stayed `0 -> 0`.
+
+The focused Release artifact is
+`.build/qualification/dflash2-review-fixes-20260820/release/focused-final.log`.
+The two broad attempt logs are `broad-release.log` and
+`broad-release-rerun.log`. No comprehensive, Promptfoo, UI, performance, or AI
+judge suite was run; those are not needed to claim the bounded production paths
+above and remain outside this qualification.
 
 ## Exact Performance Methodology
 

--- a/Research/DFlash2/TRACE.md
+++ b/Research/DFlash2/TRACE.md
@@ -72,9 +72,32 @@ Findings:
   `z-lab/dflash-mlx@415cc48d83846cfcd0d5b9da3c83e4f1478acda6`.
 
 Failure: the final and intermediate DFlash MLX dependency repositories returned
-GitHub 404 / `Repository not found`. Rejected approach: do not guess or copy an
-undocumented implementation from the release binary. Continue from auditable
-primary model/config/tensor contracts and existing Swift model primitives.
+GitHub 404 / `Repository not found`.
+
+The official release artifact resolved that blocker:
+
+```text
+curl -L <release DMG URL> -o .build/dflash2-reference/oMLX-0.6.2-dflash2.dmg
+shasum -a 256 .build/dflash2-reference/oMLX-0.6.2-dflash2.dmg
+hdiutil attach -readonly .build/dflash2-reference/oMLX-0.6.2-dflash2.dmg
+rg -n 'candidate_selector|base_kernel|accepted|rollback' \
+  /Volumes/oMLX/oMLX.app/Contents/Resources/Python/framework-mlx-base/lib/python3.11/site-packages/dflash_mlx
+```
+
+Finding: SHA-256 matched
+`94f56e14bfa8188d47e187f571bc61244a65010fb23d3601a28a2e22d5e5bd21`.
+The mounted signed app contains `dflash_mlx 0.1.10+omlx.5`, including complete
+Apache-2.0 Python source. Inspection confirmed:
+
+- stateless grouped dynamic causal convolution with base shape
+  `[2, kernel, hidden]` and `hidden -> 2*kernel*groups` projection;
+- selector top-k, hidden/predecessor/successor rank embeddings, and path walk;
+- the staged verifier token is included in each target block but excluded from
+  the proposal count;
+- longest target-matching prefix is committed, then the target verifier token
+  at the first mismatch becomes the next staged output;
+- the optimized reference maintains draft context caches and complete prefix
+  snapshots, and implements target-distribution-preserving rejection sampling.
 
 ## Current Repository Inspection
 
@@ -126,6 +149,60 @@ Findings:
   current cache/scheduler contracts are insufficient.
 - Repeating upstream speed claims as local results: no same-model local evidence.
 
+## Implementation Commands and Findings
+
+```text
+git submodule update --init vendor/mlx-swift-lm vendor/ds4
+./Scripts/apply-mlx-patches.sh
+./Scripts/apply-mlx-deepseek-v4-kernels.sh
+./Scripts/apply-mlx-official-fp8-loader.sh
+./Scripts/check-dflash2-vendor-patch.sh
+swift build --target AFMKitMLX
+swift build --target AFMCLI
+swift test --filter AFMMLXDFlash2ConfigurationTests
+swift test --filter AFMMLXSpeculativeDecodingTests
+```
+
+Build failures encountered and resolved:
+
+1. The worktree's declared vendor submodules were initially uninitialized.
+   They were initialized at their pinned commits; no upstream worktree or
+   repository was modified.
+2. The first AFMKitMLX build failed because the existing DeepSeek V4 source
+   overlay requires the repository's declared MLXFast kernel patch. Running the
+   supported `apply-mlx-deepseek-v4-kernels.sh` and official FP8 loader scripts
+   restored the expected pinned build state.
+3. The first focused test compile found two missing `try` markers in new test
+   assertions; corrected before the test checkpoint.
+4. Weight-tree inspection found dotted selector `@ModuleInfo` keys were not an
+   established MLX Swift pattern. Replaced with a nested candidate-selector
+   module and added an exact parameter-key test.
+
+Implemented runtime findings:
+
+- DFlash 2 needs its own MLX primitive. Existing DFlash/DSpark concepts are
+  reusable only for orchestration, fallback, streaming, cancellation, model
+  download, and neutral telemetry.
+- Greedy verification is target-lossless in the tiny deterministic fixture.
+- The correctness-first loop restores and replays committed target state. It
+  does not yet implement the reference draft KV cache, prefix snapshots,
+  rejection sampling, or batched row-aligned verification.
+- Existing 22-case speculative policy suite remains green.
+- No heavy Qwen/Muse inference was started. Compile/unit work is ready for the
+  requested coordination point.
+
+Pushed checkpoints:
+
+```text
+00c6191 Document DFlash 2 integration plan
+bb44f0b Add DFlash 2 MLX vendor primitive
+be00de3 Fix DFlash 2 selector weight hierarchy
+d15cd5d Integrate opt-in DFlash 2 runtime
+a07a795 Use monotonic DFlash 2 phase timings
+75f9bb0 Expose DFlash 2 request policy to tests
+158e3f5 Test DFlash 2 contracts and losslessness
+```
+
 ## Exact Performance Methodology
 
 The live methodology is normative in `TEST_MATRIX.md`. Raw run records must
@@ -133,4 +210,3 @@ include command, git revision, target/draft Hub revisions, config hash, hardware
 OS/power/thermal state, warmups, prompt bytes, seed/sampling, cache state,
 concurrency, token outputs, acceptance/cycle counters, timings, and memory.
 Compare AR and DFlash 2 only with the same target checkpoint and request matrix.
-

--- a/Scripts/apply-mlx-patches.sh
+++ b/Scripts/apply-mlx-patches.sh
@@ -28,6 +28,12 @@ PATCH_FILES+=("MuseGlimmer.swift")
 TARGET_PATHS+=("Libraries/MLXVLM/Models/MuseGlimmer.swift")
 NEW_FILES+=("MuseGlimmer.swift")
 
+# DFlash2 model primitives are isolated in MLXLMCommon; target adapters stay
+# with their model implementations and AFMKit owns server orchestration.
+PATCH_FILES+=("DFlash2.swift")
+TARGET_PATHS+=("Libraries/MLXLMCommon/DFlash2.swift")
+NEW_FILES+=("DFlash2.swift")
+
 # --- Package-level patches (sed replacements in Package.swift) ---
 # Each entry: "search_pattern|replacement"
 # These fix dependency version pins that can't be handled by file-copy patches.

--- a/Scripts/check-dflash2-vendor-patch.sh
+++ b/Scripts/check-dflash2-vendor-patch.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENDOR="$ROOT/vendor/mlx-swift-lm"
+
+if [ ! -f "$VENDOR/Package.swift" ]; then
+  echo "error: initialize vendor/mlx-swift-lm before checking DFlash2 patches" >&2
+  exit 1
+fi
+
+"$ROOT/Scripts/apply-mlx-patches.sh" --check
+
+test -f "$VENDOR/Libraries/MLXLMCommon/DFlash2.swift"
+grep -Fq 'public final class DFlash2DraftModel' \
+  "$VENDOR/Libraries/MLXLMCommon/DFlash2.swift"
+grep -Fq 'extension Qwen3_5MoEModel: DFlash2Target' \
+  "$VENDOR/Libraries/MLXLLM/Models/Qwen3_5MoE.swift"
+grep -Fq 'extension MuseGlimmer: DFlash2Target' \
+  "$VENDOR/Libraries/MLXVLM/Models/MuseGlimmer.swift"
+
+echo "DFlash2 vendor patch application: OK"

--- a/Scripts/patches/DFlash2.swift
+++ b/Scripts/patches/DFlash2.swift
@@ -28,6 +28,37 @@ public protocol DFlash2Target: AnyObject {
     func dflash2RestoreCache(_ snapshot: Any, into cache: [any KVCache])
 }
 
+/// A verifier cache snapshot must preserve both storage and cursor metadata.
+/// Rotating caches update their backing arrays in place after wrapping, so
+/// retaining array references or trimming by offset is not a rollback.
+public enum DFlash2CacheSnapshot {
+    public struct Layer {
+        fileprivate let state: [MLXArray]
+        fileprivate let metaState: [String]
+    }
+
+    public static func capture(_ cache: [any KVCache]) -> [Layer] {
+        cache.map { entry in
+            let state = entry.state.map { ($0 + MLXArray(0)).asType($0.dtype) }
+            if !state.isEmpty { eval(state) }
+            return Layer(state: state, metaState: entry.metaState)
+        }
+    }
+
+    public static func restore(_ snapshot: [Layer], into cache: [any KVCache]) {
+        precondition(snapshot.count == cache.count, "DFlash cache snapshot layer mismatch")
+        for (index, layer) in snapshot.enumerated() {
+            var entry = cache[index]
+            if !layer.state.isEmpty {
+                let state = layer.state.map { ($0 + MLXArray(0)).asType($0.dtype) }
+                eval(state)
+                entry.state = state
+            }
+            entry.metaState = layer.metaState
+        }
+    }
+}
+
 public struct DFlash2GenerationStatistics: Sendable {
     public let draftedTokens: Int
     public let acceptedDraftTokens: Int
@@ -50,7 +81,13 @@ public struct DFlash2GenerationResult: Sendable {
     public let statistics: DFlash2GenerationStatistics
 }
 
+public enum DFlashDraftArchitecture: String, Sendable {
+    case dflash = "MuseGlimmerAssistantModel"
+    case dflash2 = "DFlash2DraftModel"
+}
+
 public struct DFlash2DraftConfiguration: Sendable {
+    public let architecture: DFlashDraftArchitecture
     public let hiddenSize: Int
     public let intermediateSize: Int
     public let hiddenLayers: Int
@@ -72,16 +109,29 @@ public struct DFlash2DraftConfiguration: Sendable {
     public let layerTypes: [String]
     public let slidingWindow: Int?
 
-    public static func load(directory: String) throws -> Self {
+    public static func load(
+        directory: String,
+        targetLayers resolvedTargetLayers: Int? = nil,
+        vocabularySize resolvedVocabularySize: Int? = nil
+    ) throws -> Self {
         let data = try Data(contentsOf: URL(fileURLWithPath: directory + "/config.json"))
-        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              (root["architectures"] as? [String])?.contains("DFlash2DraftModel") == true,
-              (root["is_causal"] as? Bool) == false,
-              let dflash = root["dflash_config"] as? [String: Any]
-        else {
-            throw DFlash2Error.invalidConfiguration(
-                "architectures must contain DFlash2DraftModel and is_causal must be false")
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw DFlash2Error.invalidConfiguration("config.json must contain an object")
         }
+        let architectures = root["architectures"] as? [String] ?? []
+        let architecture: DFlashDraftArchitecture
+        if architectures.contains(DFlashDraftArchitecture.dflash2.rawValue) {
+            architecture = .dflash2
+        } else if architectures.contains(DFlashDraftArchitecture.dflash.rawValue) {
+            architecture = .dflash
+        } else {
+            throw DFlash2Error.invalidConfiguration(
+                "unsupported draft architectures: \(architectures)")
+        }
+        if architecture == .dflash2, (root["is_causal"] as? Bool) != false {
+            throw DFlash2Error.invalidConfiguration("DFlash2 requires is_causal=false")
+        }
+        let dflash = root["dflash_config"] as? [String: Any] ?? root
         func integer(_ object: [String: Any], _ key: String) throws -> Int {
             guard let value = (object[key] as? NSNumber)?.intValue else {
                 throw DFlash2Error.invalidConfiguration("missing \(key)")
@@ -96,40 +146,52 @@ public struct DFlash2DraftConfiguration: Sendable {
         }
         let hidden = try integer(root, "hidden_size")
         let layers = try integer(root, "num_hidden_layers")
-        let targetLayers = try integer(root, "num_target_layers")
+        let targetLayers = (root["num_target_layers"] as? NSNumber)?.intValue
+            ?? resolvedTargetLayers
+        let vocabularySize = (root["vocab_size"] as? NSNumber)?.intValue
+            ?? resolvedVocabularySize
+        guard let targetLayers, let vocabularySize else {
+            throw DFlash2Error.invalidConfiguration(
+                "draft config requires target num_hidden_layers and vocab_size")
+        }
         let targetIDs = (dflash["target_layer_ids"] as? [NSNumber])?.map(\.intValue) ?? []
-        let groupSize = try integer(dflash, "conv_group_size")
-        let kernelSize = try integer(dflash, "conv_kernel_size")
+        let groupSize = (dflash["conv_group_size"] as? NSNumber)?.intValue ?? 0
+        let kernelSize = (dflash["conv_kernel_size"] as? NSNumber)?.intValue ?? 0
         let layerTypes = root["layer_types"] as? [String] ?? []
         let slidingWindow = (root["sliding_window"] as? NSNumber)?.intValue
         let rope = root["rope_parameters"] as? [String: Any]
             ?? root["rope_scaling"] as? [String: Any]
             ?? root
-        guard hidden > 0, layers > 0, hidden.isMultiple(of: groupSize), kernelSize == 2,
+        guard hidden > 0, layers > 0,
               targetIDs.count == layers,
               targetIDs == targetIDs.sorted(), Set(targetIDs).count == targetIDs.count,
               targetIDs.allSatisfy({ $0 >= 0 && $0 < targetLayers }),
               layerTypes.count == layers,
               layerTypes.allSatisfy({ $0 == "sliding_attention" || $0 == "full_attention" }),
               !layerTypes.contains("sliding_attention") || (slidingWindow ?? 0) > 0 else {
-            throw DFlash2Error.invalidConfiguration("invalid hidden, convolution, or target-layer layout")
+            throw DFlash2Error.invalidConfiguration("invalid hidden or target-layer layout")
+        }
+        if architecture == .dflash2,
+           !(groupSize > 0 && hidden.isMultiple(of: groupSize) && kernelSize == 2) {
+            throw DFlash2Error.invalidConfiguration("invalid DFlash2 convolution layout")
         }
         return Self(
+            architecture: architecture,
             hiddenSize: hidden,
             intermediateSize: try integer(root, "intermediate_size"),
             hiddenLayers: layers,
             attentionHeads: try integer(root, "num_attention_heads"),
             keyValueHeads: try integer(root, "num_key_value_heads"),
             headDimension: try integer(root, "head_dim"),
-            vocabularySize: try integer(root, "vocab_size"),
+            vocabularySize: vocabularySize,
             targetLayers: targetLayers,
             targetLayerIDs: targetIDs,
             blockSize: try integer(dflash, "block_size"),
             maskTokenID: try integer(dflash, "mask_token_id"),
             convolutionKernelSize: kernelSize,
             convolutionGroupSize: groupSize,
-            selectorRank: try integer(dflash, "selector_rank"),
-            selectorTopK: try integer(dflash, "selector_top_k"),
+            selectorRank: (dflash["selector_rank"] as? NSNumber)?.intValue ?? 0,
+            selectorTopK: (dflash["selector_top_k"] as? NSNumber)?.intValue ?? 0,
             rmsNormEpsilon: try floating(root, "rms_norm_eps"),
             ropeTheta: try floating(rope, "rope_theta"),
             maxPositionEmbeddings: try integer(root, "max_position_embeddings"),
@@ -137,6 +199,12 @@ public struct DFlash2DraftConfiguration: Sendable {
             slidingWindow: slidingWindow
         )
     }
+}
+
+public protocol DFlashDraftingModel: AnyObject {
+    var config: DFlash2DraftConfiguration { get }
+    func callAsFunction(noiseEmbedding: MLXArray, targetHidden: MLXArray) -> MLXArray
+    func select(hidden: MLXArray, logits: MLXArray, anchor: Int) -> [Int]
 }
 
 public enum DFlash2Error: LocalizedError {
@@ -224,6 +292,7 @@ private final class DFlash2Attention: Module {
     let headDimension: Int
     let scale: Float
     let slidingWindow: Int?
+    let isCausal: Bool
     @ModuleInfo(key: "q_proj") var query: Linear
     @ModuleInfo(key: "k_proj") var key: Linear
     @ModuleInfo(key: "v_proj") var value: Linear
@@ -239,6 +308,7 @@ private final class DFlash2Attention: Module {
         scale = pow(Float(config.headDimension), -0.5)
         slidingWindow = config.layerTypes[layerIndex] == "sliding_attention"
             ? config.slidingWindow : nil
+        isCausal = config.architecture == .dflash && slidingWindow != nil
         _query.wrappedValue = Linear(config.hiddenSize, heads * headDimension, bias: false)
         _key.wrappedValue = Linear(config.hiddenSize, keyValueHeads * headDimension, bias: false)
         _value.wrappedValue = Linear(config.hiddenSize, keyValueHeads * headDimension, bias: false)
@@ -286,7 +356,10 @@ private final class DFlash2Attention: Module {
                 Int32(contextStart) ..< Int32(fullContext + block))[.newAxis, 0...]
             let contextMask = (keyIndices .< Int32(fullContext))
                 .&& ((queryIndices - keyIndices) .< Int32(slidingWindow))
-            let blockMask = keyIndices .>= Int32(fullContext)
+            var blockMask = keyIndices .>= Int32(fullContext)
+            if isCausal {
+                blockMask = blockMask .&& (keyIndices .<= queryIndices)
+            }
             mask = .array(contextMask .|| blockMask)
         } else {
             mask = .none
@@ -298,6 +371,28 @@ private final class DFlash2Attention: Module {
             scale: scale,
             mask: mask)
         return output(attended.transposed(0, 2, 1, 3).reshaped(batch, block, -1))
+    }
+}
+
+private final class DFlashDecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var attention: DFlash2Attention
+    @ModuleInfo var mlp: DFlash2MLP
+    @ModuleInfo(key: "input_layernorm") var inputNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionNorm: RMSNorm
+
+    init(_ config: DFlash2DraftConfiguration, layerIndex: Int) {
+        _attention.wrappedValue = DFlash2Attention(config, layerIndex: layerIndex)
+        _mlp.wrappedValue = DFlash2MLP(config)
+        _inputNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
+        _postAttentionNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
+    }
+
+    func callAsFunction(_ hidden: MLXArray, targetContext: MLXArray) -> MLXArray {
+        var result = hidden + attention(inputNorm(hidden), targetContext: targetContext)
+        result = result + mlp(postAttentionNorm(result))
+        return result
     }
 }
 
@@ -364,7 +459,46 @@ private final class DFlash2CandidateSelector: Module {
     }
 }
 
-public final class DFlash2DraftModel: Module {
+public final class DFlashDraftModel: Module, DFlashDraftingModel {
+    public let config: DFlash2DraftConfiguration
+    @ModuleInfo private var layers: [DFlashDecoderLayer]
+    @ModuleInfo private var norm: RMSNorm
+    @ModuleInfo private var fc: Linear
+    @ModuleInfo(key: "hidden_norm") private var hiddenNorm: RMSNorm
+
+    public init(_ config: DFlash2DraftConfiguration) {
+        precondition(config.architecture == .dflash)
+        self.config = config
+        _layers.wrappedValue = (0 ..< config.hiddenLayers).map {
+            DFlashDecoderLayer(config, layerIndex: $0)
+        }
+        _norm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
+        _fc.wrappedValue = Linear(
+            config.targetLayerIDs.count * config.hiddenSize, config.hiddenSize, bias: false)
+        _hiddenNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
+    }
+
+    public func callAsFunction(
+        noiseEmbedding: MLXArray, targetHidden: MLXArray
+    ) -> MLXArray {
+        let context = hiddenNorm(fc(targetHidden))
+        var hidden = noiseEmbedding
+        for layer in layers {
+            hidden = layer(hidden, targetContext: context)
+        }
+        return norm(hidden)
+    }
+
+    public func select(hidden: MLXArray, logits: MLXArray, anchor: Int) -> [Int] {
+        (0 ..< logits.dim(1)).map { position in
+            argMax(logits[0, position, 0...], axis: -1).item(Int.self)
+        }
+    }
+}
+
+public final class DFlash2DraftModel: Module, DFlashDraftingModel {
     public let config: DFlash2DraftConfiguration
     @ModuleInfo private var layers: [DFlash2DecoderLayer]
     @ModuleInfo private var norm: RMSNorm
@@ -373,6 +507,7 @@ public final class DFlash2DraftModel: Module {
     @ModuleInfo(key: "candidate_selector") private var candidateSelector: DFlash2CandidateSelector
 
     public init(_ config: DFlash2DraftConfiguration) {
+        precondition(config.architecture == .dflash2)
         self.config = config
         _layers.wrappedValue = (0 ..< config.hiddenLayers).map {
             DFlash2DecoderLayer(config, layerIndex: $0)
@@ -399,35 +534,79 @@ public final class DFlash2DraftModel: Module {
         candidateSelector.select(hidden: hidden, logits: logits, anchor: anchor)
     }
 
-    public static func load(directory: String) throws -> DFlash2DraftModel {
-        let config = try DFlash2DraftConfiguration.load(directory: directory)
-        let model = DFlash2DraftModel(config)
+}
+
+public enum DFlashDraftModelFactory {
+    public static func load(
+        directory: String,
+        targetLayers: Int? = nil,
+        vocabularySize: Int? = nil
+    ) throws -> any DFlashDraftingModel {
+        let config = try DFlash2DraftConfiguration.load(
+            directory: directory,
+            targetLayers: targetLayers,
+            vocabularySize: vocabularySize)
+        let weights = try loadWeights(directory: directory, architecture: config.architecture)
+        switch config.architecture {
+        case .dflash:
+            let model = DFlashDraftModel(config)
+            try model.update(parameters: ModuleParameters.unflattened(weights), verify: [.all])
+            eval(model)
+            return model
+        case .dflash2:
+            let model = DFlash2DraftModel(config)
+            try model.update(parameters: ModuleParameters.unflattened(weights), verify: [.all])
+            eval(model)
+            return model
+        }
+    }
+
+    private static func loadWeights(
+        directory: String,
+        architecture: DFlashDraftArchitecture
+    ) throws -> [String: MLXArray] {
         var weights: [String: MLXArray] = [:]
         for file in try FileManager.default.contentsOfDirectory(atPath: directory)
             where file.hasSuffix(".safetensors") {
             for (key, value) in try MLX.loadArrays(
                 url: URL(fileURLWithPath: directory + "/" + file)) {
                 var mapped = key
-                if mapped == "candidate_selector.predecessor_codebook" {
+                if mapped == "candidate_selector.predecessor_codebook"
+                    || mapped == "candidate_selector.successor_codebook" {
                     mapped += ".weight"
-                } else if mapped == "candidate_selector.successor_codebook" {
-                    mapped += ".weight"
+                } else if architecture == .dflash, mapped == "encoder.fc.weight" {
+                    mapped = "fc.weight"
+                } else if architecture == .dflash,
+                          mapped == "encoder.output_norm_enc.weight" {
+                    mapped = "hidden_norm.weight"
                 }
                 weights[mapped] = value
             }
         }
-        try model.update(parameters: ModuleParameters.unflattened(weights), verify: [.all])
-        eval(model)
+        return weights
+    }
+}
+
+public extension DFlash2DraftModel {
+    static func load(directory: String) throws -> DFlash2DraftModel {
+        let model = try DFlashDraftModelFactory.load(directory: directory)
+        guard let model = model as? DFlash2DraftModel else {
+            throw DFlash2Error.invalidConfiguration("expected DFlash2DraftModel")
+        }
         return model
     }
 }
 
 public final class DFlash2Generator {
     private let target: any DFlash2Target
-    private let draft: DFlash2DraftModel
+    private let draft: any DFlashDraftingModel
     private let blockSize: Int
 
-    public init(target: any DFlash2Target, draft: DFlash2DraftModel, blockSize: Int) throws {
+    public init(
+        target: any DFlash2Target,
+        draft: any DFlashDraftingModel,
+        blockSize: Int
+    ) throws {
         guard target.dflash2HiddenSize == draft.config.hiddenSize,
               target.dflash2LayerCount == draft.config.targetLayers,
               target.dflash2VocabularySize == draft.config.vocabularySize else {
@@ -505,7 +684,7 @@ public final class DFlash2Generator {
             let noiseIDs = [staged] + Array(
                 repeating: draft.config.maskTokenID, count: cycleBlock - 1)
             let draftStart = DispatchTime.now().uptimeNanoseconds
-            let draftHidden = draft(
+            let draftHidden = draft.callAsFunction(
                 noiseEmbedding: target.dflash2Embed(array(noiseIDs)),
                 targetHidden: context)
             let proposalHidden = draftHidden[0..., 1..., 0...]
@@ -515,6 +694,7 @@ public final class DFlash2Generator {
             eval(proposalLogits)
             draftTime += elapsedSeconds(since: draftStart)
             draftedCount += proposal.count
+            if shouldStop() { throw CancellationError() }
 
             let candidate = [staged] + proposal
             let snapshot = target.dflash2CaptureCache(cache)
@@ -524,12 +704,17 @@ public final class DFlash2Generator {
             eval(verified.logits, verified.hidden)
             verifyTime += elapsedSeconds(since: verifyStart)
             cycles += 1
+            if shouldStop() { throw CancellationError() }
 
-            var accepted = 0
-            while accepted < proposal.count,
-                  proposal[accepted] == greedy(verified.logits, position: accepted) {
-                accepted += 1
+            var matched = 0
+            while matched < proposal.count,
+                  proposal[matched] == greedy(verified.logits, position: matched) {
+                matched += 1
             }
+            let terminalIndex = proposal.prefix(matched).firstIndex {
+                stopTokenIDs.contains($0)
+            }
+            let accepted = terminalIndex.map { $0 + 1 } ?? matched
             acceptedCount += accepted
             let committed = Array(candidate.prefix(accepted + 1))
 

--- a/Scripts/patches/DFlash2.swift
+++ b/Scripts/patches/DFlash2.swift
@@ -33,6 +33,7 @@ public struct DFlash2GenerationStatistics: Sendable {
     public let acceptedDraftTokens: Int
     public let emittedTokens: Int
     public let verificationCycles: Int
+    public let prefillSeconds: Double
     public let draftSeconds: Double
     public let verificationSeconds: Double
     public let rollbackSeconds: Double
@@ -459,19 +460,23 @@ public final class DFlash2Generator {
         stopTokenIDs: Set<Int> = [],
         shouldStop: () -> Bool = { false },
         onToken: ((Int) -> Bool)? = nil
-    ) -> DFlash2GenerationResult {
+    ) throws -> DFlash2GenerationResult {
         guard !promptIDs.isEmpty, maxTokens > 0 else {
             return DFlash2GenerationResult(
                 tokenIDs: [],
                 statistics: DFlash2GenerationStatistics(
                     draftedTokens: 0, acceptedDraftTokens: 0, emittedTokens: 0,
-                    verificationCycles: 0, draftSeconds: 0,
+                    verificationCycles: 0, prefillSeconds: 0, draftSeconds: 0,
                     verificationSeconds: 0, rollbackSeconds: 0))
         }
 
         let cache = target.dflash2NewCache()
+        if shouldStop() { throw CancellationError() }
+        let prefillStart = DispatchTime.now().uptimeNanoseconds
         let prefill = target.dflash2Forward(
             array(promptIDs), captureLayerIDs: draft.config.targetLayerIDs, cache: cache)
+        eval(prefill.hidden, prefill.logits)
+        let prefillTime = elapsedSeconds(since: prefillStart)
         var context = prefill.hidden
         var staged = greedy(prefill.logits, position: prefill.logits.dim(1) - 1)
         var output: [Int] = []
@@ -483,15 +488,16 @@ public final class DFlash2Generator {
         var rollbackTime = 0.0
         var stopped = false
 
-        func emit(_ token: Int) -> Bool {
-            if shouldStop() { return false }
+        func emit(_ token: Int) throws -> Bool {
+            if shouldStop() { throw CancellationError() }
+            if stopTokenIDs.contains(token) { return false }
             output.append(token)
-            if let onToken, !onToken(token) { return false }
-            return output.count < maxTokens && !stopTokenIDs.contains(token)
+            if let onToken, !onToken(token) { throw CancellationError() }
+            return output.count < maxTokens
         }
 
         while output.count < maxTokens, !stopped {
-            guard emit(staged) else { break }
+            guard try emit(staged) else { break }
             let remaining = maxTokens - output.count
             if remaining <= 0 { break }
 
@@ -536,7 +542,7 @@ public final class DFlash2Generator {
             rollbackTime += elapsedSeconds(since: rollbackStart)
 
             for token in proposal.prefix(accepted) {
-                if !emit(token) {
+                if try emit(token) == false {
                     stopped = true
                     break
                 }
@@ -545,6 +551,8 @@ public final class DFlash2Generator {
             staged = greedy(verified.logits, position: accepted)
         }
 
+        if shouldStop() { throw CancellationError() }
+
         return DFlash2GenerationResult(
             tokenIDs: output,
             statistics: DFlash2GenerationStatistics(
@@ -552,6 +560,7 @@ public final class DFlash2Generator {
                 acceptedDraftTokens: acceptedCount,
                 emittedTokens: output.count,
                 verificationCycles: cycles,
+                prefillSeconds: prefillTime,
                 draftSeconds: draftTime,
                 verificationSeconds: verifyTime,
                 rollbackSeconds: rollbackTime))

--- a/Scripts/patches/DFlash2.swift
+++ b/Scripts/patches/DFlash2.swift
@@ -286,46 +286,25 @@ private final class DFlash2DecoderLayer: Module {
     }
 }
 
-public final class DFlash2DraftModel: Module {
-    public let config: DFlash2DraftConfiguration
-    @ModuleInfo private var layers: [DFlash2DecoderLayer]
-    @ModuleInfo private var norm: RMSNorm
-    @ModuleInfo private var fc: Linear
-    @ModuleInfo(key: "hidden_norm") private var hiddenNorm: RMSNorm
-    @ModuleInfo(key: "candidate_selector.hidden_projection") private var selectorHidden: Linear
-    @ModuleInfo(key: "candidate_selector.predecessor_codebook") private var predecessor: Embedding
-    @ModuleInfo(key: "candidate_selector.successor_codebook") private var successor: Embedding
+private final class DFlash2CandidateSelector: Module {
+    let topK: Int
+    @ModuleInfo(key: "hidden_projection") var hiddenProjection: Linear
+    @ModuleInfo(key: "predecessor_codebook") var predecessor: Embedding
+    @ModuleInfo(key: "successor_codebook") var successor: Embedding
 
-    public init(_ config: DFlash2DraftConfiguration) {
-        self.config = config
-        _layers.wrappedValue = (0 ..< config.hiddenLayers).map { _ in DFlash2DecoderLayer(config) }
-        _norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
-        _fc.wrappedValue = Linear(
-            config.targetLayerIDs.count * config.hiddenSize, config.hiddenSize, bias: false)
-        _hiddenNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
-        _selectorHidden.wrappedValue = Linear(config.hiddenSize, config.selectorRank, bias: false)
+    init(_ config: DFlash2DraftConfiguration) {
+        topK = config.selectorTopK
+        _hiddenProjection.wrappedValue = Linear(config.hiddenSize, config.selectorRank, bias: false)
         _predecessor.wrappedValue = Embedding(
             embeddingCount: config.vocabularySize, dimensions: config.selectorRank)
         _successor.wrappedValue = Embedding(
             embeddingCount: config.vocabularySize, dimensions: config.selectorRank)
     }
 
-    public func callAsFunction(noiseEmbedding: MLXArray, targetHidden: MLXArray) -> MLXArray {
-        let context = hiddenNorm(fc(targetHidden))
-        var hidden = noiseEmbedding
-        for layer in layers {
-            hidden = layer(hidden, targetContext: context)
-        }
-        return norm(hidden)
-    }
-
-    /// DFlash2's selector greedily walks adjacent candidate pairs. The target
-    /// verifier still decides every emitted token.
-    public func select(hidden: MLXArray, logits: MLXArray, anchor: Int) -> [Int] {
-        let topK = config.selectorTopK
+    func select(hidden: MLXArray, logits: MLXArray, anchor: Int) -> [Int] {
         let candidates = argPartition(logits, kth: -topK, axis: -1)[.ellipsis, (-topK)...]
         let unary = takeAlong(logits, candidates, axis: -1)
-        let projected = selectorHidden(hidden)
+        let projected = hiddenProjection(hidden)
         var previous = MLXArray([Int32(anchor)])
         var path: [Int] = []
         for position in 0 ..< hidden.dim(1) {
@@ -340,6 +319,40 @@ public final class DFlash2DraftModel: Module {
             path.append(previous.item(Int.self))
         }
         return path
+    }
+}
+
+public final class DFlash2DraftModel: Module {
+    public let config: DFlash2DraftConfiguration
+    @ModuleInfo private var layers: [DFlash2DecoderLayer]
+    @ModuleInfo private var norm: RMSNorm
+    @ModuleInfo private var fc: Linear
+    @ModuleInfo(key: "hidden_norm") private var hiddenNorm: RMSNorm
+    @ModuleInfo(key: "candidate_selector") private var candidateSelector: DFlash2CandidateSelector
+
+    public init(_ config: DFlash2DraftConfiguration) {
+        self.config = config
+        _layers.wrappedValue = (0 ..< config.hiddenLayers).map { _ in DFlash2DecoderLayer(config) }
+        _norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
+        _fc.wrappedValue = Linear(
+            config.targetLayerIDs.count * config.hiddenSize, config.hiddenSize, bias: false)
+        _hiddenNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
+        _candidateSelector.wrappedValue = DFlash2CandidateSelector(config)
+    }
+
+    public func callAsFunction(noiseEmbedding: MLXArray, targetHidden: MLXArray) -> MLXArray {
+        let context = hiddenNorm(fc(targetHidden))
+        var hidden = noiseEmbedding
+        for layer in layers {
+            hidden = layer(hidden, targetContext: context)
+        }
+        return norm(hidden)
+    }
+
+    /// DFlash2's selector greedily walks adjacent candidate pairs. The target
+    /// verifier still decides every emitted token.
+    public func select(hidden: MLXArray, logits: MLXArray, anchor: Int) -> [Int] {
+        candidateSelector.select(hidden: hidden, logits: logits, anchor: anchor)
     }
 
     public static func load(directory: String) throws -> DFlash2DraftModel {

--- a/Scripts/patches/DFlash2.swift
+++ b/Scripts/patches/DFlash2.swift
@@ -406,6 +406,10 @@ public final class DFlash2Generator {
         argMax(logits[0, position, 0...], axis: -1).item(Int.self)
     }
 
+    private func elapsedSeconds(since start: UInt64) -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000_000
+    }
+
     public func generate(
         promptIDs: [Int],
         maxTokens: Int,
@@ -451,7 +455,7 @@ public final class DFlash2Generator {
             let cycleBlock = min(blockSize, remaining + 1)
             let noiseIDs = [staged] + Array(
                 repeating: draft.config.maskTokenID, count: cycleBlock - 1)
-            let draftStart = Date.timeIntervalSinceReferenceDate
+            let draftStart = DispatchTime.now().uptimeNanoseconds
             let draftHidden = draft(
                 noiseEmbedding: target.dflash2Embed(array(noiseIDs)),
                 targetHidden: context)
@@ -460,16 +464,16 @@ public final class DFlash2Generator {
             let proposal = draft.select(
                 hidden: proposalHidden, logits: proposalLogits, anchor: staged)
             eval(proposalLogits)
-            draftTime += Date.timeIntervalSinceReferenceDate - draftStart
+            draftTime += elapsedSeconds(since: draftStart)
             draftedCount += proposal.count
 
             let candidate = [staged] + proposal
             let snapshot = target.dflash2CaptureCache(cache)
-            let verifyStart = Date.timeIntervalSinceReferenceDate
+            let verifyStart = DispatchTime.now().uptimeNanoseconds
             let verified = target.dflash2Forward(
                 array(candidate), captureLayerIDs: draft.config.targetLayerIDs, cache: cache)
             eval(verified.logits, verified.hidden)
-            verifyTime += Date.timeIntervalSinceReferenceDate - verifyStart
+            verifyTime += elapsedSeconds(since: verifyStart)
             cycles += 1
 
             var accepted = 0
@@ -480,13 +484,13 @@ public final class DFlash2Generator {
             acceptedCount += accepted
             let committed = Array(candidate.prefix(accepted + 1))
 
-            let rollbackStart = Date.timeIntervalSinceReferenceDate
+            let rollbackStart = DispatchTime.now().uptimeNanoseconds
             target.dflash2RestoreCache(snapshot, into: cache)
             let replay = target.dflash2Forward(
                 array(committed), captureLayerIDs: draft.config.targetLayerIDs, cache: cache)
             eval(replay.hidden)
             context = concatenated([context, replay.hidden], axis: 1)
-            rollbackTime += Date.timeIntervalSinceReferenceDate - rollbackStart
+            rollbackTime += elapsedSeconds(since: rollbackStart)
 
             for token in proposal.prefix(accepted) {
                 if !emit(token) {

--- a/Scripts/patches/DFlash2.swift
+++ b/Scripts/patches/DFlash2.swift
@@ -67,6 +67,9 @@ public struct DFlash2DraftConfiguration: Sendable {
     public let selectorTopK: Int
     public let rmsNormEpsilon: Float
     public let ropeTheta: Float
+    public let maxPositionEmbeddings: Int
+    public let layerTypes: [String]
+    public let slidingWindow: Int?
 
     public static func load(directory: String) throws -> Self {
         let data = try Data(contentsOf: URL(fileURLWithPath: directory + "/config.json"))
@@ -96,9 +99,18 @@ public struct DFlash2DraftConfiguration: Sendable {
         let targetIDs = (dflash["target_layer_ids"] as? [NSNumber])?.map(\.intValue) ?? []
         let groupSize = try integer(dflash, "conv_group_size")
         let kernelSize = try integer(dflash, "conv_kernel_size")
+        let layerTypes = root["layer_types"] as? [String] ?? []
+        let slidingWindow = (root["sliding_window"] as? NSNumber)?.intValue
+        let rope = root["rope_parameters"] as? [String: Any]
+            ?? root["rope_scaling"] as? [String: Any]
+            ?? root
         guard hidden > 0, layers > 0, hidden.isMultiple(of: groupSize), kernelSize == 2,
               targetIDs.count == layers,
-              targetIDs.allSatisfy({ $0 >= 0 && $0 < targetLayers }) else {
+              targetIDs == targetIDs.sorted(), Set(targetIDs).count == targetIDs.count,
+              targetIDs.allSatisfy({ $0 >= 0 && $0 < targetLayers }),
+              layerTypes.count == layers,
+              layerTypes.allSatisfy({ $0 == "sliding_attention" || $0 == "full_attention" }),
+              !layerTypes.contains("sliding_attention") || (slidingWindow ?? 0) > 0 else {
             throw DFlash2Error.invalidConfiguration("invalid hidden, convolution, or target-layer layout")
         }
         return Self(
@@ -118,7 +130,10 @@ public struct DFlash2DraftConfiguration: Sendable {
             selectorRank: try integer(dflash, "selector_rank"),
             selectorTopK: try integer(dflash, "selector_top_k"),
             rmsNormEpsilon: try floating(root, "rms_norm_eps"),
-            ropeTheta: try floating(root, "rope_theta")
+            ropeTheta: try floating(rope, "rope_theta"),
+            maxPositionEmbeddings: try integer(root, "max_position_embeddings"),
+            layerTypes: layerTypes,
+            slidingWindow: slidingWindow
         )
     }
 }
@@ -207,6 +222,7 @@ private final class DFlash2Attention: Module {
     let keyValueHeads: Int
     let headDimension: Int
     let scale: Float
+    let slidingWindow: Int?
     @ModuleInfo(key: "q_proj") var query: Linear
     @ModuleInfo(key: "k_proj") var key: Linear
     @ModuleInfo(key: "v_proj") var value: Linear
@@ -215,11 +231,13 @@ private final class DFlash2Attention: Module {
     @ModuleInfo(key: "k_norm") var keyNorm: RMSNorm
     let rope: RoPE
 
-    init(_ config: DFlash2DraftConfiguration) {
+    init(_ config: DFlash2DraftConfiguration, layerIndex: Int) {
         heads = config.attentionHeads
         keyValueHeads = config.keyValueHeads
         headDimension = config.headDimension
         scale = pow(Float(config.headDimension), -0.5)
+        slidingWindow = config.layerTypes[layerIndex] == "sliding_attention"
+            ? config.slidingWindow : nil
         _query.wrappedValue = Linear(config.hiddenSize, heads * headDimension, bias: false)
         _key.wrappedValue = Linear(config.hiddenSize, keyValueHeads * headDimension, bias: false)
         _value.wrappedValue = Linear(config.hiddenSize, keyValueHeads * headDimension, bias: false)
@@ -232,29 +250,52 @@ private final class DFlash2Attention: Module {
     func callAsFunction(_ hidden: MLXArray, targetContext: MLXArray) -> MLXArray {
         let batch = hidden.dim(0)
         let block = hidden.dim(1)
-        let context = targetContext.dim(1)
+        let fullContext = targetContext.dim(1)
+        let contextStart: Int
+        let visibleContext: MLXArray
+        if let slidingWindow, fullContext > slidingWindow - 1 {
+            contextStart = fullContext - (slidingWindow - 1)
+            visibleContext = targetContext[0..., contextStart..., 0...]
+        } else {
+            contextStart = 0
+            visibleContext = targetContext
+        }
+        let context = visibleContext.dim(1)
         var q = query(hidden).reshaped(batch, block, heads, headDimension)
         q = queryNorm(q).transposed(0, 2, 1, 3)
-        q = rope(q, offset: context)
+        q = rope(q, offset: fullContext)
 
-        var contextK = key(targetContext).reshaped(batch, context, keyValueHeads, headDimension)
+        var contextK = key(visibleContext).reshaped(batch, context, keyValueHeads, headDimension)
         contextK = keyNorm(contextK).transposed(0, 2, 1, 3)
-        contextK = rope(contextK, offset: 0)
-        let contextV = value(targetContext).reshaped(
+        contextK = rope(contextK, offset: contextStart)
+        let contextV = value(visibleContext).reshaped(
             batch, context, keyValueHeads, headDimension).transposed(0, 2, 1, 3)
 
         var blockK = key(hidden).reshaped(batch, block, keyValueHeads, headDimension)
         blockK = keyNorm(blockK).transposed(0, 2, 1, 3)
-        blockK = rope(blockK, offset: context)
+        blockK = rope(blockK, offset: fullContext)
         let blockV = value(hidden).reshaped(
             batch, block, keyValueHeads, headDimension).transposed(0, 2, 1, 3)
 
+        let mask: MLXFast.ScaledDotProductAttentionMaskMode
+        if let slidingWindow {
+            let queryIndices = MLXArray(
+                Int32(fullContext) ..< Int32(fullContext + block))[0..., .newAxis]
+            let keyIndices = MLXArray(
+                Int32(contextStart) ..< Int32(fullContext + block))[.newAxis, 0...]
+            let contextMask = (keyIndices .< Int32(fullContext))
+                .&& ((queryIndices - keyIndices) .< Int32(slidingWindow))
+            let blockMask = keyIndices .>= Int32(fullContext)
+            mask = .array(contextMask .|| blockMask)
+        } else {
+            mask = .none
+        }
         let attended = MLXFast.scaledDotProductAttention(
             queries: q,
             keys: concatenated([contextK, blockK], axis: 2),
             values: concatenated([contextV, blockV], axis: 2),
             scale: scale,
-            mask: .none)
+            mask: mask)
         return output(attended.transposed(0, 2, 1, 3).reshaped(batch, block, -1))
     }
 }
@@ -267,8 +308,8 @@ private final class DFlash2DecoderLayer: Module {
     @ModuleInfo(key: "attention_conv") var attentionConv: DFlash2GroupedDynamicCausalConv
     @ModuleInfo(key: "mlp_conv") var mlpConv: DFlash2GroupedDynamicCausalConv
 
-    init(_ config: DFlash2DraftConfiguration) {
-        _attention.wrappedValue = DFlash2Attention(config)
+    init(_ config: DFlash2DraftConfiguration, layerIndex: Int) {
+        _attention.wrappedValue = DFlash2Attention(config, layerIndex: layerIndex)
         _mlp.wrappedValue = DFlash2MLP(config)
         _inputNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
         _postAttentionNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
@@ -332,7 +373,9 @@ public final class DFlash2DraftModel: Module {
 
     public init(_ config: DFlash2DraftConfiguration) {
         self.config = config
-        _layers.wrappedValue = (0 ..< config.hiddenLayers).map { _ in DFlash2DecoderLayer(config) }
+        _layers.wrappedValue = (0 ..< config.hiddenLayers).map {
+            DFlash2DecoderLayer(config, layerIndex: $0)
+        }
         _norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
         _fc.wrappedValue = Linear(
             config.targetLayerIDs.count * config.hiddenSize, config.hiddenSize, bias: false)

--- a/Scripts/patches/DFlash2.swift
+++ b/Scripts/patches/DFlash2.swift
@@ -1,0 +1,499 @@
+import Foundation
+import MLX
+import MLXNN
+
+public struct DFlash2TargetOutput {
+    public let hidden: MLXArray
+    public let logits: MLXArray
+
+    public init(hidden: MLXArray, logits: MLXArray) {
+        self.hidden = hidden
+        self.logits = logits
+    }
+}
+
+public protocol DFlash2Target: AnyObject {
+    var dflash2HiddenSize: Int { get }
+    var dflash2LayerCount: Int { get }
+    var dflash2VocabularySize: Int { get }
+    func dflash2NewCache() -> [any KVCache]
+    func dflash2Embed(_ tokenIDs: MLXArray) -> MLXArray
+    func dflash2Project(_ hidden: MLXArray) -> MLXArray
+    func dflash2Forward(
+        _ tokenIDs: MLXArray,
+        captureLayerIDs: [Int],
+        cache: [any KVCache]
+    ) -> DFlash2TargetOutput
+    func dflash2CaptureCache(_ cache: [any KVCache]) -> Any
+    func dflash2RestoreCache(_ snapshot: Any, into cache: [any KVCache])
+}
+
+public struct DFlash2GenerationStatistics: Sendable {
+    public let draftedTokens: Int
+    public let acceptedDraftTokens: Int
+    public let emittedTokens: Int
+    public let verificationCycles: Int
+    public let draftSeconds: Double
+    public let verificationSeconds: Double
+    public let rollbackSeconds: Double
+
+    public var meanAcceptanceLength: Double {
+        verificationCycles > 0
+            ? Double(acceptedDraftTokens) / Double(verificationCycles)
+            : 0
+    }
+}
+
+public struct DFlash2GenerationResult: Sendable {
+    public let tokenIDs: [Int]
+    public let statistics: DFlash2GenerationStatistics
+}
+
+public struct DFlash2DraftConfiguration: Sendable {
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let hiddenLayers: Int
+    public let attentionHeads: Int
+    public let keyValueHeads: Int
+    public let headDimension: Int
+    public let vocabularySize: Int
+    public let targetLayers: Int
+    public let targetLayerIDs: [Int]
+    public let blockSize: Int
+    public let maskTokenID: Int
+    public let convolutionKernelSize: Int
+    public let convolutionGroupSize: Int
+    public let selectorRank: Int
+    public let selectorTopK: Int
+    public let rmsNormEpsilon: Float
+    public let ropeTheta: Float
+
+    public static func load(directory: String) throws -> Self {
+        let data = try Data(contentsOf: URL(fileURLWithPath: directory + "/config.json"))
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              (root["architectures"] as? [String])?.contains("DFlash2DraftModel") == true,
+              (root["is_causal"] as? Bool) == false,
+              let dflash = root["dflash_config"] as? [String: Any]
+        else {
+            throw DFlash2Error.invalidConfiguration(
+                "architectures must contain DFlash2DraftModel and is_causal must be false")
+        }
+        func integer(_ object: [String: Any], _ key: String) throws -> Int {
+            guard let value = (object[key] as? NSNumber)?.intValue else {
+                throw DFlash2Error.invalidConfiguration("missing \(key)")
+            }
+            return value
+        }
+        func floating(_ object: [String: Any], _ key: String) throws -> Float {
+            guard let value = (object[key] as? NSNumber)?.floatValue else {
+                throw DFlash2Error.invalidConfiguration("missing \(key)")
+            }
+            return value
+        }
+        let hidden = try integer(root, "hidden_size")
+        let layers = try integer(root, "num_hidden_layers")
+        let targetLayers = try integer(root, "num_target_layers")
+        let targetIDs = (dflash["target_layer_ids"] as? [NSNumber])?.map(\.intValue) ?? []
+        let groupSize = try integer(dflash, "conv_group_size")
+        let kernelSize = try integer(dflash, "conv_kernel_size")
+        guard hidden > 0, layers > 0, hidden.isMultiple(of: groupSize), kernelSize == 2,
+              targetIDs.count == layers,
+              targetIDs.allSatisfy({ $0 >= 0 && $0 < targetLayers }) else {
+            throw DFlash2Error.invalidConfiguration("invalid hidden, convolution, or target-layer layout")
+        }
+        return Self(
+            hiddenSize: hidden,
+            intermediateSize: try integer(root, "intermediate_size"),
+            hiddenLayers: layers,
+            attentionHeads: try integer(root, "num_attention_heads"),
+            keyValueHeads: try integer(root, "num_key_value_heads"),
+            headDimension: try integer(root, "head_dim"),
+            vocabularySize: try integer(root, "vocab_size"),
+            targetLayers: targetLayers,
+            targetLayerIDs: targetIDs,
+            blockSize: try integer(dflash, "block_size"),
+            maskTokenID: try integer(dflash, "mask_token_id"),
+            convolutionKernelSize: kernelSize,
+            convolutionGroupSize: groupSize,
+            selectorRank: try integer(dflash, "selector_rank"),
+            selectorTopK: try integer(dflash, "selector_top_k"),
+            rmsNormEpsilon: try floating(root, "rms_norm_eps"),
+            ropeTheta: try floating(root, "rope_theta")
+        )
+    }
+}
+
+public enum DFlash2Error: LocalizedError {
+    case invalidConfiguration(String)
+    case incompatibleTarget(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration(let message): return "Invalid DFlash2 configuration: \(message)"
+        case .incompatibleTarget(let message): return "Incompatible DFlash2 target: \(message)"
+        }
+    }
+}
+
+private final class DFlash2MLP: Module, UnaryLayer {
+    @ModuleInfo(key: "gate_proj") var gate: Linear
+    @ModuleInfo(key: "up_proj") var up: Linear
+    @ModuleInfo(key: "down_proj") var down: Linear
+
+    init(_ config: DFlash2DraftConfiguration) {
+        _gate.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        _up.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        _down.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        down(silu(gate(value)) * up(value))
+    }
+}
+
+private final class DFlash2GroupedDynamicCausalConv: Module {
+    let groupSize: Int
+    let groups: Int
+    let kernelSize: Int
+    @ModuleInfo(key: "kernel_projection") var kernelProjection: Linear
+    @ParameterInfo(key: "base_kernel") var baseKernel: MLXArray
+
+    init(_ config: DFlash2DraftConfiguration) {
+        groupSize = config.convolutionGroupSize
+        groups = config.hiddenSize / config.convolutionGroupSize
+        kernelSize = config.convolutionKernelSize
+        _kernelProjection.wrappedValue = Linear(
+            config.hiddenSize, 2 * kernelSize * groups, bias: false)
+        _baseKernel.wrappedValue = MLXArray.zeros(
+            [2, kernelSize, config.hiddenSize], dtype: .float32)
+    }
+
+    private func convolve(_ hidden: MLXArray, dynamic: MLXArray, phase: Int) -> MLXArray {
+        let batch = hidden.dim(0)
+        let length = hidden.dim(1)
+        let blocks = hidden.reshaped(batch, length, groups, groupSize)
+        var output = MLXArray.zeros(like: blocks)
+        for offset in 0 ..< kernelSize {
+            let values: MLXArray
+            if offset == 0 {
+                values = blocks
+            } else {
+                let padding = MLXArray.zeros(
+                    [batch, offset, groups, groupSize], dtype: blocks.dtype)
+                values = concatenated(
+                    [padding, blocks[0..., 0 ..< (length - offset), 0..., 0...]], axis: 1)
+            }
+            let fixed = baseKernel[phase, offset, 0...].reshaped(1, 1, groups, groupSize)
+            let generated = dynamic[0..., 0..., offset, 0..., .newAxis]
+            output = output + (fixed + generated) * values
+        }
+        return output.reshaped(hidden.shape)
+    }
+
+    func prepare(_ hidden: MLXArray) -> (MLXArray, MLXArray) {
+        let dynamic = kernelProjection(hidden).reshaped(
+            hidden.dim(0), hidden.dim(1), 2, kernelSize, groups)
+        return (convolve(hidden, dynamic: dynamic[0..., 0..., 0, 0..., 0...], phase: 0),
+                dynamic[0..., 0..., 1, 0..., 0...])
+    }
+
+    func finish(_ hidden: MLXArray, dynamic: MLXArray) -> MLXArray {
+        convolve(hidden, dynamic: dynamic, phase: 1)
+    }
+}
+
+private final class DFlash2Attention: Module {
+    let heads: Int
+    let keyValueHeads: Int
+    let headDimension: Int
+    let scale: Float
+    @ModuleInfo(key: "q_proj") var query: Linear
+    @ModuleInfo(key: "k_proj") var key: Linear
+    @ModuleInfo(key: "v_proj") var value: Linear
+    @ModuleInfo(key: "o_proj") var output: Linear
+    @ModuleInfo(key: "q_norm") var queryNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") var keyNorm: RMSNorm
+    let rope: RoPE
+
+    init(_ config: DFlash2DraftConfiguration) {
+        heads = config.attentionHeads
+        keyValueHeads = config.keyValueHeads
+        headDimension = config.headDimension
+        scale = pow(Float(config.headDimension), -0.5)
+        _query.wrappedValue = Linear(config.hiddenSize, heads * headDimension, bias: false)
+        _key.wrappedValue = Linear(config.hiddenSize, keyValueHeads * headDimension, bias: false)
+        _value.wrappedValue = Linear(config.hiddenSize, keyValueHeads * headDimension, bias: false)
+        _output.wrappedValue = Linear(heads * headDimension, config.hiddenSize, bias: false)
+        _queryNorm.wrappedValue = RMSNorm(dimensions: headDimension, eps: config.rmsNormEpsilon)
+        _keyNorm.wrappedValue = RMSNorm(dimensions: headDimension, eps: config.rmsNormEpsilon)
+        rope = RoPE(dimensions: headDimension, traditional: false, base: config.ropeTheta)
+    }
+
+    func callAsFunction(_ hidden: MLXArray, targetContext: MLXArray) -> MLXArray {
+        let batch = hidden.dim(0)
+        let block = hidden.dim(1)
+        let context = targetContext.dim(1)
+        var q = query(hidden).reshaped(batch, block, heads, headDimension)
+        q = queryNorm(q).transposed(0, 2, 1, 3)
+        q = rope(q, offset: context)
+
+        var contextK = key(targetContext).reshaped(batch, context, keyValueHeads, headDimension)
+        contextK = keyNorm(contextK).transposed(0, 2, 1, 3)
+        contextK = rope(contextK, offset: 0)
+        let contextV = value(targetContext).reshaped(
+            batch, context, keyValueHeads, headDimension).transposed(0, 2, 1, 3)
+
+        var blockK = key(hidden).reshaped(batch, block, keyValueHeads, headDimension)
+        blockK = keyNorm(blockK).transposed(0, 2, 1, 3)
+        blockK = rope(blockK, offset: context)
+        let blockV = value(hidden).reshaped(
+            batch, block, keyValueHeads, headDimension).transposed(0, 2, 1, 3)
+
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: concatenated([contextK, blockK], axis: 2),
+            values: concatenated([contextV, blockV], axis: 2),
+            scale: scale,
+            mask: .none)
+        return output(attended.transposed(0, 2, 1, 3).reshaped(batch, block, -1))
+    }
+}
+
+private final class DFlash2DecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var attention: DFlash2Attention
+    @ModuleInfo var mlp: DFlash2MLP
+    @ModuleInfo(key: "input_layernorm") var inputNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionNorm: RMSNorm
+    @ModuleInfo(key: "attention_conv") var attentionConv: DFlash2GroupedDynamicCausalConv
+    @ModuleInfo(key: "mlp_conv") var mlpConv: DFlash2GroupedDynamicCausalConv
+
+    init(_ config: DFlash2DraftConfiguration) {
+        _attention.wrappedValue = DFlash2Attention(config)
+        _mlp.wrappedValue = DFlash2MLP(config)
+        _inputNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
+        _postAttentionNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
+        _attentionConv.wrappedValue = DFlash2GroupedDynamicCausalConv(config)
+        _mlpConv.wrappedValue = DFlash2GroupedDynamicCausalConv(config)
+    }
+
+    func callAsFunction(_ hidden: MLXArray, targetContext: MLXArray) -> MLXArray {
+        let (attentionInput, attentionKernel) = attentionConv.prepare(inputNorm(hidden))
+        var result = hidden + attentionConv.finish(
+            attention(attentionInput, targetContext: targetContext), dynamic: attentionKernel)
+        let (mlpInput, mlpKernel) = mlpConv.prepare(postAttentionNorm(result))
+        result = result + mlpConv.finish(mlp(mlpInput), dynamic: mlpKernel)
+        return result
+    }
+}
+
+public final class DFlash2DraftModel: Module {
+    public let config: DFlash2DraftConfiguration
+    @ModuleInfo private var layers: [DFlash2DecoderLayer]
+    @ModuleInfo private var norm: RMSNorm
+    @ModuleInfo private var fc: Linear
+    @ModuleInfo(key: "hidden_norm") private var hiddenNorm: RMSNorm
+    @ModuleInfo(key: "candidate_selector.hidden_projection") private var selectorHidden: Linear
+    @ModuleInfo(key: "candidate_selector.predecessor_codebook") private var predecessor: Embedding
+    @ModuleInfo(key: "candidate_selector.successor_codebook") private var successor: Embedding
+
+    public init(_ config: DFlash2DraftConfiguration) {
+        self.config = config
+        _layers.wrappedValue = (0 ..< config.hiddenLayers).map { _ in DFlash2DecoderLayer(config) }
+        _norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
+        _fc.wrappedValue = Linear(
+            config.targetLayerIDs.count * config.hiddenSize, config.hiddenSize, bias: false)
+        _hiddenNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEpsilon)
+        _selectorHidden.wrappedValue = Linear(config.hiddenSize, config.selectorRank, bias: false)
+        _predecessor.wrappedValue = Embedding(
+            embeddingCount: config.vocabularySize, dimensions: config.selectorRank)
+        _successor.wrappedValue = Embedding(
+            embeddingCount: config.vocabularySize, dimensions: config.selectorRank)
+    }
+
+    public func callAsFunction(noiseEmbedding: MLXArray, targetHidden: MLXArray) -> MLXArray {
+        let context = hiddenNorm(fc(targetHidden))
+        var hidden = noiseEmbedding
+        for layer in layers {
+            hidden = layer(hidden, targetContext: context)
+        }
+        return norm(hidden)
+    }
+
+    /// DFlash2's selector greedily walks adjacent candidate pairs. The target
+    /// verifier still decides every emitted token.
+    public func select(hidden: MLXArray, logits: MLXArray, anchor: Int) -> [Int] {
+        let topK = config.selectorTopK
+        let candidates = argPartition(logits, kth: -topK, axis: -1)[.ellipsis, (-topK)...]
+        let unary = takeAlong(logits, candidates, axis: -1)
+        let projected = selectorHidden(hidden)
+        var previous = MLXArray([Int32(anchor)])
+        var path: [Int] = []
+        for position in 0 ..< hidden.dim(1) {
+            let candidate = candidates[0..., position, 0...]
+            let edge = MLX.sum(
+                predecessor(previous)[0..., .newAxis, 0...]
+                    * projected[0..., position, .newAxis, 0...]
+                    * successor(candidate),
+                axis: -1)
+            let selected = argMax(unary[0..., position, 0...] + edge, axis: -1)
+            previous = takeAlong(candidate, selected[.ellipsis, .newAxis], axis: -1)[.ellipsis, 0]
+            path.append(previous.item(Int.self))
+        }
+        return path
+    }
+
+    public static func load(directory: String) throws -> DFlash2DraftModel {
+        let config = try DFlash2DraftConfiguration.load(directory: directory)
+        let model = DFlash2DraftModel(config)
+        var weights: [String: MLXArray] = [:]
+        for file in try FileManager.default.contentsOfDirectory(atPath: directory)
+            where file.hasSuffix(".safetensors") {
+            for (key, value) in try MLX.loadArrays(
+                url: URL(fileURLWithPath: directory + "/" + file)) {
+                var mapped = key
+                if mapped == "candidate_selector.predecessor_codebook" {
+                    mapped += ".weight"
+                } else if mapped == "candidate_selector.successor_codebook" {
+                    mapped += ".weight"
+                }
+                weights[mapped] = value
+            }
+        }
+        try model.update(parameters: ModuleParameters.unflattened(weights), verify: [.all])
+        eval(model)
+        return model
+    }
+}
+
+public final class DFlash2Generator {
+    private let target: any DFlash2Target
+    private let draft: DFlash2DraftModel
+    private let blockSize: Int
+
+    public init(target: any DFlash2Target, draft: DFlash2DraftModel, blockSize: Int) throws {
+        guard target.dflash2HiddenSize == draft.config.hiddenSize,
+              target.dflash2LayerCount == draft.config.targetLayers,
+              target.dflash2VocabularySize == draft.config.vocabularySize else {
+            throw DFlash2Error.incompatibleTarget(
+                "hidden size, layer count, and vocabulary must match the drafter config")
+        }
+        guard blockSize >= 2 else {
+            throw DFlash2Error.invalidConfiguration("runtime block size must be at least 2")
+        }
+        self.target = target
+        self.draft = draft
+        self.blockSize = min(blockSize, draft.config.blockSize)
+    }
+
+    private func array(_ ids: [Int]) -> MLXArray {
+        MLXArray(ids.map(Int32.init)).reshaped(1, ids.count)
+    }
+
+    private func greedy(_ logits: MLXArray, position: Int) -> Int {
+        argMax(logits[0, position, 0...], axis: -1).item(Int.self)
+    }
+
+    public func generate(
+        promptIDs: [Int],
+        maxTokens: Int,
+        stopTokenIDs: Set<Int> = [],
+        shouldStop: () -> Bool = { false },
+        onToken: ((Int) -> Bool)? = nil
+    ) -> DFlash2GenerationResult {
+        guard !promptIDs.isEmpty, maxTokens > 0 else {
+            return DFlash2GenerationResult(
+                tokenIDs: [],
+                statistics: DFlash2GenerationStatistics(
+                    draftedTokens: 0, acceptedDraftTokens: 0, emittedTokens: 0,
+                    verificationCycles: 0, draftSeconds: 0,
+                    verificationSeconds: 0, rollbackSeconds: 0))
+        }
+
+        let cache = target.dflash2NewCache()
+        let prefill = target.dflash2Forward(
+            array(promptIDs), captureLayerIDs: draft.config.targetLayerIDs, cache: cache)
+        var context = prefill.hidden
+        var staged = greedy(prefill.logits, position: prefill.logits.dim(1) - 1)
+        var output: [Int] = []
+        var draftedCount = 0
+        var acceptedCount = 0
+        var cycles = 0
+        var draftTime = 0.0
+        var verifyTime = 0.0
+        var rollbackTime = 0.0
+        var stopped = false
+
+        func emit(_ token: Int) -> Bool {
+            if shouldStop() { return false }
+            output.append(token)
+            if let onToken, !onToken(token) { return false }
+            return output.count < maxTokens && !stopTokenIDs.contains(token)
+        }
+
+        while output.count < maxTokens, !stopped {
+            guard emit(staged) else { break }
+            let remaining = maxTokens - output.count
+            if remaining <= 0 { break }
+
+            let cycleBlock = min(blockSize, remaining + 1)
+            let noiseIDs = [staged] + Array(
+                repeating: draft.config.maskTokenID, count: cycleBlock - 1)
+            let draftStart = Date.timeIntervalSinceReferenceDate
+            let draftHidden = draft(
+                noiseEmbedding: target.dflash2Embed(array(noiseIDs)),
+                targetHidden: context)
+            let proposalHidden = draftHidden[0..., 1..., 0...]
+            let proposalLogits = target.dflash2Project(proposalHidden)
+            let proposal = draft.select(
+                hidden: proposalHidden, logits: proposalLogits, anchor: staged)
+            eval(proposalLogits)
+            draftTime += Date.timeIntervalSinceReferenceDate - draftStart
+            draftedCount += proposal.count
+
+            let candidate = [staged] + proposal
+            let snapshot = target.dflash2CaptureCache(cache)
+            let verifyStart = Date.timeIntervalSinceReferenceDate
+            let verified = target.dflash2Forward(
+                array(candidate), captureLayerIDs: draft.config.targetLayerIDs, cache: cache)
+            eval(verified.logits, verified.hidden)
+            verifyTime += Date.timeIntervalSinceReferenceDate - verifyStart
+            cycles += 1
+
+            var accepted = 0
+            while accepted < proposal.count,
+                  proposal[accepted] == greedy(verified.logits, position: accepted) {
+                accepted += 1
+            }
+            acceptedCount += accepted
+            let committed = Array(candidate.prefix(accepted + 1))
+
+            let rollbackStart = Date.timeIntervalSinceReferenceDate
+            target.dflash2RestoreCache(snapshot, into: cache)
+            let replay = target.dflash2Forward(
+                array(committed), captureLayerIDs: draft.config.targetLayerIDs, cache: cache)
+            eval(replay.hidden)
+            context = concatenated([context, replay.hidden], axis: 1)
+            rollbackTime += Date.timeIntervalSinceReferenceDate - rollbackStart
+
+            for token in proposal.prefix(accepted) {
+                if !emit(token) {
+                    stopped = true
+                    break
+                }
+            }
+            if stopped { break }
+            staged = greedy(verified.logits, position: accepted)
+        }
+
+        return DFlash2GenerationResult(
+            tokenIDs: output,
+            statistics: DFlash2GenerationStatistics(
+                draftedTokens: draftedCount,
+                acceptedDraftTokens: acceptedCount,
+                emittedTokens: output.count,
+                verificationCycles: cycles,
+                draftSeconds: draftTime,
+                verificationSeconds: verifyTime,
+                rollbackSeconds: rollbackTime))
+    }
+}

--- a/Scripts/patches/MuseGlimmer.swift
+++ b/Scripts/patches/MuseGlimmer.swift
@@ -1225,14 +1225,6 @@ extension MuseGlimmer: LoRAModel {
     }
 }
 
-private struct MuseDFlash2CacheSnapshot {
-    struct Layer {
-        let state: [MLXArray]
-        let offset: Int
-    }
-    let layers: [Layer]
-}
-
 extension MuseGlimmer: DFlash2Target {
     public var dflash2HiddenSize: Int { config.textConfiguration.hiddenSize }
     public var dflash2LayerCount: Int { config.textConfiguration.hiddenLayers }
@@ -1254,22 +1246,13 @@ extension MuseGlimmer: DFlash2Target {
             tokenIDs, captureLayerIDs: captureLayerIDs, cache: cache)
     }
     public func dflash2CaptureCache(_ cache: [any KVCache]) -> Any {
-        MuseDFlash2CacheSnapshot(
-            layers: cache.map { .init(state: $0.state, offset: $0.offset) })
+        DFlash2CacheSnapshot.capture(cache)
     }
     public func dflash2RestoreCache(_ snapshot: Any, into cache: [any KVCache]) {
-        guard let snapshot = snapshot as? MuseDFlash2CacheSnapshot else {
+        guard let snapshot = snapshot as? [DFlash2CacheSnapshot.Layer] else {
             preconditionFailure("Invalid Muse DFlash2 cache snapshot")
         }
-        for (index, layer) in snapshot.layers.enumerated() {
-            var entry = cache[index]
-            if entry.isTrimmable {
-                let excess = entry.offset - layer.offset
-                if excess > 0 { _ = entry.trim(excess) }
-            } else {
-                entry.state = layer.state
-            }
-        }
+        DFlash2CacheSnapshot.restore(snapshot, into: cache)
     }
 }
 

--- a/Scripts/patches/MuseGlimmer.swift
+++ b/Scripts/patches/MuseGlimmer.swift
@@ -528,6 +528,31 @@ private class MuseGlimmerTextModel: Module {
         }
         return norm(h)
     }
+
+    func dflash2Forward(
+        _ inputs: MLXArray,
+        captureLayerIDs: [Int],
+        cache: [KVCache]
+    ) -> (hidden: MLXArray, normalized: MLXArray) {
+        var h = embedNorm(embedTokens(inputs))
+        let fullMask = createAttentionMask(h: h, cache: cache[fullAttentionIndex])
+        var slidingMask = MLXFast.ScaledDotProductAttentionMaskMode.none
+        if let slidingAttentionIndex {
+            slidingMask = createAttentionMask(
+                h: h, cache: cache[slidingAttentionIndex], windowSize: config.slidingWindow)
+        }
+        let capture = Set(captureLayerIDs)
+        var selected: [MLXArray] = []
+        for (index, layer) in layers.enumerated() {
+            h = layer(
+                h,
+                mask: layer.isSliding ? slidingMask : fullMask,
+                cache: cache[index])
+            if capture.contains(index) { selected.append(h) }
+        }
+        precondition(selected.count == captureLayerIDs.count)
+        return (concatenated(selected, axis: -1), norm(h))
+    }
 }
 
 private class MuseGlimmerLanguageModel: Module, KVCacheDimensionProvider {
@@ -569,6 +594,26 @@ private class MuseGlimmerLanguageModel: Module, KVCacheDimensionProvider {
             logits = tanh(logits / cap) * cap
         }
         return LMOutput(logits: logits)
+    }
+
+    func projectDFlash2(_ hidden: MLXArray) -> MLXArray {
+        var logits = lmHead(hidden) * config.outputMultiplier
+        if config.finalLogitSoftcapping > 0 {
+            logits = tanh(logits / config.finalLogitSoftcapping)
+                * config.finalLogitSoftcapping
+        }
+        return logits
+    }
+
+    func dflash2Forward(
+        _ tokenIDs: MLXArray,
+        captureLayerIDs: [Int],
+        cache: [KVCache]
+    ) -> DFlash2TargetOutput {
+        let result = model.dflash2Forward(
+            tokenIDs, captureLayerIDs: captureLayerIDs, cache: cache)
+        return DFlash2TargetOutput(
+            hidden: result.hidden, logits: projectDFlash2(result.normalized))
     }
 }
 
@@ -1177,6 +1222,54 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
 extension MuseGlimmer: LoRAModel {
     public var loraLayers: [Module] {
         languageModel.model.layers
+    }
+}
+
+private struct MuseDFlash2CacheSnapshot {
+    struct Layer {
+        let state: [MLXArray]
+        let offset: Int
+    }
+    let layers: [Layer]
+}
+
+extension MuseGlimmer: DFlash2Target {
+    public var dflash2HiddenSize: Int { config.textConfiguration.hiddenSize }
+    public var dflash2LayerCount: Int { config.textConfiguration.hiddenLayers }
+    public var dflash2VocabularySize: Int { config.textConfiguration.vocabularySize }
+
+    public func dflash2NewCache() -> [any KVCache] { newCache(parameters: nil) }
+    public func dflash2Embed(_ tokenIDs: MLXArray) -> MLXArray {
+        languageModel.model.embedNorm(languageModel.model.embedTokens(tokenIDs))
+    }
+    public func dflash2Project(_ hidden: MLXArray) -> MLXArray {
+        languageModel.projectDFlash2(hidden)
+    }
+    public func dflash2Forward(
+        _ tokenIDs: MLXArray,
+        captureLayerIDs: [Int],
+        cache: [any KVCache]
+    ) -> DFlash2TargetOutput {
+        languageModel.dflash2Forward(
+            tokenIDs, captureLayerIDs: captureLayerIDs, cache: cache)
+    }
+    public func dflash2CaptureCache(_ cache: [any KVCache]) -> Any {
+        MuseDFlash2CacheSnapshot(
+            layers: cache.map { .init(state: $0.state, offset: $0.offset) })
+    }
+    public func dflash2RestoreCache(_ snapshot: Any, into cache: [any KVCache]) {
+        guard let snapshot = snapshot as? MuseDFlash2CacheSnapshot else {
+            preconditionFailure("Invalid Muse DFlash2 cache snapshot")
+        }
+        for (index, layer) in snapshot.layers.enumerated() {
+            var entry = cache[index]
+            if entry.isTrimmable {
+                let excess = entry.offset - layer.offset
+                if excess > 0 { _ = entry.trim(excess) }
+            } else {
+                entry.state = layer.state
+            }
+        }
     }
 }
 

--- a/Scripts/patches/Qwen3_5MoE.swift
+++ b/Scripts/patches/Qwen3_5MoE.swift
@@ -1290,14 +1290,14 @@ extension Qwen3_5MoEModel: DFlash2Target {
     }
 
     public func dflash2CaptureCache(_ cache: [any KVCache]) -> Any {
-        Qwen3MTPCacheSnapshot.capture(cache)
+        DFlash2CacheSnapshot.capture(cache)
     }
 
     public func dflash2RestoreCache(_ snapshot: Any, into cache: [any KVCache]) {
-        guard let snapshot = snapshot as? [Qwen3MTPCacheSnapshot.Layer] else {
+        guard let snapshot = snapshot as? [DFlash2CacheSnapshot.Layer] else {
             preconditionFailure("Invalid Qwen DFlash2 cache snapshot")
         }
-        Qwen3MTPCacheSnapshot.restore(snapshot, into: cache)
+        DFlash2CacheSnapshot.restore(snapshot, into: cache)
     }
 }
 

--- a/Scripts/patches/Qwen3_5MoE.swift
+++ b/Scripts/patches/Qwen3_5MoE.swift
@@ -860,6 +860,24 @@ class Qwen3_5TextModelInner: Module {
 
         return norm(h)
     }
+
+    func dflash2Forward(
+        _ inputs: MLXArray,
+        captureLayerIDs: [Int],
+        cache: [KVCache]
+    ) -> (hidden: MLXArray, normalized: MLXArray) {
+        var h = embedTokens(inputs)
+        let faMask = createAttentionMask(h: h, cache: cache[faIdx])
+        let ssmMask = createSSMMask(h: h, cache: cache[ssmIdx] as? MambaCache)
+        let capture = Set(captureLayerIDs)
+        var selected: [MLXArray] = []
+        for (index, layer) in layers.enumerated() {
+            h = layer(h, faMask: faMask, ssmMask: ssmMask, cache: cache[index])
+            if capture.contains(index) { selected.append(h) }
+        }
+        precondition(selected.count == captureLayerIDs.count)
+        return (concatenated(selected, axis: -1), norm(h))
+    }
 }
 
 // MARK: - MTP (Multi-Token Prediction) Head — text LLM variant
@@ -1247,6 +1265,39 @@ public class Qwen3_5MoEModel: Module, LLMModel, KVCacheDimensionProvider {
         }
 
         return sanitizedWeights
+    }
+}
+
+extension Qwen3_5MoEModel: DFlash2Target {
+    public var dflash2HiddenSize: Int { configuration.textConfig.hiddenSize }
+    public var dflash2LayerCount: Int { configuration.textConfig.hiddenLayers }
+    public var dflash2VocabularySize: Int { configuration.textConfig.vocabularySize }
+
+    public func dflash2NewCache() -> [any KVCache] { newCache(parameters: nil) }
+    public func dflash2Embed(_ tokenIDs: MLXArray) -> MLXArray { embedTokens(tokenIDs) }
+    public func dflash2Project(_ hidden: MLXArray) -> MLXArray { projectLMHead(hidden) }
+
+    public func dflash2Forward(
+        _ tokenIDs: MLXArray,
+        captureLayerIDs: [Int],
+        cache: [any KVCache]
+    ) -> DFlash2TargetOutput {
+        let result = languageModel.model.dflash2Forward(
+            tokenIDs, captureLayerIDs: captureLayerIDs, cache: cache)
+        return DFlash2TargetOutput(
+            hidden: result.hidden,
+            logits: languageModel.projectLMHead(result.normalized))
+    }
+
+    public func dflash2CaptureCache(_ cache: [any KVCache]) -> Any {
+        Qwen3MTPCacheSnapshot.capture(cache)
+    }
+
+    public func dflash2RestoreCache(_ snapshot: Any, into cache: [any KVCache]) {
+        guard let snapshot = snapshot as? [Qwen3MTPCacheSnapshot.Layer] else {
+            preconditionFailure("Invalid Qwen DFlash2 cache snapshot")
+        }
+        Qwen3MTPCacheSnapshot.restore(snapshot, into: cache)
     }
 }
 

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -241,6 +241,9 @@ struct MlxCommand: ParsableCommand {
           --dspark-confidence: DSpark confidence-pruning threshold (default: 0.7)
           --dspark-strict: Load DSpark support but use target-only decoding
           --eagle3: EAGLE3 drafter directory for compatible dense Gemma4 models
+          --dflash2: DFlash 2 drafter repository or local directory for a compatible Qwen 3.8 or Muse Glimmer target
+          --dflash2-block: Verification block size including the verifier token (default: 5)
+          --dflash2-required: Fail when DFlash 2 cannot serve an eligible request instead of falling back to AR
           --tool-call-parser: Override tool call format (none, afm_adaptive_xml, hermes, llama3_json, gemma, mistral, qwen3_xml). Omit for default native mode and MLX Python-style parity; use "none" for raw output; use "afm_adaptive_xml" for opt-in repair mode.
           --fix-tool-args: Opt-in repair-mode helper that post-processes tool call arg names to match original tool schema
           --enable-grammar-constraints: Enable grammar-constrained decoding engine. When active, API requests with strict: true on tools or response_format.json_schema use xgrammar for token-level enforcement. Without this flag, strict: true is silently downgraded to best-effort.

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -485,6 +485,15 @@ struct MlxCommand: ParsableCommand {
     @Option(name: .long, help: "Enable EAGLE3 speculative decoding for a dense Gemma4 verifier. Pass the drafter directory (config.json + safetensors). Faster decode, quality-preserving (near-greedy output). No-op if the verifier is not a dense Gemma4 text model.")
     var eagle3: String?
 
+    @Option(name: .customLong("dflash2"), help: "Enable DFlash 2 with a metadata-compatible Hugging Face repository or local drafter directory. Opt-in; target and drafter configs are validated before inference.")
+    var dflash2: String?
+
+    @Option(name: .customLong("dflash2-block"), help: "DFlash 2 verification block size, including the verifier token (2...checkpoint limit; default: 5).")
+    var dflash2Block: Int = 5
+
+    @Flag(name: .customLong("dflash2-required"), help: "Fail instead of using autoregressive decoding when DFlash 2 cannot be used for a request.")
+    var dflash2Required: Bool = false
+
     @Option(name: .long, help: "Write cache timing profile records as JSONL to this file")
     var cacheProfilePath: String?
 
@@ -618,6 +627,16 @@ struct MlxCommand: ParsableCommand {
             parsedKwargs["enable_thinking"] = false
             parsedKwargs.removeValue(forKey: "reasoning_effort")
         }
+        guard dflash2Block >= 2 else {
+            throw ValidationError("--dflash2-block must be at least 2")
+        }
+        let speculativeSelections = [mtp, eagle3 != nil, dflash2 != nil].filter { $0 }.count
+        guard speculativeSelections <= 1 else {
+            throw ValidationError("Choose only one of --mtp, --eagle3, or --dflash2")
+        }
+        if dflash2Required, dflash2 == nil {
+            throw ValidationError("--dflash2-required requires --dflash2")
+        }
 
         var defaultGuidedJsonSchema: ResponseFormat?
         if let guidedJson {
@@ -675,6 +694,9 @@ struct MlxCommand: ParsableCommand {
             mtpDepth: mtpDepth,
             mtpModelID: mtpModel,
             eagle3DrafterPath: eagle3,
+            dflash2Drafter: dflash2,
+            dflash2BlockSize: dflash2Block,
+            dflash2Requirement: dflash2Required ? .required : .preferred,
             maxConcurrent: concurrent ?? 0,
             toolCallParser: toolCallParser,
             enableGrammarConstraints: enableGrammarConstraints,
@@ -991,7 +1013,7 @@ struct MlxCommand: ParsableCommand {
         if !media.isEmpty || vlm {
             throw ValidationError("The DwarfStar runtime currently supports text input only")
         }
-        if kvBits != nil || mtp || eagle3 != nil {
+        if kvBits != nil || mtp || eagle3 != nil || dflash2 != nil {
             throw ValidationError(
                 "KV quantization and speculative decoding are unavailable in the DwarfStar runtime")
         }
@@ -1192,6 +1214,13 @@ struct MlxCommand: ParsableCommand {
                     mtpDepth: self.mtpDepth,
                     mtpModelID: self.mtpModel,
                     eagle3DrafterPath: self.eagle3,
+                    speculativeDecoding: self.dflash2.map {
+                        AFMSpeculativeDecodingConfiguration(
+                            mode: "dflash2",
+                            drafter: $0,
+                            maxDraftTokens: self.dflash2Block - 1,
+                            requirement: self.dflash2Required ? "required" : "preferred")
+                    },
                     enableGrammarConstraints: self.enableGrammarConstraints,
                     toolCallParser: self.toolCallParser,
                     prefillStepSize: self.prefillStepSize,

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -252,7 +252,7 @@ struct MlxCommand: ParsableCommand {
           --concurrent: Maximum concurrent requests; values greater than one enable batch mode
           --default-chat-template-kwargs: JSON object merged into chat template context
           --cache-profile-path: Write cache timing profile records as JSONL
-          --gpu-capture <path>: Capture Metal GPU trace to .gputrace file for Xcode analysis (auto-limits to 5 tokens)
+          --gpu-capture <path>: Capture a serial Metal GPU trace to .gputrace (auto-limits to 5 tokens)
           --gpu-trace <seconds>: Record Metal System Trace via xctrace for N seconds (lightweight per-kernel timing)
           --gpu-profile: Print per-request GPU profiling stats (device info, memory, bandwidth estimates)
           --gpu-profile-bw: Also sample DRAM bandwidth with mactop
@@ -515,7 +515,7 @@ struct MlxCommand: ParsableCommand {
     @Option(name: .long, help: "Max concurrent requests (enables batch mode; 0 or 1 reverts to serial)")
     var concurrent: Int?
 
-    @Option(name: .long, help: "Capture a Metal GPU trace to the given path (e.g. /tmp/afm-trace.gputrace). Opens in Xcode for per-kernel analysis. Auto-limits to 5 tokens to keep trace small.")
+    @Option(name: .long, help: "Capture a serial Metal GPU trace to the given path (e.g. /tmp/afm-trace.gputrace). Opens in Xcode for per-kernel analysis. Auto-limits to 5 tokens to keep trace small.")
     var gpuCapture: String?
 
     @Option(name: .long, help: "Record a Metal System Trace for N seconds using Instruments xctrace (e.g. --gpu-trace 10). Lightweight per-kernel GPU timing without massive trace files. Output: /tmp/afm-metal.trace")
@@ -542,6 +542,13 @@ struct MlxCommand: ParsableCommand {
         if gateway {
             print("Error: -g/--gateway is not supported in 'afm mlx' mode.")
             throw ExitCode.failure
+        }
+
+        if let incompatibility = AFMMLXGPUCapturePolicy.incompatibility(
+            maxConcurrent: concurrent ?? 0,
+            capturePath: gpuCapture
+        ) {
+            throw ValidationError(incompatibility)
         }
 
         // GPU capture: set MTL_CAPTURE_ENABLED before Metal device is created

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -913,12 +913,16 @@ struct MlxCommand: ParsableCommand {
             }
             return .mlx
         }
-        guard AFMDwarfStarCheckpointCatalog.isDwarfStarCompatibleGGUF(at: modelURL) else {
+        let ggufArchitecture = AFMDwarfStarCheckpointCatalog.ggufArchitecture(at: modelURL)
+        guard ggufArchitecture == "deepseek4" else {
             if requested == .dwarfstar {
-                let architecture = AFMDwarfStarCheckpointCatalog.ggufArchitecture(at: modelURL)
-                    ?? "unreadable"
+                let architecture = ggufArchitecture ?? "unreadable"
                 throw ValidationError(
                     "DwarfStar does not support GGUF architecture \(architecture)")
+            }
+            if let ggufArchitecture {
+                throw ValidationError(
+                    "Auto runtime cannot execute GGUF architecture \(ggufArchitecture): DwarfStar requires deepseek4 and MLX requires a safetensors checkpoint")
             }
             return .mlx
         }

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -243,7 +243,7 @@ struct MlxCommand: ParsableCommand {
           --eagle3: EAGLE3 drafter directory for compatible dense Gemma4 models
           --dflash2: DFlash 2 drafter repository or local directory for a compatible Qwen 3.8 or Muse Glimmer target
           --dflash2-block: Verification block size including the verifier token (default: 5)
-          --dflash2-required: Fail when DFlash 2 cannot serve an eligible request instead of falling back to AR
+          --dflash2-required: Reject requests that cannot use explicit-greedy serial DFlash 2 instead of falling back to AR
           --tool-call-parser: Override tool call format (none, afm_adaptive_xml, hermes, llama3_json, gemma, mistral, qwen3_xml). Omit for default native mode and MLX Python-style parity; use "none" for raw output; use "afm_adaptive_xml" for opt-in repair mode.
           --fix-tool-args: Opt-in repair-mode helper that post-processes tool call arg names to match original tool schema
           --enable-grammar-constraints: Enable grammar-constrained decoding engine. When active, API requests with strict: true on tools or response_format.json_schema use xgrammar for token-level enforcement. Without this flag, strict: true is silently downgraded to best-effort.
@@ -494,7 +494,7 @@ struct MlxCommand: ParsableCommand {
     @Option(name: .customLong("dflash2-block"), help: "DFlash 2 verification block size, including the verifier token (2...checkpoint limit; default: 5).")
     var dflash2Block: Int = 5
 
-    @Flag(name: .customLong("dflash2-required"), help: "Fail instead of using autoregressive decoding when DFlash 2 cannot be used for a request.")
+    @Flag(name: .customLong("dflash2-required"), help: "Reject requests that cannot use explicit-greedy serial DFlash 2 instead of falling back to autoregressive decoding.")
     var dflash2Required: Bool = false
 
     @Option(name: .long, help: "Write cache timing profile records as JSONL to this file")

--- a/Sources/AFMKit/AFMEngine.swift
+++ b/Sources/AFMKit/AFMEngine.swift
@@ -17,6 +17,26 @@ public enum AFMBackend: Sendable {
     case provider(providerID: AFMProviderID, modelID: AFMModelID)
 }
 
+/// Provider-neutral startup configuration for an optional speculative decoder.
+public struct AFMSpeculativeDecodingConfiguration: Sendable {
+    public var mode: String
+    public var drafter: String?
+    public var maxDraftTokens: Int?
+    public var requirement: String
+
+    public init(
+        mode: String,
+        drafter: String? = nil,
+        maxDraftTokens: Int? = nil,
+        requirement: String = "preferred"
+    ) {
+        self.mode = mode
+        self.drafter = drafter
+        self.maxDraftTokens = maxDraftTokens
+        self.requirement = requirement
+    }
+}
+
 /// Engine-level configuration — set once when the engine is created. Mirrors the
 /// `afm`/`afm mlx` server flags that configure the runtime (not per-request sampling).
 public struct EngineConfig: Sendable {
@@ -32,6 +52,7 @@ public struct EngineConfig: Sendable {
     public var mtpDepth: Int
     public var mtpModelID: String?
     public var eagle3DrafterPath: String?
+    public var speculativeDecoding: AFMSpeculativeDecodingConfiguration?
     public var enableGrammarConstraints: Bool
     public var toolCallParser: String?
     public var maxConcurrent: Int
@@ -57,6 +78,7 @@ public struct EngineConfig: Sendable {
         mtpDepth: Int = 3,
         mtpModelID: String? = nil,
         eagle3DrafterPath: String? = nil,
+        speculativeDecoding: AFMSpeculativeDecodingConfiguration? = nil,
         enableGrammarConstraints: Bool = false,
         toolCallParser: String? = nil,
         maxConcurrent: Int = 0,
@@ -81,6 +103,7 @@ public struct EngineConfig: Sendable {
         self.mtpDepth = mtpDepth
         self.mtpModelID = mtpModelID
         self.eagle3DrafterPath = eagle3DrafterPath
+        self.speculativeDecoding = speculativeDecoding
         self.enableGrammarConstraints = enableGrammarConstraints
         self.toolCallParser = toolCallParser
         self.maxConcurrent = maxConcurrent
@@ -121,6 +144,19 @@ private extension EngineConfig {
         }
         if let mtpModelID {
             values["mtpModelID"] = .string(mtpModelID)
+        }
+        if let speculativeDecoding {
+            var speculative: [String: AFMJSONValue] = [
+                "mode": .string(speculativeDecoding.mode),
+                "requirement": .string(speculativeDecoding.requirement),
+            ]
+            if let drafter = speculativeDecoding.drafter {
+                speculative["drafter"] = .string(drafter)
+            }
+            if let maxDraftTokens = speculativeDecoding.maxDraftTokens {
+                speculative["maxDraftTokens"] = .integer(maxDraftTokens)
+            }
+            values["speculativeDecoding"] = .object(speculative)
         }
         if let toolCallParser {
             values["toolCallParser"] = .string(toolCallParser)

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarCheckpoint.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarCheckpoint.swift
@@ -80,6 +80,13 @@ public struct AFMDwarfStarCheckpointCatalog: Sendable {
         try? GGUFMetadataReader(url: url.resolvingSymlinksInPath()).architecture()
     }
 
+    /// Reads GGUF architecture metadata from a bounded header buffer. Remote
+    /// resolvers use this to reject unsupported artifacts before downloading
+    /// tensor payloads.
+    public static func ggufArchitecture(in data: Data) -> String? {
+        try? GGUFMetadataReader(data: data).architecture()
+    }
+
     public static func isDwarfStarCompatibleGGUF(at url: URL) -> Bool {
         ggufArchitecture(at: url) == "deepseek4"
     }
@@ -355,15 +362,23 @@ public struct AFMDwarfStarCheckpointCatalog: Sendable {
 }
 
 private final class GGUFMetadataReader {
-    private let handle: FileHandle
+    private let handle: FileHandle?
+    private let data: Data?
+    private var offset = 0
 
     init(url: URL) throws {
         let values = try url.resourceValues(forKeys: [.isRegularFileKey])
         guard values.isRegularFile == true else { throw CocoaError(.fileReadCorruptFile) }
         handle = try FileHandle(forReadingFrom: url)
+        data = nil
     }
 
-    deinit { try? handle.close() }
+    init(data: Data) {
+        handle = nil
+        self.data = data
+    }
+
+    deinit { try? handle?.close() }
 
     func architecture() throws -> String? {
         guard try bytes(4) == Data("GGUF".utf8), try u32() == 3 else {
@@ -383,9 +398,18 @@ private final class GGUFMetadataReader {
     }
 
     private func bytes(_ count: Int) throws -> Data {
-        let data = try handle.read(upToCount: count) ?? Data()
-        guard data.count == count else { throw CocoaError(.fileReadCorruptFile) }
-        return data
+        if let handle {
+            let value = try handle.read(upToCount: count) ?? Data()
+            guard value.count == count else { throw CocoaError(.fileReadCorruptFile) }
+            return value
+        }
+        guard let data, count >= 0, offset <= data.count,
+              count <= data.count - offset else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        let end = offset + count
+        defer { offset = end }
+        return data.subdata(in: offset..<end)
     }
 
     private func u32() throws -> UInt32 { try integer(UInt32.self) }

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarHubResolver.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarHubResolver.swift
@@ -32,6 +32,8 @@ public enum AFMDwarfStarHubSelectionError: LocalizedError, Equatable {
     case noModelGGUF(String)
     case requestedFileNotFound(String)
     case modelExceedsMemoryBudget(path: String, size: Int64, budget: Int64)
+    case unsupportedArchitecture(path: String, architecture: String)
+    case unreadableArchitecture(String)
 
     public var errorDescription: String? {
         switch self {
@@ -43,6 +45,10 @@ public enum AFMDwarfStarHubSelectionError: LocalizedError, Equatable {
             return "Requested GGUF file was not found in the repository: \(path)"
         case .modelExceedsMemoryBudget(let path, let size, let budget):
             return "GGUF \(path) is \(Self.bytes(size)), exceeding the \(Self.bytes(budget)) memory budget. Use --gguf-file to select it explicitly."
+        case .unsupportedArchitecture(let path, let architecture):
+            return "GGUF \(path) declares unsupported architecture \(architecture); DwarfStar requires general.architecture=deepseek4."
+        case .unreadableArchitecture(let path):
+            return "GGUF \(path) does not expose readable general.architecture metadata in its header."
         }
     }
 
@@ -52,6 +58,18 @@ public enum AFMDwarfStarHubSelectionError: LocalizedError, Equatable {
 }
 
 public enum AFMDwarfStarHubSelector {
+    public static func validateArchitecture(_ architecture: String?, path: String) throws {
+        guard let architecture else {
+            throw AFMDwarfStarHubSelectionError.unreadableArchitecture(path)
+        }
+        guard architecture == "deepseek4" else {
+            throw AFMDwarfStarHubSelectionError.unsupportedArchitecture(
+                path: path,
+                architecture: architecture
+            )
+        }
+    }
+
     public static func selectModel(
         from artifacts: [AFMDwarfStarHubArtifact],
         repositoryID: String,
@@ -134,34 +152,53 @@ public struct AFMDwarfStarHubResolver: Sendable {
         let expectedBytes = max(Int64(entry.size ?? 1), 1)
         let snapshot = try cache.snapshotPath(repo: repo, kind: .model, commitHash: revision)
         let cachedArtifact = snapshot.appendingPathComponent(entry.path)
-        let cachedTarget = cachedArtifact.resolvingSymlinksInPath()
-        if AFMDwarfStarResumableDownload.fileSize(cachedTarget) == expectedBytes {
-            print("Using cached DwarfStar model: \(cachedArtifact.path)")
-            return cachedArtifact
-        }
         let blobKey = Self.hubBlobKey(repo: repo, revision: revision, entry: entry)
         let destination = try cache.blobPath(repo: repo, kind: .model, etag: blobKey)
         let partial = try cache.incompleteBlobPath(repo: repo, kind: .model, etag: blobKey)
         let segment = partial.appendingPathExtension("xet-segment")
-        print("Download destination: \(cacheDirectory.path)")
-        try FileManager.default.createDirectory(at: partial.deletingLastPathComponent(), withIntermediateDirectories: true)
-        let token = try await TokenProvider.environment.getToken()
-        let listedSHA256 = entry.oid.flatMap(Self.normalizedSHA256)
-        let xetMetadata: AFMDwarfStarXetMetadata
-        do {
-            xetMetadata = try await AFMDwarfStarResumableDownload.fetchXetMetadata(
+        return try await AFMDwarfStarHubCacheCoordinator.withArtifactLock(
+            cacheDirectory: cacheDirectory,
+            artifact: destination
+        ) {
+            let cachedTarget = cachedArtifact.resolvingSymlinksInPath()
+            if AFMDwarfStarResumableDownload.fileSize(cachedTarget) == expectedBytes {
+                try AFMDwarfStarHubSelector.validateArchitecture(
+                    AFMDwarfStarCheckpointCatalog.ggufArchitecture(at: cachedTarget),
+                    path: entry.path
+                )
+                print("Using cached DwarfStar model: \(cachedArtifact.path)")
+                return cachedArtifact
+            }
+
+            print("Download destination: \(cacheDirectory.path)")
+            try FileManager.default.createDirectory(at: partial.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let token = try await TokenProvider.environment.getToken()
+            let remoteArchitecture = try await AFMDwarfStarResumableDownload.fetchGGUFArchitecture(
                 repositoryID: repositoryID,
                 revision: revision,
                 path: entry.path,
-                expectedBytes: expectedBytes,
-                token: token)
-        } catch {
-            print("Hugging Face Xet metadata unavailable: \(AFMDwarfStarResumableDownload.detailedError(error)); using cache-local LFS")
-            xetMetadata = AFMDwarfStarXetMetadata(
-                fileID: nil,
-                expectedBytes: expectedBytes,
-                expectedSHA256: listedSHA256)
-        }
+                token: token
+            )
+            try AFMDwarfStarHubSelector.validateArchitecture(
+                remoteArchitecture,
+                path: entry.path
+            )
+            let listedSHA256 = entry.oid.flatMap(Self.normalizedSHA256)
+            let xetMetadata: AFMDwarfStarXetMetadata
+            do {
+                xetMetadata = try await AFMDwarfStarResumableDownload.fetchXetMetadata(
+                    repositoryID: repositoryID,
+                    revision: revision,
+                    path: entry.path,
+                    expectedBytes: expectedBytes,
+                    token: token)
+            } catch {
+                print("Hugging Face Xet metadata unavailable: \(AFMDwarfStarResumableDownload.detailedError(error)); using cache-local LFS")
+                xetMetadata = AFMDwarfStarXetMetadata(
+                    fileID: nil,
+                    expectedBytes: expectedBytes,
+                    expectedSHA256: listedSHA256)
+            }
         let aggregate = Progress(totalUnitCount: xetMetadata.expectedBytes)
         let file = AFMDownloadProgressUserInfo.File(
             path: entry.path,
@@ -276,7 +313,8 @@ public struct AFMDwarfStarHubResolver: Sendable {
         file.progress.completedUnitCount = xetMetadata.expectedBytes
         AFMDownloadProgressUserInfo.enrich(aggregate, files: [file])
         progress?(aggregate)
-        return snapshot.appendingPathComponent(entry.path)
+            return snapshot.appendingPathComponent(entry.path)
+        }
     }
 
     private static func hubBlobKey(
@@ -309,5 +347,27 @@ public struct AFMDwarfStarHubResolver: Sendable {
         }
         return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".cache/huggingface/hub")
+    }
+}
+
+enum AFMDwarfStarHubCacheCoordinator {
+    static func withArtifactLock<T>(
+        cacheDirectory: URL,
+        artifact: URL,
+        operation: () async throws -> T
+    ) async throws -> T {
+        let cache = HubCache(cacheDirectory: cacheDirectory)
+        let lock = FileLock(
+            path: cache.lockPath(for: artifact),
+            maxRetries: nil,
+            retryDelay: 0.05
+        )
+        return try await lock.withLock(operation)
+    }
+
+    static func lockFileURL(cacheDirectory: URL, artifact: URL) -> URL {
+        HubCache(cacheDirectory: cacheDirectory)
+            .lockPath(for: artifact)
+            .appendingPathExtension("lock")
     }
 }

--- a/Sources/AFMKitDwarfStar/AFMDwarfStarResumableDownload.swift
+++ b/Sources/AFMKitDwarfStar/AFMDwarfStarResumableDownload.swift
@@ -33,6 +33,27 @@ enum AFMDwarfStarDownloadError: LocalizedError {
 }
 
 enum AFMDwarfStarResumableDownload {
+    private static let ggufHeaderProbeBytes = 1_048_576
+
+    static func fetchGGUFArchitecture(
+        repositoryID: String,
+        revision: String,
+        path: String,
+        token: String?
+    ) async throws -> String? {
+        let url = try resolveURL(repositoryID: repositoryID, revision: revision, path: path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.setValue("bytes=0-\(ggufHeaderProbeBytes - 1)", forHTTPHeaderField: "Range")
+        if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
+        let delegate = AFMDwarfStarBoundedRangeDataDelegate(maximumBytes: ggufHeaderProbeBytes)
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+        let data = try await delegate.run(request: request, session: session)
+        return AFMDwarfStarCheckpointCatalog.ggufArchitecture(in: data)
+    }
+
     static func fetchXetMetadata(
         repositoryID: String,
         revision: String,
@@ -253,6 +274,78 @@ private final class NoRedirectDelegate: NSObject, URLSessionTaskDelegate, @unche
         completionHandler: @escaping (URLRequest?) -> Void
     ) {
         completionHandler(nil)
+    }
+}
+
+final class AFMDwarfStarBoundedRangeDataDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    private let maximumBytes: Int
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Data, Error>?
+    private var received = Data()
+    private var responseError: Error?
+
+    init(maximumBytes: Int) {
+        self.maximumBytes = maximumBytes
+    }
+
+    var acceptedByteCount: Int { received.count }
+
+    func run(request: URLRequest, session: URLSession) async throws -> Data {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                lock.withLock { self.continuation = continuation }
+                session.dataTask(with: request).resume()
+            }
+        } onCancel: {
+            session.invalidateAndCancel()
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let http = response as? HTTPURLResponse else {
+            responseError = AFMDwarfStarDownloadError.invalidResponse(
+                "GGUF header probe did not return HTTP metadata")
+            completionHandler(.cancel)
+            return
+        }
+        guard http.statusCode == 206 else {
+            responseError = AFMDwarfStarDownloadError.invalidResponse(
+                "GGUF header probe did not honor its byte range (HTTP \(http.statusCode))")
+            completionHandler(.cancel)
+            return
+        }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        guard data.count <= maximumBytes,
+              received.count <= maximumBytes - data.count else {
+            responseError = AFMDwarfStarDownloadError.invalidResponse(
+                "GGUF header probe exceeded its byte limit")
+            dataTask.cancel()
+            return
+        }
+        received.append(data)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        let result = responseError ?? error
+        let data = received
+        let continuation = lock.withLock { () -> CheckedContinuation<Data, Error>? in
+            defer { self.continuation = nil }
+            return self.continuation
+        }
+        if let result { continuation?.resume(throwing: result) }
+        else { continuation?.resume(returning: data) }
     }
 }
 

--- a/Sources/AFMKitMLX/AFMMLXBatchControl.swift
+++ b/Sources/AFMKitMLX/AFMMLXBatchControl.swift
@@ -1,14 +1,57 @@
 import Foundation
 
-/// Defines who admitted an attached MLX request to the scheduler.
-///
-/// Direct AFMKit model calls admit themselves. Server adapters use
-/// `callerReserved` after their controller has already reserved capacity; the
-/// attached model adopts that reservation and either transfers it to the
-/// scheduler or releases it if setup fails.
+/// Identity-bearing capacity reserved from one concrete scheduler.
+public final class AFMMLXSchedulerReservation: @unchecked Sendable, Hashable {
+    package let schedulerID: UUID
+    package let reservationID: UUID
+
+    package init(schedulerID: UUID, reservationID: UUID = UUID()) {
+        self.schedulerID = schedulerID
+        self.reservationID = reservationID
+    }
+
+    public static func == (
+        lhs: AFMMLXSchedulerReservation,
+        rhs: AFMMLXSchedulerReservation
+    ) -> Bool {
+        lhs.schedulerID == rhs.schedulerID
+            && lhs.reservationID == rhs.reservationID
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(schedulerID)
+        hasher.combine(reservationID)
+    }
+}
+
+/// Result of asking a runtime for request capacity.
+public enum AFMMLXSchedulerAdmission: Equatable, Sendable {
+    /// No scheduler is installed; the request must use the serial model path.
+    case serial
+    /// Capacity was reserved from a specific scheduler for this caller.
+    case reserved(AFMMLXSchedulerReservation)
+    /// Scheduler capacity is currently unavailable or admission is closed.
+    case unavailable
+
+    public var isAdmitted: Bool {
+        switch self {
+        case .serial, .reserved:
+            return true
+        case .unavailable:
+            return false
+        }
+    }
+
+    public var reservation: AFMMLXSchedulerReservation? {
+        guard case .reserved(let reservation) = self else { return nil }
+        return reservation
+    }
+}
+
+/// Defines who admitted an attached MLX request.
 public enum AFMMLXSchedulerAdmissionOwnership: Sendable {
     case model
-    case callerReserved
+    case caller(AFMMLXSchedulerAdmission)
 }
 
 public enum AFMMLXRequestMetadata {
@@ -22,19 +65,21 @@ public enum AFMMLXRequestMetadata {
 public protocol AFMMLXRequestScheduling: Sendable {
     var maxConcurrent: Int { get }
 
-    func tryReserveSlot() -> Bool
-    func waitForSlot(timeout: TimeInterval) async -> Bool
-    func releaseSlot()
+    func tryReserveSlot() -> AFMMLXSchedulerAdmission
+    func waitForSlot(timeout: TimeInterval) async -> AFMMLXSchedulerAdmission
+    @discardableResult
+    func releaseSlot(_ reservation: AFMMLXSchedulerReservation) -> Bool
 }
 
 public extension AFMMLXRequestScheduling {
-    func waitForSlot(timeout: TimeInterval) async -> Bool {
-        if Task.isCancelled { return false }
+    func waitForSlot(timeout: TimeInterval) async -> AFMMLXSchedulerAdmission {
+        if Task.isCancelled { return .unavailable }
         if timeout <= 0 {
             return tryReserveSlot()
         }
 
-        if tryReserveSlot() { return true }
+        var admission = tryReserveSlot()
+        if admission.isAdmitted { return admission }
 
         let initialPollNanoseconds: UInt64 = 10_000_000
         let maximumPollNanoseconds: UInt64 = 500_000_000
@@ -42,13 +87,14 @@ public extension AFMMLXRequestScheduling {
         var delay = initialPollNanoseconds
 
         while ContinuousClock.now < deadline {
-            if Task.isCancelled { return false }
+            if Task.isCancelled { return .unavailable }
             try? await Task.sleep(nanoseconds: delay)
-            if Task.isCancelled { return false }
-            if tryReserveSlot() { return true }
+            if Task.isCancelled { return .unavailable }
+            admission = tryReserveSlot()
+            if admission.isAdmitted { return admission }
             delay = min(delay * 2, maximumPollNanoseconds)
         }
-        return false
+        return .unavailable
     }
 }
 

--- a/Sources/AFMKitMLX/AFMMLXBatchControl.swift
+++ b/Sources/AFMKitMLX/AFMMLXBatchControl.swift
@@ -11,6 +11,10 @@ public enum AFMMLXSchedulerAdmissionOwnership: Sendable {
     case callerReserved
 }
 
+public enum AFMMLXRequestMetadata {
+    public static let preserveStructuralTags = "preserveStructuralTags"
+}
+
 /// Controls admission to an MLX runtime's concurrent request slots.
 ///
 /// Server and app consumers use this contract without depending on the

--- a/Sources/AFMKitMLX/AFMMLXBatchControl.swift
+++ b/Sources/AFMKitMLX/AFMMLXBatchControl.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+/// Defines who admitted an attached MLX request to the scheduler.
+///
+/// Direct AFMKit model calls admit themselves. Server adapters use
+/// `callerReserved` after their controller has already reserved capacity; the
+/// attached model adopts that reservation and either transfers it to the
+/// scheduler or releases it if setup fails.
+public enum AFMMLXSchedulerAdmissionOwnership: Sendable {
+    case model
+    case callerReserved
+}
+
 /// Controls admission to an MLX runtime's concurrent request slots.
 ///
 /// Server and app consumers use this contract without depending on the

--- a/Sources/AFMKitMLX/AFMMLXDFlash2Configuration.swift
+++ b/Sources/AFMKitMLX/AFMMLXDFlash2Configuration.swift
@@ -31,7 +31,6 @@ public enum AFMMLXDFlash2PreflightValidator {
         drafterDirectory: URL,
         requestedBlockSize: Int?
     ) throws -> AFMMLXDFlash2Preflight {
-        let configuration = try AFMMLXDFlash2Configuration(directory: drafterDirectory)
         let targetConfigurationData = try Data(
             contentsOf: targetDirectory.appendingPathComponent("config.json"))
         guard let targetMetadata = try JSONSerialization.jsonObject(
@@ -39,6 +38,9 @@ public enum AFMMLXDFlash2PreflightValidator {
             throw AFMMLXDFlash2ConfigurationError.invalidValue(
                 "target config.json must contain an object")
         }
+        let configuration = try AFMMLXDFlash2Configuration(
+            directory: drafterDirectory,
+            targetMetadata: targetMetadata)
 
         try configuration.validateTarget(metadata: targetMetadata)
         try configuration.validateWeights(in: drafterDirectory)
@@ -52,7 +54,9 @@ public enum AFMMLXDFlash2PreflightValidator {
 
 public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
     public static let architecture = "DFlash2DraftModel"
+    public static let museAssistantArchitecture = "MuseGlimmerAssistantModel"
 
+    public let draftArchitecture: String
     public let hiddenSize: Int
     public let intermediateSize: Int
     public let hiddenLayers: Int
@@ -76,17 +80,33 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
     public let eosTokenIDs: Set<Int>
     public let padTokenIDs: Set<Int>
 
-    public init(metadata: [String: Any]) throws {
+    public init(
+        metadata: [String: Any],
+        targetMetadata: [String: Any]? = nil
+    ) throws {
         let architectures = metadata["architectures"] as? [String] ?? []
-        guard architectures.contains(Self.architecture) else {
+        if architectures.contains(Self.architecture) {
+            draftArchitecture = Self.architecture
+        } else if architectures.contains(Self.museAssistantArchitecture) {
+            draftArchitecture = Self.museAssistantArchitecture
+        } else {
             throw AFMMLXDFlash2ConfigurationError.unsupportedArchitecture(architectures)
         }
-        guard (metadata["is_causal"] as? Bool) == false else {
+        guard draftArchitecture != Self.architecture
+                || (metadata["is_causal"] as? Bool) == false else {
             throw AFMMLXDFlash2ConfigurationError.invalidValue("is_causal must be false")
         }
-        guard let dflash = metadata["dflash_config"] as? [String: Any] else {
+        let dflash: [String: Any]
+        if let nested = metadata["dflash_config"] as? [String: Any] {
+            dflash = nested
+        } else if draftArchitecture == Self.museAssistantArchitecture {
+            dflash = metadata
+        } else {
             throw AFMMLXDFlash2ConfigurationError.missingValue("dflash_config")
         }
+        let targetText = targetMetadata?["text_config"] as? [String: Any]
+            ?? targetMetadata
+            ?? [:]
 
         hiddenSize = try Self.positiveInt(metadata, "hidden_size")
         intermediateSize = try Self.positiveInt(metadata, "intermediate_size")
@@ -94,15 +114,19 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
         attentionHeads = try Self.positiveInt(metadata, "num_attention_heads")
         keyValueHeads = try Self.positiveInt(metadata, "num_key_value_heads")
         headDimension = try Self.positiveInt(metadata, "head_dim")
-        vocabularySize = try Self.positiveInt(metadata, "vocab_size")
-        targetLayers = try Self.positiveInt(metadata, "num_target_layers")
+        vocabularySize = try Self.positiveInt(
+            metadata["vocab_size"] == nil ? targetText : metadata,
+            "vocab_size")
+        targetLayers = try metadata["num_target_layers"] == nil
+            ? Self.positiveInt(targetText, "num_hidden_layers")
+            : Self.positiveInt(metadata, "num_target_layers")
         targetLayerIDs = try Self.intArray(dflash, "target_layer_ids")
         checkpointBlockSize = try Self.positiveInt(dflash, "block_size")
         maskTokenID = try Self.nonnegativeInt(dflash, "mask_token_id")
-        convolutionKernelSize = try Self.positiveInt(dflash, "conv_kernel_size")
-        convolutionGroupSize = try Self.positiveInt(dflash, "conv_group_size")
-        selectorRank = try Self.positiveInt(dflash, "selector_rank")
-        selectorTopK = try Self.positiveInt(dflash, "selector_top_k")
+        convolutionKernelSize = try Self.optionalPositiveInt(dflash, "conv_kernel_size") ?? 0
+        convolutionGroupSize = try Self.optionalPositiveInt(dflash, "conv_group_size") ?? 0
+        selectorRank = try Self.optionalPositiveInt(dflash, "selector_rank") ?? 0
+        selectorTopK = try Self.optionalPositiveInt(dflash, "selector_top_k") ?? 0
         maxPositionEmbeddings = try Self.positiveInt(metadata, "max_position_embeddings")
         slidingWindow = try Self.optionalPositiveInt(metadata, "sliding_window")
         layerTypes = try Self.stringArray(metadata, "layer_types")
@@ -116,11 +140,12 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
         eosTokenIDs = Self.tokenIDs(in: metadata, key: "eos_token_id")
         padTokenIDs = Self.tokenIDs(in: metadata, key: "pad_token_id")
 
-        guard convolutionKernelSize == 2 else {
+        guard draftArchitecture != Self.architecture || convolutionKernelSize == 2 else {
             throw AFMMLXDFlash2ConfigurationError.invalidValue(
                 "conv_kernel_size must be 2 for the supported DFlash2 runtime")
         }
-        guard hiddenSize.isMultiple(of: convolutionGroupSize) else {
+        guard draftArchitecture != Self.architecture
+                || hiddenSize.isMultiple(of: convolutionGroupSize) else {
             throw AFMMLXDFlash2ConfigurationError.invalidValue(
                 "hidden_size must be divisible by conv_group_size")
         }
@@ -135,7 +160,7 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
             throw AFMMLXDFlash2ConfigurationError.invalidValue(
                 "mask_token_id must be inside the draft vocabulary")
         }
-        guard selectorTopK <= vocabularySize else {
+        guard draftArchitecture != Self.architecture || selectorTopK <= vocabularySize else {
             throw AFMMLXDFlash2ConfigurationError.invalidValue(
                 "selector_top_k must not exceed vocab_size")
         }
@@ -153,13 +178,13 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
         }
     }
 
-    public init(directory: URL) throws {
+    public init(directory: URL, targetMetadata: [String: Any]? = nil) throws {
         let url = directory.appendingPathComponent("config.json")
         let data = try Data(contentsOf: url)
         guard let metadata = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw AFMMLXDFlash2ConfigurationError.invalidValue("config.json must contain an object")
         }
-        try self.init(metadata: metadata)
+        try self.init(metadata: metadata, targetMetadata: targetMetadata)
     }
 
     public func validateTarget(metadata: [String: Any]) throws {
@@ -287,15 +312,24 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
     }
 
     func expectedTensorShapes() -> [String: [Int]] {
-        var result: [String: [Int]] = [
-            "candidate_selector.hidden_projection.weight": [selectorRank, hiddenSize],
-            "candidate_selector.predecessor_codebook.weight": [vocabularySize, selectorRank],
-            "candidate_selector.successor_codebook.weight": [vocabularySize, selectorRank],
-            "fc.weight": [hiddenSize, hiddenSize * targetLayerIDs.count],
-            "hidden_norm.weight": [hiddenSize],
-            "norm.weight": [hiddenSize],
-        ]
-        let dynamicKernelOutputs = 2 * convolutionKernelSize * (hiddenSize / convolutionGroupSize)
+        var result: [String: [Int]] = ["norm.weight": [hiddenSize]]
+        if draftArchitecture == Self.architecture {
+            result["candidate_selector.hidden_projection.weight"] = [selectorRank, hiddenSize]
+            result["candidate_selector.predecessor_codebook.weight"] = [
+                vocabularySize, selectorRank,
+            ]
+            result["candidate_selector.successor_codebook.weight"] = [
+                vocabularySize, selectorRank,
+            ]
+            result["fc.weight"] = [hiddenSize, hiddenSize * targetLayerIDs.count]
+            result["hidden_norm.weight"] = [hiddenSize]
+        } else {
+            result["encoder.fc.weight"] = [hiddenSize, hiddenSize * targetLayerIDs.count]
+            result["encoder.output_norm_enc.weight"] = [hiddenSize]
+        }
+        let dynamicKernelOutputs = draftArchitecture == Self.architecture
+            ? 2 * convolutionKernelSize * (hiddenSize / convolutionGroupSize)
+            : 0
         for layer in 0 ..< hiddenLayers {
             let prefix = "layers.\(layer)"
             result["\(prefix).input_layernorm.weight"] = [hiddenSize]
@@ -309,9 +343,15 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
             result["\(prefix).mlp.gate_proj.weight"] = [intermediateSize, hiddenSize]
             result["\(prefix).mlp.up_proj.weight"] = [intermediateSize, hiddenSize]
             result["\(prefix).mlp.down_proj.weight"] = [hiddenSize, intermediateSize]
-            for name in ["attention_conv", "mlp_conv"] {
-                result["\(prefix).\(name).base_kernel"] = [2, convolutionKernelSize, hiddenSize]
-                result["\(prefix).\(name).kernel_projection.weight"] = [dynamicKernelOutputs, hiddenSize]
+            if draftArchitecture == Self.architecture {
+                for name in ["attention_conv", "mlp_conv"] {
+                    result["\(prefix).\(name).base_kernel"] = [
+                        2, convolutionKernelSize, hiddenSize,
+                    ]
+                    result["\(prefix).\(name).kernel_projection.weight"] = [
+                        dynamicKernelOutputs, hiddenSize,
+                    ]
+                }
             }
         }
         return result

--- a/Sources/AFMKitMLX/AFMMLXDFlash2Configuration.swift
+++ b/Sources/AFMKitMLX/AFMMLXDFlash2Configuration.swift
@@ -6,6 +6,50 @@ public enum AFMMLXDFlash2Requirement: String, Codable, CaseIterable, Sendable {
     case required
 }
 
+/// Immutable result of validating a DFlash 2 drafter against a target checkpoint.
+/// Keeping the target configuration bytes with the runtime prevents callers from
+/// accidentally reusing a validated drafter with a different model container.
+public struct AFMMLXDFlash2Preflight: Equatable, Sendable {
+    public let configuration: AFMMLXDFlash2Configuration
+    public let targetConfigurationData: Data
+    public let blockSize: Int
+
+    public init(
+        configuration: AFMMLXDFlash2Configuration,
+        targetConfigurationData: Data,
+        blockSize: Int
+    ) {
+        self.configuration = configuration
+        self.targetConfigurationData = targetConfigurationData
+        self.blockSize = blockSize
+    }
+}
+
+public enum AFMMLXDFlash2PreflightValidator {
+    public static func validate(
+        targetDirectory: URL,
+        drafterDirectory: URL,
+        requestedBlockSize: Int?
+    ) throws -> AFMMLXDFlash2Preflight {
+        let configuration = try AFMMLXDFlash2Configuration(directory: drafterDirectory)
+        let targetConfigurationData = try Data(
+            contentsOf: targetDirectory.appendingPathComponent("config.json"))
+        guard let targetMetadata = try JSONSerialization.jsonObject(
+            with: targetConfigurationData) as? [String: Any] else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "target config.json must contain an object")
+        }
+
+        try configuration.validateTarget(metadata: targetMetadata)
+        try configuration.validateWeights(in: drafterDirectory)
+        return AFMMLXDFlash2Preflight(
+            configuration: configuration,
+            targetConfigurationData: targetConfigurationData,
+            blockSize: try configuration.effectiveBlockSize(requested: requestedBlockSize)
+        )
+    }
+}
+
 public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
     public static let architecture = "DFlash2DraftModel"
 

--- a/Sources/AFMKitMLX/AFMMLXDFlash2Configuration.swift
+++ b/Sources/AFMKitMLX/AFMMLXDFlash2Configuration.swift
@@ -23,6 +23,13 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
     public let convolutionGroupSize: Int
     public let selectorRank: Int
     public let selectorTopK: Int
+    public let maxPositionEmbeddings: Int
+    public let slidingWindow: Int?
+    public let layerTypes: [String]
+    public let ropeTheta: Double
+    public let bosTokenIDs: Set<Int>
+    public let eosTokenIDs: Set<Int>
+    public let padTokenIDs: Set<Int>
 
     public init(metadata: [String: Any]) throws {
         let architectures = metadata["architectures"] as? [String] ?? []
@@ -51,6 +58,18 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
         convolutionGroupSize = try Self.positiveInt(dflash, "conv_group_size")
         selectorRank = try Self.positiveInt(dflash, "selector_rank")
         selectorTopK = try Self.positiveInt(dflash, "selector_top_k")
+        maxPositionEmbeddings = try Self.positiveInt(metadata, "max_position_embeddings")
+        slidingWindow = try Self.optionalPositiveInt(metadata, "sliding_window")
+        layerTypes = try Self.stringArray(metadata, "layer_types")
+        let rope = metadata["rope_parameters"] as? [String: Any]
+            ?? metadata["rope_scaling"] as? [String: Any]
+            ?? [:]
+        ropeTheta = try Self.positiveDouble(
+            rope["rope_theta"] == nil ? metadata : rope,
+            "rope_theta")
+        bosTokenIDs = Self.tokenIDs(in: metadata, key: "bos_token_id")
+        eosTokenIDs = Self.tokenIDs(in: metadata, key: "eos_token_id")
+        padTokenIDs = Self.tokenIDs(in: metadata, key: "pad_token_id")
 
         guard convolutionKernelSize == 2 else {
             throw AFMMLXDFlash2ConfigurationError.invalidValue(
@@ -75,6 +94,18 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
             throw AFMMLXDFlash2ConfigurationError.invalidValue(
                 "selector_top_k must not exceed vocab_size")
         }
+        guard attentionHeads.isMultiple(of: keyValueHeads) else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "num_attention_heads must be divisible by num_key_value_heads")
+        }
+        guard layerTypes.count == hiddenLayers,
+              layerTypes.allSatisfy({ $0 == "sliding_attention" || $0 == "full_attention" }) else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "layer_types must contain one supported attention type per draft layer")
+        }
+        if layerTypes.contains("sliding_attention"), slidingWindow == nil {
+            throw AFMMLXDFlash2ConfigurationError.missingValue("sliding_window")
+        }
     }
 
     public init(directory: URL) throws {
@@ -91,6 +122,7 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
         let targetHidden = try Self.positiveInt(text, "hidden_size")
         let targetLayerCount = try Self.positiveInt(text, "num_hidden_layers")
         let targetVocabulary = try Self.positiveInt(text, "vocab_size")
+        let targetMaxPositions = try Self.positiveInt(text, "max_position_embeddings")
 
         guard targetHidden == hiddenSize else {
             throw AFMMLXDFlash2ConfigurationError.incompatibleTarget(
@@ -103,6 +135,38 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
         guard targetVocabulary == vocabularySize else {
             throw AFMMLXDFlash2ConfigurationError.incompatibleTarget(
                 "vocab_size (targetVocabulary) does not match drafter (vocabularySize)")
+        }
+        guard targetMaxPositions == maxPositionEmbeddings else {
+            throw AFMMLXDFlash2ConfigurationError.incompatibleTarget(
+                "max_position_embeddings \(targetMaxPositions) does not match drafter \(maxPositionEmbeddings)")
+        }
+
+        let targetRope = text["rope_parameters"] as? [String: Any]
+            ?? text["rope_scaling"] as? [String: Any]
+            ?? [:]
+        let targetRopeTheta = try Self.positiveDouble(
+            targetRope["rope_theta"] == nil ? text : targetRope,
+            "rope_theta")
+        guard abs(targetRopeTheta - ropeTheta) <= max(1, ropeTheta) * 1e-9 else {
+            throw AFMMLXDFlash2ConfigurationError.incompatibleTarget(
+                "rope_theta \(targetRopeTheta) does not match drafter \(ropeTheta)")
+        }
+
+        try Self.validateTokenIDs(
+            name: "bos_token_id", draft: bosTokenIDs,
+            target: Self.targetTokenIDs(metadata, key: "bos_token_id"))
+        try Self.validateTokenIDs(
+            name: "eos_token_id", draft: eosTokenIDs,
+            target: Self.targetTokenIDs(metadata, key: "eos_token_id"))
+        try Self.validateTokenIDs(
+            name: "pad_token_id", draft: padTokenIDs,
+            target: Self.targetTokenIDs(metadata, key: "pad_token_id"))
+
+        if let slidingWindow,
+           let targetSlidingWindow = try Self.optionalPositiveInt(text, "sliding_window"),
+           targetSlidingWindow != slidingWindow {
+            throw AFMMLXDFlash2ConfigurationError.incompatibleTarget(
+                "sliding_window \(targetSlidingWindow) does not match drafter \(slidingWindow)")
         }
 
         let modelType = Self.canonical(text["model_type"] as? String)
@@ -125,6 +189,85 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
         return min(requested, checkpointBlockSize)
     }
 
+    /// Validate the released DFlash 2 tensor contract from safetensor headers
+    /// before MLX maps or allocates the multi-gigabyte payloads.
+    public func validateWeights(in directory: URL) throws {
+        let files = try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles])
+            .filter { $0.pathExtension == "safetensors" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        guard !files.isEmpty else {
+            throw AFMMLXDFlash2ConfigurationError.missingValue("*.safetensors")
+        }
+
+        var actual: [String: [Int]] = [:]
+        for file in files {
+            for (name, shape) in try Self.safetensorShapes(at: file) {
+                guard actual.updateValue(shape, forKey: name) == nil else {
+                    throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                        "duplicate tensor \(name)")
+                }
+            }
+        }
+
+        let expected = expectedTensorShapes()
+        for (name, shape) in expected {
+            let aliases = name.hasSuffix("_codebook.weight")
+                ? [name, String(name.dropLast(".weight".count))]
+                : [name]
+            guard let key = aliases.first(where: { actual[$0] != nil }),
+                  let found = actual[key] else {
+                throw AFMMLXDFlash2ConfigurationError.missingValue("tensor \(name)")
+            }
+            guard found == shape else {
+                throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                    "tensor \(key) has shape \(found); expected \(shape)")
+            }
+        }
+
+        let normalizedActual = Set(actual.keys.map { key in
+            key.hasSuffix("_codebook") ? key + ".weight" : key
+        })
+        let unexpected = normalizedActual.subtracting(expected.keys).sorted()
+        guard unexpected.isEmpty else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "unexpected tensors: \(unexpected.joined(separator: ", "))")
+        }
+    }
+
+    func expectedTensorShapes() -> [String: [Int]] {
+        var result: [String: [Int]] = [
+            "candidate_selector.hidden_projection.weight": [selectorRank, hiddenSize],
+            "candidate_selector.predecessor_codebook.weight": [vocabularySize, selectorRank],
+            "candidate_selector.successor_codebook.weight": [vocabularySize, selectorRank],
+            "fc.weight": [hiddenSize, hiddenSize * targetLayerIDs.count],
+            "hidden_norm.weight": [hiddenSize],
+            "norm.weight": [hiddenSize],
+        ]
+        let dynamicKernelOutputs = 2 * convolutionKernelSize * (hiddenSize / convolutionGroupSize)
+        for layer in 0 ..< hiddenLayers {
+            let prefix = "layers.\(layer)"
+            result["\(prefix).input_layernorm.weight"] = [hiddenSize]
+            result["\(prefix).post_attention_layernorm.weight"] = [hiddenSize]
+            result["\(prefix).self_attn.q_proj.weight"] = [attentionHeads * headDimension, hiddenSize]
+            result["\(prefix).self_attn.k_proj.weight"] = [keyValueHeads * headDimension, hiddenSize]
+            result["\(prefix).self_attn.v_proj.weight"] = [keyValueHeads * headDimension, hiddenSize]
+            result["\(prefix).self_attn.o_proj.weight"] = [hiddenSize, attentionHeads * headDimension]
+            result["\(prefix).self_attn.q_norm.weight"] = [headDimension]
+            result["\(prefix).self_attn.k_norm.weight"] = [headDimension]
+            result["\(prefix).mlp.gate_proj.weight"] = [intermediateSize, hiddenSize]
+            result["\(prefix).mlp.up_proj.weight"] = [intermediateSize, hiddenSize]
+            result["\(prefix).mlp.down_proj.weight"] = [hiddenSize, intermediateSize]
+            for name in ["attention_conv", "mlp_conv"] {
+                result["\(prefix).\(name).base_kernel"] = [2, convolutionKernelSize, hiddenSize]
+                result["\(prefix).\(name).kernel_projection.weight"] = [dynamicKernelOutputs, hiddenSize]
+            }
+        }
+        return result
+    }
+
     private static func canonical(_ value: String?) -> String {
         value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
     }
@@ -133,6 +276,23 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
         let value = try nonnegativeInt(object, key)
         guard value > 0 else {
             throw AFMMLXDFlash2ConfigurationError.invalidValue("\(key) must be positive")
+        }
+        return value
+    }
+
+    private static func optionalPositiveInt(
+        _ object: [String: Any], _ key: String
+    ) throws -> Int? {
+        guard object[key] != nil, !(object[key] is NSNull) else { return nil }
+        return try positiveInt(object, key)
+    }
+
+    private static func positiveDouble(_ object: [String: Any], _ key: String) throws -> Double {
+        guard let value = (object[key] as? NSNumber)?.doubleValue else {
+            throw AFMMLXDFlash2ConfigurationError.missingValue(key)
+        }
+        guard value > 0, value.isFinite else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue("\(key) must be positive and finite")
         }
         return value
     }
@@ -154,6 +314,74 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
         let result = values.compactMap { ($0 as? NSNumber)?.intValue }
         guard result.count == values.count else {
             throw AFMMLXDFlash2ConfigurationError.invalidValue("\(key) must contain integers")
+        }
+        return result
+    }
+
+    private static func stringArray(_ object: [String: Any], _ key: String) throws -> [String] {
+        guard let values = object[key] as? [String] else {
+            throw AFMMLXDFlash2ConfigurationError.missingValue(key)
+        }
+        return values
+    }
+
+    private static func tokenIDs(in object: [String: Any], key: String) -> Set<Int> {
+        if let value = object[key] as? NSNumber { return [value.intValue] }
+        if let values = object[key] as? [NSNumber] { return Set(values.map(\.intValue)) }
+        return []
+    }
+
+    private static func targetTokenIDs(_ metadata: [String: Any], key: String) -> Set<Int> {
+        var result = tokenIDs(in: metadata, key: key)
+        if let text = metadata["text_config"] as? [String: Any] {
+            result.formUnion(tokenIDs(in: text, key: key))
+        }
+        if let generation = metadata["generation_config"] as? [String: Any] {
+            result.formUnion(tokenIDs(in: generation, key: key))
+        }
+        return result
+    }
+
+    private static func validateTokenIDs(
+        name: String, draft: Set<Int>, target: Set<Int>
+    ) throws {
+        guard !draft.isEmpty, !target.isEmpty else { return }
+        guard draft.isSubset(of: target) else {
+            throw AFMMLXDFlash2ConfigurationError.incompatibleTarget(
+                "\(name) \(draft.sorted()) does not match target \(target.sorted())")
+        }
+    }
+
+    private static func safetensorShapes(at url: URL) throws -> [String: [Int]] {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        guard let prefix = try handle.read(upToCount: 8), prefix.count == 8 else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "truncated safetensor header in \(url.lastPathComponent)")
+        }
+        let headerSize = prefix.enumerated().reduce(UInt64(0)) { value, item in
+            value | (UInt64(item.element) << UInt64(item.offset * 8))
+        }
+        guard headerSize > 0, headerSize <= 64 * 1024 * 1024,
+              let header = try handle.read(upToCount: Int(headerSize)),
+              header.count == Int(headerSize),
+              let object = try JSONSerialization.jsonObject(with: header) as? [String: Any] else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "invalid safetensor header in \(url.lastPathComponent)")
+        }
+        var result: [String: [Int]] = [:]
+        for (name, entry) in object where name != "__metadata__" {
+            guard let metadata = entry as? [String: Any],
+                  let rawShape = metadata["shape"] as? [Any] else {
+                throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                    "tensor \(name) has no shape metadata")
+            }
+            let shape = rawShape.compactMap { ($0 as? NSNumber)?.intValue }
+            guard shape.count == rawShape.count, shape.allSatisfy({ $0 >= 0 }) else {
+                throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                    "tensor \(name) has invalid shape metadata")
+            }
+            result[name] = shape
         }
         return result
     }

--- a/Sources/AFMKitMLX/AFMMLXDFlash2Configuration.swift
+++ b/Sources/AFMKitMLX/AFMMLXDFlash2Configuration.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+public enum AFMMLXDFlash2Requirement: String, Codable, CaseIterable, Sendable {
+    case preferred
+    case required
+}
+
+public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
+    public static let architecture = "DFlash2DraftModel"
+
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let hiddenLayers: Int
+    public let attentionHeads: Int
+    public let keyValueHeads: Int
+    public let headDimension: Int
+    public let vocabularySize: Int
+    public let targetLayers: Int
+    public let targetLayerIDs: [Int]
+    public let checkpointBlockSize: Int
+    public let maskTokenID: Int
+    public let convolutionKernelSize: Int
+    public let convolutionGroupSize: Int
+    public let selectorRank: Int
+    public let selectorTopK: Int
+
+    public init(metadata: [String: Any]) throws {
+        let architectures = metadata["architectures"] as? [String] ?? []
+        guard architectures.contains(Self.architecture) else {
+            throw AFMMLXDFlash2ConfigurationError.unsupportedArchitecture(architectures)
+        }
+        guard (metadata["is_causal"] as? Bool) == false else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue("is_causal must be false")
+        }
+        guard let dflash = metadata["dflash_config"] as? [String: Any] else {
+            throw AFMMLXDFlash2ConfigurationError.missingValue("dflash_config")
+        }
+
+        hiddenSize = try Self.positiveInt(metadata, "hidden_size")
+        intermediateSize = try Self.positiveInt(metadata, "intermediate_size")
+        hiddenLayers = try Self.positiveInt(metadata, "num_hidden_layers")
+        attentionHeads = try Self.positiveInt(metadata, "num_attention_heads")
+        keyValueHeads = try Self.positiveInt(metadata, "num_key_value_heads")
+        headDimension = try Self.positiveInt(metadata, "head_dim")
+        vocabularySize = try Self.positiveInt(metadata, "vocab_size")
+        targetLayers = try Self.positiveInt(metadata, "num_target_layers")
+        targetLayerIDs = try Self.intArray(dflash, "target_layer_ids")
+        checkpointBlockSize = try Self.positiveInt(dflash, "block_size")
+        maskTokenID = try Self.nonnegativeInt(dflash, "mask_token_id")
+        convolutionKernelSize = try Self.positiveInt(dflash, "conv_kernel_size")
+        convolutionGroupSize = try Self.positiveInt(dflash, "conv_group_size")
+        selectorRank = try Self.positiveInt(dflash, "selector_rank")
+        selectorTopK = try Self.positiveInt(dflash, "selector_top_k")
+
+        guard convolutionKernelSize == 2 else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "conv_kernel_size must be 2 for the supported DFlash2 runtime")
+        }
+        guard hiddenSize.isMultiple(of: convolutionGroupSize) else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "hidden_size must be divisible by conv_group_size")
+        }
+        guard targetLayerIDs.count == hiddenLayers,
+              targetLayerIDs == targetLayerIDs.sorted(),
+              Set(targetLayerIDs).count == targetLayerIDs.count,
+              targetLayerIDs.allSatisfy({ $0 >= 0 && $0 < targetLayers }) else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "target_layer_ids must contain one unique, ordered target layer per draft layer")
+        }
+        guard maskTokenID < vocabularySize else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "mask_token_id must be inside the draft vocabulary")
+        }
+        guard selectorTopK <= vocabularySize else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "selector_top_k must not exceed vocab_size")
+        }
+    }
+
+    public init(directory: URL) throws {
+        let url = directory.appendingPathComponent("config.json")
+        let data = try Data(contentsOf: url)
+        guard let metadata = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue("config.json must contain an object")
+        }
+        try self.init(metadata: metadata)
+    }
+
+    public func validateTarget(metadata: [String: Any]) throws {
+        let text = metadata["text_config"] as? [String: Any] ?? metadata
+        let targetHidden = try Self.positiveInt(text, "hidden_size")
+        let targetLayerCount = try Self.positiveInt(text, "num_hidden_layers")
+        let targetVocabulary = try Self.positiveInt(text, "vocab_size")
+
+        guard targetHidden == hiddenSize else {
+            throw AFMMLXDFlash2ConfigurationError.incompatibleTarget(
+                "hidden_size (targetHidden) does not match drafter (hiddenSize)")
+        }
+        guard targetLayerCount == targetLayers else {
+            throw AFMMLXDFlash2ConfigurationError.incompatibleTarget(
+                "num_hidden_layers (targetLayerCount) does not match drafter (targetLayers)")
+        }
+        guard targetVocabulary == vocabularySize else {
+            throw AFMMLXDFlash2ConfigurationError.incompatibleTarget(
+                "vocab_size (targetVocabulary) does not match drafter (vocabularySize)")
+        }
+
+        let modelType = Self.canonical(text["model_type"] as? String)
+        let topLevelType = Self.canonical(metadata["model_type"] as? String)
+        let supported = modelType == "qwen3_5_text"
+            || modelType == "muse_glimmer_text"
+            || topLevelType == "muse_glimmer"
+        guard supported else {
+            throw AFMMLXDFlash2ConfigurationError.incompatibleTarget(
+                "target model_type is not a supported Qwen 3.8 or Muse Glimmer verifier")
+        }
+    }
+
+    public func effectiveBlockSize(requested: Int?) throws -> Int {
+        guard let requested else { return checkpointBlockSize }
+        guard requested >= 2 else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "runtime block size must be at least 2")
+        }
+        return min(requested, checkpointBlockSize)
+    }
+
+    private static func canonical(_ value: String?) -> String {
+        value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+    }
+
+    private static func positiveInt(_ object: [String: Any], _ key: String) throws -> Int {
+        let value = try nonnegativeInt(object, key)
+        guard value > 0 else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue("\(key) must be positive")
+        }
+        return value
+    }
+
+    private static func nonnegativeInt(_ object: [String: Any], _ key: String) throws -> Int {
+        guard let value = (object[key] as? NSNumber)?.intValue else {
+            throw AFMMLXDFlash2ConfigurationError.missingValue(key)
+        }
+        guard value >= 0 else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue("\(key) must be nonnegative")
+        }
+        return value
+    }
+
+    private static func intArray(_ object: [String: Any], _ key: String) throws -> [Int] {
+        guard let values = object[key] as? [Any] else {
+            throw AFMMLXDFlash2ConfigurationError.missingValue(key)
+        }
+        let result = values.compactMap { ($0 as? NSNumber)?.intValue }
+        guard result.count == values.count else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue("\(key) must contain integers")
+        }
+        return result
+    }
+}
+
+public enum AFMMLXDFlash2ConfigurationError: LocalizedError, Equatable, Sendable {
+    case missingValue(String)
+    case invalidValue(String)
+    case unsupportedArchitecture([String])
+    case incompatibleTarget(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingValue(let key):
+            return "DFlash2 config is missing \(key)"
+        case .invalidValue(let message):
+            return "Invalid DFlash2 config: \(message)"
+        case .unsupportedArchitecture(let architectures):
+            return "Expected architectures to contain \(AFMMLXDFlash2Configuration.architecture); found \(architectures)"
+        case .incompatibleTarget(let message):
+            return "DFlash2 drafter is incompatible with the target: \(message)"
+        }
+    }
+}
+
+public struct AFMMLXSpeculativeTelemetry: Equatable, Sendable {
+    public let strategy: String
+    public let draftedTokens: Int
+    public let acceptedDraftTokens: Int
+    public let emittedTokens: Int
+    public let verificationCycles: Int
+    public let draftTime: TimeInterval
+    public let verificationTime: TimeInterval
+    public let rollbackTime: TimeInterval
+
+    public init(
+        strategy: String,
+        draftedTokens: Int,
+        acceptedDraftTokens: Int,
+        emittedTokens: Int,
+        verificationCycles: Int,
+        draftTime: TimeInterval,
+        verificationTime: TimeInterval,
+        rollbackTime: TimeInterval
+    ) {
+        self.strategy = strategy
+        self.draftedTokens = draftedTokens
+        self.acceptedDraftTokens = acceptedDraftTokens
+        self.emittedTokens = emittedTokens
+        self.verificationCycles = verificationCycles
+        self.draftTime = draftTime
+        self.verificationTime = verificationTime
+        self.rollbackTime = rollbackTime
+    }
+
+    public var meanAcceptanceLength: Double {
+        verificationCycles > 0 ? Double(acceptedDraftTokens) / Double(verificationCycles) : 0
+    }
+}

--- a/Sources/AFMKitMLX/AFMMLXDFlash2Configuration.swift
+++ b/Sources/AFMKitMLX/AFMMLXDFlash2Configuration.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AFMKitCore
 
 public enum AFMMLXDFlash2Requirement: String, Codable, CaseIterable, Sendable {
     case preferred
@@ -186,7 +187,11 @@ public struct AFMMLXDFlash2Configuration: Equatable, Sendable {
             throw AFMMLXDFlash2ConfigurationError.invalidValue(
                 "runtime block size must be at least 2")
         }
-        return min(requested, checkpointBlockSize)
+        guard requested <= checkpointBlockSize else {
+            throw AFMMLXDFlash2ConfigurationError.invalidValue(
+                "runtime block size \(requested) exceeds checkpoint limit \(checkpointBlockSize)")
+        }
+        return requested
     }
 
     /// Validate the released DFlash 2 tensor contract from safetensor headers
@@ -408,6 +413,8 @@ public enum AFMMLXDFlash2ConfigurationError: LocalizedError, Equatable, Sendable
 }
 
 public struct AFMMLXSpeculativeTelemetry: Equatable, Sendable {
+    public static let metadataKey = "afm.speculative_decoding.v1"
+
     public let strategy: String
     public let draftedTokens: Int
     public let acceptedDraftTokens: Int
@@ -416,6 +423,7 @@ public struct AFMMLXSpeculativeTelemetry: Equatable, Sendable {
     public let draftTime: TimeInterval
     public let verificationTime: TimeInterval
     public let rollbackTime: TimeInterval
+    public let fallbackReason: String?
 
     public init(
         strategy: String,
@@ -425,7 +433,8 @@ public struct AFMMLXSpeculativeTelemetry: Equatable, Sendable {
         verificationCycles: Int,
         draftTime: TimeInterval,
         verificationTime: TimeInterval,
-        rollbackTime: TimeInterval
+        rollbackTime: TimeInterval,
+        fallbackReason: String? = nil
     ) {
         self.strategy = strategy
         self.draftedTokens = draftedTokens
@@ -435,9 +444,80 @@ public struct AFMMLXSpeculativeTelemetry: Equatable, Sendable {
         self.draftTime = draftTime
         self.verificationTime = verificationTime
         self.rollbackTime = rollbackTime
+        self.fallbackReason = fallbackReason
     }
 
     public var meanAcceptanceLength: Double {
         verificationCycles > 0 ? Double(acceptedDraftTokens) / Double(verificationCycles) : 0
+    }
+
+    public var metadataValue: AFMJSONValue {
+        var values: [String: AFMJSONValue] = [
+            "strategy": .string(strategy),
+            "draftedTokens": .integer(draftedTokens),
+            "acceptedDraftTokens": .integer(acceptedDraftTokens),
+            "emittedTokens": .integer(emittedTokens),
+            "verificationCycles": .integer(verificationCycles),
+            "draftSeconds": .number(draftTime),
+            "verificationSeconds": .number(verificationTime),
+            "rollbackSeconds": .number(rollbackTime),
+        ]
+        if let fallbackReason {
+            values["fallbackReason"] = .string(fallbackReason)
+        }
+        return .object(values)
+    }
+
+    public init?(metadataValue: AFMJSONValue) {
+        guard case .object(let values) = metadataValue,
+              case .string(let strategy)? = values["strategy"],
+              case .integer(let draftedTokens)? = values["draftedTokens"],
+              case .integer(let acceptedDraftTokens)? = values["acceptedDraftTokens"],
+              case .integer(let emittedTokens)? = values["emittedTokens"],
+              case .integer(let verificationCycles)? = values["verificationCycles"],
+              let draftTime = Self.number(values["draftSeconds"]),
+              let verificationTime = Self.number(values["verificationSeconds"]),
+              let rollbackTime = Self.number(values["rollbackSeconds"]) else {
+            return nil
+        }
+        let fallbackReason: String?
+        if case .string(let value)? = values["fallbackReason"] {
+            fallbackReason = value
+        } else {
+            fallbackReason = nil
+        }
+        self.init(
+            strategy: strategy,
+            draftedTokens: draftedTokens,
+            acceptedDraftTokens: acceptedDraftTokens,
+            emittedTokens: emittedTokens,
+            verificationCycles: verificationCycles,
+            draftTime: draftTime,
+            verificationTime: verificationTime,
+            rollbackTime: rollbackTime,
+            fallbackReason: fallbackReason
+        )
+    }
+
+    public static func fallback(strategy: String, reason: String) -> Self {
+        Self(
+            strategy: strategy,
+            draftedTokens: 0,
+            acceptedDraftTokens: 0,
+            emittedTokens: 0,
+            verificationCycles: 0,
+            draftTime: 0,
+            verificationTime: 0,
+            rollbackTime: 0,
+            fallbackReason: reason
+        )
+    }
+
+    private static func number(_ value: AFMJSONValue?) -> Double? {
+        switch value {
+        case .number(let value): return value
+        case .integer(let value): return Double(value)
+        default: return nil
+        }
     }
 }

--- a/Sources/AFMKitMLX/AFMMLXGenerationResult.swift
+++ b/Sources/AFMKitMLX/AFMMLXGenerationResult.swift
@@ -10,9 +10,61 @@ public typealias AFMMLXChatGenerationResult = (
     cachedTokens: Int,
     promptTime: Double,
     generateTime: Double,
-    stoppedBySequence: Bool,
-    speculativeTelemetry: AFMMLXSpeculativeTelemetry?
+    stoppedBySequence: Bool
 )
+
+/// Opt-in result wrapper that adds telemetry without changing the legacy tuple API.
+public struct AFMMLXChatGenerationResultWithTelemetry: Sendable {
+    public let result: AFMMLXChatGenerationResult
+    public let speculativeTelemetry: AFMMLXSpeculativeTelemetry?
+
+    public init(
+        result: AFMMLXChatGenerationResult,
+        speculativeTelemetry: AFMMLXSpeculativeTelemetry? = nil
+    ) {
+        self.result = result
+        self.speculativeTelemetry = speculativeTelemetry
+    }
+
+    public init(
+        modelID: String,
+        content: String,
+        promptTokens: Int,
+        completionTokens: Int,
+        tokenLogprobs: [ResolvedLogprob]?,
+        toolCalls: [ResponseToolCall]?,
+        cachedTokens: Int,
+        promptTime: Double,
+        generateTime: Double,
+        stoppedBySequence: Bool,
+        speculativeTelemetry: AFMMLXSpeculativeTelemetry? = nil
+    ) {
+        self.init(
+            result: (
+                modelID: modelID,
+                content: content,
+                promptTokens: promptTokens,
+                completionTokens: completionTokens,
+                tokenLogprobs: tokenLogprobs,
+                toolCalls: toolCalls,
+                cachedTokens: cachedTokens,
+                promptTime: promptTime,
+                generateTime: generateTime,
+                stoppedBySequence: stoppedBySequence),
+            speculativeTelemetry: speculativeTelemetry)
+    }
+
+    public var modelID: String { result.modelID }
+    public var content: String { result.content }
+    public var promptTokens: Int { result.promptTokens }
+    public var completionTokens: Int { result.completionTokens }
+    public var tokenLogprobs: [ResolvedLogprob]? { result.tokenLogprobs }
+    public var toolCalls: [ResponseToolCall]? { result.toolCalls }
+    public var cachedTokens: Int { result.cachedTokens }
+    public var promptTime: Double { result.promptTime }
+    public var generateTime: Double { result.generateTime }
+    public var stoppedBySequence: Bool { result.stoppedBySequence }
+}
 
 public typealias AFMMLXChatStreamingResult = (
     modelID: String,

--- a/Sources/AFMKitMLX/AFMMLXGenerationResult.swift
+++ b/Sources/AFMKitMLX/AFMMLXGenerationResult.swift
@@ -10,7 +10,8 @@ public typealias AFMMLXChatGenerationResult = (
     cachedTokens: Int,
     promptTime: Double,
     generateTime: Double,
-    stoppedBySequence: Bool
+    stoppedBySequence: Bool,
+    speculativeTelemetry: AFMMLXSpeculativeTelemetry?
 )
 
 public typealias AFMMLXChatStreamingResult = (

--- a/Sources/AFMKitMLX/AFMMLXModelArchitecture.swift
+++ b/Sources/AFMKitMLX/AFMMLXModelArchitecture.swift
@@ -58,7 +58,7 @@ public enum AFMMLXModelArchitecturePreflightError: Error, LocalizedError, Sendab
         case .invalidConfiguration(let modelID):
             return "Could not read model_type from \(modelID)'s config.json."
         case .draftOnlyArchitecture(let architecture, let modelID):
-            return "Model '\(modelID)' (architecture: \(architecture)) is a speculative draft checkpoint, not a standalone language model. Pair it with its full target model using a compatible speculative runtime; AFM does not currently support DFlash pairing."
+            return "Model '\(modelID)' (architecture: \(architecture)) is a speculative draft checkpoint, not a standalone language model. Start AFM with its full target model and pass this checkpoint through --dflash2."
         case .unsupportedArchitecture(let modelType, let modelID):
             return "Unsupported model architecture '\(modelType)' for \(modelID)."
         case .metalCrashArchitecture(let modelType, let modelID):

--- a/Sources/AFMKitMLX/AFMMLXOpenAIChatGenerating.swift
+++ b/Sources/AFMKitMLX/AFMMLXOpenAIChatGenerating.swift
@@ -167,6 +167,33 @@ public protocol AFMMLXOpenAIChatServing:
 {
     var defaultGuidedJsonSchema: ResponseFormat? { get }
 
+    /// Generate using capacity already acquired by the caller. The concrete
+    /// admission value is transferred to the returned stream on success.
+    func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?,
+        preserveStructuralTags: Bool,
+        requestId: String?,
+        schedulerAdmission: AFMMLXSchedulerAdmission
+    ) async throws -> AFMMLXChatStreamingResult
+
     /// Reset and read provider-specific request memory telemetry. Providers
     /// that do not execute through MLX must not initialize MLX merely to serve
     /// an OpenAI-compatible request.
@@ -611,6 +638,63 @@ extension MLXModelService {
 }
 
 extension MLXModelService: AFMMLXOpenAIChatServing {
+    public func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?,
+        preserveStructuralTags: Bool,
+        requestId: String?,
+        schedulerAdmission: AFMMLXSchedulerAdmission
+    ) async throws -> AFMMLXChatStreamingResult {
+        let submissionAdmission: BatchSchedulerSubmissionAdmission =
+            switch schedulerAdmission {
+            case .serial:
+                .unreserved
+            case .reserved(let reservation):
+                .reserved(reservation)
+            case .unavailable:
+                throw MLXServiceError.serverBusy(maxConcurrent)
+            }
+        return try await generateStreamingWithSchedulerAdmission(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: speculativeDecoding,
+            preserveStructuralTags: preserveStructuralTags,
+            requestId: requestId,
+            admission: submissionAdmission)
+    }
+
     public func resetRequestPeakMemory() {
         GPU.resetPeakMemory()
     }

--- a/Sources/AFMKitMLX/AFMMLXOpenAIChatGenerating.swift
+++ b/Sources/AFMKitMLX/AFMMLXOpenAIChatGenerating.swift
@@ -88,6 +88,52 @@ public protocol AFMMLXOpenAIChatGenerating: Sendable {
         preserveStructuralTags: Bool,
         requestId: String?
     ) async throws -> AFMMLXChatStreamingResult
+
+    func generate(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?
+    ) async throws -> AFMMLXChatGenerationResult
+
+    func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?,
+        preserveStructuralTags: Bool,
+        requestId: String?
+    ) async throws -> AFMMLXChatStreamingResult
 }
 
 public protocol AFMMLXOpenAIChatServing:
@@ -125,6 +171,81 @@ public extension AFMMLXOpenAIChatServing {
 }
 
 public extension AFMMLXOpenAIChatGenerating {
+    func generate(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?
+    ) async throws -> AFMMLXChatGenerationResult {
+        if speculativeDecoding?.requirement?.lowercased() == "required" {
+            throw NSError(
+                domain: "AFMMLXSpeculativeDecoding",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Provider cannot honor required speculative decoding"])
+        }
+        return try await generate(
+            model: model, messages: messages, temperature: temperature,
+            maxTokens: maxTokens, topP: topP, repetitionPenalty: repetitionPenalty,
+            topK: topK, minP: minP, presencePenalty: presencePenalty, seed: seed,
+            logprobs: logprobs, topLogprobs: topLogprobs, tools: tools,
+            toolChoice: toolChoice, parallelToolCalls: parallelToolCalls, stop: stop,
+            responseFormat: responseFormat, chatTemplateKwargs: chatTemplateKwargs)
+    }
+
+    func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?,
+        preserveStructuralTags: Bool,
+        requestId: String?
+    ) async throws -> AFMMLXChatStreamingResult {
+        if speculativeDecoding?.requirement?.lowercased() == "required" {
+            throw NSError(
+                domain: "AFMMLXSpeculativeDecoding",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Provider cannot honor required speculative decoding"])
+        }
+        return try await generateStreaming(
+            model: model, messages: messages, temperature: temperature,
+            maxTokens: maxTokens, topP: topP, repetitionPenalty: repetitionPenalty,
+            topK: topK, minP: minP, presencePenalty: presencePenalty, seed: seed,
+            logprobs: logprobs, topLogprobs: topLogprobs, tools: tools,
+            toolChoice: toolChoice, parallelToolCalls: parallelToolCalls, stop: stop,
+            responseFormat: responseFormat, chatTemplateKwargs: chatTemplateKwargs,
+            preserveStructuralTags: preserveStructuralTags, requestId: requestId)
+    }
+
     func generate(
         model: String,
         messages: [Message],
@@ -251,6 +372,134 @@ public extension AFMMLXOpenAIChatGenerating {
             preserveStructuralTags: false,
             requestId: nil
         )
+    }
+}
+
+extension MLXModelService {
+    public func generate(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?
+    ) async throws -> AFMMLXChatGenerationResult {
+        try await generate(
+            model: model, messages: messages, temperature: temperature,
+            maxTokens: maxTokens, topP: topP, repetitionPenalty: repetitionPenalty,
+            topK: topK, minP: minP, presencePenalty: presencePenalty, seed: seed,
+            logprobs: logprobs, topLogprobs: topLogprobs, tools: tools,
+            parallelToolCalls: parallelToolCalls, stop: stop,
+            responseFormat: responseFormat, chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: speculativeDecoding)
+    }
+
+    public func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?,
+        preserveStructuralTags: Bool,
+        requestId: String?
+    ) async throws -> AFMMLXChatStreamingResult {
+        try await generateStreaming(
+            model: model, messages: messages, temperature: temperature,
+            maxTokens: maxTokens, topP: topP, repetitionPenalty: repetitionPenalty,
+            topK: topK, minP: minP, presencePenalty: presencePenalty, seed: seed,
+            logprobs: logprobs, topLogprobs: topLogprobs, tools: tools,
+            parallelToolCalls: parallelToolCalls, stop: stop,
+            responseFormat: responseFormat, chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: speculativeDecoding,
+            preserveStructuralTags: preserveStructuralTags, requestId: requestId)
+    }
+
+    public func generate(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?
+    ) async throws -> AFMMLXChatGenerationResult {
+        try await generate(
+            model: model, messages: messages, temperature: temperature,
+            maxTokens: maxTokens, topP: topP, repetitionPenalty: repetitionPenalty,
+            topK: topK, minP: minP, presencePenalty: presencePenalty, seed: seed,
+            logprobs: logprobs, topLogprobs: topLogprobs, tools: tools,
+            parallelToolCalls: parallelToolCalls, stop: stop,
+            responseFormat: responseFormat, chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: nil)
+    }
+
+    public func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        preserveStructuralTags: Bool,
+        requestId: String?
+    ) async throws -> AFMMLXChatStreamingResult {
+        try await generateStreaming(
+            model: model, messages: messages, temperature: temperature,
+            maxTokens: maxTokens, topP: topP, repetitionPenalty: repetitionPenalty,
+            topK: topK, minP: minP, presencePenalty: presencePenalty, seed: seed,
+            logprobs: logprobs, topLogprobs: topLogprobs, tools: tools,
+            parallelToolCalls: parallelToolCalls, stop: stop,
+            responseFormat: responseFormat, chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: nil,
+            preserveStructuralTags: preserveStructuralTags, requestId: requestId)
     }
 }
 

--- a/Sources/AFMKitMLX/AFMMLXOpenAIChatGenerating.swift
+++ b/Sources/AFMKitMLX/AFMMLXOpenAIChatGenerating.swift
@@ -111,6 +111,28 @@ public protocol AFMMLXOpenAIChatGenerating: Sendable {
         speculativeDecoding: SpeculativeDecodingOptions?
     ) async throws -> AFMMLXChatGenerationResult
 
+    func generateWithTelemetry(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?
+    ) async throws -> AFMMLXChatGenerationResultWithTelemetry
+
     func generateStreaming(
         model: String,
         messages: [Message],
@@ -171,6 +193,49 @@ public extension AFMMLXOpenAIChatServing {
 }
 
 public extension AFMMLXOpenAIChatGenerating {
+    func generateWithTelemetry(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?
+    ) async throws -> AFMMLXChatGenerationResultWithTelemetry {
+        AFMMLXChatGenerationResultWithTelemetry(result: try await generate(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: speculativeDecoding))
+    }
+
     func generate(
         model: String,
         messages: [Message],
@@ -376,6 +441,48 @@ public extension AFMMLXOpenAIChatGenerating {
 }
 
 extension MLXModelService {
+    public func generateWithTelemetry(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?
+    ) async throws -> AFMMLXChatGenerationResultWithTelemetry {
+        try await generateWithTelemetry(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: speculativeDecoding)
+    }
+
     public func generate(
         model: String,
         messages: [Message],

--- a/Sources/AFMKitMLX/AFMMLXProvider.swift
+++ b/Sources/AFMKitMLX/AFMMLXProvider.swift
@@ -68,6 +68,7 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
     private let runtime: AFMMLXRuntime
     private let service: MLXModelService
     private let modelID: String
+    private let schedulerAdmissionOwnership: AFMMLXSchedulerAdmissionOwnership
 
     public init(
         modelID: AFMModelID,
@@ -85,6 +86,7 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
         self.runtime = runtime
         self.service = runtime.service
         self.modelID = runtime.modelID
+        self.schedulerAdmissionOwnership = .model
         self.descriptor = runtime.descriptor
     }
 
@@ -92,7 +94,8 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
     public init(
         modelID: AFMModelID,
         resolver: MLXCacheResolver = .init(),
-        attachedService service: MLXModelService
+        attachedService service: MLXModelService,
+        schedulerAdmissionOwnership: AFMMLXSchedulerAdmissionOwnership = .model
     ) {
         let runtime = AFMMLXRuntime(
             modelID: modelID.rawValue,
@@ -103,6 +106,7 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
         self.runtime = runtime
         self.service = service
         self.modelID = runtime.modelID
+        self.schedulerAdmissionOwnership = schedulerAdmissionOwnership
         self.descriptor = runtime.descriptor
     }
 
@@ -229,10 +233,13 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
             let task = Task {
                 do {
                     _ = try await load(progress: nil)
-                    guard await service.waitForSlot(timeout: 30) else {
-                        throw AFMError.unavailable("MLX scheduler is at capacity")
+                    var ownsReservation = schedulerAdmissionOwnership == .callerReserved
+                    if schedulerAdmissionOwnership == .model {
+                        guard await service.waitForSlot(timeout: 30) else {
+                            throw AFMError.unavailable("MLX scheduler is at capacity")
+                        }
+                        ownsReservation = true
                     }
-                    var ownsReservation = true
                     defer {
                         if ownsReservation { service.releaseSlot() }
                     }

--- a/Sources/AFMKitMLX/AFMMLXProvider.swift
+++ b/Sources/AFMKitMLX/AFMMLXProvider.swift
@@ -263,6 +263,7 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                         responseFormat: request.openAIResponseFormat(),
                         chatTemplateKwargs: request.chatTemplateKwargs(),
                         speculativeDecoding: request.speculativeDecodingOptions(),
+                        preserveStructuralTags: request.preserveStructuralTags,
                         requestId: nil
                     )
                     ownsReservation = false
@@ -754,6 +755,13 @@ public enum AFMMLXModelDescriptor {
 }
 
 extension AFMRequest {
+    var preserveStructuralTags: Bool {
+        guard case .bool(let value)? =
+            metadata[AFMMLXRequestMetadata.preserveStructuralTags]
+        else { return false }
+        return value
+    }
+
     func speculativeDecodingOptions() -> SpeculativeDecodingOptions? {
         guard case .object(let values)? = metadata["speculativeDecoding"] else {
             return nil

--- a/Sources/AFMKitMLX/AFMMLXProvider.swift
+++ b/Sources/AFMKitMLX/AFMMLXProvider.swift
@@ -153,9 +153,18 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
     }
 
     public func respond(to request: AFMRequest) async throws -> AFMModelResponse {
-        var ownsCallerReservation = schedulerAdmissionOwnership == .callerReserved
+        let callerAdmission: AFMMLXSchedulerAdmission? = switch schedulerAdmissionOwnership {
+        case .model:
+            nil
+        case .caller(let admission):
+            admission
+        }
+        guard callerAdmission?.isAdmitted != false else {
+            throw AFMError.unavailable("MLX scheduler is at capacity")
+        }
+        var callerReservation = callerAdmission?.reservation
         defer {
-            if ownsCallerReservation { service.releaseSlot() }
+            if let callerReservation { service.releaseSlot(callerReservation) }
         }
         _ = try await load(progress: nil)
         do {
@@ -163,7 +172,7 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                 == .schedulerStream {
                 var accumulator = AFMMLXResponseAccumulator(modelID: modelID)
                 let stream = streamResponse(to: request)
-                ownsCallerReservation = false
+                callerReservation = nil
                 for try await event in stream {
                     accumulator.consume(event)
                 }
@@ -261,9 +270,15 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
     ) -> AsyncThrowingStream<AFMGenerationEvent, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {
-                var ownsReservation = schedulerAdmissionOwnership == .callerReserved
+                var reservation: AFMMLXSchedulerReservation? =
+                    switch schedulerAdmissionOwnership {
+                    case .model:
+                        nil
+                    case .caller(let admission):
+                        admission.reservation
+                    }
                 defer {
-                    if ownsReservation { service.releaseSlot() }
+                    if let reservation { service.releaseSlot(reservation) }
                 }
                 do {
                     if let streamingLoadOverride {
@@ -271,12 +286,26 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                     } else {
                         _ = try await load(progress: nil)
                     }
-                    if schedulerAdmissionOwnership == .model {
-                        guard await service.waitForSlot(timeout: 30) else {
-                            throw AFMError.unavailable("MLX scheduler is at capacity")
-                        }
-                        ownsReservation = true
+                    let schedulerAdmission: AFMMLXSchedulerAdmission
+                    switch schedulerAdmissionOwnership {
+                    case .model:
+                        schedulerAdmission = await service.waitForSlot(timeout: 30)
+                    case .caller(let admission):
+                        schedulerAdmission = admission
                     }
+                    guard schedulerAdmission.isAdmitted else {
+                        throw AFMError.unavailable("MLX scheduler is at capacity")
+                    }
+                    reservation = schedulerAdmission.reservation
+                    let submissionAdmission: BatchSchedulerSubmissionAdmission =
+                        switch schedulerAdmission {
+                        case .serial:
+                            .unreserved
+                        case .reserved(let reservation):
+                            .reserved(reservation)
+                        case .unavailable:
+                            .unreserved
+                        }
                     let tools = request.effectiveOpenAITools()
                     let result = try await service.generateStreamingWithSchedulerAdmission(
                         model: modelID,
@@ -299,9 +328,9 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                         speculativeDecoding: request.speculativeDecodingOptions(),
                         preserveStructuralTags: request.preserveStructuralTags,
                         requestId: nil,
-                        admission: ownsReservation ? .reserved : .unreserved
+                        admission: submissionAdmission
                     )
-                    ownsReservation = false
+                    reservation = nil
                     var translator = MLXStreamEventTranslator(
                         thinkStartTag: result.thinkStartTag,
                         thinkEndTag: result.thinkEndTag,

--- a/Sources/AFMKitMLX/AFMMLXProvider.swift
+++ b/Sources/AFMKitMLX/AFMMLXProvider.swift
@@ -69,6 +69,7 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
     private let service: MLXModelService
     private let modelID: String
     private let schedulerAdmissionOwnership: AFMMLXSchedulerAdmissionOwnership
+    private let streamingLoadOverride: (@Sendable () async throws -> Void)?
 
     public init(
         modelID: AFMModelID,
@@ -87,6 +88,7 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
         self.service = runtime.service
         self.modelID = runtime.modelID
         self.schedulerAdmissionOwnership = .model
+        self.streamingLoadOverride = nil
         self.descriptor = runtime.descriptor
     }
 
@@ -107,6 +109,28 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
         self.service = service
         self.modelID = runtime.modelID
         self.schedulerAdmissionOwnership = schedulerAdmissionOwnership
+        self.streamingLoadOverride = nil
+        self.descriptor = runtime.descriptor
+    }
+
+    init(
+        modelID: AFMModelID,
+        resolver: MLXCacheResolver = .init(),
+        attachedService service: MLXModelService,
+        schedulerAdmissionOwnership: AFMMLXSchedulerAdmissionOwnership,
+        testingStreamingLoad: @escaping @Sendable () async throws -> Void
+    ) {
+        let runtime = AFMMLXRuntime(
+            modelID: modelID.rawValue,
+            attaching: service,
+            resolver: resolver
+        )
+
+        self.runtime = runtime
+        self.service = service
+        self.modelID = runtime.modelID
+        self.schedulerAdmissionOwnership = schedulerAdmissionOwnership
+        self.streamingLoadOverride = testingStreamingLoad
         self.descriptor = runtime.descriptor
     }
 
@@ -129,12 +153,18 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
     }
 
     public func respond(to request: AFMRequest) async throws -> AFMModelResponse {
+        var ownsCallerReservation = schedulerAdmissionOwnership == .callerReserved
+        defer {
+            if ownsCallerReservation { service.releaseSlot() }
+        }
         _ = try await load(progress: nil)
         do {
             if AFMMLXGenerationRoute.resolve(maxConcurrent: service.maxConcurrent)
                 == .schedulerStream {
                 var accumulator = AFMMLXResponseAccumulator(modelID: modelID)
-                for try await event in streamResponse(to: request) {
+                let stream = streamResponse(to: request)
+                ownsCallerReservation = false
+                for try await event in stream {
                     accumulator.consume(event)
                 }
                 return accumulator.response
@@ -231,20 +261,24 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
     ) -> AsyncThrowingStream<AFMGenerationEvent, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {
+                var ownsReservation = schedulerAdmissionOwnership == .callerReserved
+                defer {
+                    if ownsReservation { service.releaseSlot() }
+                }
                 do {
-                    _ = try await load(progress: nil)
-                    var ownsReservation = schedulerAdmissionOwnership == .callerReserved
+                    if let streamingLoadOverride {
+                        try await streamingLoadOverride()
+                    } else {
+                        _ = try await load(progress: nil)
+                    }
                     if schedulerAdmissionOwnership == .model {
                         guard await service.waitForSlot(timeout: 30) else {
                             throw AFMError.unavailable("MLX scheduler is at capacity")
                         }
                         ownsReservation = true
                     }
-                    defer {
-                        if ownsReservation { service.releaseSlot() }
-                    }
                     let tools = request.effectiveOpenAITools()
-                    let result = try await service.generateStreaming(
+                    let result = try await service.generateStreamingWithSchedulerAdmission(
                         model: modelID,
                         messages: try request.openAIMessages(),
                         temperature: request.options.temperature,
@@ -264,7 +298,8 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                         chatTemplateKwargs: request.chatTemplateKwargs(),
                         speculativeDecoding: request.speculativeDecodingOptions(),
                         preserveStructuralTags: request.preserveStructuralTags,
-                        requestId: nil
+                        requestId: nil,
+                        admission: ownsReservation ? .reserved : .unreserved
                     )
                     ownsReservation = false
                     var translator = MLXStreamEventTranslator(

--- a/Sources/AFMKitMLX/AFMMLXProvider.swift
+++ b/Sources/AFMKitMLX/AFMMLXProvider.swift
@@ -143,7 +143,8 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                 parallelToolCalls: request.parallelToolCalls,
                 stop: request.options.stopSequences,
                 responseFormat: request.openAIResponseFormat(),
-                chatTemplateKwargs: request.chatTemplateKwargs()
+                chatTemplateKwargs: request.chatTemplateKwargs(),
+                speculativeDecoding: request.speculativeDecodingOptions()
             )
             let split = Self.splitReasoning(
                 result.content,
@@ -231,6 +232,7 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                         stop: request.options.stopSequences,
                         responseFormat: request.openAIResponseFormat(),
                         chatTemplateKwargs: request.chatTemplateKwargs(),
+                        speculativeDecoding: request.speculativeDecodingOptions(),
                         requestId: nil
                     )
                     var translator = MLXStreamEventTranslator(
@@ -632,6 +634,26 @@ public enum AFMMLXModelDescriptor {
 }
 
 extension AFMRequest {
+    func speculativeDecodingOptions() -> SpeculativeDecodingOptions? {
+        guard case .object(let values)? = metadata["speculativeDecoding"] else {
+            return nil
+        }
+        func string(_ key: String) -> String? {
+            guard case .string(let value)? = values[key] else { return nil }
+            return value
+        }
+        func integer(_ key: String) -> Int? {
+            guard case .integer(let value)? = values[key] else { return nil }
+            return value
+        }
+        return SpeculativeDecodingOptions(
+            mode: string("mode"),
+            requirement: string("requirement"),
+            drafter: string("drafter"),
+            maxDraftTokens: integer("maxDraftTokens")
+        )
+    }
+
     var requiresToolCall: Bool {
         metadata["toolCallingMode"] == .string("required")
     }

--- a/Sources/AFMKitMLX/AFMMLXProvider.swift
+++ b/Sources/AFMKitMLX/AFMMLXProvider.swift
@@ -168,6 +168,15 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                 completionTokens: result.completionTokens,
                 maximumResponseTokens: request.options.maximumResponseTokens
             )
+            var metadata: [String: AFMJSONValue] = [
+                "modelID": .string(result.modelID),
+                "promptTime": .number(result.promptTime),
+                "generateTime": .number(result.generateTime),
+                "stoppedBySequence": .bool(result.stoppedBySequence),
+            ]
+            if let telemetry = result.speculativeTelemetry {
+                metadata[AFMMLXSpeculativeTelemetry.metadataKey] = telemetry.metadataValue
+            }
             return AFMModelResponse(
                 text: split.text,
                 reasoning: split.reasoning,
@@ -192,12 +201,7 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                         }
                     )
                 },
-                metadata: [
-                    "modelID": .string(result.modelID),
-                    "promptTime": .number(result.promptTime),
-                    "generateTime": .number(result.generateTime),
-                    "stoppedBySequence": .bool(result.stoppedBySequence)
-                ]
+                metadata: metadata
             )
         } catch let error as AFMError {
             throw error

--- a/Sources/AFMKitMLX/AFMMLXProvider.swift
+++ b/Sources/AFMKitMLX/AFMMLXProvider.swift
@@ -140,7 +140,7 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                 return accumulator.response
             }
             let tools = request.effectiveOpenAITools()
-            let result = try await service.generate(
+            let result = try await service.generateWithTelemetry(
                 model: modelID,
                 messages: try request.openAIMessages(),
                 temperature: request.options.temperature,

--- a/Sources/AFMKitMLX/AFMMLXProvider.swift
+++ b/Sources/AFMKitMLX/AFMMLXProvider.swift
@@ -156,7 +156,7 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                 chatTemplateKwargs: request.chatTemplateKwargs(),
                 speculativeDecoding: request.speculativeDecodingOptions()
             )
-            let split = Self.splitReasoning(
+            let normalized = Self.normalizedGeneratedResponse(
                 result.content,
                 startTag: service.thinkStartTag,
                 endTag: service.thinkEndTag
@@ -188,8 +188,8 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                 metadata[AFMMLXSpeculativeTelemetry.metadataKey] = telemetry.metadataValue
             }
             return AFMModelResponse(
-                text: split.text,
-                reasoning: split.reasoning,
+                text: normalized.text,
+                reasoning: normalized.reasoning,
                 toolCalls: toolCalls,
                 usage: AFMUsage(
                     inputTokens: result.promptTokens,
@@ -364,9 +364,28 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                 break
             }
         }
-        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        let trimmedReasoning = reasoning.trimmingCharacters(in: .whitespacesAndNewlines)
-        return (trimmedText, trimmedReasoning.isEmpty ? nil : trimmedReasoning)
+        return (text, reasoning.isEmpty ? nil : reasoning)
+    }
+
+    static func normalizedGeneratedResponse(
+        _ value: String,
+        startTag: String?,
+        endTag: String?
+    ) -> (text: String, reasoning: String?) {
+        let split = splitReasoning(value, startTag: startTag, endTag: endTag)
+        return normalizeResponse(text: split.text, reasoning: split.reasoning)
+    }
+
+    static func normalizeResponse(
+        text: String,
+        reasoning: String?
+    ) -> (text: String, reasoning: String?) {
+        let normalizedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedReasoning = reasoning?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (
+            normalizedText,
+            normalizedReasoning?.isEmpty == false ? normalizedReasoning : nil)
     }
 
     static func sanitizedToolName(_ value: String) -> String {
@@ -453,9 +472,12 @@ struct AFMMLXResponseAccumulator {
     }
 
     var response: AFMModelResponse {
-        AFMModelResponse(
+        let normalized = AFMMLXModel.normalizeResponse(
             text: text,
-            reasoning: reasoning.isEmpty ? nil : reasoning,
+            reasoning: reasoning.isEmpty ? nil : reasoning)
+        return AFMModelResponse(
+            text: normalized.text,
+            reasoning: normalized.reasoning,
             toolCalls: toolOrder.compactMap { toolCalls[$0] },
             usage: usage,
             finishReason: finishReason,

--- a/Sources/AFMKitMLX/AFMMLXProvider.swift
+++ b/Sources/AFMKitMLX/AFMMLXProvider.swift
@@ -117,6 +117,8 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
             return try await runtime.load(
                 progress: { progress?($0.fractionCompleted) }
             )
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             throw AFMError.loadingFailed(error.localizedDescription)
         }
@@ -203,6 +205,8 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                 },
                 metadata: metadata
             )
+        } catch is CancellationError {
+            throw CancellationError()
         } catch let error as AFMError {
             throw error
         } catch {
@@ -654,7 +658,8 @@ extension AFMRequest {
             mode: string("mode"),
             requirement: string("requirement"),
             drafter: string("drafter"),
-            maxDraftTokens: integer("maxDraftTokens")
+            maxDraftTokens: integer("maxDraftTokens"),
+            forceAutoregressiveReason: string("forceAutoregressiveReason")
         )
     }
 

--- a/Sources/AFMKitMLX/AFMMLXProvider.swift
+++ b/Sources/AFMKitMLX/AFMMLXProvider.swift
@@ -127,6 +127,14 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
     public func respond(to request: AFMRequest) async throws -> AFMModelResponse {
         _ = try await load(progress: nil)
         do {
+            if AFMMLXGenerationRoute.resolve(maxConcurrent: service.maxConcurrent)
+                == .schedulerStream {
+                var accumulator = AFMMLXResponseAccumulator(modelID: modelID)
+                for try await event in streamResponse(to: request) {
+                    accumulator.consume(event)
+                }
+                return accumulator.response
+            }
             let tools = request.effectiveOpenAITools()
             let result = try await service.generate(
                 model: modelID,
@@ -221,6 +229,13 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
             let task = Task {
                 do {
                     _ = try await load(progress: nil)
+                    guard await service.waitForSlot(timeout: 30) else {
+                        throw AFMError.unavailable("MLX scheduler is at capacity")
+                    }
+                    var ownsReservation = true
+                    defer {
+                        if ownsReservation { service.releaseSlot() }
+                    }
                     let tools = request.effectiveOpenAITools()
                     let result = try await service.generateStreaming(
                         model: modelID,
@@ -243,6 +258,7 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
                         speculativeDecoding: request.speculativeDecodingOptions(),
                         requestId: nil
                     )
+                    ownsReservation = false
                     var translator = MLXStreamEventTranslator(
                         thinkStartTag: result.thinkStartTag,
                         thinkEndTag: result.thinkEndTag,
@@ -390,6 +406,73 @@ public final class AFMMLXModel: AFMModel, AFMTextTokenizing, @unchecked Sendable
             return .length
         }
         return .stop
+    }
+}
+
+struct AFMMLXResponseAccumulator {
+    private var text = ""
+    private var reasoning = ""
+    private var toolOrder: [String] = []
+    private var toolCalls: [String: AFMToolCall] = [:]
+    private var usage = AFMUsage()
+    private var finishReason = AFMFinishReason.stop
+    private var tokenLogprobs: [AFMTokenLogProbability] = []
+    private var metadata: [String: AFMJSONValue]
+
+    init(modelID: String) {
+        self.metadata = ["modelID": .string(modelID)]
+    }
+
+    mutating func consume(_ event: AFMGenerationEvent) {
+        switch event {
+        case .responseText(let action, let value, _):
+            Self.apply(action, value: value, to: &text)
+        case .reasoningText(let action, let value, _):
+            Self.apply(action, value: value, to: &reasoning)
+        case .tokenLogprobs(let values):
+            tokenLogprobs.append(contentsOf: values)
+        case .toolCall(let call, let stage):
+            switch stage {
+            case .retracted:
+                toolCalls.removeValue(forKey: call.id)
+            case .started, .argumentsDelta, .completed:
+                if !toolOrder.contains(call.id) {
+                    toolOrder.append(call.id)
+                }
+                toolCalls[call.id] = call
+            }
+        case .usage(let value):
+            usage = value
+        case .metadata(let values):
+            metadata.merge(values) { _, new in new }
+        case .completed(let reason):
+            finishReason = reason
+        case .custom:
+            break
+        }
+    }
+
+    var response: AFMModelResponse {
+        AFMModelResponse(
+            text: text,
+            reasoning: reasoning.isEmpty ? nil : reasoning,
+            toolCalls: toolOrder.compactMap { toolCalls[$0] },
+            usage: usage,
+            finishReason: finishReason,
+            tokenLogprobs: tokenLogprobs.isEmpty ? nil : tokenLogprobs,
+            metadata: metadata
+        )
+    }
+
+    private static func apply(
+        _ action: AFMTextUpdateAction,
+        value: String,
+        to destination: inout String
+    ) {
+        switch action {
+        case .append: destination += value
+        case .replace: destination = value
+        }
     }
 }
 

--- a/Sources/AFMKitMLX/AFMMLXRuntime.swift
+++ b/Sources/AFMKitMLX/AFMMLXRuntime.swift
@@ -39,6 +39,25 @@ public enum AFMMLXKernelEngine: String, CaseIterable, Sendable {
     }
 }
 
+enum AFMMLXDFlash2DraftTokenPolicy {
+    static func validationMessage(maxDraftTokens: Int) -> String? {
+        guard maxDraftTokens >= 1 else {
+            return "speculative_decoding.max_draft_tokens must be at least 1"
+        }
+        guard maxDraftTokens < Int.max else {
+            return "speculative_decoding.max_draft_tokens must be less than Int.max"
+        }
+        return nil
+    }
+
+    static func blockSize(maxDraftTokens: Int) -> Int? {
+        guard validationMessage(maxDraftTokens: maxDraftTokens) == nil else {
+            return nil
+        }
+        return maxDraftTokens + 1
+    }
+}
+
 public struct AFMMLXRuntimeConfiguration: Sendable {
     public var kvBits: Int?
     public var enablePrefixCaching: Bool
@@ -66,6 +85,7 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
     public var defaultChatTemplateKwargs: [String: AFMJSONValue]?
     public var forceDisableThinking: Bool
     public var defaultGuidedJsonSchema: ResponseFormat?
+    public private(set) var startupValidationError: String?
 
     public init(
         kvBits: Int? = nil,
@@ -121,6 +141,7 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
         self.defaultChatTemplateKwargs = defaultChatTemplateKwargs
         self.forceDisableThinking = forceDisableThinking
         self.defaultGuidedJsonSchema = defaultGuidedJsonSchema
+        self.startupValidationError = nil
     }
 
     public init(providerConfiguration configuration: AFMProviderConfiguration) {
@@ -132,10 +153,13 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
         if let speculative = configuration.object("speculativeDecoding"),
            speculative.string("mode")?.lowercased() == "dflash2" {
             dflash2Drafter = speculative.string("drafter")
-            if let maxDraftTokens = speculative.integer("maxDraftTokens"),
-               maxDraftTokens >= 1,
-               maxDraftTokens < Int.max {
-                dflash2BlockSize = maxDraftTokens + 1
+            if let maxDraftTokens = speculative.integer("maxDraftTokens") {
+                startupValidationError = AFMMLXDFlash2DraftTokenPolicy.validationMessage(
+                    maxDraftTokens: maxDraftTokens)
+                if let blockSize = AFMMLXDFlash2DraftTokenPolicy.blockSize(
+                    maxDraftTokens: maxDraftTokens) {
+                    dflash2BlockSize = blockSize
+                }
             }
             if let value = speculative.string("requirement"),
                let requirement = AFMMLXDFlash2Requirement(rawValue: value.lowercased()) {
@@ -214,6 +238,12 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
         }
         if let value = configuration.bool("forceDisableThinking") ?? configuration.bool("noThinking") {
             forceDisableThinking = value
+        }
+    }
+
+    public func validateForStartup() throws {
+        if let startupValidationError {
+            throw MLXServiceError.loadFailed(startupValidationError)
         }
     }
 
@@ -344,6 +374,7 @@ public final class AFMMLXRuntime: @unchecked Sendable {
         progress: (@Sendable (Progress) -> Void)? = nil,
         stage: (@Sendable (MLXLoadStage) -> Void)? = nil
     ) async throws -> AFMModelDescriptor {
+        try configuration.validateForStartup()
         try MLXMetalLibrary.ensureAvailable(verbose: false)
         _ = try await service.ensureLoaded(
             model: modelID,

--- a/Sources/AFMKitMLX/AFMMLXRuntime.swift
+++ b/Sources/AFMKitMLX/AFMMLXRuntime.swift
@@ -2,6 +2,15 @@ import Foundation
 import AFMKitCore
 import AFMOpenAICompat
 
+enum AFMMLXGenerationRoute: Equatable {
+    case serial
+    case schedulerStream
+
+    static func resolve(maxConcurrent: Int) -> Self {
+        maxConcurrent >= 2 ? .schedulerStream : .serial
+    }
+}
+
 public enum AFMMLXKernelEngine: String, CaseIterable, Sendable {
     case native
     case ds4
@@ -333,7 +342,15 @@ public final class AFMMLXRuntime: @unchecked Sendable {
         messages: [Message] = [Message(role: "user", content: "warmup")],
         maxTokens: Int = 4
     ) async throws {
-        _ = try await service.generate(
+        _ = try await load()
+        guard await service.waitForSlot(timeout: 30) else {
+            throw AFMError.unavailable("MLX scheduler is at capacity during prewarm")
+        }
+        var ownsReservation = true
+        defer {
+            if ownsReservation { service.releaseSlot() }
+        }
+        let result = try await service.generateStreaming(
             model: modelID,
             messages: messages,
             temperature: 0,
@@ -341,6 +358,10 @@ public final class AFMMLXRuntime: @unchecked Sendable {
             topP: nil,
             repetitionPenalty: nil
         )
+        ownsReservation = false
+        for try await _ in result.stream {
+            try Task.checkCancellation()
+        }
     }
 
     public func unload(

--- a/Sources/AFMKitMLX/AFMMLXRuntime.swift
+++ b/Sources/AFMKitMLX/AFMMLXRuntime.swift
@@ -132,7 +132,9 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
         if let speculative = configuration.object("speculativeDecoding"),
            speculative.string("mode")?.lowercased() == "dflash2" {
             dflash2Drafter = speculative.string("drafter")
-            if let maxDraftTokens = speculative.integer("maxDraftTokens") {
+            if let maxDraftTokens = speculative.integer("maxDraftTokens"),
+               maxDraftTokens >= 1,
+               maxDraftTokens < Int.max {
                 dflash2BlockSize = maxDraftTokens + 1
             }
             if let value = speculative.string("requirement"),
@@ -366,13 +368,14 @@ public final class AFMMLXRuntime: @unchecked Sendable {
         defer {
             if ownsReservation { service.releaseSlot() }
         }
-        let result = try await service.generateStreaming(
+        let result = try await service.generateStreamingWithSchedulerAdmission(
             model: modelID,
             messages: messages,
             temperature: 0,
             maxTokens: maxTokens,
             topP: nil,
-            repetitionPenalty: nil
+            repetitionPenalty: nil,
+            admission: .reserved
         )
         ownsReservation = false
         for try await _ in result.stream {

--- a/Sources/AFMKitMLX/AFMMLXRuntime.swift
+++ b/Sources/AFMKitMLX/AFMMLXRuntime.swift
@@ -392,12 +392,21 @@ public final class AFMMLXRuntime: @unchecked Sendable {
         maxTokens: Int = 4
     ) async throws {
         _ = try await load()
-        guard await service.waitForSlot(timeout: 30) else {
+        let schedulerAdmission = await service.waitForSlot(timeout: 30)
+        guard schedulerAdmission.isAdmitted else {
             throw AFMError.unavailable("MLX scheduler is at capacity during prewarm")
         }
-        var ownsReservation = true
+        var reservation = schedulerAdmission.reservation
         defer {
-            if ownsReservation { service.releaseSlot() }
+            if let reservation { service.releaseSlot(reservation) }
+        }
+        let submissionAdmission: BatchSchedulerSubmissionAdmission = switch schedulerAdmission {
+        case .serial:
+            .unreserved
+        case .reserved(let reservation):
+            .reserved(reservation)
+        case .unavailable:
+            .unreserved
         }
         let result = try await service.generateStreamingWithSchedulerAdmission(
             model: modelID,
@@ -406,9 +415,9 @@ public final class AFMMLXRuntime: @unchecked Sendable {
             maxTokens: maxTokens,
             topP: nil,
             repetitionPenalty: nil,
-            admission: .reserved
+            admission: submissionAdmission
         )
-        ownsReservation = false
+        reservation = nil
         for try await _ in result.stream {
             try Task.checkCancellation()
         }

--- a/Sources/AFMKitMLX/AFMMLXRuntime.swift
+++ b/Sources/AFMKitMLX/AFMMLXRuntime.swift
@@ -11,6 +11,22 @@ enum AFMMLXGenerationRoute: Equatable {
     }
 }
 
+public enum AFMMLXGPUCapturePolicy {
+    public static let concurrentIncompatibility =
+        "--gpu-capture cannot be combined with --concurrent values greater than 1; GPU capture requires serial generation"
+
+    public static func incompatibility(
+        maxConcurrent: Int,
+        capturePath: String?
+    ) -> String? {
+        guard maxConcurrent > 1,
+              let capturePath,
+              !capturePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        return concurrentIncompatibility
+    }
+}
+
 public enum AFMMLXKernelEngine: String, CaseIterable, Sendable {
     case native
     case ds4

--- a/Sources/AFMKitMLX/AFMMLXRuntime.swift
+++ b/Sources/AFMKitMLX/AFMMLXRuntime.swift
@@ -22,6 +22,9 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
     public var mtpDepth: Int
     public var mtpModelID: String?
     public var eagle3DrafterPath: String?
+    public var dflash2Drafter: String?
+    public var dflash2BlockSize: Int
+    public var dflash2Requirement: AFMMLXDFlash2Requirement
     public var maxConcurrent: Int
     public var toolCallParser: String?
     public var enableGrammarConstraints: Bool
@@ -47,6 +50,9 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
         mtpDepth: Int = 3,
         mtpModelID: String? = nil,
         eagle3DrafterPath: String? = nil,
+        dflash2Drafter: String? = nil,
+        dflash2BlockSize: Int = 5,
+        dflash2Requirement: AFMMLXDFlash2Requirement = .preferred,
         maxConcurrent: Int = 0,
         toolCallParser: String? = nil,
         enableGrammarConstraints: Bool = false,
@@ -71,6 +77,9 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
         self.mtpDepth = mtpDepth
         self.mtpModelID = mtpModelID
         self.eagle3DrafterPath = eagle3DrafterPath
+        self.dflash2Drafter = dflash2Drafter
+        self.dflash2BlockSize = dflash2BlockSize
+        self.dflash2Requirement = dflash2Requirement
         self.maxConcurrent = max(0, maxConcurrent)
         self.toolCallParser = toolCallParser
         self.enableGrammarConstraints = enableGrammarConstraints
@@ -95,6 +104,17 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
     }
 
     public mutating func apply(_ configuration: AFMProviderConfiguration) {
+        if let speculative = configuration.object("speculativeDecoding"),
+           speculative.string("mode")?.lowercased() == "dflash2" {
+            dflash2Drafter = speculative.string("drafter")
+            if let maxDraftTokens = speculative.integer("maxDraftTokens") {
+                dflash2BlockSize = maxDraftTokens + 1
+            }
+            if let value = speculative.string("requirement"),
+               let requirement = AFMMLXDFlash2Requirement(rawValue: value.lowercased()) {
+                dflash2Requirement = requirement
+            }
+        }
         if let value = configuration.integer("kvBits") {
             kvBits = value
         }
@@ -115,6 +135,16 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
         }
         if let value = configuration.string("eagle3DrafterPath") {
             eagle3DrafterPath = value
+        }
+        if let value = configuration.string("dflash2Drafter") {
+            dflash2Drafter = value
+        }
+        if let value = configuration.integer("dflash2BlockSize") {
+            dflash2BlockSize = value
+        }
+        if let value = configuration.string("dflash2Requirement"),
+           let requirement = AFMMLXDFlash2Requirement(rawValue: value.lowercased()) {
+            dflash2Requirement = requirement
         }
         if let value = configuration.integer("maxConcurrent") {
             maxConcurrent = max(0, value)
@@ -168,6 +198,9 @@ public struct AFMMLXRuntimeConfiguration: Sendable {
         service.mtpDepth = mtpDepth
         service.mtpModelID = mtpModelID
         service.eagle3DrafterPath = eagle3DrafterPath
+        service.dflash2Drafter = dflash2Drafter
+        service.dflash2BlockSize = dflash2BlockSize
+        service.dflash2Requirement = dflash2Requirement
         service.maxConcurrent = maxConcurrent >= 2 ? maxConcurrent : 0
         service.toolCallParser = toolCallParser
         service.enableGrammarConstraints = enableGrammarConstraints
@@ -247,6 +280,9 @@ public final class AFMMLXRuntime: @unchecked Sendable {
             mtpEnabled: service.mtpEnabled,
             mtpDepth: service.mtpDepth,
             mtpModelID: service.mtpModelID,
+            dflash2Drafter: service.dflash2Drafter,
+            dflash2BlockSize: service.dflash2BlockSize,
+            dflash2Requirement: service.dflash2Requirement,
             maxConcurrent: service.maxConcurrent,
             enableGrammarConstraints: service.enableGrammarConstraints,
             forceDisableThinking: service.forceDisableThinking,
@@ -319,6 +355,11 @@ public final class AFMMLXRuntime: @unchecked Sendable {
 }
 
 extension AFMProviderConfiguration {
+    func object(_ key: String) -> [String: AFMJSONValue]? {
+        guard case .object(let value) = values[key] else { return nil }
+        return value
+    }
+
     func bool(_ key: String) -> Bool? {
         guard case .bool(let value) = values[key] else { return nil }
         return value
@@ -331,6 +372,18 @@ extension AFMProviderConfiguration {
 
     func string(_ key: String) -> String? {
         guard case .string(let value) = values[key] else { return nil }
+        return value
+    }
+}
+
+private extension Dictionary where Key == String, Value == AFMJSONValue {
+    func integer(_ key: String) -> Int? {
+        guard case .integer(let value) = self[key] else { return nil }
+        return value
+    }
+
+    func string(_ key: String) -> String? {
+        guard case .string(let value) = self[key] else { return nil }
         return value
     }
 }

--- a/Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift
+++ b/Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift
@@ -6,12 +6,22 @@ import MLXLLM
 import MLXVLM
 import Tokenizers
 
+public final class AFMMLXDFlash2Runtime: @unchecked Sendable {
+    public let draft: DFlash2DraftModel
+    public let preflight: AFMMLXDFlash2Preflight
+
+    init(draft: DFlash2DraftModel, preflight: AFMMLXDFlash2Preflight) {
+        self.draft = draft
+        self.preflight = preflight
+    }
+}
+
 public enum AFMMLXSpeculativeRuntime {
     case none
     case mtpLLM(Qwen3_5MoEMTPGenerator)
     case mtpVLM(MTPGenerator)
     case eagle3(Gemma4Eagle3Drafter)
-    case dflash2(DFlash2DraftModel, blockSize: Int)
+    case dflash2(AFMMLXDFlash2Runtime)
 
     public var kind: AFMMLXSpeculativeRuntimeKind {
         switch self {
@@ -466,12 +476,37 @@ public struct AFMMLXRuntimeAdapter: Sendable {
         return .eagle3(drafter)
     }
 
-    public nonisolated func makeDFlash2Runtime(
+    public func makeDFlash2Runtime(
+        container: ModelContainer,
+        targetDirectory: URL,
         drafterDirectory: URL,
         blockSize: Int
-    ) throws -> AFMMLXSpeculativeRuntime {
+    ) async throws -> AFMMLXSpeculativeRuntime {
+        let preflight = try AFMMLXDFlash2PreflightValidator.validate(
+            targetDirectory: targetDirectory,
+            drafterDirectory: drafterDirectory,
+            requestedBlockSize: blockSize)
         let draft = try DFlash2DraftModel.load(directory: drafterDirectory.path)
-        return .dflash2(draft, blockSize: blockSize)
+        let targetCompatible = try await container.perform { context in
+            let loadedTargetData = try Data(contentsOf: context.configuration
+                .modelDirectory()
+                .appendingPathComponent("config.json"))
+            guard loadedTargetData == preflight.targetConfigurationData else {
+                throw AFMMLXDFlash2ConfigurationError.incompatibleTarget(
+                    "validated target metadata does not match the loaded model container")
+            }
+            guard let target = context.model as? any DFlash2Target else { return false }
+            _ = try DFlash2Generator(
+                target: target,
+                draft: draft,
+                blockSize: preflight.blockSize)
+            return true
+        }
+        guard targetCompatible else {
+            throw AFMMLXDFlash2ConfigurationError.incompatibleTarget(
+                "loaded target runtime does not expose DFlash2 hidden-state and rollback hooks")
+        }
+        return .dflash2(AFMMLXDFlash2Runtime(draft: draft, preflight: preflight))
     }
 
     @MainActor public func runSpeculativeGeneration(
@@ -489,7 +524,9 @@ public struct AFMMLXRuntimeAdapter: Sendable {
             let promptIds = Self.extractTokenArray(input)
             guard !promptIds.isEmpty else { return 0 }
 
-            let eos = Set((context.tokenizer.eosTokenId).map { [$0] } ?? [])
+            let eos = Self.completeEOSTokenIDs(
+                configuration: context.configuration,
+                tokenizer: context.tokenizer)
             var allTokens: [Int] = []
             var previousText = ""
 
@@ -526,11 +563,13 @@ public struct AFMMLXRuntimeAdapter: Sendable {
                     blockSize: 2,
                     onToken: emit
                 )
-            case .dflash2(let draft, let blockSize):
+            case .dflash2(let runtime):
                 guard let target = context.model as? any DFlash2Target else { return 0 }
                 let generator = try DFlash2Generator(
-                    target: target, draft: draft, blockSize: blockSize)
-                let result = generator.generate(
+                    target: target,
+                    draft: runtime.draft,
+                    blockSize: runtime.preflight.blockSize)
+                let result = try generator.generate(
                     promptIDs: promptIds,
                     maxTokens: maxTokens,
                     stopTokenIDs: eos,
@@ -550,6 +589,10 @@ public struct AFMMLXRuntimeAdapter: Sendable {
                 return 0
             }
 
+            try Task.checkCancellation()
+            if shouldStop() {
+                throw CancellationError()
+            }
             return allTokens.count
         }
     }
@@ -567,5 +610,21 @@ public struct AFMMLXRuntimeAdapter: Sendable {
 
     private nonisolated static func isMultimodalInput(_ input: LMInput) -> Bool {
         input.image != nil || input.video != nil
+    }
+
+    private nonisolated static func completeEOSTokenIDs(
+        configuration: ModelConfiguration,
+        tokenizer: any Tokenizer
+    ) -> Set<Int> {
+        var result = configuration.eosTokenIds
+        if let eosTokenID = tokenizer.eosTokenId {
+            result.insert(eosTokenID)
+        }
+        for token in configuration.extraEOSTokens {
+            if let tokenID = tokenizer.convertTokenToId(token) {
+                result.insert(tokenID)
+            }
+        }
+        return result
     }
 }

--- a/Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift
+++ b/Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift
@@ -7,10 +7,10 @@ import MLXVLM
 import Tokenizers
 
 public final class AFMMLXDFlash2Runtime: @unchecked Sendable {
-    public let draft: DFlash2DraftModel
+    public let draft: any DFlashDraftingModel
     public let preflight: AFMMLXDFlash2Preflight
 
-    init(draft: DFlash2DraftModel, preflight: AFMMLXDFlash2Preflight) {
+    init(draft: any DFlashDraftingModel, preflight: AFMMLXDFlash2Preflight) {
         self.draft = draft
         self.preflight = preflight
     }
@@ -486,7 +486,10 @@ public struct AFMMLXRuntimeAdapter: Sendable {
             targetDirectory: targetDirectory,
             drafterDirectory: drafterDirectory,
             requestedBlockSize: blockSize)
-        let draft = try DFlash2DraftModel.load(directory: drafterDirectory.path)
+        let draft = try DFlashDraftModelFactory.load(
+            directory: drafterDirectory.path,
+            targetLayers: preflight.configuration.targetLayers,
+            vocabularySize: preflight.configuration.vocabularySize)
         let targetCompatible = try await container.perform { context in
             let loadedTargetData = try Data(contentsOf: context.configuration
                 .modelDirectory()
@@ -619,6 +622,9 @@ public struct AFMMLXRuntimeAdapter: Sendable {
         var result = configuration.eosTokenIds
         if let eosTokenID = tokenizer.eosTokenId {
             result.insert(eosTokenID)
+        }
+        if let unknownTokenID = tokenizer.unknownTokenId {
+            result.insert(unknownTokenID)
         }
         for token in configuration.extraEOSTokens {
             if let tokenID = tokenizer.convertTokenToId(token) {

--- a/Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift
+++ b/Sources/AFMKitMLX/AFMMLXRuntimeAdapter.swift
@@ -11,12 +11,14 @@ public enum AFMMLXSpeculativeRuntime {
     case mtpLLM(Qwen3_5MoEMTPGenerator)
     case mtpVLM(MTPGenerator)
     case eagle3(Gemma4Eagle3Drafter)
+    case dflash2(DFlash2DraftModel, blockSize: Int)
 
     public var kind: AFMMLXSpeculativeRuntimeKind {
         switch self {
         case .none: return .none
         case .mtpLLM, .mtpVLM: return .mtp
         case .eagle3: return .eagle3
+        case .dflash2: return .dflash2
         }
     }
 }
@@ -464,13 +466,22 @@ public struct AFMMLXRuntimeAdapter: Sendable {
         return .eagle3(drafter)
     }
 
+    public nonisolated func makeDFlash2Runtime(
+        drafterDirectory: URL,
+        blockSize: Int
+    ) throws -> AFMMLXSpeculativeRuntime {
+        let draft = try DFlash2DraftModel.load(directory: drafterDirectory.path)
+        return .dflash2(draft, blockSize: blockSize)
+    }
+
     @MainActor public func runSpeculativeGeneration(
         container: ModelContainer,
         userInput: UserInput,
         runtime: AFMMLXSpeculativeRuntime,
         maxTokens: Int,
         shouldStop: @escaping @Sendable () -> Bool,
-        onChunk: @escaping @Sendable (String) -> Void
+        onChunk: @escaping @Sendable (String) -> Void,
+        onTelemetry: @escaping @Sendable (AFMMLXSpeculativeTelemetry) -> Void = { _ in }
     ) async throws -> Int {
         try await container.perform { context -> Int in
             let input = try await context.processor.prepare(input: userInput)
@@ -515,6 +526,26 @@ public struct AFMMLXRuntimeAdapter: Sendable {
                     blockSize: 2,
                     onToken: emit
                 )
+            case .dflash2(let draft, let blockSize):
+                guard let target = context.model as? any DFlash2Target else { return 0 }
+                let generator = try DFlash2Generator(
+                    target: target, draft: draft, blockSize: blockSize)
+                let result = generator.generate(
+                    promptIDs: promptIds,
+                    maxTokens: maxTokens,
+                    stopTokenIDs: eos,
+                    shouldStop: { Task.isCancelled || shouldStop() },
+                    onToken: emit)
+                let stats = result.statistics
+                onTelemetry(AFMMLXSpeculativeTelemetry(
+                    strategy: "dflash2",
+                    draftedTokens: stats.draftedTokens,
+                    acceptedDraftTokens: stats.acceptedDraftTokens,
+                    emittedTokens: stats.emittedTokens,
+                    verificationCycles: stats.verificationCycles,
+                    draftTime: stats.draftSeconds,
+                    verificationTime: stats.verificationSeconds,
+                    rollbackTime: stats.rollbackSeconds))
             case .none:
                 return 0
             }

--- a/Sources/AFMKitMLX/AFMMLXSpeculativeDecoding.swift
+++ b/Sources/AFMKitMLX/AFMMLXSpeculativeDecoding.swift
@@ -54,7 +54,7 @@ public struct AFMMLXSpeculativeModeAvailability: Equatable, Sendable {
                 mode: .auto,
                 isSelectable: modelLoaded && hasAccelerationPath,
                 reason: modelLoaded
-                    ? "Auto requires a loaded model with MTP or dense Gemma4 EAGLE3 support."
+                    ? "Auto requires a loaded model with MTP, dense Gemma4 EAGLE3, or DFlash 2 support."
                     : "Load a supported MLX model before enabling acceleration."
             ),
             .mtp: AFMMLXSpeculativeModeAvailability(
@@ -105,7 +105,7 @@ public struct AFMMLXSpeculativeModeAvailability: Equatable, Sendable {
                 isSelectable: hasAccelerationPath,
                 reason: hasAccelerationPath
                     ? "Use the selected model's acceleration path after loading."
-                    : "Select a model with MTP or dense Gemma4 EAGLE3 support."
+                    : "Select a model with MTP, dense Gemma4 EAGLE3, or DFlash 2 support."
             ),
             .mtp: AFMMLXSpeculativeModeAvailability(
                 mode: .mtp,

--- a/Sources/AFMKitMLX/AFMMLXSpeculativeDecoding.swift
+++ b/Sources/AFMKitMLX/AFMMLXSpeculativeDecoding.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AFMKitCore
+import AFMOpenAICompat
 
 public enum AFMMLXSpeculativeDecodingMode: String, Codable, CaseIterable, Identifiable, Hashable, Sendable {
     case off
@@ -197,6 +198,22 @@ public enum AFMMLXSpeculativeRuntimeKind: Equatable, Sendable {
     case mtp
     case eagle3
     case dflash2
+}
+
+public enum AFMMLXBatchSpeculativePolicy {
+    /// Batch rows stay on deterministic autoregressive scheduling until a
+    /// row-aligned speculative verifier exists. Required requests fail closed;
+    /// preferred requests carry a stable fallback reason into telemetry.
+    public static func forceAutoregressive(
+        _ options: SpeculativeDecodingOptions?
+    ) -> SpeculativeDecodingOptions {
+        SpeculativeDecodingOptions(
+            mode: options?.mode,
+            requirement: options?.requirement,
+            drafter: options?.drafter,
+            maxDraftTokens: options?.maxDraftTokens,
+            forceAutoregressiveReason: "batch")
+    }
 }
 
 public enum AFMMLXSpeculativeGenerationPath: String, Equatable, Sendable {

--- a/Sources/AFMKitMLX/AFMMLXSpeculativeDecoding.swift
+++ b/Sources/AFMKitMLX/AFMMLXSpeculativeDecoding.swift
@@ -6,6 +6,7 @@ public enum AFMMLXSpeculativeDecodingMode: String, Codable, CaseIterable, Identi
     case auto
     case mtp
     case eagle3
+    case dflash2
 
     public var id: String { rawValue }
 
@@ -15,6 +16,7 @@ public enum AFMMLXSpeculativeDecodingMode: String, Codable, CaseIterable, Identi
         case .auto: return "Auto"
         case .mtp: return "MTP"
         case .eagle3: return "EAGLE3"
+        case .dflash2: return "DFlash 2"
         }
     }
 }
@@ -37,9 +39,10 @@ public struct AFMMLXSpeculativeModeAvailability: Equatable, Sendable {
     public static func evaluate(
         modelLoaded: Bool,
         mtpCompatible: Bool,
-        denseGemma4Verifier: Bool
+        denseGemma4Verifier: Bool,
+        dflash2Compatible: Bool = false
     ) -> [AFMMLXSpeculativeDecodingMode: AFMMLXSpeculativeModeAvailability] {
-        let hasAccelerationPath = mtpCompatible || denseGemma4Verifier
+        let hasAccelerationPath = mtpCompatible || denseGemma4Verifier || dflash2Compatible
 
         return [
             .off: AFMMLXSpeculativeModeAvailability(
@@ -67,6 +70,13 @@ public struct AFMMLXSpeculativeModeAvailability: Equatable, Sendable {
                 reason: modelLoaded
                     ? "EAGLE3 requires a loaded dense Gemma4 verifier model."
                     : "Load a dense Gemma4 model before selecting EAGLE3."
+            ),
+            .dflash2: AFMMLXSpeculativeModeAvailability(
+                mode: .dflash2,
+                isSelectable: modelLoaded && dflash2Compatible,
+                reason: modelLoaded
+                    ? "DFlash 2 requires a compatible metadata-validated drafter."
+                    : "Load a compatible Qwen 3.8 or Muse Glimmer target before selecting DFlash 2."
             )
         ]
     }
@@ -79,9 +89,10 @@ public struct AFMMLXSpeculativeModeAvailability: Equatable, Sendable {
 
     public static func pendingSelection(
         mtpCompatible: Bool,
-        denseGemma4Verifier: Bool
+        denseGemma4Verifier: Bool,
+        dflash2Compatible: Bool = false
     ) -> [AFMMLXSpeculativeDecodingMode: AFMMLXSpeculativeModeAvailability] {
-        let hasAccelerationPath = mtpCompatible || denseGemma4Verifier
+        let hasAccelerationPath = mtpCompatible || denseGemma4Verifier || dflash2Compatible
 
         return [
             .off: AFMMLXSpeculativeModeAvailability(
@@ -109,6 +120,13 @@ public struct AFMMLXSpeculativeModeAvailability: Equatable, Sendable {
                 reason: denseGemma4Verifier
                     ? "Use EAGLE3 after loading the selected dense Gemma4 model."
                     : "Select a dense Gemma4 model before selecting EAGLE3."
+            ),
+            .dflash2: AFMMLXSpeculativeModeAvailability(
+                mode: .dflash2,
+                isSelectable: dflash2Compatible,
+                reason: dflash2Compatible
+                    ? "Use DFlash 2 after loading the selected target and drafter."
+                    : "Select a metadata-compatible Qwen 3.8 or Muse Glimmer target and DFlash 2 drafter."
             )
         ]
     }
@@ -178,12 +196,14 @@ public enum AFMMLXSpeculativeRuntimeKind: Equatable, Sendable {
     case none
     case mtp
     case eagle3
+    case dflash2
 }
 
 public enum AFMMLXSpeculativeGenerationPath: String, Equatable, Sendable {
     case normal = "Normal MLX"
     case mtp = "MTP"
     case eagle3 = "EAGLE3"
+    case dflash2 = "DFlash 2"
     case fallback = "Fallback"
 }
 
@@ -242,7 +262,9 @@ public struct AFMMLXSpeculativeGenerationDecision: Equatable, Sendable {
             return AFMMLXSpeculativeGenerationDecision(path: .mtp, reason: nil)
         case (.auto, .eagle3), (.eagle3, .eagle3):
             return AFMMLXSpeculativeGenerationDecision(path: .eagle3, reason: nil)
-        case (.mtp, _), (.eagle3, _), (.auto, .none):
+        case (.auto, .dflash2), (.dflash2, .dflash2):
+            return AFMMLXSpeculativeGenerationDecision(path: .dflash2, reason: nil)
+        case (.mtp, _), (.eagle3, _), (.dflash2, _), (.auto, .none):
             return AFMMLXSpeculativeGenerationDecision(path: .fallback, reason: .runtimeUnavailable)
         case (.off, _):
             return AFMMLXSpeculativeGenerationDecision(path: .normal, reason: .modeOff)
@@ -253,7 +275,9 @@ public struct AFMMLXSpeculativeGenerationDecision: Equatable, Sendable {
         initialDecision: AFMMLXSpeculativeGenerationDecision,
         emittedChunkCount: Int
     ) -> AFMMLXSpeculativeGenerationDecision {
-        guard (initialDecision.path == .mtp || initialDecision.path == .eagle3),
+        guard (initialDecision.path == .mtp
+                || initialDecision.path == .eagle3
+                || initialDecision.path == .dflash2),
               emittedChunkCount <= 0 else {
             return initialDecision
         }

--- a/Sources/AFMKitMLX/MLXStreamEventTranslator.swift
+++ b/Sources/AFMKitMLX/MLXStreamEventTranslator.swift
@@ -92,6 +92,9 @@ public struct MLXStreamEventTranslator {
         if let stoppedBySequence = chunk.stoppedBySequence {
             metadata["stoppedBySequence"] = .bool(stoppedBySequence)
         }
+        if let telemetry = chunk.speculativeTelemetry {
+            metadata[AFMMLXSpeculativeTelemetry.metadataKey] = telemetry.metadataValue
+        }
         if !metadata.isEmpty {
             events.append(.metadata(metadata))
         }

--- a/Sources/AFMKitMLX/MLXStreamEventTranslator.swift
+++ b/Sources/AFMKitMLX/MLXStreamEventTranslator.swift
@@ -259,7 +259,11 @@ public struct MLXStreamEventTranslator {
                 events.append(.toolCall(call: state.call, stage: .started))
             }
 
-            let finalArguments = completedCall.function.arguments
+            let rawFinalArguments = completedCall.function.arguments
+            let finalArguments = rawFinalArguments
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? "{}"
+                : rawFinalArguments
             if finalArguments.hasPrefix(state.arguments) {
                 let suffix = String(finalArguments.dropFirst(state.arguments.count))
                 if !suffix.isEmpty {

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -31,7 +31,7 @@ extension Gemma4VLM: FixedDecodeCohortModel {
 }
 
 enum BatchSchedulerSubmissionAdmission: Sendable {
-    case reserved
+    case reserved(AFMMLXSchedulerReservation)
     case unreserved
 }
 
@@ -45,49 +45,62 @@ final class BatchSchedulerAdmissionState: @unchecked Sendable {
 
     private struct State {
         var inFlightCount = 0
-        var reservedCount = 0
+        var reservationIDs = Set<UUID>()
     }
 
     let maxConcurrent: Int
+    let schedulerID: UUID
     private let state = OSAllocatedUnfairLock(initialState: State())
 
-    init(maxConcurrent: Int) {
+    init(maxConcurrent: Int, schedulerID: UUID = UUID()) {
         self.maxConcurrent = maxConcurrent
+        self.schedulerID = schedulerID
     }
 
-    func tryReserve() -> Bool {
-        state.withLock { state in
-            guard state.inFlightCount < maxConcurrent else { return false }
-            state.inFlightCount += 1
-            state.reservedCount += 1
-            return true
-        }
-    }
-
-    func tryReserveMultiple(count: Int) -> Bool {
-        guard count > 0 else { return true }
+    func tryReserve() -> AFMMLXSchedulerReservation? {
+        let reservation = AFMMLXSchedulerReservation(schedulerID: schedulerID)
         return state.withLock { state in
-            guard state.inFlightCount + count <= maxConcurrent else { return false }
-            state.inFlightCount += count
-            state.reservedCount += count
-            return true
+            guard state.inFlightCount < maxConcurrent else { return nil }
+            state.inFlightCount += 1
+            state.reservationIDs.insert(reservation.reservationID)
+            return reservation
         }
     }
 
-    func releaseReservation(count: Int = 1) {
-        guard count > 0 else { return }
-        state.withLock { state in
-            let released = min(count, state.reservedCount)
-            state.reservedCount -= released
-            state.inFlightCount = max(0, state.inFlightCount - released)
+    func tryReserveMultiple(count: Int) -> [AFMMLXSchedulerReservation]? {
+        guard count > 0 else { return [] }
+        let reservations = (0 ..< count).map { _ in
+            AFMMLXSchedulerReservation(schedulerID: schedulerID)
+        }
+        return state.withLock { state in
+            guard state.inFlightCount + count <= maxConcurrent else { return nil }
+            state.inFlightCount += count
+            state.reservationIDs.formUnion(reservations.map(\.reservationID))
+            return reservations
+        }
+    }
+
+    @discardableResult
+    func releaseReservation(_ reservation: AFMMLXSchedulerReservation) -> Bool {
+        guard reservation.schedulerID == schedulerID else { return false }
+        return state.withLock { state in
+            guard state.reservationIDs.remove(reservation.reservationID) != nil else {
+                return false
+            }
+            state.inFlightCount = max(0, state.inFlightCount - 1)
+            return true
         }
     }
 
     /// Transfer one caller-owned reservation to a submitted request.
-    func consumeReservationForSubmission() -> Bool {
-        state.withLock { state in
-            guard state.reservedCount > 0 else { return false }
-            state.reservedCount -= 1
+    func consumeReservationForSubmission(
+        _ reservation: AFMMLXSchedulerReservation
+    ) -> Bool {
+        guard reservation.schedulerID == schedulerID else { return false }
+        return state.withLock { state in
+            guard state.reservationIDs.remove(reservation.reservationID) != nil else {
+                return false
+            }
             return true
         }
     }
@@ -111,7 +124,7 @@ final class BatchSchedulerAdmissionState: @unchecked Sendable {
     func reset() {
         state.withLock { state in
             state.inFlightCount = 0
-            state.reservedCount = 0
+            state.reservationIDs.removeAll(keepingCapacity: false)
         }
     }
 
@@ -119,7 +132,7 @@ final class BatchSchedulerAdmissionState: @unchecked Sendable {
         state.withLock {
             Snapshot(
                 inFlightCount: $0.inFlightCount,
-                reservedCount: $0.reservedCount)
+                reservedCount: $0.reservationIDs.count)
         }
     }
 }
@@ -525,10 +538,10 @@ actor BatchScheduler {
     /// suspension point while slots are active.
     private let _cancelledSlotIDs = OSAllocatedUnfairLock(initialState: Set<UUID>())
 
-    /// Atomically reserve a slot if under capacity. Returns true if reserved.
-    nonisolated func tryReserve() -> Bool {
+    /// Atomically reserve a slot if under capacity.
+    nonisolated func tryReserve() -> AFMMLXSchedulerReservation? {
         admissionLock.withLock {
-            guard !_isShutdown.withLock({ $0 }) else { return false }
+            guard !_isShutdown.withLock({ $0 }) else { return nil }
             return admissionState.tryReserve()
         }
     }
@@ -538,41 +551,52 @@ actor BatchScheduler {
     private static let maxPollInterval: UInt64     = 500_000_000  // 500ms
 
     /// Wait up to `timeout` seconds for a slot to become available.
-    /// Returns true if a slot was reserved, false if timed out, cancelled, or shutdown.
-    nonisolated func waitForSlot(timeout: TimeInterval = 30) async -> Bool {
-        if Task.isCancelled || _isShutdown.withLock({ $0 }) { return false }
-        if tryReserve() { return true }
+    /// Returns a reservation, or nil if timed out, cancelled, or shut down.
+    nonisolated func waitForSlot(
+        timeout: TimeInterval = 30
+    ) async -> AFMMLXSchedulerReservation? {
+        if Task.isCancelled || _isShutdown.withLock({ $0 }) { return nil }
+        if let reservation = tryReserve() { return reservation }
 
         let deadline = ContinuousClock.now + .seconds(timeout)
         var delay = Self.initialPollInterval
 
         while ContinuousClock.now < deadline {
-            if Task.isCancelled || _isShutdown.withLock({ $0 }) { return false }
+            if Task.isCancelled || _isShutdown.withLock({ $0 }) { return nil }
             try? await Task.sleep(nanoseconds: delay)
-            if Task.isCancelled || _isShutdown.withLock({ $0 }) { return false }
-            if tryReserve() { return true }
+            if Task.isCancelled || _isShutdown.withLock({ $0 }) { return nil }
+            if let reservation = tryReserve() { return reservation }
             delay = min(delay * 2, Self.maxPollInterval)
         }
-        return false
+        return nil
     }
 
     /// Release a reserved slot (call if request fails before reaching submit).
-    nonisolated func releaseReservation() {
-        admissionState.releaseReservation()
+    @discardableResult
+    nonisolated func releaseReservation(
+        _ reservation: AFMMLXSchedulerReservation
+    ) -> Bool {
+        admissionState.releaseReservation(reservation)
     }
 
     /// Atomically reserve N slots. Returns true if all N were reserved,
     /// false if insufficient capacity (no slots reserved in that case).
-    nonisolated func tryReserveMultiple(count: Int) -> Bool {
+    nonisolated func tryReserveMultiple(
+        count: Int
+    ) -> [AFMMLXSchedulerReservation]? {
         admissionLock.withLock {
-            guard !_isShutdown.withLock({ $0 }) else { return false }
+            guard !_isShutdown.withLock({ $0 }) else { return nil }
             return admissionState.tryReserveMultiple(count: count)
         }
     }
 
     /// Release N slot reservations at once.
-    nonisolated func releaseMultipleReservations(count: Int) {
-        admissionState.releaseReservation(count: count)
+    nonisolated func releaseMultipleReservations(
+        _ reservations: [AFMMLXSchedulerReservation]
+    ) {
+        for reservation in reservations {
+            admissionState.releaseReservation(reservation)
+        }
     }
 
     /// Current number of active + pending slots (for teardown decisions).
@@ -740,14 +764,14 @@ actor BatchScheduler {
         // shutdown cannot drain immediately before a late enqueue.
         let admissionResult = admissionLock.withLock { () -> AdmissionResult in
             guard !_isShutdown.withLock({ $0 }) else {
-                if case .reserved = admission {
-                    admissionState.releaseReservation()
+                if case .reserved(let reservation) = admission {
+                    admissionState.releaseReservation(reservation)
                 }
                 return .shuttingDown
             }
             let admitted = switch admission {
-            case .reserved:
-                admissionState.consumeReservationForSubmission()
+            case .reserved(let reservation):
+                admissionState.consumeReservationForSubmission(reservation)
             case .unreserved:
                 admissionState.reserveForUnreservedSubmission()
             }

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -30,6 +30,11 @@ extension Gemma4VLM: FixedDecodeCohortModel {
     var requiresFixedDecodeCohorts: Bool { true }
 }
 
+enum BatchSchedulerSubmissionAdmission: Sendable {
+    case reserved
+    case unreserved
+}
+
 /// Tracks scheduler reservations separately from submitted requests so a
 /// promotion-time submit can safely perform its own capacity admission.
 final class BatchSchedulerAdmissionState: @unchecked Sendable {
@@ -78,17 +83,18 @@ final class BatchSchedulerAdmissionState: @unchecked Sendable {
         }
     }
 
-    /// Consume a controller reservation or reserve capacity at submit time.
-    ///
-    /// The submit-time fallback is required when admission raced scheduler
-    /// promotion: the earlier controller check may have observed serial mode,
-    /// while generation is routed to the scheduler after promotion completes.
-    func consumeReservationOrReserveForSubmission() -> Bool {
+    /// Transfer one caller-owned reservation to a submitted request.
+    func consumeReservationForSubmission() -> Bool {
         state.withLock { state in
-            if state.reservedCount > 0 {
-                state.reservedCount -= 1
-                return true
-            }
+            guard state.reservedCount > 0 else { return false }
+            state.reservedCount -= 1
+            return true
+        }
+    }
+
+    /// Admit a request that did not reserve capacity before submission.
+    func reserveForUnreservedSubmission() -> Bool {
+        state.withLock { state in
             guard state.inFlightCount < maxConcurrent else { return false }
             state.inFlightCount += 1
             return true
@@ -712,7 +718,8 @@ actor BatchScheduler {
         stopSequences: [String] = [],
         thinkStartTag: String? = nil,
         thinkEndTag: String? = nil,
-        requestId: String = ""
+        requestId: String = "",
+        admission: BatchSchedulerSubmissionAdmission = .unreserved
     ) -> AsyncThrowingStream<StreamChunk, Error> {
         let (stream, continuation) = AsyncThrowingStream<StreamChunk, Error>.makeStream()
         let slotID = UUID()
@@ -733,10 +740,18 @@ actor BatchScheduler {
         // shutdown cannot drain immediately before a late enqueue.
         let admissionResult = admissionLock.withLock { () -> AdmissionResult in
             guard !_isShutdown.withLock({ $0 }) else {
-                admissionState.releaseReservation()
+                if case .reserved = admission {
+                    admissionState.releaseReservation()
+                }
                 return .shuttingDown
             }
-            guard admissionState.consumeReservationOrReserveForSubmission() else {
+            let admitted = switch admission {
+            case .reserved:
+                admissionState.consumeReservationForSubmission()
+            case .unreserved:
+                admissionState.reserveForUnreservedSubmission()
+            }
+            guard admitted else {
                 return .atCapacity
             }
             _pendingQueue.withLock {

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -30,6 +30,94 @@ extension Gemma4VLM: FixedDecodeCohortModel {
     var requiresFixedDecodeCohorts: Bool { true }
 }
 
+/// Tracks scheduler reservations separately from submitted requests so a
+/// promotion-time submit can safely perform its own capacity admission.
+final class BatchSchedulerAdmissionState: @unchecked Sendable {
+    struct Snapshot: Equatable, Sendable {
+        let inFlightCount: Int
+        let reservedCount: Int
+    }
+
+    private struct State {
+        var inFlightCount = 0
+        var reservedCount = 0
+    }
+
+    let maxConcurrent: Int
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    init(maxConcurrent: Int) {
+        self.maxConcurrent = maxConcurrent
+    }
+
+    func tryReserve() -> Bool {
+        state.withLock { state in
+            guard state.inFlightCount < maxConcurrent else { return false }
+            state.inFlightCount += 1
+            state.reservedCount += 1
+            return true
+        }
+    }
+
+    func tryReserveMultiple(count: Int) -> Bool {
+        guard count > 0 else { return true }
+        return state.withLock { state in
+            guard state.inFlightCount + count <= maxConcurrent else { return false }
+            state.inFlightCount += count
+            state.reservedCount += count
+            return true
+        }
+    }
+
+    func releaseReservation(count: Int = 1) {
+        guard count > 0 else { return }
+        state.withLock { state in
+            let released = min(count, state.reservedCount)
+            state.reservedCount -= released
+            state.inFlightCount = max(0, state.inFlightCount - released)
+        }
+    }
+
+    /// Consume a controller reservation or reserve capacity at submit time.
+    ///
+    /// The submit-time fallback is required when admission raced scheduler
+    /// promotion: the earlier controller check may have observed serial mode,
+    /// while generation is routed to the scheduler after promotion completes.
+    func consumeReservationOrReserveForSubmission() -> Bool {
+        state.withLock { state in
+            if state.reservedCount > 0 {
+                state.reservedCount -= 1
+                return true
+            }
+            guard state.inFlightCount < maxConcurrent else { return false }
+            state.inFlightCount += 1
+            return true
+        }
+    }
+
+    func finish(count: Int = 1) {
+        guard count > 0 else { return }
+        state.withLock { state in
+            state.inFlightCount = max(0, state.inFlightCount - count)
+        }
+    }
+
+    func reset() {
+        state.withLock { state in
+            state.inFlightCount = 0
+            state.reservedCount = 0
+        }
+    }
+
+    var snapshot: Snapshot {
+        state.withLock {
+            Snapshot(
+                inFlightCount: $0.inFlightCount,
+                reservedCount: $0.reservedCount)
+        }
+    }
+}
+
 /// Manages concurrent generation with dynamic slot allocation and request queuing.
 ///
 /// **Phase 2: Dense Batched Decoding**
@@ -423,9 +511,8 @@ actor BatchScheduler {
     private let _isShutdown = OSAllocatedUnfairLock(initialState: false)
     private let admissionLock = NSLock()
 
-    /// Thread-safe in-flight counter (pending + active). Incremented in submit(),
-    /// decremented in finishSlot() and error paths. Used for capacity checks.
-    private let _inFlightCount = OSAllocatedUnfairLock(initialState: 0)
+    /// Thread-safe capacity state for reservations plus pending/active requests.
+    private let admissionState: BatchSchedulerAdmissionState
 
     /// Cancellation must be observable from the synchronous GPU loop without
     /// waiting for an actor hop. The generation loop intentionally contains no
@@ -436,11 +523,7 @@ actor BatchScheduler {
     nonisolated func tryReserve() -> Bool {
         admissionLock.withLock {
             guard !_isShutdown.withLock({ $0 }) else { return false }
-            return _inFlightCount.withLock { count in
-                if count >= maxConcurrent { return false }
-                count += 1
-                return true
-            }
+            return admissionState.tryReserve()
         }
     }
 
@@ -469,7 +552,7 @@ actor BatchScheduler {
 
     /// Release a reserved slot (call if request fails before reaching submit).
     nonisolated func releaseReservation() {
-        _inFlightCount.withLock { $0 = max($0 - 1, 0) }
+        admissionState.releaseReservation()
     }
 
     /// Atomically reserve N slots. Returns true if all N were reserved,
@@ -477,26 +560,18 @@ actor BatchScheduler {
     nonisolated func tryReserveMultiple(count: Int) -> Bool {
         admissionLock.withLock {
             guard !_isShutdown.withLock({ $0 }) else { return false }
-            return _inFlightCount.withLock { current in
-                if current + count <= maxConcurrent {
-                    current += count
-                    return true
-                }
-                return false
-            }
+            return admissionState.tryReserveMultiple(count: count)
         }
     }
 
     /// Release N slot reservations at once.
     nonisolated func releaseMultipleReservations(count: Int) {
-        _inFlightCount.withLock { current in
-            current = max(0, current - count)
-        }
+        admissionState.releaseReservation(count: count)
     }
 
     /// Current number of active + pending slots (for teardown decisions).
     nonisolated var activeSlotCount: Int {
-        _inFlightCount.withLock { $0 }
+        admissionState.snapshot.inFlightCount
     }
 
     /// Cancel pending or active scheduler slots. This is nonisolated so an SSE
@@ -516,7 +591,7 @@ actor BatchScheduler {
         }
         guard !removed.isEmpty else { return }
 
-        _inFlightCount.withLock { $0 = max(0, $0 - removed.count) }
+        admissionState.finish(count: removed.count)
         for request in removed {
             clearCancellation(request.id)
             request.continuation.finish(throwing: CancellationError())
@@ -560,6 +635,8 @@ actor BatchScheduler {
         self.processor = processor
         self.configuration = configuration
         self.maxConcurrent = maxConcurrent
+        self.admissionState = BatchSchedulerAdmissionState(
+            maxConcurrent: maxConcurrent)
         self.cacheProfilePath = cacheProfilePath
         self.admissionWindowNanoseconds = admissionWindowNanoseconds
         self.requiresFixedDecodeCohorts = Self.requiresFixedDecodeCohorts(
@@ -584,7 +661,7 @@ actor BatchScheduler {
         self.eosTokenIds = eos
 
         // Wire gauge readers into the global stats aggregator. `num_running`
-        // is (inflight - waiting), since _inFlightCount covers both actively
+        // is (inflight - waiting), since admissionState covers both actively
         // decoding and still-pending requests. `num_waiting` reads the
         // pending queue directly. Both closures read nonisolated state
         // through existing unfair locks — no actor hop, no async.
@@ -593,10 +670,10 @@ actor BatchScheduler {
         // nonisolated lock pointers, so they do not extend scheduler
         // lifetime beyond MLXModelService's hold.
         let pending = self._pendingQueue
-        let inflight = self._inFlightCount
+        let admissionState = self.admissionState
         StatsAggregator.shared.registerGaugeReaders(
             running: {
-                let total = inflight.withLock { $0 }
+                let total = admissionState.snapshot.inFlightCount
                 let queued = pending.withLock { $0.count }
                 return max(0, total - queued)
             },
@@ -636,11 +713,23 @@ actor BatchScheduler {
             self?.cancelSlots(ids: [slotID])
         }
 
-        // Note: slot already reserved by tryReserve() in the controller layer.
-        // Serialize the shutdown check with enqueue so shutdown cannot drain the
-        // queue immediately before a late submit appends an unreachable request.
-        let accepted = admissionLock.withLock {
-            guard !_isShutdown.withLock({ $0 }) else { return false }
+        enum AdmissionResult {
+            case accepted
+            case atCapacity
+            case shuttingDown
+        }
+
+        // Serialize admission with enqueue so promotion-time requests that did
+        // not reserve against this scheduler still cannot exceed capacity, and
+        // shutdown cannot drain immediately before a late enqueue.
+        let admissionResult = admissionLock.withLock { () -> AdmissionResult in
+            guard !_isShutdown.withLock({ $0 }) else {
+                admissionState.releaseReservation()
+                return .shuttingDown
+            }
+            guard admissionState.consumeReservationOrReserveForSubmission() else {
+                return .atCapacity
+            }
             _pendingQueue.withLock {
                 $0.append(PendingRequest(
                     id: slotID,
@@ -657,15 +746,22 @@ actor BatchScheduler {
                     continuation: continuation
                 ))
             }
-            return true
+            return .accepted
         }
-        guard accepted else {
+
+        switch admissionResult {
+        case .accepted:
+            break
+        case .atCapacity:
+            continuation.finish(throwing: MLXServiceError.serverBusy(maxConcurrent))
+            return stream
+        case .shuttingDown:
             continuation.finish(throwing: MLXServiceError.serviceShuttingDown)
             return stream
         }
 
         StatsAggregator.shared.requestStarted()
-        DebugLogger.log("[BatchScheduler] Request enqueued req=\(requestId) (\(_inFlightCount.withLock { $0 })/\(maxConcurrent))")
+        DebugLogger.log("[BatchScheduler] Request enqueued req=\(requestId) (\(admissionState.snapshot.inFlightCount)/\(maxConcurrent))")
         Task { await self.ensureLoopRunning() }
 
         return stream
@@ -739,8 +835,7 @@ actor BatchScheduler {
             slot.continuation.finish(throwing: MLXServiceError.serviceShuttingDown)
             slot.constraintRuntime?.matcherHandle?.release()
         }
-        // Reset in-flight counter
-        _inFlightCount.withLock { $0 = 0 }
+        admissionState.reset()
         slots.removeAll()
         batchCaches = []
         batchState = nil
@@ -799,7 +894,7 @@ actor BatchScheduler {
             }
             if Task.isCancelled || _isShutdown.withLock({ $0 }) {
                 for req in newRequests {
-                    _inFlightCount.withLock { $0 = max(0, $0 - 1) }
+                    admissionState.finish()
                     req.continuation.finish(
                         throwing: MLXServiceError.serviceShuttingDown)
                     StatsAggregator.shared.requestSucceeded(reason: "abort")
@@ -817,7 +912,7 @@ actor BatchScheduler {
                 for req in newRequests {
                     if isCancellationRequested(req.id) {
                         clearCancellation(req.id)
-                        _inFlightCount.withLock { $0 = max(0, $0 - 1) }
+                        admissionState.finish()
                         req.continuation.finish(throwing: CancellationError())
                         StatsAggregator.shared.requestSucceeded(reason: "abort")
                         StatsAggregator.shared.requestCompleted()
@@ -1973,7 +2068,7 @@ actor BatchScheduler {
         print("[\(batchTs())] [ChunkStats] stage=final | stream=true | cached_tokens=\(slot.cachedTokens) | prompt_tokens=\(slot.promptTokenCount) | completion_tokens=\(slot.tokenCount) | prompt_time=\(String(format: "%.3f", slot.prefillTime))s | generate_time=\(String(format: "%.3f", generateTime))s")
         slot.continuation.finish()
         slot.constraintRuntime?.matcherHandle?.release()
-        _inFlightCount.withLock { $0 = max($0 - 1, 0) }
+        admissionState.finish()
 
         // ─── Per-request /metrics observations ────────────────────────────
         // Determine the OpenAI-style finished_reason from the slot's
@@ -2007,7 +2102,7 @@ actor BatchScheduler {
         StatsAggregator.shared.requestCompleted()
         clearCancellation(slot.id)
 
-        DebugLogger.log("[BatchScheduler] Finished slot req=\(slot.requestId) (\(slot.tokenCount) tok, \(String(format: "%.2f", elapsed))s, in-flight: \(_inFlightCount.withLock { $0 })/\(maxConcurrent))")
+        DebugLogger.log("[BatchScheduler] Finished slot req=\(slot.requestId) (\(slot.tokenCount) tok, \(String(format: "%.2f", elapsed))s, in-flight: \(admissionState.snapshot.inFlightCount)/\(maxConcurrent))")
 
         // Remove from batch cache and state
         let keepIndices = (0..<slots.count).filter { $0 != index }

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -177,6 +177,7 @@ actor BatchScheduler {
     private let configuration: ModelConfiguration
     private let cacheProfilePath: String?
     private let admissionWindowNanoseconds: UInt64
+    private let testingDecodeBarrier: (@Sendable () -> Void)?
     /// Some models change attention behavior when a later, shorter sequence is
     /// left-padded into an active batch. Keep their decode cohorts fixed so
     /// staggered arrivals retain the same path as serial generation.
@@ -608,6 +609,10 @@ actor BatchScheduler {
         admissionState.snapshot
     }
 
+    nonisolated var isAdmissionClosed: Bool {
+        _isShutdown.withLock { $0 }
+    }
+
     /// Cancel pending or active scheduler slots. This is nonisolated so an SSE
     /// stream's termination handler can signal the synchronous GPU loop.
     nonisolated func cancelSlots(ids: Set<UUID>) {
@@ -663,7 +668,8 @@ actor BatchScheduler {
         enablePrefixCaching: Bool = false,
         cacheProfilePath: String? = nil,
         admissionWindowNanoseconds: UInt64 = BatchScheduler.defaultAdmissionWindowNanoseconds,
-        requiresFixedDecodeCohorts: Bool? = nil
+        requiresFixedDecodeCohorts: Bool? = nil,
+        testingDecodeBarrier: (@Sendable () -> Void)? = nil
     ) {
         self.model = model
         self.tokenizer = tokenizer
@@ -674,6 +680,7 @@ actor BatchScheduler {
             maxConcurrent: maxConcurrent)
         self.cacheProfilePath = cacheProfilePath
         self.admissionWindowNanoseconds = admissionWindowNanoseconds
+        self.testingDecodeBarrier = testingDecodeBarrier
         self.requiresFixedDecodeCohorts = requiresFixedDecodeCohorts
             ?? Self.requiresFixedDecodeCohorts(for: type(of: model))
 
@@ -728,7 +735,14 @@ actor BatchScheduler {
     /// Prepare UserInput into LMInput (tokenization + chat template).
     /// Actor-isolated — processor.prepare may not be thread-safe despite Sendable conformance.
     func prepareInput(_ userInput: UserInput) async throws -> LMInput {
-        try await processor.prepare(input: userInput)
+        guard !isAdmissionClosed else {
+            throw MLXServiceError.serviceShuttingDown
+        }
+        let input = try await processor.prepare(input: userInput)
+        guard !isAdmissionClosed else {
+            throw MLXServiceError.serviceShuttingDown
+        }
+        return input
     }
 
     /// Submit a generation request. Returns a stream of StreamChunks immediately.
@@ -859,10 +873,8 @@ actor BatchScheduler {
         return requests
     }
 
-    /// Gracefully shut down. Closing admission and draining the pending queue
-    /// are nonisolated so shutdown does not wait behind the synchronous decode
-    /// loop before making forward progress.
-    nonisolated func shutdown() async {
+    /// Close admission immediately without waiting for the actor decode loop.
+    nonisolated func beginShutdown() {
         let pending = admissionLock.withLock { () -> [PendingRequest] in
             _isShutdown.withLock { $0 = true }
             return _pendingQueue.withLock { q in
@@ -877,11 +889,15 @@ actor BatchScheduler {
             StatsAggregator.shared.requestSucceeded(reason: "abort")
             StatsAggregator.shared.requestCompleted()
         }
-
-        await finishShutdown()
     }
 
-    private func finishShutdown() async {
+    /// Gracefully close admission, then drain actor-isolated decode state.
+    nonisolated func shutdown() async {
+        beginShutdown()
+        await finishShutdownAfterAdmissionClosed()
+    }
+
+    func finishShutdownAfterAdmissionClosed() async {
         if let task = loopTask {
             task.cancel()
             await task.value
@@ -1024,6 +1040,8 @@ actor BatchScheduler {
                 Stream.gpu.synchronize()
                 return
             }
+
+            testingDecodeBarrier?()
 
             // --- Batched decode: build graph from lastTokenArray (CPU, ~2.7ms) ---
             let activeB = slots.count

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -421,6 +421,7 @@ actor BatchScheduler {
 
     /// Thread-safe shutdown flag — accessed without actor isolation.
     private let _isShutdown = OSAllocatedUnfairLock(initialState: false)
+    private let admissionLock = NSLock()
 
     /// Thread-safe in-flight counter (pending + active). Incremented in submit(),
     /// decremented in finishSlot() and error paths. Used for capacity checks.
@@ -433,10 +434,13 @@ actor BatchScheduler {
 
     /// Atomically reserve a slot if under capacity. Returns true if reserved.
     nonisolated func tryReserve() -> Bool {
-        _inFlightCount.withLock { count in
-            if count >= maxConcurrent { return false }
-            count += 1
-            return true
+        admissionLock.withLock {
+            guard !_isShutdown.withLock({ $0 }) else { return false }
+            return _inFlightCount.withLock { count in
+                if count >= maxConcurrent { return false }
+                count += 1
+                return true
+            }
         }
     }
 
@@ -471,12 +475,15 @@ actor BatchScheduler {
     /// Atomically reserve N slots. Returns true if all N were reserved,
     /// false if insufficient capacity (no slots reserved in that case).
     nonisolated func tryReserveMultiple(count: Int) -> Bool {
-        _inFlightCount.withLock { current in
-            if current + count <= maxConcurrent {
-                current += count
-                return true
+        admissionLock.withLock {
+            guard !_isShutdown.withLock({ $0 }) else { return false }
+            return _inFlightCount.withLock { current in
+                if current + count <= maxConcurrent {
+                    current += count
+                    return true
+                }
+                return false
             }
-            return false
         }
     }
 
@@ -621,10 +628,6 @@ actor BatchScheduler {
         thinkEndTag: String? = nil,
         requestId: String = ""
     ) -> AsyncThrowingStream<StreamChunk, Error> {
-        if _isShutdown.withLock({ $0 }) {
-            return AsyncThrowingStream { $0.finish(throwing: MLXServiceError.serviceShuttingDown) }
-        }
-
         let (stream, continuation) = AsyncThrowingStream<StreamChunk, Error>.makeStream()
         let slotID = UUID()
 
@@ -634,21 +637,31 @@ actor BatchScheduler {
         }
 
         // Note: slot already reserved by tryReserve() in the controller layer.
-        _pendingQueue.withLock {
-            $0.append(PendingRequest(
-                id: slotID,
-                requestId: requestId,
-                queuedAt: Date(),
-                input: input,
-                parameters: parameters,
-                promptTokens: promptTokens,
-                toolCallRuntimeConfig: toolCallRuntimeConfig,
-                constraintRuntimeConfig: constraintRuntimeConfig,
-                stopSequences: stopSequences,
-                thinkStartTag: thinkStartTag,
-                thinkEndTag: thinkEndTag,
-                continuation: continuation
-            ))
+        // Serialize the shutdown check with enqueue so shutdown cannot drain the
+        // queue immediately before a late submit appends an unreachable request.
+        let accepted = admissionLock.withLock {
+            guard !_isShutdown.withLock({ $0 }) else { return false }
+            _pendingQueue.withLock {
+                $0.append(PendingRequest(
+                    id: slotID,
+                    requestId: requestId,
+                    queuedAt: Date(),
+                    input: input,
+                    parameters: parameters,
+                    promptTokens: promptTokens,
+                    toolCallRuntimeConfig: toolCallRuntimeConfig,
+                    constraintRuntimeConfig: constraintRuntimeConfig,
+                    stopSequences: stopSequences,
+                    thinkStartTag: thinkStartTag,
+                    thinkEndTag: thinkEndTag,
+                    continuation: continuation
+                ))
+            }
+            return true
+        }
+        guard accepted else {
+            continuation.finish(throwing: MLXServiceError.serviceShuttingDown)
+            return stream
         }
 
         StatsAggregator.shared.requestStarted()
@@ -704,7 +717,9 @@ actor BatchScheduler {
 
     /// Gracefully shut down.
     func shutdown() async {
-        _isShutdown.withLock { $0 = true }
+        admissionLock.withLock {
+            _isShutdown.withLock { $0 = true }
+        }
 
         // Drain and cancel any pending requests
         let pending = _pendingQueue.withLock { q in

--- a/Sources/AFMKitMLX/Models/BatchScheduler.swift
+++ b/Sources/AFMKitMLX/Models/BatchScheduler.swift
@@ -574,6 +574,10 @@ actor BatchScheduler {
         admissionState.snapshot.inFlightCount
     }
 
+    nonisolated var admissionSnapshot: BatchSchedulerAdmissionState.Snapshot {
+        admissionState.snapshot
+    }
+
     /// Cancel pending or active scheduler slots. This is nonisolated so an SSE
     /// stream's termination handler can signal the synchronous GPU loop.
     nonisolated func cancelSlots(ids: Set<UUID>) {
@@ -628,7 +632,8 @@ actor BatchScheduler {
         maxConcurrent: Int = BatchScheduler.defaultMaxConcurrent,
         enablePrefixCaching: Bool = false,
         cacheProfilePath: String? = nil,
-        admissionWindowNanoseconds: UInt64 = BatchScheduler.defaultAdmissionWindowNanoseconds
+        admissionWindowNanoseconds: UInt64 = BatchScheduler.defaultAdmissionWindowNanoseconds,
+        requiresFixedDecodeCohorts: Bool? = nil
     ) {
         self.model = model
         self.tokenizer = tokenizer
@@ -639,8 +644,8 @@ actor BatchScheduler {
             maxConcurrent: maxConcurrent)
         self.cacheProfilePath = cacheProfilePath
         self.admissionWindowNanoseconds = admissionWindowNanoseconds
-        self.requiresFixedDecodeCohorts = Self.requiresFixedDecodeCohorts(
-            for: type(of: model))
+        self.requiresFixedDecodeCohorts = requiresFixedDecodeCohorts
+            ?? Self.requiresFixedDecodeCohorts(for: type(of: model))
 
         let debug = ProcessInfo.processInfo.environment["AFM_DEBUG"] == "1"
         self.radixCache = RadixTreeCache(
@@ -685,6 +690,10 @@ actor BatchScheduler {
 
     /// Number of requests currently generating.
     var activeCount: Int { slots.count }
+
+    nonisolated var pendingRequestCount: Int {
+        _pendingQueue.withLock { $0.count }
+    }
 
     /// Prepare UserInput into LMInput (tokenization + chat template).
     /// Actor-isolated — processor.prepare may not be thread-safe despite Sendable conformance.
@@ -811,20 +820,29 @@ actor BatchScheduler {
         return requests
     }
 
-    /// Gracefully shut down.
-    func shutdown() async {
-        admissionLock.withLock {
+    /// Gracefully shut down. Closing admission and draining the pending queue
+    /// are nonisolated so shutdown does not wait behind the synchronous decode
+    /// loop before making forward progress.
+    nonisolated func shutdown() async {
+        let pending = admissionLock.withLock { () -> [PendingRequest] in
             _isShutdown.withLock { $0 = true }
+            return _pendingQueue.withLock { q in
+                let result = q
+                q.removeAll()
+                return result
+            }
         }
-
-        // Drain and cancel any pending requests
-        let pending = _pendingQueue.withLock { q in
-            let result = q; q.removeAll(); return result
-        }
+        admissionState.finish(count: pending.count)
         for req in pending {
             req.continuation.finish(throwing: MLXServiceError.serviceShuttingDown)
+            StatsAggregator.shared.requestSucceeded(reason: "abort")
+            StatsAggregator.shared.requestCompleted()
         }
 
+        await finishShutdown()
+    }
+
+    private func finishShutdown() async {
         if let task = loopTask {
             task.cancel()
             await task.value
@@ -834,6 +852,8 @@ actor BatchScheduler {
         for slot in slots {
             slot.continuation.finish(throwing: MLXServiceError.serviceShuttingDown)
             slot.constraintRuntime?.matcherHandle?.release()
+            StatsAggregator.shared.requestSucceeded(reason: "abort")
+            StatsAggregator.shared.requestCompleted()
         }
         admissionState.reset()
         slots.removeAll()

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -85,20 +85,32 @@ actor MLXModelExecutionCoordinator {
     struct Snapshot: Equatable, Sendable {
         let activeSerialGenerations: Int
         let activeSchedulerUsers: Int
+        let waitingGenerationAcquisitions: Int
         let promotionInProgress: Bool
         let schedulerInstalled: Bool
     }
 
     private var activeSerialGenerations = 0
     private var activeSchedulerUsers = 0
+    private var waitingGenerationAcquisitions = 0
     private var promotionInProgress = false
     private var schedulerInstalled = false
     private var shutdownRequested = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
 
     func acquireGeneration() async -> Lease {
+        var registeredAsWaiting = false
         while promotionInProgress {
+            if !registeredAsWaiting {
+                waitingGenerationAcquisitions += 1
+                registeredAsWaiting = true
+                signalChange()
+            }
             await waitForChange()
+        }
+        if registeredAsWaiting {
+            waitingGenerationAcquisitions -= 1
+            signalChange()
         }
         if schedulerInstalled {
             activeSchedulerUsers += 1
@@ -176,6 +188,7 @@ actor MLXModelExecutionCoordinator {
         Snapshot(
             activeSerialGenerations: activeSerialGenerations,
             activeSchedulerUsers: activeSchedulerUsers,
+            waitingGenerationAcquisitions: waitingGenerationAcquisitions,
             promotionInProgress: promotionInProgress,
             schedulerInstalled: schedulerInstalled)
     }
@@ -722,6 +735,9 @@ public final class MLXModelService: @unchecked Sendable {
 
     /// Deterministic test barrier between promotion ownership and construction.
     var schedulerPromotionBarrier: (@Sendable () async -> Void)?
+    /// Deterministic test hooks around scheduler setup and active decode.
+    var schedulerSetupBarrier: (@Sendable () async -> Void)?
+    var schedulerDecodeBarrier: (@Sendable () -> Void)?
 
     /// Scheduled teardown work item (cancelled if new batch arrives).
     private var teardownWorkItem: DispatchWorkItem?
@@ -2505,6 +2521,7 @@ public final class MLXModelService: @unchecked Sendable {
         }
         let prefixCaching = self.enablePrefixCaching
         let limit = self.maxConcurrent
+        let decodeBarrier = withStateLock { schedulerDecodeBarrier }
         let sched = await container.perform { context -> BatchScheduler in
             BatchScheduler(
                 model: context.model,
@@ -2514,7 +2531,8 @@ public final class MLXModelService: @unchecked Sendable {
                 maxConcurrent: limit,
                 enablePrefixCaching: prefixCaching,
                 cacheProfilePath: self.cacheProfilePath,
-                requiresFixedDecodeCohorts: requiresFixedDecodeCohorts
+                requiresFixedDecodeCohorts: requiresFixedDecodeCohorts,
+                testingDecodeBarrier: decodeBarrier
             )
         }
         let published = withStateLock { () -> Bool in
@@ -2560,6 +2578,7 @@ public final class MLXModelService: @unchecked Sendable {
         // Promote: create scheduler
         let limit = max(concurrency, 8)
         self.maxConcurrent = limit
+        let decodeBarrier = withStateLock { schedulerDecodeBarrier }
 
         guard let container = withStateLock({ currentContainer }) else {
             await modelExecutionCoordinator.finishPromotion(schedulerInstalled: false)
@@ -2574,7 +2593,8 @@ public final class MLXModelService: @unchecked Sendable {
                 configuration: context.configuration,
                 maxConcurrent: limit,
                 enablePrefixCaching: true,
-                cacheProfilePath: self.cacheProfilePath
+                cacheProfilePath: self.cacheProfilePath,
+                testingDecodeBarrier: decodeBarrier
             )
         }
 
@@ -4129,6 +4149,9 @@ public final class MLXModelService: @unchecked Sendable {
             }
 
             let tToolSetup = debugLogging ? Date() : Date.distantPast
+            if let setupBarrier = withStateLock({ schedulerSetupBarrier }) {
+                await setupBarrier()
+            }
             let input = try await scheduler.prepareInput(userInput)
             let tTokenize = debugLogging ? Date() : Date.distantPast
             let preparedPromptTokens = input.text.tokens.reshaped(-1).asArray(Int.self).count
@@ -5022,19 +5045,22 @@ public final class MLXModelService: @unchecked Sendable {
     }
 
     public func shutdownAndReleaseResources(verbose: Bool = false, timeoutSeconds: TimeInterval = 30) async {
-        _ = beginShutdown()
+        let scheduler = beginShutdown()
+        // Closing admission is nonisolated and must happen before coordinator
+        // waits: setup may itself be queued behind the active decode actor.
+        scheduler?.beginShutdown()
         await modelExecutionCoordinator.beginShutdown()
-        let scheduler = withStateLock { self.scheduler }
 
-        // Shut down concurrent scheduler first (cancels pending + active)
+        // Drain concurrent scheduler state after setup users observe closure.
         if let scheduler {
-            if await modelExecutionCoordinator.beginSchedulerRemoval() {
-                await scheduler.shutdown()
-                withStateLock {
-                    if self.scheduler === scheduler {
-                        self.scheduler = nil
-                    }
+            let ownsRemoval = await modelExecutionCoordinator.beginSchedulerRemoval()
+            await scheduler.finishShutdownAfterAdmissionClosed()
+            withStateLock {
+                if self.scheduler === scheduler {
+                    self.scheduler = nil
                 }
+            }
+            if ownsRemoval {
                 await modelExecutionCoordinator.finishSchedulerRemoval()
             }
         }

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -107,8 +107,9 @@ public struct StreamChunk: Sendable {
     public let promptTime: Double?
     public let generateTime: Double?
     public let stoppedBySequence: Bool?
+    public let speculativeTelemetry: AFMMLXSpeculativeTelemetry?
 
-    public init(text: String, logprobs: [ResolvedLogprob]? = nil, toolCalls: [ResponseToolCall]? = nil, toolCallDeltas: [StreamDeltaToolCall]? = nil, promptTokens: Int? = nil, completionTokens: Int? = nil, cachedTokens: Int? = nil, promptTime: Double? = nil, generateTime: Double? = nil, stoppedBySequence: Bool? = nil) {
+    public init(text: String, logprobs: [ResolvedLogprob]? = nil, toolCalls: [ResponseToolCall]? = nil, toolCallDeltas: [StreamDeltaToolCall]? = nil, promptTokens: Int? = nil, completionTokens: Int? = nil, cachedTokens: Int? = nil, promptTime: Double? = nil, generateTime: Double? = nil, stoppedBySequence: Bool? = nil, speculativeTelemetry: AFMMLXSpeculativeTelemetry? = nil) {
         self.text = text
         self.logprobs = logprobs
         self.toolCalls = toolCalls
@@ -119,6 +120,7 @@ public struct StreamChunk: Sendable {
         self.promptTime = promptTime
         self.generateTime = generateTime
         self.stoppedBySequence = stoppedBySequence
+        self.speculativeTelemetry = speculativeTelemetry
     }
 }
 
@@ -1498,6 +1500,11 @@ public final class MLXModelService: @unchecked Sendable {
             throw MLXServiceError.loadFailed(
                 "speculative_decoding.max_draft_tokens must be at least 1")
         }
+        if let maxDraftTokens = options?.maxDraftTokens,
+           maxDraftTokens + 1 > dflash2BlockSize {
+            throw MLXServiceError.loadFailed(
+                "speculative_decoding.max_draft_tokens exceeds the loaded DFlash2 block limit \(dflash2BlockSize - 1)")
+        }
 
         let mode = options?.mode?.lowercased()
         guard mode == nil || mode == "auto" || mode == "dflash2"
@@ -2232,7 +2239,7 @@ public final class MLXModelService: @unchecked Sendable {
         responseFormat: ResponseFormat? = nil,
         chatTemplateKwargs: [String: AnyCodable]? = nil,
         speculativeDecoding: SpeculativeDecodingOptions? = nil
-    ) async throws -> (modelID: String, content: String, promptTokens: Int, completionTokens: Int, tokenLogprobs: [ResolvedLogprob]?, toolCalls: [ResponseToolCall]?, cachedTokens: Int, promptTime: Double, generateTime: Double, stoppedBySequence: Bool) {
+    ) async throws -> (modelID: String, content: String, promptTokens: Int, completionTokens: Int, tokenLogprobs: [ResolvedLogprob]?, toolCalls: [ResponseToolCall]?, cachedTokens: Int, promptTime: Double, generateTime: Double, stoppedBySequence: Bool, speculativeTelemetry: AFMMLXSpeculativeTelemetry?) {
         try beginOperation()
         defer { endOperation() }
 
@@ -2296,6 +2303,14 @@ public final class MLXModelService: @unchecked Sendable {
             throw MLXServiceError.loadFailed(
                 "DFlash2 is required but this request uses sampling, tools, grammar, logprobs, or stop sequences")
         }
+        let dflash2WasRequested = dflash2Drafter != nil || speculativeDecoding != nil
+        let dflash2FallbackTelemetry: AFMMLXSpeculativeTelemetry? = dflash2WasRequested
+            ? .fallback(
+                strategy: "dflash2",
+                reason: !dflash2Policy.permitsRuntime
+                    ? "disabled"
+                    : (dflash2Active == nil ? "unavailable" : "incompatible_request"))
+            : nil
         // GPU capture/trace/profile: start before inference
         let capturePath = gpuCapturePath
         let capturing = beginGPUCaptureIfNeeded()
@@ -2340,14 +2355,14 @@ public final class MLXModelService: @unchecked Sendable {
                 serialRequestRecorded = true
                 StatsAggregator.shared.requestSucceeded(reason: "stop")
                 StatsAggregator.shared.requestCompleted()
-                return (modelID, result.0, result.1, result.2, nil, nil, 0, 0, 0, false)
+                return (modelID, result.0, result.1, result.2, nil, nil, 0, 0, 0, false, dflash2FallbackTelemetry)
             }
         }
 
 
         // ---- DFlash2 one-pass parallel draft/verify path ----
         if dflash2Eligible, let installed = dflash2Active {
-            if let result = try await container.perform({ context -> (String, Int, Int)? in
+            if let result = try await container.perform({ context -> (String, Int, Int, AFMMLXSpeculativeTelemetry)? in
                 guard let target = context.model as? any DFlash2Target else { return nil }
                 let lmInput = try await context.processor.prepare(input: scratch.userInput)
                 if self.isMultimodalInput(lmInput) { return nil }
@@ -2369,10 +2384,20 @@ public final class MLXModelService: @unchecked Sendable {
                 let textIDs = (ids.last.map { eos.contains($0) } ?? false)
                     ? Array(ids.dropLast()) : ids
                 let stats = generated.statistics
+                let telemetry = AFMMLXSpeculativeTelemetry(
+                    strategy: "dflash2",
+                    draftedTokens: stats.draftedTokens,
+                    acceptedDraftTokens: stats.acceptedDraftTokens,
+                    emittedTokens: stats.emittedTokens,
+                    verificationCycles: stats.verificationCycles,
+                    draftTime: stats.draftSeconds,
+                    verificationTime: stats.verificationSeconds,
+                    rollbackTime: stats.rollbackSeconds)
                 StatsAggregator.shared.addSpeculative(
                     strategy: "dflash2",
                     draftedTokens: stats.draftedTokens,
                     acceptedDraftTokens: stats.acceptedDraftTokens,
+                    emittedTokens: stats.emittedTokens,
                     verificationCycles: stats.verificationCycles,
                     draftSeconds: stats.draftSeconds,
                     verificationSeconds: stats.verificationSeconds,
@@ -2380,12 +2405,12 @@ public final class MLXModelService: @unchecked Sendable {
                 if debugLogging {
                     print("[\(ts())] [DFlash2] \(ids.count) tokens, \(stats.verificationCycles) cycles, mean acceptance \(String(format: "%.2f", stats.meanAcceptanceLength))")
                 }
-                return (context.tokenizer.decode(tokens: textIDs), promptIDs.count, ids.count)
+                return (context.tokenizer.decode(tokens: textIDs), promptIDs.count, ids.count, telemetry)
             }) {
                 serialRequestRecorded = true
                 StatsAggregator.shared.requestSucceeded(reason: "stop")
                 StatsAggregator.shared.requestCompleted()
-                return (modelID, result.0, result.1, result.2, nil, nil, 0, 0, 0, false)
+                return (modelID, result.0, result.1, result.2, nil, nil, 0, 0, 0, false, result.3)
             }
             if requestRequiresDFlash2 {
                 throw MLXServiceError.loadFailed(
@@ -2424,7 +2449,7 @@ public final class MLXModelService: @unchecked Sendable {
                 serialRequestRecorded = true
                 StatsAggregator.shared.requestSucceeded(reason: "stop")
                 StatsAggregator.shared.requestCompleted()
-                return (modelID, mtpResult.0, mtpResult.1, mtpResult.2, nil, nil, 0, 0, 0, false)
+                return (modelID, mtpResult.0, mtpResult.1, mtpResult.2, nil, nil, 0, 0, 0, false, dflash2FallbackTelemetry)
             }
         }
 
@@ -2466,7 +2491,7 @@ public final class MLXModelService: @unchecked Sendable {
                 serialRequestRecorded = true
                 StatsAggregator.shared.requestSucceeded(reason: "stop")
                 StatsAggregator.shared.requestCompleted()
-                return (modelID, e3Result.0, e3Result.1, e3Result.2, nil, nil, 0, 0, 0, false)
+                return (modelID, e3Result.0, e3Result.1, e3Result.2, nil, nil, 0, 0, 0, false, dflash2FallbackTelemetry)
             }
         }
 
@@ -2671,7 +2696,7 @@ public final class MLXModelService: @unchecked Sendable {
             StatsAggregator.shared.requestCompleted()
             serialRequestRecorded = true
 
-            return (modelID, finalContent, promptTokens, completionTokens, nil, responseToolCalls, 0, promptTime, generateTime, stoppedBySequence)
+            return (modelID, finalContent, promptTokens, completionTokens, nil, responseToolCalls, 0, promptTime, generateTime, stoppedBySequence, dflash2FallbackTelemetry)
         }
 
         let generated: String = try await container.perform { context in
@@ -3226,7 +3251,7 @@ public final class MLXModelService: @unchecked Sendable {
             StatsAggregator.shared.requestCompleted()
             serialRequestRecorded = true
 
-            return (modelID, finalContent, promptTokens, completionTokens, resolvedLogprobs, responseToolCalls, cachedTokenCount, promptTime, generateTime, stoppedBySequence)
+            return (modelID, finalContent, promptTokens, completionTokens, resolvedLogprobs, responseToolCalls, cachedTokenCount, promptTime, generateTime, stoppedBySequence, dflash2FallbackTelemetry)
         }
 
     public func generateStreaming(
@@ -3320,6 +3345,7 @@ public final class MLXModelService: @unchecked Sendable {
         )
         let dflash2Policy = try dflash2RequestPolicy(speculativeDecoding)
         let requestRequiresDFlash2 = dflash2Policy.requiresRuntime
+        let dflash2WasRequested = dflash2Drafter != nil || speculativeDecoding != nil
 
         // --- Concurrent path: bypass container.perform lock, route through BatchScheduler ---
         if let scheduler = self.scheduler {
@@ -3392,7 +3418,7 @@ public final class MLXModelService: @unchecked Sendable {
                 thinkEndTag: self.thinkEndTag,
                 requestId: reqId
             )
-            let effectiveStream: AsyncThrowingStream<StreamChunk, Error>
+            var effectiveStream: AsyncThrowingStream<StreamChunk, Error>
             if templateOpenedThink, let thinkStart = self.thinkStartTag {
                 effectiveStream = AsyncThrowingStream { continuation in
                     let task = Task {
@@ -3410,6 +3436,27 @@ public final class MLXModelService: @unchecked Sendable {
                 }
             } else {
                 effectiveStream = schedulerStream
+            }
+            if dflash2WasRequested {
+                let upstream = effectiveStream
+                let telemetry = AFMMLXSpeculativeTelemetry.fallback(
+                    strategy: "dflash2",
+                    reason: dflash2Policy.permitsRuntime ? "concurrency" : "disabled")
+                effectiveStream = AsyncThrowingStream { continuation in
+                    let task = Task {
+                        do {
+                            for try await chunk in upstream {
+                                continuation.yield(chunk)
+                            }
+                            continuation.yield(StreamChunk(
+                                text: "", speculativeTelemetry: telemetry))
+                            continuation.finish()
+                        } catch {
+                            continuation.finish(throwing: error)
+                        }
+                    }
+                    continuation.onTermination = { _ in task.cancel() }
+                }
             }
             self.cleanupTempFiles(mediaTempFiles)
 
@@ -3450,6 +3497,14 @@ public final class MLXModelService: @unchecked Sendable {
         let dflash2StreamEligible = specGreedyStream
             && dflash2Policy.permitsRuntime
             && DFlash2Runtime.shared.active != nil
+        let dflash2FallbackTelemetry: AFMMLXSpeculativeTelemetry? = dflash2WasRequested
+            ? .fallback(
+                strategy: "dflash2",
+                reason: !dflash2Policy.permitsRuntime
+                    ? "disabled"
+                    : (DFlash2Runtime.shared.active == nil
+                        ? "unavailable" : "incompatible_request"))
+            : nil
         let eagle3StreamEligible = specGreedyStream && Eagle3Runtime.shared.active != nil
         let mtpStreamEligible = specGreedyStream && mtpBinding != nil
         if requestRequiresDFlash2,
@@ -3502,10 +3557,12 @@ public final class MLXModelService: @unchecked Sendable {
                         }
                         let t0 = Date.timeIntervalSinceReferenceDate
                         do {
-                            let outCount = try await container.perform { context -> Int in
+                            let generation = try await container.perform {
+                                context -> (tokenCount: Int, telemetry: AFMMLXSpeculativeTelemetry?) in
                                 let eos = Set((context.tokenizer.eosTokenId).map { [$0] } ?? [])
                                 var allTokens: [Int] = []
                                 var prevText = ""
+                                var telemetry: AFMMLXSpeculativeTelemetry?
                                 let emit: (Int) -> Bool = { tok in
                                     if Task.isCancelled { return false }    // client disconnected
                                     if eos.contains(tok) { return false }   // stop; never stream EOS
@@ -3541,10 +3598,20 @@ public final class MLXModelService: @unchecked Sendable {
                                         shouldStop: { Task.isCancelled },
                                         onToken: emit)
                                     let stats = result.statistics
+                                    telemetry = AFMMLXSpeculativeTelemetry(
+                                        strategy: "dflash2",
+                                        draftedTokens: stats.draftedTokens,
+                                        acceptedDraftTokens: stats.acceptedDraftTokens,
+                                        emittedTokens: stats.emittedTokens,
+                                        verificationCycles: stats.verificationCycles,
+                                        draftTime: stats.draftSeconds,
+                                        verificationTime: stats.verificationSeconds,
+                                        rollbackTime: stats.rollbackSeconds)
                                     StatsAggregator.shared.addSpeculative(
                                         strategy: "dflash2",
                                         draftedTokens: stats.draftedTokens,
                                         acceptedDraftTokens: stats.acceptedDraftTokens,
+                                        emittedTokens: stats.emittedTokens,
                                         verificationCycles: stats.verificationCycles,
                                         draftSeconds: stats.draftSeconds,
                                         verificationSeconds: stats.verificationSeconds,
@@ -3560,9 +3627,10 @@ public final class MLXModelService: @unchecked Sendable {
                                     _ = gen.generate(promptIds: promptIds, maxTokens: maxTok,
                                                      eosIds: eos, onToken: emit)
                                 }
-                                return allTokens.count
+                                return (allTokens.count, telemetry)
                             }
                             let gt = Date.timeIntervalSinceReferenceDate - t0
+                            let outCount = generation.tokenCount
                             if dbg {
                                 let tps = gt > 0 ? Double(outCount) / gt : 0
                                 let engine = useDSpark ? "DSpARK"
@@ -3570,7 +3638,10 @@ public final class MLXModelService: @unchecked Sendable {
                                 print("[\(ts())] [\(engine)] streamed \(outCount) tok in \(String(format: "%.2f", gt))s (\(String(format: "%.1f", tps)) tok/s)")
                             }
                             continuation.yield(StreamChunk(text: "", promptTokens: promptIds.count,
-                                                           completionTokens: outCount, promptTime: 0, generateTime: gt))
+                                                           completionTokens: outCount, promptTime: 0,
+                                                           generateTime: gt,
+                                                           speculativeTelemetry: generation.telemetry
+                                                               ?? dflash2FallbackTelemetry))
                             StatsAggregator.shared.requestSucceeded(reason: "stop")
                             StatsAggregator.shared.requestCompleted()
                             continuation.finish()
@@ -4101,6 +4172,11 @@ public final class MLXModelService: @unchecked Sendable {
                     }
                     StatsAggregator.shared.requestSucceeded(reason: streamReason)
                     StatsAggregator.shared.requestCompleted()
+
+                    if let dflash2FallbackTelemetry {
+                        continuation.yield(StreamChunk(
+                            text: "", speculativeTelemetry: dflash2FallbackTelemetry))
+                    }
 
                     continuation.finish()
                 } catch {

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -54,25 +54,26 @@ final class Eagle3Runtime: @unchecked Sendable {
     var active: Gemma4Eagle3Drafter? { lock.withLock { drafter } }
 }
 
-final class DFlash2Runtime: @unchecked Sendable {
-    static let shared = DFlash2Runtime()
-    private let lock = NSLock()
-    private var value: (draft: DFlash2DraftModel, blockSize: Int)?
-
-    func install(draft: DFlash2DraftModel, blockSize: Int) {
-        lock.withLock { value = (draft, blockSize) }
-    }
-    func clear() { lock.withLock { value = nil } }
-    var active: (draft: DFlash2DraftModel, blockSize: Int)? {
-        lock.withLock { value }
-    }
+private struct DFlash2ModelRuntimeState: @unchecked Sendable {
+    let ownerID: UUID
+    let modelID: String
+    let configuredDrafter: String?
+    let runtime: AFMMLXDFlash2Runtime?
+    let fallbackReason: String?
 }
 
 struct DFlash2RequestPolicy {
     let permitsRuntime: Bool
+    let permitsOtherRuntimes: Bool
     let requiresRuntime: Bool
     let requestedBlockSize: Int?
     let denialReason: String?
+}
+
+struct SpeculativeRequestCompatibility: Equatable {
+    let denialReason: String?
+
+    var isEligible: Bool { denialReason == nil }
 }
 
 /// Resolved log probability entry with token strings (ready for API response).
@@ -244,6 +245,7 @@ public final class MLXModelService: @unchecked Sendable {
     }()
 
     private let resolver: MLXCacheResolver
+    let dflash2RuntimeScopeID = UUID()
     private let registry = MLXModelRegistry()
     private let stateLock = NSLock()
     private var currentModelID: String?
@@ -253,6 +255,7 @@ public final class MLXModelService: @unchecked Sendable {
     /// capture both under `stateLock`, so a concurrent model switch cannot pair
     /// one model's container with another model's MTP generator.
     private var currentMTPBinding: MTPGeneratorBinding?
+    private var currentDFlash2State: DFlash2ModelRuntimeState?
     private var activeOperations: Int = 0
     private var isShuttingDown = false
     private var gpuInitialized = false
@@ -1521,13 +1524,131 @@ public final class MLXModelService: @unchecked Sendable {
             throw MLXServiceError.loadFailed(
                 "per-request DFlash2 drafter switching is not supported; restart with drafter \(drafter)")
         }
-        let reason = explicitlyDisabled ? "request disabled speculative decoding" : nil
+        let explicitlyDFlash2 = mode == "dflash2"
+            || options?.drafter != nil
+            || options?.maxDraftTokens != nil
+            || options?.requirement != nil
+        let reason: String?
+        if explicitlyDisabled {
+            reason = "disabled"
+        } else if let forcedReason = options?.forceAutoregressiveReason {
+            reason = forcedReason
+        } else if dflash2Drafter == nil && explicitlyDFlash2 {
+            reason = "unavailable"
+        } else {
+            reason = nil
+        }
         return DFlash2RequestPolicy(
             permitsRuntime: reason == nil,
+            permitsOtherRuntimes: reason == nil && !explicitlyDFlash2,
             requiresRuntime: !explicitlyDisabled
                 && (dflash2Requirement == .required || requirement == "required"),
             requestedBlockSize: options?.maxDraftTokens.map { $0 + 1 },
             denialReason: reason)
+    }
+
+    func speculativeRequestCompatibility(
+        temperature: Double?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        hasTools: Bool,
+        hasResponseFormat: Bool,
+        wantsLogprobs: Bool,
+        hasStopSequences: Bool
+    ) -> SpeculativeRequestCompatibility {
+        guard let temperature, temperature <= 0 else {
+            return SpeculativeRequestCompatibility(denialReason: "sampling")
+        }
+        if let topP, topP < 1
+            || (topK ?? 0) > 0
+            || (minP ?? 0) > 0 {
+            return SpeculativeRequestCompatibility(denialReason: "sampling")
+        }
+        if let repetitionPenalty, abs(repetitionPenalty - 1) > 0.000_001
+            || abs(presencePenalty ?? 0) > 0.000_001 {
+            return SpeculativeRequestCompatibility(denialReason: "penalties")
+        }
+        if hasTools || hasResponseFormat || wantsLogprobs || hasStopSequences {
+            return SpeculativeRequestCompatibility(denialReason: "incompatible_request")
+        }
+        return SpeculativeRequestCompatibility(denialReason: nil)
+    }
+
+    func dflash2StartupFallbackReason() -> String? {
+        if maxConcurrent >= 2 { return "concurrency" }
+        if enablePrefixCaching { return "prefix_cache" }
+        return nil
+    }
+
+    func dflash2WasRequested(
+        _ options: SpeculativeDecodingOptions?,
+        configuredDrafter: String?
+    ) -> Bool {
+        if configuredDrafter != nil { return true }
+        let mode = options?.mode?.lowercased()
+        return mode == "auto"
+            || mode == "dflash2"
+            || options?.drafter != nil
+            || options?.maxDraftTokens != nil
+            || options?.requirement != nil
+    }
+
+    func recordSpeculativeRequestCompletion(
+        queuedAt: Date,
+        completedAt: Date = Date(),
+        promptTokens: Int,
+        completionTokens: Int,
+        promptTime: Double,
+        maxTokens: Int
+    ) {
+        let firstTokenAt = completionTokens > 0
+            ? queuedAt.addingTimeInterval(promptTime)
+            : nil
+        StatsAggregator.shared.addPromptTokens(promptTokens)
+        StatsAggregator.shared.addGenTokens(completionTokens)
+        StatsAggregator.shared.observeRequest(
+            StatsAggregator.RequestObservation(
+                queuedAt: queuedAt.timeIntervalSince1970,
+                startedAt: queuedAt.timeIntervalSince1970,
+                firstTokenAt: firstTokenAt?.timeIntervalSince1970,
+                completedAt: completedAt.timeIntervalSince1970,
+                promptTokens: promptTokens,
+                generationTokens: completionTokens))
+        StatsAggregator.shared.requestSucceeded(
+            reason: completionTokens >= maxTokens ? "length" : "stop")
+        StatsAggregator.shared.requestCompleted()
+    }
+
+    static func completeEOSTokenIDs(
+        configuredTokenIDs: Set<Int>,
+        tokenizerTokenID: Int?,
+        extraTokens: [String],
+        tokenID: (String) -> Int?
+    ) -> Set<Int> {
+        var result = configuredTokenIDs
+        if let tokenizerTokenID {
+            result.insert(tokenizerTokenID)
+        }
+        for token in extraTokens {
+            if let id = tokenID(token) {
+                result.insert(id)
+            }
+        }
+        return result
+    }
+
+    private static func completeEOSTokenIDs(
+        configuration: ModelConfiguration,
+        tokenizer: any Tokenizer
+    ) -> Set<Int> {
+        completeEOSTokenIDs(
+            configuredTokenIDs: configuration.eosTokenIds,
+            tokenizerTokenID: tokenizer.eosTokenId,
+            extraTokens: Array(configuration.extraEOSTokens),
+            tokenID: tokenizer.convertTokenToId)
     }
 
     private func mtpQuantization(for sidecarPath: String) -> (
@@ -1568,19 +1689,20 @@ public final class MLXModelService: @unchecked Sendable {
         }
 
         let modelID = normalizeModel(rawModel)
+        let configuredDFlash2Drafter = dflash2Drafter
         guard !modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw MLXServiceError.invalidModel(rawModel)
         }
         let speculativeSelections = [
             mtpEnabled,
             eagle3DrafterPath?.isEmpty == false,
-            dflash2Drafter?.isEmpty == false,
+            configuredDFlash2Drafter?.isEmpty == false,
         ].filter { $0 }.count
         guard speculativeSelections <= 1 else {
             throw MLXServiceError.loadFailed(
                 "Choose only one speculative runtime: MTP, EAGLE3, or DFlash2")
         }
-        guard dflash2Drafter == nil || dflash2BlockSize >= 2 else {
+        guard configuredDFlash2Drafter == nil || dflash2BlockSize >= 2 else {
             throw MLXServiceError.loadFailed("DFlash2 block size must be at least 2")
         }
         stage?(.checkingCache)
@@ -1592,13 +1714,16 @@ public final class MLXModelService: @unchecked Sendable {
                     requestedModelID: modelID,
                     mtpEnabled: mtpEnabled,
                     bindingModelID: currentMTPBinding?.modelID
-                  ) else { return nil }
+                  ),
+                  currentDFlash2State?.ownerID == dflash2RuntimeScopeID,
+                  currentDFlash2State?.modelID == modelID,
+                  currentDFlash2State?.configuredDrafter == configuredDFlash2Drafter
+            else { return nil }
             return (modelID, container)
         }) {
             stage?(.ready)
             return cached.0
         }
-        DFlash2Runtime.shared.clear()
         Eagle3Runtime.shared.clear()
 
         // Loading priority:
@@ -1780,16 +1905,6 @@ public final class MLXModelService: @unchecked Sendable {
                 print("[\(ts())] [MTP] matching head cached; pass --mtp to enable serial speculative decoding")
             }
 
-            // Publish the container and its MTP generator as one state change.
-            // A failed sidecar load leaves the previous model state untouched.
-            withStateLock {
-                currentContainer = loaded
-                currentModelID = modelID
-                currentModelArchitecture = modelArchitecture
-                currentToolCallFormat = detectedFormat
-                currentMTPBinding = loadedMTPBinding
-            }
-
             if AFMMLXMTPRuntimePolicy.shouldPrefetchInBackground(
                 mtpEnabled: mtpEnabled,
                 resolvedSidecar: resolvedMTPSidecar,
@@ -1835,46 +1950,53 @@ public final class MLXModelService: @unchecked Sendable {
                     print("[\(ts())] [EAGLE3] no config.json at \(drafterPath) — EAGLE3 disabled (AR decode)")
                 }
             }
-            if dflash2Drafter != nil {
+            var loadedDFlash2Runtime: AFMMLXDFlash2Runtime?
+            var dflash2FallbackReason: String?
+            if configuredDFlash2Drafter != nil {
                 do {
-                    guard maxConcurrent < 2 else {
-                        throw MLXServiceError.loadFailed(
-                            "DFlash2 currently requires serial scheduling; remove --concurrent")
-                    }
-                    guard !enablePrefixCaching else {
-                        throw MLXServiceError.loadFailed(
-                            "DFlash2 prefix snapshots are not yet integrated; disable --enable-prefix-caching")
+                    if let conflict = dflash2StartupFallbackReason() {
+                        dflash2FallbackReason = conflict
+                        let message = conflict == "concurrency"
+                            ? "DFlash2 currently requires serial scheduling; remove --concurrent"
+                            : "DFlash2 prefix snapshots are not yet integrated; disable --enable-prefix-caching"
+                        throw MLXServiceError.loadFailed(message)
                     }
                     guard let draftDirectory = try await resolveDFlash2Directory(
                         progress: progress, stage: stage) else {
                         throw MLXServiceError.loadFailed("DFlash2 drafter was not resolved")
                     }
-                    let draftConfig = try AFMMLXDFlash2Configuration(directory: draftDirectory)
-                    let targetData = try Data(contentsOf: directory.appendingPathComponent("config.json"))
-                    guard let targetMetadata = try JSONSerialization.jsonObject(
-                        with: targetData) as? [String: Any] else {
-                        throw MLXServiceError.loadFailed("Target config.json is not an object")
+                    let runtime = try await AFMMLXRuntimeAdapter().makeDFlash2Runtime(
+                        container: loaded,
+                        targetDirectory: directory,
+                        drafterDirectory: draftDirectory,
+                        blockSize: dflash2BlockSize)
+                    guard case .dflash2(let dflash2Runtime) = runtime else {
+                        throw MLXServiceError.loadFailed("DFlash2 runtime setup returned no runtime")
                     }
-                    try draftConfig.validateTarget(metadata: targetMetadata)
-                    try draftConfig.validateWeights(in: draftDirectory)
-                    let block = try draftConfig.effectiveBlockSize(requested: dflash2BlockSize)
-                    let draft = try DFlash2DraftModel.load(directory: draftDirectory.path)
-                    let targetCompatible = try await loaded.perform { context in
-                        guard let target = context.model as? any DFlash2Target else { return false }
-                        _ = try DFlash2Generator(target: target, draft: draft, blockSize: block)
-                        return true
-                    }
-                    guard targetCompatible else {
-                        throw MLXServiceError.loadFailed(
-                            "Loaded target runtime does not expose DFlash2 hidden-state and rollback hooks")
-                    }
-                    DFlash2Runtime.shared.install(draft: draft, blockSize: block)
-                    print("[\(ts())] [DFlash2] ready from \(draftDirectory.path) (block \(block))")
+                    loadedDFlash2Runtime = dflash2Runtime
+                    print("[\(ts())] [DFlash2] ready from \(draftDirectory.path) (block \(dflash2Runtime.preflight.blockSize))")
                 } catch {
-                    DFlash2Runtime.shared.clear()
+                    dflash2FallbackReason = dflash2FallbackReason ?? "unavailable"
                     if dflash2Requirement == .required { throw error }
                     print("[\(ts())] [DFlash2] unavailable (\(error)); using autoregressive decoding")
                 }
+            }
+
+            // Publish the container and every container-bound speculative runtime
+            // in one state change. Requests can never observe a drafter validated
+            // for a different target model or service instance.
+            withStateLock {
+                currentContainer = loaded
+                currentModelID = modelID
+                currentModelArchitecture = modelArchitecture
+                currentToolCallFormat = detectedFormat
+                currentMTPBinding = loadedMTPBinding
+                currentDFlash2State = DFlash2ModelRuntimeState(
+                    ownerID: dflash2RuntimeScopeID,
+                    modelID: modelID,
+                    configuredDrafter: configuredDFlash2Drafter,
+                    runtime: loadedDFlash2Runtime,
+                    fallbackReason: dflash2FallbackReason)
             }
             // Detect think start/end tags from tokenizer vocabulary
             // Run the tokenizer-vocabulary inspection inside `perform` so the
@@ -2257,7 +2379,8 @@ public final class MLXModelService: @unchecked Sendable {
         var serialRequestRecorded = false
         defer {
             if !serialRequestRecorded {
-                StatsAggregator.shared.requestSucceeded(reason: "error")
+                StatsAggregator.shared.requestSucceeded(
+                    reason: Task.isCancelled ? "abort" : "error")
                 StatsAggregator.shared.requestCompleted()
             }
         }
@@ -2265,6 +2388,7 @@ public final class MLXModelService: @unchecked Sendable {
         let runtime = try validatedRuntimeForRequest(modelID: modelID, messages: messages)
         let container = runtime.container
         let mtpBinding = runtime.mtpBinding
+        let dflash2State = runtime.dflash2State
 
         let promptText = buildPrompt(from: messages)
         let toolSpecs = convertToToolSpecs(tools, includePythonJSON: shouldUseNativePythonToolJSONTemplate(for: tools))
@@ -2287,29 +2411,40 @@ public final class MLXModelService: @unchecked Sendable {
         scratch.userInput = userInput
         let dflash2Policy = try dflash2RequestPolicy(speculativeDecoding)
         let requestRequiresDFlash2 = dflash2Policy.requiresRuntime
+        let speculativeCompatibility = speculativeRequestCompatibility(
+            temperature: temperature,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            hasTools: !(tools?.isEmpty ?? true),
+            hasResponseFormat: responseFormat != nil,
+            wantsLogprobs: wantLogprobs,
+            hasStopSequences: !(stop?.isEmpty ?? true))
         let dflash2Active = dflash2Policy.permitsRuntime
-            ? DFlash2Runtime.shared.active : nil
+            ? dflash2State?.runtime : nil
         let dflash2Eligible = dflash2Active != nil
-            && (temperature ?? 0) <= 0.0
-            && (tools?.isEmpty ?? true)
-            && responseFormat == nil
-            && !wantLogprobs
-            && (stop?.isEmpty ?? true)
+            && speculativeCompatibility.isEligible
         if requestRequiresDFlash2, dflash2Active == nil {
             throw MLXServiceError.loadFailed(
                 "DFlash2 is required but unavailable: \(dflash2Policy.denialReason ?? "no compatible runtime is active")")
         }
         if requestRequiresDFlash2, !dflash2Eligible {
             throw MLXServiceError.loadFailed(
-                "DFlash2 is required but this request uses sampling, tools, grammar, logprobs, or stop sequences")
+                "DFlash2 is required but this request is unsupported: \(speculativeCompatibility.denialReason ?? "incompatible request")")
         }
-        let dflash2WasRequested = dflash2Drafter != nil || speculativeDecoding != nil
+        let dflash2WasRequested = dflash2WasRequested(
+            speculativeDecoding,
+            configuredDrafter: dflash2State?.configuredDrafter)
         let dflash2FallbackTelemetry: AFMMLXSpeculativeTelemetry? = dflash2WasRequested
             ? .fallback(
                 strategy: "dflash2",
                 reason: !dflash2Policy.permitsRuntime
-                    ? "disabled"
-                    : (dflash2Active == nil ? "unavailable" : "incompatible_request"))
+                    ? (dflash2Policy.denialReason ?? "disabled")
+                    : (dflash2Active == nil
+                        ? (dflash2State?.fallbackReason ?? "unavailable")
+                        : (speculativeCompatibility.denialReason ?? "incompatible_request")))
             : nil
         // GPU capture/trace/profile: start before inference
         let capturePath = gpuCapturePath
@@ -2319,12 +2454,10 @@ public final class MLXModelService: @unchecked Sendable {
         // ---- Embedded DSpARK fast path (greedy, text-only, no tools/grammar/logprobs) ----
         // DeepSeek V4 checkpoints advertise this capability through metadata and carry the
         // drafter weights themselves; no model-id allowlist or separately loaded package.
-        let dsparkEligible = dflash2Active == nil
+        let dsparkEligible = dflash2Policy.permitsOtherRuntimes
+            && dflash2Active == nil
             && afmDSparkEnabled()
-            && (temperature ?? 0) <= 0.0
-            && (tools?.isEmpty ?? true)
-            && responseFormat == nil
-            && !wantLogprobs
+            && speculativeCompatibility.isEligible
         if dsparkEligible {
             if let result = try await container.perform({ context -> (String, Int, Int)? in
                 guard let model = context.model as? DeepseekV4Model,
@@ -2333,7 +2466,9 @@ public final class MLXModelService: @unchecked Sendable {
                 if self.isMultimodalInput(lmInput) { return nil }
                 let promptIds = self.extractTokenArray(lmInput)
                 guard !promptIds.isEmpty else { return nil }
-                let eos = Set((context.tokenizer.eosTokenId).map { [$0] } ?? [])
+                let eos = Self.completeEOSTokenIDs(
+                    configuration: context.configuration,
+                    tokenizer: context.tokenizer)
                 let limit = ProcessInfo.processInfo.environment["AFM_DSPARK_DRAFT"]
                     .flatMap(Int.init)
                 let t0 = Date.timeIntervalSinceReferenceDate
@@ -2362,28 +2497,34 @@ public final class MLXModelService: @unchecked Sendable {
 
         // ---- DFlash2 one-pass parallel draft/verify path ----
         if dflash2Eligible, let installed = dflash2Active {
-            if let result = try await container.perform({ context -> (String, Int, Int, AFMMLXSpeculativeTelemetry)? in
+            if let result = try await container.perform({ context -> (String, Int, Int, Double, Double, AFMMLXSpeculativeTelemetry)? in
                 guard let target = context.model as? any DFlash2Target else { return nil }
+                let prepareStart = Date.timeIntervalSinceReferenceDate
                 let lmInput = try await context.processor.prepare(input: scratch.userInput)
                 if self.isMultimodalInput(lmInput) { return nil }
                 let promptIDs = self.extractTokenArray(lmInput)
                 guard !promptIDs.isEmpty else { return nil }
-                let eos = Set((context.tokenizer.eosTokenId).map { [$0] } ?? [])
+                let preparationTime = Date.timeIntervalSinceReferenceDate - prepareStart
+                let eos = Self.completeEOSTokenIDs(
+                    configuration: context.configuration,
+                    tokenizer: context.tokenizer)
                 let generator = try DFlash2Generator(
                     target: target,
                     draft: installed.draft,
                     blockSize: dflash2Policy.requestedBlockSize.map {
-                        min(installed.blockSize, $0)
-                    } ?? installed.blockSize)
-                let generated = generator.generate(
+                        min(installed.preflight.blockSize, $0)
+                    } ?? installed.preflight.blockSize)
+                let generationStart = Date.timeIntervalSinceReferenceDate
+                let generated = try generator.generate(
                     promptIDs: promptIDs,
                     maxTokens: effectiveMaxTokens,
                     stopTokenIDs: eos,
                     shouldStop: { Task.isCancelled })
+                let totalGenerationTime = Date.timeIntervalSinceReferenceDate - generationStart
                 let ids = generated.tokenIDs
-                let textIDs = (ids.last.map { eos.contains($0) } ?? false)
-                    ? Array(ids.dropLast()) : ids
                 let stats = generated.statistics
+                let promptTime = preparationTime + stats.prefillSeconds
+                let generateTime = max(0, totalGenerationTime - stats.prefillSeconds)
                 let telemetry = AFMMLXSpeculativeTelemetry(
                     strategy: "dflash2",
                     draftedTokens: stats.draftedTokens,
@@ -2405,12 +2546,22 @@ public final class MLXModelService: @unchecked Sendable {
                 if debugLogging {
                     print("[\(ts())] [DFlash2] \(ids.count) tokens, \(stats.verificationCycles) cycles, mean acceptance \(String(format: "%.2f", stats.meanAcceptanceLength))")
                 }
-                return (context.tokenizer.decode(tokens: textIDs), promptIDs.count, ids.count, telemetry)
+                let promptSuffix = context.tokenizer.decode(tokens: Array(promptIDs.suffix(8)))
+                let text = Self.restorePromptOpenedReasoningBoundary(
+                    generatedText: context.tokenizer.decode(tokens: ids),
+                    promptSuffix: promptSuffix,
+                    startTag: self.thinkStartTag,
+                    endTag: self.thinkEndTag)
+                return (text, promptIDs.count, ids.count, promptTime, generateTime, telemetry)
             }) {
+                recordSpeculativeRequestCompletion(
+                    queuedAt: serialQueuedAt,
+                    promptTokens: result.1,
+                    completionTokens: result.2,
+                    promptTime: result.3,
+                    maxTokens: effectiveMaxTokens)
                 serialRequestRecorded = true
-                StatsAggregator.shared.requestSucceeded(reason: "stop")
-                StatsAggregator.shared.requestCompleted()
-                return (modelID, result.0, result.1, result.2, nil, nil, 0, 0, 0, false, result.3)
+                return (modelID, result.0, result.1, result.2, nil, nil, 0, result.3, result.4, false, result.5)
             }
             if requestRequiresDFlash2 {
                 throw MLXServiceError.loadFailed(
@@ -2421,11 +2572,9 @@ public final class MLXModelService: @unchecked Sendable {
         // ---- MTP self-speculative fast path (greedy, text-only, no tools/grammar/logprobs) ----
         // Eligible when an MTP head is installed and the request is plain greedy generation.
         // Produces output identical to greedy AR (validated P2) but with fewer trunk forwards.
-        let mtpEligible = mtpBinding != nil
-            && (temperature ?? 0) <= 0.0
-            && (tools?.isEmpty ?? true)
-            && responseFormat == nil
-            && !wantLogprobs
+        let mtpEligible = dflash2Policy.permitsOtherRuntimes
+            && mtpBinding != nil
+            && speculativeCompatibility.isEligible
         if mtpEligible {
             if let mtpResult = try await container.perform({ context -> (String, Int, Int)? in
                 guard let gen = mtpBinding?.generator else { return nil }
@@ -2433,7 +2582,9 @@ public final class MLXModelService: @unchecked Sendable {
                 if self.isMultimodalInput(lmInput) { return nil }   // MTP is text-only
                 let promptIds = self.extractTokenArray(lmInput)
                 guard !promptIds.isEmpty else { return nil }
-                let eos = Set((context.tokenizer.eosTokenId).map { [$0] } ?? [])
+                let eos = Self.completeEOSTokenIDs(
+                    configuration: context.configuration,
+                    tokenizer: context.tokenizer)
                 let t0 = Date.timeIntervalSinceReferenceDate
                 let outIds = gen.generate(promptIds: promptIds, maxTokens: effectiveMaxTokens, eosIds: eos)
                 let gt = Date.timeIntervalSinceReferenceDate - t0
@@ -2456,11 +2607,9 @@ public final class MLXModelService: @unchecked Sendable {
         // ---- EAGLE3 speculative fast path (greedy, text-only, no tools/grammar/logprobs) ----
         // Eligible when a drafter is installed and the request is plain greedy generation.
         // Produces output identical to greedy AR (validated P1) with fewer verifier trunk forwards.
-        let eagle3Eligible = Eagle3Runtime.shared.active != nil
-            && (temperature ?? 0) <= 0.0
-            && (tools?.isEmpty ?? true)
-            && responseFormat == nil
-            && !wantLogprobs
+        let eagle3Eligible = dflash2Policy.permitsOtherRuntimes
+            && Eagle3Runtime.shared.active != nil
+            && speculativeCompatibility.isEligible
         if eagle3Eligible {
             if let e3Result = try await container.perform({ context -> (String, Int, Int)? in
                 guard let drafter = Eagle3Runtime.shared.active,
@@ -2469,7 +2618,9 @@ public final class MLXModelService: @unchecked Sendable {
                 if self.isMultimodalInput(lmInput) { return nil }   // EAGLE3 is text-only
                 let promptIds = self.extractTokenArray(lmInput)
                 guard !promptIds.isEmpty else { return nil }
-                let eos = Set((context.tokenizer.eosTokenId).map { [$0] } ?? [])
+                let eos = Self.completeEOSTokenIDs(
+                    configuration: context.configuration,
+                    tokenizer: context.tokenizer)
                 let t0 = Date.timeIntervalSinceReferenceDate
                 let gen = Gemma4Eagle3Generator(drafter: drafter)
                 // blockSize 2 is the sweet spot on the dense 31B (each round drafts only the carried
@@ -3292,6 +3443,7 @@ public final class MLXModelService: @unchecked Sendable {
         let runtime = try validatedRuntimeForRequest(modelID: modelID, messages: messages)
         let container = runtime.container
         let mtpBinding = runtime.mtpBinding
+        let dflash2State = runtime.dflash2State
 
         let promptText = buildPrompt(from: messages)
         let toolSpecs = convertToToolSpecs(tools, includePythonJSON: shouldUseNativePythonToolJSONTemplate(for: tools))
@@ -3345,7 +3497,20 @@ public final class MLXModelService: @unchecked Sendable {
         )
         let dflash2Policy = try dflash2RequestPolicy(speculativeDecoding)
         let requestRequiresDFlash2 = dflash2Policy.requiresRuntime
-        let dflash2WasRequested = dflash2Drafter != nil || speculativeDecoding != nil
+        let dflash2WasRequested = dflash2WasRequested(
+            speculativeDecoding,
+            configuredDrafter: dflash2State?.configuredDrafter)
+        let speculativeCompatibility = speculativeRequestCompatibility(
+            temperature: temperature,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            hasTools: !(tools?.isEmpty ?? true),
+            hasResponseFormat: responseFormat != nil,
+            wantsLogprobs: wantLogprobs,
+            hasStopSequences: !(stop?.isEmpty ?? true))
 
         // --- Concurrent path: bypass container.perform lock, route through BatchScheduler ---
         if let scheduler = self.scheduler {
@@ -3441,7 +3606,9 @@ public final class MLXModelService: @unchecked Sendable {
                 let upstream = effectiveStream
                 let telemetry = AFMMLXSpeculativeTelemetry.fallback(
                     strategy: "dflash2",
-                    reason: dflash2Policy.permitsRuntime ? "concurrency" : "disabled")
+                    reason: dflash2Policy.permitsRuntime
+                        ? "concurrency"
+                        : (dflash2Policy.denialReason ?? "disabled"))
                 effectiveStream = AsyncThrowingStream { continuation in
                     let task = Task {
                         do {
@@ -3483,8 +3650,7 @@ public final class MLXModelService: @unchecked Sendable {
         // The generator's per-token `onToken` callback drives incremental detokenization, yielding
         // an SSE text delta per emitted token; think-tag extraction is done by the controller from
         // those deltas (we return the think tags). Output matches the non-streaming fast path.
-        let specGreedyStream = (temperature ?? 0) <= 0.0 && (tools?.isEmpty ?? true)
-            && responseFormat == nil && !wantLogprobs && (stop?.isEmpty ?? true)
+        let specGreedyStream = speculativeCompatibility.isEligible
         let loadedSupportsDSpark: Bool
         if specGreedyStream && afmDSparkEnabled() {
             loadedSupportsDSpark = await container.perform { context in
@@ -3493,20 +3659,24 @@ public final class MLXModelService: @unchecked Sendable {
         } else {
             loadedSupportsDSpark = false
         }
-        let dsparkStreamEligible = specGreedyStream && loadedSupportsDSpark
+        let dsparkStreamEligible = dflash2Policy.permitsOtherRuntimes
+            && specGreedyStream && loadedSupportsDSpark
         let dflash2StreamEligible = specGreedyStream
             && dflash2Policy.permitsRuntime
-            && DFlash2Runtime.shared.active != nil
+            && dflash2State?.runtime != nil
         let dflash2FallbackTelemetry: AFMMLXSpeculativeTelemetry? = dflash2WasRequested
             ? .fallback(
                 strategy: "dflash2",
                 reason: !dflash2Policy.permitsRuntime
-                    ? "disabled"
-                    : (DFlash2Runtime.shared.active == nil
-                        ? "unavailable" : "incompatible_request"))
+                    ? (dflash2Policy.denialReason ?? "disabled")
+                    : (dflash2State?.runtime == nil
+                        ? (dflash2State?.fallbackReason ?? "unavailable")
+                        : (speculativeCompatibility.denialReason ?? "incompatible_request")))
             : nil
-        let eagle3StreamEligible = specGreedyStream && Eagle3Runtime.shared.active != nil
-        let mtpStreamEligible = specGreedyStream && mtpBinding != nil
+        let eagle3StreamEligible = dflash2Policy.permitsOtherRuntimes
+            && specGreedyStream && Eagle3Runtime.shared.active != nil
+        let mtpStreamEligible = dflash2Policy.permitsOtherRuntimes
+            && specGreedyStream && mtpBinding != nil
         if requestRequiresDFlash2,
            !dflash2StreamEligible {
             throw MLXServiceError.loadFailed(
@@ -3518,7 +3688,8 @@ public final class MLXModelService: @unchecked Sendable {
             // thinking models whose chat template begins reasoning in the prompt, the generated
             // stream never contains the opening tag, so we must synthesize a leading thinkStart chunk
             // (mirrors the scheduler/serial paths) or the controller classifies reasoning as content.
-            let prep: (ids: [Int], openedThink: Bool)? = try await container.perform { context -> (ids: [Int], openedThink: Bool)? in
+            let prep: (ids: [Int], openedThink: Bool, preparationTime: Double)? = try await container.perform { context -> (ids: [Int], openedThink: Bool, preparationTime: Double)? in
+                let prepareStart = Date.timeIntervalSinceReferenceDate
                 let lmInput = try await context.processor.prepare(input: userInput)
                 if self.isMultimodalInput(lmInput) { return nil }
                 if dsparkStreamEligible
@@ -3537,11 +3708,15 @@ public final class MLXModelService: @unchecked Sendable {
                         endTag: self.thinkEndTag
                     )
                 }
-                return (ids, opened)
+                return (
+                    ids,
+                    opened,
+                    Date.timeIntervalSinceReferenceDate - prepareStart)
             }
             if let prep {
                 let promptIds = prep.ids
                 let openedThink = prep.openedThink
+                let preparationTime = prep.preparationTime
                 let useDFlash2 = dflash2StreamEligible
                 let useDSpark = !useDFlash2 && dsparkStreamEligible
                 let useEagle3 = !useDSpark && !useDFlash2 && eagle3StreamEligible
@@ -3558,11 +3733,15 @@ public final class MLXModelService: @unchecked Sendable {
                         let t0 = Date.timeIntervalSinceReferenceDate
                         do {
                             let generation = try await container.perform {
-                                context -> (tokenCount: Int, telemetry: AFMMLXSpeculativeTelemetry?) in
-                                let eos = Set((context.tokenizer.eosTokenId).map { [$0] } ?? [])
+                                context -> (tokenCount: Int, promptTime: Double, generateTime: Double, telemetry: AFMMLXSpeculativeTelemetry?) in
+                                let eos = Self.completeEOSTokenIDs(
+                                    configuration: context.configuration,
+                                    tokenizer: context.tokenizer)
                                 var allTokens: [Int] = []
                                 var prevText = ""
                                 var telemetry: AFMMLXSpeculativeTelemetry?
+                                var speculativePrefillTime = 0.0
+                                let decodeStart = Date.timeIntervalSinceReferenceDate
                                 let emit: (Int) -> Bool = { tok in
                                     if Task.isCancelled { return false }    // client disconnected
                                     if eos.contains(tok) { return false }   // stop; never stream EOS
@@ -3583,21 +3762,22 @@ public final class MLXModelService: @unchecked Sendable {
                                         promptIds: promptIds, maxTokens: maxTok,
                                         eosIds: eos, onToken: emit)
                                 } else if useDFlash2,
-                                          let installed = DFlash2Runtime.shared.active,
+                                          let installed = dflash2State?.runtime,
                                           let target = context.model as? any DFlash2Target {
                                     let generator = try DFlash2Generator(
                                         target: target,
                                         draft: installed.draft,
                                         blockSize: dflash2Policy.requestedBlockSize.map {
-                                            min(installed.blockSize, $0)
-                                        } ?? installed.blockSize)
-                                    let result = generator.generate(
+                                            min(installed.preflight.blockSize, $0)
+                                        } ?? installed.preflight.blockSize)
+                                    let result = try generator.generate(
                                         promptIDs: promptIds,
                                         maxTokens: maxTok,
                                         stopTokenIDs: eos,
                                         shouldStop: { Task.isCancelled },
                                         onToken: emit)
                                     let stats = result.statistics
+                                    speculativePrefillTime = stats.prefillSeconds
                                     telemetry = AFMMLXSpeculativeTelemetry(
                                         strategy: "dflash2",
                                         draftedTokens: stats.draftedTokens,
@@ -3627,7 +3807,13 @@ public final class MLXModelService: @unchecked Sendable {
                                     _ = gen.generate(promptIds: promptIds, maxTokens: maxTok,
                                                      eosIds: eos, onToken: emit)
                                 }
-                                return (allTokens.count, telemetry)
+                                try Task.checkCancellation()
+                                let elapsed = Date.timeIntervalSinceReferenceDate - decodeStart
+                                return (
+                                    allTokens.count,
+                                    preparationTime + speculativePrefillTime,
+                                    max(0, elapsed - speculativePrefillTime),
+                                    telemetry)
                             }
                             let gt = Date.timeIntervalSinceReferenceDate - t0
                             let outCount = generation.tokenCount
@@ -3638,17 +3824,24 @@ public final class MLXModelService: @unchecked Sendable {
                                 print("[\(ts())] [\(engine)] streamed \(outCount) tok in \(String(format: "%.2f", gt))s (\(String(format: "%.1f", tps)) tok/s)")
                             }
                             continuation.yield(StreamChunk(text: "", promptTokens: promptIds.count,
-                                                           completionTokens: outCount, promptTime: 0,
-                                                           generateTime: gt,
+                                                           completionTokens: outCount,
+                                                           promptTime: generation.promptTime,
+                                                           generateTime: generation.generateTime,
                                                            speculativeTelemetry: generation.telemetry
                                                                ?? dflash2FallbackTelemetry))
-                            StatsAggregator.shared.requestSucceeded(reason: "stop")
-                            StatsAggregator.shared.requestCompleted()
+                            self.recordSpeculativeRequestCompletion(
+                                queuedAt: streamQueuedAt,
+                                promptTokens: promptIds.count,
+                                completionTokens: outCount,
+                                promptTime: generation.promptTime,
+                                maxTokens: effectiveMaxTokens)
                             continuation.finish()
                         } catch {
                             // Surface model/tokenizer/generator failures instead of masking them as
                             // an empty success (don't emit a final usage chunk; fail the stream).
-                            StatsAggregator.shared.requestSucceeded(reason: "error")
+                            StatsAggregator.shared.requestSucceeded(
+                                reason: error is CancellationError || Task.isCancelled
+                                    ? "abort" : "error")
                             StatsAggregator.shared.requestCompleted()
                             continuation.finish(throwing: error)
                         }
@@ -4132,6 +4325,7 @@ public final class MLXModelService: @unchecked Sendable {
                             truncateTime: saveTruncateTime,
                             insertTime: saveInsertTime
                         )
+                        try Task.checkCancellation()
                     }
                     // Re-bind metric counters from the scratch box so the
                     // observation below reads them by their original names.
@@ -4187,7 +4381,9 @@ public final class MLXModelService: @unchecked Sendable {
                     self.cleanupTempFiles(mediaTempFiles)
                     // /metrics: error path — still complete the lifecycle so
                     // requests_completed_total tracks requests_started_total.
-                    StatsAggregator.shared.requestSucceeded(reason: "error")
+                    StatsAggregator.shared.requestSucceeded(
+                        reason: error is CancellationError || Task.isCancelled
+                            ? "abort" : "error")
                     StatsAggregator.shared.requestCompleted()
                     continuation.finish(throwing: error)
                 }
@@ -4238,9 +4434,9 @@ public final class MLXModelService: @unchecked Sendable {
                 currentModelID = nil
                 currentModelArchitecture = nil
                 currentMTPBinding = nil
+                currentDFlash2State = nil
             }
         }
-        DFlash2Runtime.shared.clear()
         Eagle3Runtime.shared.clear()
 
         if gpuInitialized {
@@ -6347,11 +6543,21 @@ public final class MLXModelService: @unchecked Sendable {
     private func validatedRuntimeForRequest(
         modelID: String,
         messages: [AFMOpenAICompat.Message]
-    ) throws -> (container: ModelContainer, mtpBinding: MTPGeneratorBinding?) {
+    ) throws -> (
+        container: ModelContainer,
+        mtpBinding: MTPGeneratorBinding?,
+        dflash2State: DFlash2ModelRuntimeState?
+    ) {
         let state = withStateLock {
-            (currentContainer, currentModelArchitecture, currentMTPBinding, currentModelID == modelID)
+            (
+                currentContainer,
+                currentModelArchitecture,
+                currentMTPBinding,
+                currentDFlash2State,
+                currentModelID == modelID
+            )
         }
-        guard let container = state.0, state.3 else { throw MLXServiceError.noModelLoaded }
+        guard let container = state.0, state.4 else { throw MLXServiceError.noModelLoaded }
         guard let architecture = state.1 else {
             throw MLXServiceError.loadFailed("\(modelID): model architecture is unavailable")
         }
@@ -6381,7 +6587,9 @@ public final class MLXModelService: @unchecked Sendable {
             mtpEnabled: mtpEnabled,
             bindingModelID: state.2?.modelID
         ) ? state.2 : nil
-        return (container, binding)
+        let dflash2State = state.3?.ownerID == dflash2RuntimeScopeID
+            && state.3?.modelID == modelID ? state.3 : nil
+        return (container, binding, dflash2State)
     }
 
     private func buildPrompt(from messages: [AFMOpenAICompat.Message]) -> String {
@@ -7643,6 +7851,23 @@ public final class MLXModelService: @unchecked Sendable {
             return true
         }
         return startRange.lowerBound > endRange.lowerBound
+    }
+
+    static func restorePromptOpenedReasoningBoundary(
+        generatedText: String,
+        promptSuffix: String,
+        startTag: String?,
+        endTag: String?
+    ) -> String {
+        guard let startTag,
+              promptSuffixOpensThink(
+                promptSuffix,
+                startTag: startTag,
+                endTag: endTag)
+        else {
+            return generatedText
+        }
+        return startTag + generatedText
     }
 
     /// Adapted from vLLM's tool_chat_template_mistral.jinja — Mistral v7 format.

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -185,6 +185,28 @@ actor MLXModelExecutionCoordinator {
     }
 }
 
+final class MLXModelServiceOperationToken: @unchecked Sendable {
+    private let lock = NSLock()
+    private var finishHandler: (() -> Void)?
+
+    init(finishHandler: @escaping () -> Void) {
+        self.finishHandler = finishHandler
+    }
+
+    func finish() {
+        let handler = lock.withLock { () -> (() -> Void)? in
+            let handler = finishHandler
+            finishHandler = nil
+            return handler
+        }
+        handler?()
+    }
+
+    deinit {
+        finish()
+    }
+}
+
 /// Resolved log probability entry with token strings (ready for API response).
 public struct ResolvedLogprob: Sendable {
     public let token: String
@@ -1800,16 +1822,8 @@ public final class MLXModelService: @unchecked Sendable {
         stage: (@Sendable (MLXLoadStage) -> Void)? = nil,
         countOperation: Bool = true
     ) async throws -> String {
-        var didBeginOperation = false
-        if countOperation {
-            try beginOperation()
-            didBeginOperation = true
-        }
-        defer {
-            if didBeginOperation {
-                endOperation()
-            }
-        }
+        let operation = countOperation ? try beginOperation() : nil
+        defer { operation?.finish() }
 
         let modelID = normalizeModel(rawModel)
         let configuredDFlash2Drafter = dflash2Drafter
@@ -2482,8 +2496,8 @@ public final class MLXModelService: @unchecked Sendable {
         chatTemplateKwargs: [String: AnyCodable]? = nil,
         speculativeDecoding: SpeculativeDecodingOptions? = nil
     ) async throws -> (modelID: String, content: String, promptTokens: Int, completionTokens: Int, tokenLogprobs: [ResolvedLogprob]?, toolCalls: [ResponseToolCall]?, cachedTokens: Int, promptTime: Double, generateTime: Double, stoppedBySequence: Bool, speculativeTelemetry: AFMMLXSpeculativeTelemetry?) {
-        try beginOperation()
-        defer { endOperation() }
+        let operation = try beginOperation()
+        defer { operation.finish() }
 
         // /metrics: serial-path timestamps. The serial generate() has no
         // explicit queue, so queuedAt == startedAt (queue_time observes ~0).
@@ -3561,16 +3575,16 @@ public final class MLXModelService: @unchecked Sendable {
         requestId: String? = nil
     ) async throws -> (modelID: String, stream: AsyncThrowingStream<StreamChunk, Error>, promptTokens: Int, toolCallStartTag: String?, toolCallEndTag: String?, thinkStartTag: String?, thinkEndTag: String?) {
         let reqId = requestId ?? ""
-        try beginOperation()
-        var endOperationOnExit = true
+        let operation = try beginOperation()
+        var operationOwnedByStream = false
         defer {
-            if endOperationOnExit {
-                endOperation()
+            if !operationOwnedByStream {
+                operation.finish()
             }
         }
         // Streaming keeps the operation open until the background Task finishes.
         // The fallback defer above only handles setup failures before the Task
-        // is created; the Task itself owns the normal endOperation() call.
+        // or operation-owning stream is created.
 
         let modelID = try await ensureLoaded(model: model, countOperation: false)
         let runtime = try validatedRuntimeForRequest(modelID: modelID, messages: messages)
@@ -3794,8 +3808,11 @@ public final class MLXModelService: @unchecked Sendable {
             // Derive tool call tags (same logic as serial path, below)
             let toolTags = toolRuntimeConfig.map { ($0.startTag, $0.endTag) }
 
-            endOperationOnExit = false
-            return (modelID, effectiveStream, preparedPromptTokens, toolTags?.0, toolTags?.1, self.thinkStartTag, self.thinkEndTag)
+            let operationStream = Self.ownOperation(
+                effectiveStream,
+                operation: operation)
+            operationOwnedByStream = true
+            return (modelID, operationStream, preparedPromptTokens, toolTags?.0, toolTags?.1, self.thinkStartTag, self.thinkEndTag)
         }
 
         // --- MTP / EAGLE3 speculative streaming fast path (serial, greedy, text-only) ---
@@ -3885,6 +3902,7 @@ public final class MLXModelService: @unchecked Sendable {
                     let task = Task {
                         defer {
                             self.cleanupTempFiles(mediaTempFiles)
+                            operation.finish()
                             Task { await self.modelExecutionCoordinator.releaseSerialGeneration() }
                         }
                         StatsAggregator.shared.requestStarted()
@@ -4006,13 +4024,12 @@ public final class MLXModelService: @unchecked Sendable {
                             StatsAggregator.shared.requestCompleted()
                             continuation.finish(throwing: error)
                         }
-                        self.endOperation()
                     }
                     // Cancel the decode if the SSE client disconnects (frees the serial lock + GPU).
                     continuation.onTermination = { _ in task.cancel() }
                 }
                 streamOwnsTempFiles = true
-                endOperationOnExit = false
+                operationOwnedByStream = true
                 releaseSerialExecutionOnExit = false
                 return (modelID, stream, promptTokens, nil, nil, self.thinkStartTag, self.thinkEndTag)
             }
@@ -4042,7 +4059,7 @@ public final class MLXModelService: @unchecked Sendable {
             streamScratch.userInput = userInput
             let task = Task {
                 defer {
-                    self.endOperation()
+                    operation.finish()
                     Task { await self.modelExecutionCoordinator.releaseSerialGeneration() }
                 }
                 do {
@@ -4568,7 +4585,7 @@ public final class MLXModelService: @unchecked Sendable {
         }
 
         streamOwnsTempFiles = true
-        endOperationOnExit = false
+        operationOwnedByStream = true
         releaseSerialExecutionOnExit = false
         return (modelID, stream, promptTokens, toolTags?.start, toolTags?.end, self.thinkStartTag, self.thinkEndTag)
     }
@@ -5933,12 +5950,37 @@ public final class MLXModelService: @unchecked Sendable {
 
     // MARK: - Private helpers
 
-    private func beginOperation() throws {
+    func beginOperation() throws -> MLXModelServiceOperationToken {
         try withStateLock {
             if isShuttingDown {
                 throw MLXServiceError.serviceShuttingDown
             }
             activeOperations += 1
+        }
+        return MLXModelServiceOperationToken { self.endOperation() }
+    }
+
+    var activeOperationCount: Int {
+        withStateLock { activeOperations }
+    }
+
+    static func ownOperation(
+        _ upstream: AsyncThrowingStream<StreamChunk, Error>,
+        operation: MLXModelServiceOperationToken
+    ) -> AsyncThrowingStream<StreamChunk, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                defer { operation.finish() }
+                do {
+                    for try await chunk in upstream {
+                        continuation.yield(chunk)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
         }
     }
 

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -207,6 +207,40 @@ final class MLXModelServiceOperationToken: @unchecked Sendable {
     }
 }
 
+struct MLXGenerationDiagnosticsMetrics: Equatable, Sendable {
+    var promptTokens = 0
+    var completionTokens = 0
+    var promptTime = 0.0
+    var generateTime = 0.0
+}
+
+/// Owns request-scoped GPU diagnostics and guarantees one cleanup call.
+final class MLXGenerationDiagnosticsScope: @unchecked Sendable {
+    private let lock = NSLock()
+    private var finishHandler: ((MLXGenerationDiagnosticsMetrics) -> Void)?
+
+    init(start: () -> ((MLXGenerationDiagnosticsMetrics) -> Void)) {
+        finishHandler = start()
+    }
+
+    var isFinished: Bool {
+        lock.withLock { finishHandler == nil }
+    }
+
+    func finish(metrics: MLXGenerationDiagnosticsMetrics = .init()) {
+        let handler = lock.withLock {
+            let handler = finishHandler
+            finishHandler = nil
+            return handler
+        }
+        handler?(metrics)
+    }
+
+    deinit {
+        finish()
+    }
+}
+
 /// Resolved log probability entry with token strings (ready for API response).
 public struct ResolvedLogprob: Sendable {
     public let token: String
@@ -755,6 +789,38 @@ public final class MLXModelService: @unchecked Sendable {
             return capped
         }
         return maxTokens
+    }
+
+    private func beginGenerationDiagnostics() -> MLXGenerationDiagnosticsScope {
+        let capturePath = gpuCapturePath
+        return MLXGenerationDiagnosticsScope {
+            let capturing = self.beginGPUCaptureIfNeeded()
+            let tracing = self.beginGPUTraceIfNeeded()
+            let profiling = self.gpuProfile
+            if profiling {
+                self.printGPUProfileHeader()
+            }
+
+            return { [weak self] metrics in
+                guard let self else { return }
+                if capturing || tracing || profiling {
+                    Stream.gpu.synchronize()
+                }
+                if capturing, let capturePath {
+                    self.endGPUCapture(path: capturePath)
+                }
+                if tracing {
+                    self.endGPUTrace()
+                }
+                if profiling {
+                    self.printGPUProfileFooter(
+                        promptTokens: metrics.promptTokens,
+                        completionTokens: metrics.completionTokens,
+                        promptTime: metrics.promptTime,
+                        generateTime: metrics.generateTime)
+                }
+            }
+        }
     }
 
     /// Active xctrace Process (launched by beginGPUTrace, stopped by endGPUTrace).
@@ -2593,11 +2659,10 @@ public final class MLXModelService: @unchecked Sendable {
                         ? (dflash2State?.fallbackReason ?? "unavailable")
                         : (speculativeCompatibility.denialReason ?? "incompatible_request")))
             : nil
-        // GPU capture/trace/profile: start before inference
-        let capturePath = gpuCapturePath
-        let capturing = beginGPUCaptureIfNeeded()
-        let tracing = beginGPUTraceIfNeeded()
-        if gpuProfile { printGPUProfileHeader() }
+        // Scope diagnostics across every generation exit, including speculative fast paths.
+        let diagnostics = beginGenerationDiagnostics()
+        var diagnosticsMetrics = MLXGenerationDiagnosticsMetrics()
+        defer { diagnostics.finish(metrics: diagnosticsMetrics) }
         // ---- Embedded DSpARK fast path (greedy, text-only, no tools/grammar/logprobs) ----
         // DeepSeek V4 checkpoints advertise this capability through metadata and carry the
         // drafter weights themselves; no model-id allowlist or separately loaded package.
@@ -2634,6 +2699,8 @@ public final class MLXModelService: @unchecked Sendable {
                 }
                 return (context.tokenizer.decode(tokens: textIds), promptIds.count, ids.count)
             }) {
+                diagnosticsMetrics.promptTokens = result.1
+                diagnosticsMetrics.completionTokens = result.2
                 serialRequestRecorded = true
                 StatsAggregator.shared.requestSucceeded(reason: "stop")
                 StatsAggregator.shared.requestCompleted()
@@ -2701,6 +2768,11 @@ public final class MLXModelService: @unchecked Sendable {
                     endTag: self.thinkEndTag)
                 return (text, promptIDs.count, ids.count, promptTime, generateTime, telemetry)
             }) {
+                diagnosticsMetrics = MLXGenerationDiagnosticsMetrics(
+                    promptTokens: result.1,
+                    completionTokens: result.2,
+                    promptTime: result.3,
+                    generateTime: result.4)
                 recordSpeculativeRequestCompletion(
                     queuedAt: serialQueuedAt,
                     promptTokens: result.1,
@@ -2744,6 +2816,8 @@ public final class MLXModelService: @unchecked Sendable {
                 }
                 return (text, promptIds.count, outIds.count)
             }) {
+                diagnosticsMetrics.promptTokens = mtpResult.1
+                diagnosticsMetrics.completionTokens = mtpResult.2
                 serialRequestRecorded = true
                 StatsAggregator.shared.requestSucceeded(reason: "stop")
                 StatsAggregator.shared.requestCompleted()
@@ -2786,6 +2860,8 @@ public final class MLXModelService: @unchecked Sendable {
                 }
                 return (text, promptIds.count, outIds.count)
             }) {
+                diagnosticsMetrics.promptTokens = e3Result.1
+                diagnosticsMetrics.completionTokens = e3Result.2
                 serialRequestRecorded = true
                 StatsAggregator.shared.requestSucceeded(reason: "stop")
                 StatsAggregator.shared.requestCompleted()
@@ -2904,20 +2980,6 @@ public final class MLXModelService: @unchecked Sendable {
                 generationTask.cancel()
             }
 
-            if capturing, let path = capturePath {
-                endGPUCapture(path: path)
-            }
-            if tracing {
-                endGPUTrace()
-            }
-            if gpuProfile {
-                let pTok = completionInfo?.promptTokenCount ?? estimateTokens(promptText)
-                let cTok = completionInfo?.generationTokenCount ?? estimateTokens(generated)
-                let pTime = completionInfo?.promptTime ?? 0
-                let gTime = completionInfo?.generateTime ?? 0
-                printGPUProfileFooter(promptTokens: pTok, completionTokens: cTok, promptTime: pTime, generateTime: gTime)
-            }
-
             var finalToolCalls = collectedToolCalls
             var finalContent = generated
             if finalToolCalls.isEmpty && tools != nil && !self.toolCallParserDisabled {
@@ -2945,6 +3007,11 @@ public final class MLXModelService: @unchecked Sendable {
             let completionTokens = completionInfo?.generationTokenCount ?? estimateTokens(generated)
             let promptTime = completionInfo?.promptTime ?? 0
             let generateTime = completionInfo?.generateTime ?? 0
+            diagnosticsMetrics = MLXGenerationDiagnosticsMetrics(
+                promptTokens: promptTokens,
+                completionTokens: completionTokens,
+                promptTime: promptTime,
+                generateTime: generateTime)
             self.logCacheProfile(
                 phase: "restore",
                 mode: "non-streaming",
@@ -3440,21 +3507,6 @@ public final class MLXModelService: @unchecked Sendable {
         let saveTruncateTime = scratch.saveTruncateTime
         let saveInsertTime = scratch.saveInsertTime
 
-        // GPU capture/trace/profile: end after GPU sync completes inside container.perform
-        if capturing, let path = capturePath {
-            endGPUCapture(path: path)
-        }
-        if tracing {
-            endGPUTrace()
-        }
-        if gpuProfile {
-            let pTok = completionInfo?.promptTokenCount ?? estimateTokens(promptText)
-            let cTok = completionInfo?.generationTokenCount ?? estimateTokens(generated)
-            let pTime = completionInfo?.promptTime ?? 0
-            let gTime = completionInfo?.generateTime ?? 0
-            printGPUProfileFooter(promptTokens: pTok, completionTokens: cTok, promptTime: pTime, generateTime: gTime)
-        }
-
         // If the vendor ToolCallProcessor didn't detect tool calls, try fallback parsing.
         // Qwen3-Coder outputs <tool_call><function=name>...</function></tool_call> which
         // the vendor's XMLFunctionParser misses (regex doesn't match multiline content).
@@ -3489,6 +3541,11 @@ public final class MLXModelService: @unchecked Sendable {
             let completionTokens = completionInfo?.generationTokenCount ?? estimateTokens(generated)
             let promptTime = completionInfo?.promptTime ?? 0
             let generateTime = completionInfo?.generateTime ?? 0
+            diagnosticsMetrics = MLXGenerationDiagnosticsMetrics(
+                promptTokens: promptTokens,
+                completionTokens: completionTokens,
+                promptTime: promptTime,
+                generateTime: generateTime)
             self.logCacheProfile(
                 phase: "restore",
                 mode: "non-streaming",
@@ -3898,9 +3955,13 @@ public final class MLXModelService: @unchecked Sendable {
                 let maxTok = effectiveMaxTokens
                 let dbg = debugLogging
                 let thinkStartTag = self.thinkStartTag
+                let diagnostics = beginGenerationDiagnostics()
                 let stream = AsyncThrowingStream<StreamChunk, Error> { continuation in
                     let task = Task {
+                        var diagnosticsMetrics = MLXGenerationDiagnosticsMetrics(
+                            promptTokens: promptIds.count)
                         defer {
+                            diagnostics.finish(metrics: diagnosticsMetrics)
                             self.cleanupTempFiles(mediaTempFiles)
                             operation.finish()
                             Task { await self.modelExecutionCoordinator.releaseSerialGeneration() }
@@ -3996,6 +4057,11 @@ public final class MLXModelService: @unchecked Sendable {
                             }
                             let gt = Date.timeIntervalSinceReferenceDate - t0
                             let outCount = generation.tokenCount
+                            diagnosticsMetrics = MLXGenerationDiagnosticsMetrics(
+                                promptTokens: promptIds.count,
+                                completionTokens: outCount,
+                                promptTime: generation.promptTime,
+                                generateTime: generation.generateTime)
                             if dbg {
                                 let tps = gt > 0 ? Double(outCount) / gt : 0
                                 let engine = useDSpark ? "DSpARK"

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -1744,20 +1744,17 @@ public final class MLXModelService: @unchecked Sendable {
         }
         let requestedBlockSize: Int?
         if let maxDraftTokens = options?.maxDraftTokens {
-            guard maxDraftTokens >= 1 else {
-                throw MLXServiceError.loadFailed(
-                    "speculative_decoding.max_draft_tokens must be at least 1")
-            }
-            guard maxDraftTokens < Int.max else {
-                throw MLXServiceError.loadFailed(
-                    "speculative_decoding.max_draft_tokens must be less than Int.max")
+            if let message = AFMMLXDFlash2DraftTokenPolicy.validationMessage(
+                maxDraftTokens: maxDraftTokens) {
+                throw MLXServiceError.loadFailed(message)
             }
             let loadedDraftLimit = dflash2BlockSize > 1 ? dflash2BlockSize - 1 : 0
             guard maxDraftTokens <= loadedDraftLimit else {
                 throw MLXServiceError.loadFailed(
                     "speculative_decoding.max_draft_tokens exceeds the loaded DFlash2 block limit \(loadedDraftLimit)")
             }
-            requestedBlockSize = maxDraftTokens + 1
+            requestedBlockSize = AFMMLXDFlash2DraftTokenPolicy.blockSize(
+                maxDraftTokens: maxDraftTokens)
         } else {
             requestedBlockSize = nil
         }

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -711,18 +711,50 @@ public final class MLXModelService: @unchecked Sendable {
     private var teardownWorkItem: DispatchWorkItem?
 
     /// Atomically reserve a concurrent slot. Returns true if reserved (or serial mode).
-    public func tryReserveSlot() -> Bool { scheduler?.tryReserve() ?? true }
+    public func tryReserveSlot() -> Bool {
+        withStateLock({ scheduler })?.tryReserve() ?? true
+    }
     /// Wait for a concurrent slot with timeout. Returns true if reserved (or serial mode).
     public func waitForSlot(timeout: TimeInterval = 30) async -> Bool {
-        guard let sched = scheduler else { return true }
+        guard let sched = withStateLock({ scheduler }) else { return true }
         return await sched.waitForSlot(timeout: timeout)
     }
     /// Release a reserved slot (call if request fails before generation starts).
-    public func releaseSlot() { scheduler?.releaseReservation() }
+    public func releaseSlot() {
+        withStateLock({ scheduler })?.releaseReservation()
+    }
+
+    var schedulerAdmissionSnapshot: BatchSchedulerAdmissionState.Snapshot? {
+        withStateLock({ scheduler })?.admissionSnapshot
+    }
+
+    var installedScheduler: BatchScheduler? {
+        withStateLock { scheduler }
+    }
     public init(resolver: MLXCacheResolver) {
         _ = Self.registerModelFactoriesOnce
         self.resolver = resolver
         self.resolver.applyEnvironment()
+    }
+
+    convenience init(
+        resolver: MLXCacheResolver,
+        testingModelID: String,
+        container: ModelContainer,
+        architecture: AFMMLXModelArchitecturePreflight
+    ) {
+        self.init(resolver: resolver)
+        withStateLock {
+            currentModelID = testingModelID
+            currentModelArchitecture = architecture
+            currentContainer = container
+            currentDFlash2State = DFlash2ModelRuntimeState(
+                ownerID: dflash2RuntimeScopeID,
+                modelID: testingModelID,
+                configuredDrafter: nil,
+                runtime: nil,
+                fallbackReason: nil)
+        }
     }
 
     /// Configure MLX GPU settings once, before first model load.
@@ -2405,6 +2437,12 @@ public final class MLXModelService: @unchecked Sendable {
     /// Initialize the concurrent BatchScheduler by extracting model/tokenizer/processor
     /// from the container. Must be called after ensureLoaded() and only when maxConcurrent >= 2.
     public func initScheduler() async throws {
+        try await initScheduler(requiresFixedDecodeCohorts: nil)
+    }
+
+    func initScheduler(
+        requiresFixedDecodeCohorts: Bool?
+    ) async throws {
         guard maxConcurrent >= 2 else { return }
         if forceSerialGeneration {
             print("[\(ts())] Concurrent mode requested but model requires serial generation — running serially (correct output, requests serialized through model lock)")
@@ -2427,7 +2465,8 @@ public final class MLXModelService: @unchecked Sendable {
                 configuration: context.configuration,
                 maxConcurrent: limit,
                 enablePrefixCaching: prefixCaching,
-                cacheProfilePath: self.cacheProfilePath
+                cacheProfilePath: self.cacheProfilePath,
+                requiresFixedDecodeCohorts: requiresFixedDecodeCohorts
             )
         }
         withStateLock { self.scheduler = sched }
@@ -2564,26 +2603,6 @@ public final class MLXModelService: @unchecked Sendable {
     ) async throws -> (modelID: String, content: String, promptTokens: Int, completionTokens: Int, tokenLogprobs: [ResolvedLogprob]?, toolCalls: [ResponseToolCall]?, cachedTokens: Int, promptTime: Double, generateTime: Double, stoppedBySequence: Bool, speculativeTelemetry: AFMMLXSpeculativeTelemetry?) {
         let operation = try beginOperation()
         defer { operation.finish() }
-
-        // /metrics: serial-path timestamps. The serial generate() has no
-        // explicit queue, so queuedAt == startedAt (queue_time observes ~0).
-        // Token counters (prompt_tokens_total / generation_tokens_total) and
-        // the per-request histograms are recorded at the bottom of this
-        // function, after `completionInfo` is available.
-        let serialQueuedAt = Date()
-        StatsAggregator.shared.requestStarted()
-        // Balance the requests_started_total counter on every exit, including
-        // throws between here and the success path below. Without this, an
-        // error during model load or input prep increments started_total
-        // without a matching completed_total, breaking dashboards and alerts.
-        var serialRequestRecorded = false
-        defer {
-            if !serialRequestRecorded {
-                StatsAggregator.shared.requestSucceeded(
-                    reason: Task.isCancelled ? "abort" : "error")
-                StatsAggregator.shared.requestCompleted()
-            }
-        }
         let modelID = try await ensureLoaded(model: model, countOperation: false)
         let runtime = try validatedRuntimeForRequest(modelID: modelID, messages: messages)
         let container = runtime.container
@@ -2592,11 +2611,42 @@ public final class MLXModelService: @unchecked Sendable {
         let executionLease = await modelExecutionCoordinator.acquireGeneration()
         if case .scheduler = executionLease {
             await modelExecutionCoordinator.releaseSchedulerGeneration()
-            throw MLXServiceError.loadFailed(
-                "Direct generation is unavailable while the batch scheduler owns the model")
+            operation.finish()
+            return try await collectStreamingGeneration(
+                model: model,
+                messages: messages,
+                temperature: temperature,
+                maxTokens: maxTokens,
+                topP: topP,
+                repetitionPenalty: repetitionPenalty,
+                topK: topK,
+                minP: minP,
+                presencePenalty: presencePenalty,
+                seed: seed,
+                logprobs: logprobs,
+                topLogprobs: topLogprobs,
+                tools: tools,
+                parallelToolCalls: parallelToolCalls,
+                stop: stop,
+                responseFormat: responseFormat,
+                chatTemplateKwargs: chatTemplateKwargs,
+                speculativeDecoding: speculativeDecoding)
         }
         defer {
             Task { await self.modelExecutionCoordinator.releaseSerialGeneration() }
+        }
+
+        // /metrics: serial-path timestamps. Scheduler-backed direct generation
+        // is collected above and leaves admission and metrics to BatchScheduler.
+        let serialQueuedAt = Date()
+        StatsAggregator.shared.requestStarted()
+        var serialRequestRecorded = false
+        defer {
+            if !serialRequestRecorded {
+                StatsAggregator.shared.requestSucceeded(
+                    reason: Task.isCancelled ? "abort" : "error")
+                StatsAggregator.shared.requestCompleted()
+            }
         }
 
         let promptText = buildPrompt(from: messages)
@@ -3608,6 +3658,90 @@ public final class MLXModelService: @unchecked Sendable {
 
             return (modelID, finalContent, promptTokens, completionTokens, resolvedLogprobs, responseToolCalls, cachedTokenCount, promptTime, generateTime, stoppedBySequence, dflash2FallbackTelemetry)
         }
+
+    private func collectStreamingGeneration(
+        model: String,
+        messages: [AFMOpenAICompat.Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?
+    ) async throws -> (modelID: String, content: String, promptTokens: Int, completionTokens: Int, tokenLogprobs: [ResolvedLogprob]?, toolCalls: [ResponseToolCall]?, cachedTokens: Int, promptTime: Double, generateTime: Double, stoppedBySequence: Bool, speculativeTelemetry: AFMMLXSpeculativeTelemetry?) {
+        let result = try await generateStreaming(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: speculativeDecoding,
+            preserveStructuralTags: false,
+            requestId: nil)
+
+        var content = ""
+        var promptTokens = result.promptTokens
+        var completionTokens = 0
+        var tokenLogprobs: [ResolvedLogprob] = []
+        var toolCalls: [ResponseToolCall]?
+        var cachedTokens = 0
+        var promptTime = 0.0
+        var generateTime = 0.0
+        var stoppedBySequence = false
+        var speculativeTelemetry: AFMMLXSpeculativeTelemetry?
+
+        for try await chunk in result.stream {
+            content += chunk.text
+            if let values = chunk.logprobs {
+                tokenLogprobs.append(contentsOf: values)
+            }
+            if let values = chunk.toolCalls {
+                toolCalls = values
+            }
+            promptTokens = chunk.promptTokens ?? promptTokens
+            completionTokens = chunk.completionTokens ?? completionTokens
+            cachedTokens = chunk.cachedTokens ?? cachedTokens
+            promptTime = chunk.promptTime ?? promptTime
+            generateTime = chunk.generateTime ?? generateTime
+            stoppedBySequence = chunk.stoppedBySequence ?? stoppedBySequence
+            speculativeTelemetry = chunk.speculativeTelemetry ?? speculativeTelemetry
+        }
+
+        return (
+            modelID: result.modelID,
+            content: content,
+            promptTokens: promptTokens,
+            completionTokens: completionTokens,
+            tokenLogprobs: tokenLogprobs.isEmpty ? nil : tokenLogprobs,
+            toolCalls: toolCalls,
+            cachedTokens: cachedTokens,
+            promptTime: promptTime,
+            generateTime: generateTime,
+            stoppedBySequence: stoppedBySequence,
+            speculativeTelemetry: speculativeTelemetry)
+    }
 
     public func generateStreaming(
         model: String,
@@ -4657,8 +4791,10 @@ public final class MLXModelService: @unchecked Sendable {
     }
 
     public func shutdownAndReleaseResources(verbose: Bool = false, timeoutSeconds: TimeInterval = 30) async {
+        let scheduler = beginShutdown()
+
         // Shut down concurrent scheduler first (cancels pending + active)
-        if let scheduler = self.scheduler {
+        if let scheduler {
             if await modelExecutionCoordinator.beginSchedulerRemoval() {
                 await scheduler.shutdown()
                 withStateLock {
@@ -4671,7 +4807,6 @@ public final class MLXModelService: @unchecked Sendable {
         }
 
         let start = Date()
-        withStateLock { isShuttingDown = true }
 
         while Date().timeIntervalSince(start) < timeoutSeconds {
             if withStateLock({ activeOperations == 0 }) {
@@ -4713,6 +4848,13 @@ public final class MLXModelService: @unchecked Sendable {
             } else {
                 print("MLX memory after shutdown - GPU was not initialized")
             }
+        }
+    }
+
+    func beginShutdown() -> BatchScheduler? {
+        withStateLock {
+            isShuttingDown = true
+            return scheduler
         }
     }
 
@@ -6028,6 +6170,10 @@ public final class MLXModelService: @unchecked Sendable {
 
     var activeOperationCount: Int {
         withStateLock { activeOperations }
+    }
+
+    var shuttingDown: Bool {
+        withStateLock { isShuttingDown }
     }
 
     static func ownOperation(

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -1495,28 +1495,30 @@ public final class MLXModelService: @unchecked Sendable {
                 "speculative_decoding.requirement must be preferred or required")
         }
         if let maxDraftTokens = options?.maxDraftTokens, maxDraftTokens < 1 {
-            let required = dflash2Requirement == .required || requirement == "required"
-            return DFlash2RequestPolicy(
-                permitsRuntime: false,
-                requiresRuntime: required,
-                requestedBlockSize: nil,
-                denialReason: "max_draft_tokens must be at least 1")
+            throw MLXServiceError.loadFailed(
+                "speculative_decoding.max_draft_tokens must be at least 1")
         }
 
         let mode = options?.mode?.lowercased()
-        let modePermits = mode == nil || mode == "auto" || mode == "dflash2"
-        let drafterMatches = options?.drafter == nil || options?.drafter == dflash2Drafter
-        let reason: String?
-        if !modePermits {
-            reason = "request selected speculative mode \(mode ?? "off")"
-        } else if !drafterMatches {
-            reason = "per-request drafter does not match the server-loaded drafter"
-        } else {
-            reason = nil
+        guard mode == nil || mode == "auto" || mode == "dflash2"
+                || mode == "off" || mode == "disabled" else {
+            throw MLXServiceError.loadFailed(
+                "speculative_decoding.mode must be auto, dflash2, or off")
         }
+        let explicitlyDisabled = mode == "off" || mode == "disabled"
+        if explicitlyDisabled, requirement == "required" {
+            throw MLXServiceError.loadFailed(
+                "speculative_decoding cannot be both off and required")
+        }
+        if let drafter = options?.drafter, drafter != dflash2Drafter {
+            throw MLXServiceError.loadFailed(
+                "per-request DFlash2 drafter switching is not supported; restart with drafter \(drafter)")
+        }
+        let reason = explicitlyDisabled ? "request disabled speculative decoding" : nil
         return DFlash2RequestPolicy(
             permitsRuntime: reason == nil,
-            requiresRuntime: dflash2Requirement == .required || requirement == "required",
+            requiresRuntime: !explicitlyDisabled
+                && (dflash2Requirement == .required || requirement == "required"),
             requestedBlockSize: options?.maxDraftTokens.map { $0 + 1 },
             denialReason: reason)
     }
@@ -1847,6 +1849,7 @@ public final class MLXModelService: @unchecked Sendable {
                         throw MLXServiceError.loadFailed("Target config.json is not an object")
                     }
                     try draftConfig.validateTarget(metadata: targetMetadata)
+                    try draftConfig.validateWeights(in: draftDirectory)
                     let block = try draftConfig.effectiveBlockSize(requested: dflash2BlockSize)
                     let draft = try DFlash2DraftModel.load(directory: draftDirectory.path)
                     let targetCompatible = try await loaded.perform { context in
@@ -2275,6 +2278,24 @@ public final class MLXModelService: @unchecked Sendable {
         // awaited before these fields are read, so access stays single-sequence.
         let scratch = NonStreamingScratch()
         scratch.userInput = userInput
+        let dflash2Policy = try dflash2RequestPolicy(speculativeDecoding)
+        let requestRequiresDFlash2 = dflash2Policy.requiresRuntime
+        let dflash2Active = dflash2Policy.permitsRuntime
+            ? DFlash2Runtime.shared.active : nil
+        let dflash2Eligible = dflash2Active != nil
+            && (temperature ?? 0) <= 0.0
+            && (tools?.isEmpty ?? true)
+            && responseFormat == nil
+            && !wantLogprobs
+            && (stop?.isEmpty ?? true)
+        if requestRequiresDFlash2, dflash2Active == nil {
+            throw MLXServiceError.loadFailed(
+                "DFlash2 is required but unavailable: \(dflash2Policy.denialReason ?? "no compatible runtime is active")")
+        }
+        if requestRequiresDFlash2, !dflash2Eligible {
+            throw MLXServiceError.loadFailed(
+                "DFlash2 is required but this request uses sampling, tools, grammar, logprobs, or stop sequences")
+        }
         // GPU capture/trace/profile: start before inference
         let capturePath = gpuCapturePath
         let capturing = beginGPUCaptureIfNeeded()
@@ -2283,7 +2304,8 @@ public final class MLXModelService: @unchecked Sendable {
         // ---- Embedded DSpARK fast path (greedy, text-only, no tools/grammar/logprobs) ----
         // DeepSeek V4 checkpoints advertise this capability through metadata and carry the
         // drafter weights themselves; no model-id allowlist or separately loaded package.
-        let dsparkEligible = afmDSparkEnabled()
+        let dsparkEligible = dflash2Active == nil
+            && afmDSparkEnabled()
             && (temperature ?? 0) <= 0.0
             && (tools?.isEmpty ?? true)
             && responseFormat == nil
@@ -2324,24 +2346,6 @@ public final class MLXModelService: @unchecked Sendable {
 
 
         // ---- DFlash2 one-pass parallel draft/verify path ----
-        let dflash2Policy = try dflash2RequestPolicy(speculativeDecoding)
-        let requestRequiresDFlash2 = dflash2Policy.requiresRuntime
-        let dflash2Active = dflash2Policy.permitsRuntime
-            ? DFlash2Runtime.shared.active : nil
-        let dflash2Eligible = dflash2Active != nil
-            && (temperature ?? 0) <= 0.0
-            && (tools?.isEmpty ?? true)
-            && responseFormat == nil
-            && !wantLogprobs
-            && (stop?.isEmpty ?? true)
-        if requestRequiresDFlash2, dflash2Active == nil {
-            throw MLXServiceError.loadFailed(
-                "DFlash2 is required but unavailable: \(dflash2Policy.denialReason ?? "no compatible runtime is active")")
-        }
-        if requestRequiresDFlash2, dflash2Active != nil, !dflash2Eligible {
-            throw MLXServiceError.loadFailed(
-                "DFlash2 is required but this request uses sampling, tools, grammar, logprobs, or stop sequences")
-        }
         if dflash2Eligible, let installed = dflash2Active {
             if let result = try await container.perform({ context -> (String, Int, Int)? in
                 guard let target = context.model as? any DFlash2Target else { return nil }
@@ -3314,9 +3318,15 @@ public final class MLXModelService: @unchecked Sendable {
             topLogprobsCount: wantLogprobs ? min(max(topLogprobs ?? 0, 0), 20) : 0,
             prefillStepSize: self.prefillStepSize
         )
+        let dflash2Policy = try dflash2RequestPolicy(speculativeDecoding)
+        let requestRequiresDFlash2 = dflash2Policy.requiresRuntime
 
         // --- Concurrent path: bypass container.perform lock, route through BatchScheduler ---
         if let scheduler = self.scheduler {
+            if requestRequiresDFlash2 {
+                throw MLXServiceError.loadFailed(
+                    "DFlash2 is required but concurrent and batch execution use autoregressive decoding")
+            }
             let pipelineStart = debugLogging ? Date() : Date.distantPast
 
             // Use scheduler's tokenizer directly — no container lock needed.
@@ -3437,8 +3447,6 @@ public final class MLXModelService: @unchecked Sendable {
             loadedSupportsDSpark = false
         }
         let dsparkStreamEligible = specGreedyStream && loadedSupportsDSpark
-        let dflash2Policy = try dflash2RequestPolicy(speculativeDecoding)
-        let requestRequiresDFlash2 = dflash2Policy.requiresRuntime
         let dflash2StreamEligible = specGreedyStream
             && dflash2Policy.permitsRuntime
             && DFlash2Runtime.shared.active != nil
@@ -3479,8 +3487,8 @@ public final class MLXModelService: @unchecked Sendable {
             if let prep {
                 let promptIds = prep.ids
                 let openedThink = prep.openedThink
-                let useDSpark = dsparkStreamEligible
-                let useDFlash2 = !useDSpark && dflash2StreamEligible
+                let useDFlash2 = dflash2StreamEligible
+                let useDSpark = !useDFlash2 && dsparkStreamEligible
                 let useEagle3 = !useDSpark && !useDFlash2 && eagle3StreamEligible
                 let maxTok = effectiveMaxTokens
                 let dbg = debugLogging

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -2444,6 +2444,7 @@ public final class MLXModelService: @unchecked Sendable {
         requiresFixedDecodeCohorts: Bool?
     ) async throws {
         guard maxConcurrent >= 2 else { return }
+        try validateGPUCaptureCompatibility(maxConcurrent: maxConcurrent)
         if forceSerialGeneration {
             print("[\(ts())] Concurrent mode requested but model requires serial generation — running serially (correct output, requests serialized through model lock)")
             return
@@ -2478,6 +2479,7 @@ public final class MLXModelService: @unchecked Sendable {
     /// Waits for active serial generations to leave the model before publishing
     /// the scheduler, and blocks new serial generations while promotion runs.
     public func ensureBatchMode(concurrency: Int) async throws {
+        try validateGPUCaptureCompatibility(maxConcurrent: max(concurrency, 8))
         // Models that require serial generation never get a scheduler. Still increment the
         // batch reference so the caller's matching releaseBatchReference() stays balanced;
         // per-request generateStreaming() routes to the serial path when scheduler == nil.
@@ -3828,7 +3830,10 @@ public final class MLXModelService: @unchecked Sendable {
         }
         let promptTokens = estimateTokens(promptText)
         let wantLogprobs = logprobs == true
-        let effectiveMaxTokens = capMaxTokensForCapture(maxTokens ?? 2000)
+        let requestedMaxTokens = maxTokens ?? 2000
+        let effectiveMaxTokens = hasSerialExecutionLease
+            ? capMaxTokensForCapture(requestedMaxTokens)
+            : requestedMaxTokens
         // /metrics: streaming-path queue timestamp. The actual
         // requestStarted/observe calls happen ONLY in the serial-path
         // task below (the batch path's stats are owned by BatchScheduler).
@@ -3870,6 +3875,7 @@ public final class MLXModelService: @unchecked Sendable {
 
         // --- Concurrent path: bypass container.perform lock, route through BatchScheduler ---
         if case .scheduler = executionLease {
+            try validateGPUCaptureCompatibility(maxConcurrent: maxConcurrent)
             guard let scheduler = withStateLock({ self.scheduler }) else {
                 throw MLXServiceError.noModelLoaded
             }
@@ -4855,6 +4861,17 @@ public final class MLXModelService: @unchecked Sendable {
         withStateLock {
             isShuttingDown = true
             return scheduler
+        }
+    }
+
+    private func validateGPUCaptureCompatibility(
+        maxConcurrent: Int
+    ) throws {
+        if let incompatibility = AFMMLXGPUCapturePolicy.incompatibility(
+            maxConcurrent: maxConcurrent,
+            capturePath: gpuCapturePath
+        ) {
+            throw MLXServiceError.loadFailed(incompatibility)
         }
     }
 

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -76,6 +76,93 @@ struct SpeculativeRequestCompatibility: Equatable {
     var isEligible: Bool { denialReason == nil }
 }
 
+actor MLXModelExecutionCoordinator {
+    enum Lease: Sendable {
+        case serial
+        case scheduler
+    }
+
+    struct Snapshot: Equatable, Sendable {
+        let activeSerialGenerations: Int
+        let promotionInProgress: Bool
+        let schedulerInstalled: Bool
+    }
+
+    private var activeSerialGenerations = 0
+    private var promotionInProgress = false
+    private var schedulerInstalled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquireGeneration() async -> Lease {
+        while promotionInProgress {
+            await waitForChange()
+        }
+        guard !schedulerInstalled else { return .scheduler }
+        activeSerialGenerations += 1
+        return .serial
+    }
+
+    func releaseSerialGeneration() {
+        precondition(activeSerialGenerations > 0)
+        activeSerialGenerations -= 1
+        signalChange()
+    }
+
+    /// Returns true only to the caller that owns scheduler construction.
+    func beginPromotion() async -> Bool {
+        while promotionInProgress {
+            await waitForChange()
+        }
+        guard !schedulerInstalled else { return false }
+
+        promotionInProgress = true
+        while activeSerialGenerations > 0 {
+            await waitForChange()
+        }
+        return true
+    }
+
+    func finishPromotion(schedulerInstalled: Bool) {
+        self.schedulerInstalled = schedulerInstalled
+        promotionInProgress = false
+        signalChange()
+    }
+
+    func beginSchedulerRemoval() async {
+        while promotionInProgress {
+            await waitForChange()
+        }
+        promotionInProgress = true
+    }
+
+    func finishSchedulerRemoval() {
+        schedulerInstalled = false
+        promotionInProgress = false
+        signalChange()
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(
+            activeSerialGenerations: activeSerialGenerations,
+            promotionInProgress: promotionInProgress,
+            schedulerInstalled: schedulerInstalled)
+    }
+
+    private func waitForChange() async {
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    private func signalChange() {
+        let pending = waiters
+        waiters.removeAll(keepingCapacity: true)
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+}
+
 /// Resolved log probability entry with token strings (ready for API response).
 public struct ResolvedLogprob: Sendable {
     public let token: String
@@ -538,8 +625,9 @@ public final class MLXModelService: @unchecked Sendable {
     /// Number of in-flight batch operations (for auto-teardown).
     private let _activeBatchCount = OSAllocatedUnfairLock(initialState: 0)
 
-    /// Whether a promotion is currently in progress (prevents races).
-    private var promotionInProgress = false
+    /// Prevents the scheduler and serial `container.perform` generations from
+    /// owning the same model at the same time during dynamic promotion.
+    private let modelExecutionCoordinator = MLXModelExecutionCoordinator()
 
     /// Scheduled teardown work item (cancelled if new batch arrives).
     private var teardownWorkItem: DispatchWorkItem?
@@ -1633,12 +1721,16 @@ public final class MLXModelService: @unchecked Sendable {
     static func completeEOSTokenIDs(
         configuredTokenIDs: Set<Int>,
         tokenizerTokenID: Int?,
+        unknownTokenID: Int?,
         extraTokens: [String],
         tokenID: (String) -> Int?
     ) -> Set<Int> {
         var result = configuredTokenIDs
         if let tokenizerTokenID {
             result.insert(tokenizerTokenID)
+        }
+        if let unknownTokenID {
+            result.insert(unknownTokenID)
         }
         for token in extraTokens {
             if let id = tokenID(token) {
@@ -1655,6 +1747,7 @@ public final class MLXModelService: @unchecked Sendable {
         completeEOSTokenIDs(
             configuredTokenIDs: configuration.eosTokenIds,
             tokenizerTokenID: tokenizer.eosTokenId,
+            unknownTokenID: tokenizer.unknownTokenId,
             extraTokens: Array(configuration.extraEOSTokens),
             tokenID: tokenizer.convertTokenToId)
     }
@@ -2216,7 +2309,10 @@ public final class MLXModelService: @unchecked Sendable {
             return
         }
         startedInBatchMode = true
+        let ownsPromotion = await modelExecutionCoordinator.beginPromotion()
+        guard ownsPromotion else { return }
         guard let container = withStateLock({ currentContainer }) else {
+            await modelExecutionCoordinator.finishPromotion(schedulerInstalled: false)
             throw MLXServiceError.noModelLoaded
         }
         let prefixCaching = self.enablePrefixCaching
@@ -2232,12 +2328,14 @@ public final class MLXModelService: @unchecked Sendable {
                 cacheProfilePath: self.cacheProfilePath
             )
         }
-        self.scheduler = sched
+        withStateLock { self.scheduler = sched }
+        await modelExecutionCoordinator.finishPromotion(schedulerInstalled: true)
         print("[\(ts())] Concurrent mode: up to \(limit) parallel generations\(prefixCaching ? " (prefix caching enabled)" : "")")
     }
 
     /// Auto-promote from serial to batch mode for batch requests.
-    /// Thread-safe: uses stateLock + promotionInProgress to prevent races.
+    /// Waits for active serial generations to leave the model before publishing
+    /// the scheduler, and blocks new serial generations while promotion runs.
     public func ensureBatchMode(concurrency: Int) async throws {
         // Models that require serial generation never get a scheduler. Still increment the
         // batch reference so the caller's matching releaseBatchReference() stays balanced;
@@ -2246,33 +2344,13 @@ public final class MLXModelService: @unchecked Sendable {
             _activeBatchCount.withLock { $0 += 1 }
             return
         }
-        // Fast path: scheduler already exists
-        if withStateLock({ scheduler != nil }) {
+        teardownWorkItem?.cancel()
+        teardownWorkItem = nil
+        let ownsPromotion = await modelExecutionCoordinator.beginPromotion()
+        if !ownsPromotion {
             _activeBatchCount.withLock { $0 += 1 }
-            // Cancel any pending teardown
             teardownWorkItem?.cancel()
             teardownWorkItem = nil
-            return
-        }
-
-        // Check if another caller is already promoting
-        let shouldPromote = withStateLock { () -> Bool in
-            if scheduler != nil { return false }
-            if promotionInProgress { return false }
-            promotionInProgress = true
-            return true
-        }
-
-        if !shouldPromote {
-            // Wait for the other caller to finish promotion
-            while withStateLock({ promotionInProgress && scheduler == nil }) {
-                try await Task.sleep(nanoseconds: 10_000_000) // 10ms
-            }
-            // Verify scheduler was actually installed — promotion may have failed
-            guard withStateLock({ scheduler != nil }) else {
-                throw MLXServiceError.noModelLoaded
-            }
-            _activeBatchCount.withLock { $0 += 1 }
             return
         }
 
@@ -2281,7 +2359,7 @@ public final class MLXModelService: @unchecked Sendable {
         self.maxConcurrent = limit
 
         guard let container = withStateLock({ currentContainer }) else {
-            withStateLock { promotionInProgress = false }
+            await modelExecutionCoordinator.finishPromotion(schedulerInstalled: false)
             throw MLXServiceError.noModelLoaded
         }
 
@@ -2299,8 +2377,8 @@ public final class MLXModelService: @unchecked Sendable {
 
         withStateLock {
             self.scheduler = sched
-            self.promotionInProgress = false
         }
+        await modelExecutionCoordinator.finishPromotion(schedulerInstalled: true)
         _activeBatchCount.withLock { $0 += 1 }
         print("[\(ts())] Auto-promoted to batch mode: \(limit) concurrent slots (prefix caching enabled)")
     }
@@ -2337,10 +2415,12 @@ public final class MLXModelService: @unchecked Sendable {
             guard sched.activeSlotCount == 0 else { return }
         }
 
+        await modelExecutionCoordinator.beginSchedulerRemoval()
         withStateLock {
             self.scheduler = nil
             self.maxConcurrent = 0
         }
+        await modelExecutionCoordinator.finishSchedulerRemoval()
         print("[\(ts())] Auto-teardown: returned to serial mode")
     }
 
@@ -2397,6 +2477,14 @@ public final class MLXModelService: @unchecked Sendable {
         let container = runtime.container
         let mtpBinding = runtime.mtpBinding
         let dflash2State = runtime.dflash2State
+        let executionLease = await modelExecutionCoordinator.acquireGeneration()
+        guard case .serial = executionLease else {
+            throw MLXServiceError.loadFailed(
+                "Direct generation is unavailable while the batch scheduler owns the model")
+        }
+        defer {
+            Task { await self.modelExecutionCoordinator.releaseSerialGeneration() }
+        }
 
         let promptText = buildPrompt(from: messages)
         let toolSpecs = convertToToolSpecs(tools, includePythonJSON: shouldUseNativePythonToolJSONTemplate(for: tools))
@@ -3456,6 +3544,20 @@ public final class MLXModelService: @unchecked Sendable {
         let container = runtime.container
         let mtpBinding = runtime.mtpBinding
         let dflash2State = runtime.dflash2State
+        let executionLease = await modelExecutionCoordinator.acquireGeneration()
+        let hasSerialExecutionLease: Bool
+        switch executionLease {
+        case .serial:
+            hasSerialExecutionLease = true
+        case .scheduler:
+            hasSerialExecutionLease = false
+        }
+        var releaseSerialExecutionOnExit = hasSerialExecutionLease
+        defer {
+            if releaseSerialExecutionOnExit {
+                Task { await self.modelExecutionCoordinator.releaseSerialGeneration() }
+            }
+        }
 
         let promptText = buildPrompt(from: messages)
         let toolSpecs = convertToToolSpecs(tools, includePythonJSON: shouldUseNativePythonToolJSONTemplate(for: tools))
@@ -3525,7 +3627,10 @@ public final class MLXModelService: @unchecked Sendable {
             hasStopSequences: !(stop?.isEmpty ?? true))
 
         // --- Concurrent path: bypass container.perform lock, route through BatchScheduler ---
-        if let scheduler = self.scheduler {
+        if case .scheduler = executionLease {
+            guard let scheduler = withStateLock({ self.scheduler }) else {
+                throw MLXServiceError.noModelLoaded
+            }
             if requestRequiresDFlash2 {
                 throw MLXServiceError.loadFailed(
                     "DFlash2 is required but concurrent and batch execution use autoregressive decoding")
@@ -3741,7 +3846,10 @@ public final class MLXModelService: @unchecked Sendable {
                 let thinkStartTag = self.thinkStartTag
                 let stream = AsyncThrowingStream<StreamChunk, Error> { continuation in
                     let task = Task {
-                        defer { self.cleanupTempFiles(mediaTempFiles) }
+                        defer {
+                            self.cleanupTempFiles(mediaTempFiles)
+                            Task { await self.modelExecutionCoordinator.releaseSerialGeneration() }
+                        }
                         StatsAggregator.shared.requestStarted()
                         if openedThink, let thinkStartTag {
                             continuation.yield(StreamChunk(text: thinkStartTag))
@@ -3868,6 +3976,7 @@ public final class MLXModelService: @unchecked Sendable {
                 }
                 streamOwnsTempFiles = true
                 endOperationOnExit = false
+                releaseSerialExecutionOnExit = false
                 return (modelID, stream, promptTokens, nil, nil, self.thinkStartTag, self.thinkEndTag)
             }
             if requestRequiresDFlash2 {
@@ -3895,7 +4004,10 @@ public final class MLXModelService: @unchecked Sendable {
             let streamScratch = StreamingScratch()
             streamScratch.userInput = userInput
             let task = Task {
-                defer { self.endOperation() }
+                defer {
+                    self.endOperation()
+                    Task { await self.modelExecutionCoordinator.releaseSerialGeneration() }
+                }
                 do {
                     try await container.perform { context in
                         // Local generation params (the outer `params` is a captured
@@ -4420,14 +4532,17 @@ public final class MLXModelService: @unchecked Sendable {
 
         streamOwnsTempFiles = true
         endOperationOnExit = false
+        releaseSerialExecutionOnExit = false
         return (modelID, stream, promptTokens, toolTags?.start, toolTags?.end, self.thinkStartTag, self.thinkEndTag)
     }
 
     public func shutdownAndReleaseResources(verbose: Bool = false, timeoutSeconds: TimeInterval = 30) async {
         // Shut down concurrent scheduler first (cancels pending + active)
         if let scheduler = self.scheduler {
+            await modelExecutionCoordinator.beginSchedulerRemoval()
             await scheduler.shutdown()
-            self.scheduler = nil
+            withStateLock { self.scheduler = nil }
+            await modelExecutionCoordinator.finishSchedulerRemoval()
         }
 
         let start = Date()

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -2602,7 +2602,48 @@ public final class MLXModelService: @unchecked Sendable {
         responseFormat: ResponseFormat? = nil,
         chatTemplateKwargs: [String: AnyCodable]? = nil,
         speculativeDecoding: SpeculativeDecodingOptions? = nil
-    ) async throws -> (modelID: String, content: String, promptTokens: Int, completionTokens: Int, tokenLogprobs: [ResolvedLogprob]?, toolCalls: [ResponseToolCall]?, cachedTokens: Int, promptTime: Double, generateTime: Double, stoppedBySequence: Bool, speculativeTelemetry: AFMMLXSpeculativeTelemetry?) {
+    ) async throws -> AFMMLXChatGenerationResult {
+        try await generateWithTelemetry(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: speculativeDecoding).result
+    }
+
+    public func generateWithTelemetry(
+        model: String,
+        messages: [AFMOpenAICompat.Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int? = nil,
+        minP: Double? = nil,
+        presencePenalty: Double? = nil,
+        seed: Int? = nil,
+        logprobs: Bool? = nil,
+        topLogprobs: Int? = nil,
+        tools: [RequestTool]? = nil,
+        parallelToolCalls: Bool? = nil,
+        stop: [String]? = nil,
+        responseFormat: ResponseFormat? = nil,
+        chatTemplateKwargs: [String: AnyCodable]? = nil,
+        speculativeDecoding: SpeculativeDecodingOptions? = nil
+    ) async throws -> AFMMLXChatGenerationResultWithTelemetry {
         let operation = try beginOperation()
         defer { operation.finish() }
         let modelID = try await ensureLoaded(model: model, countOperation: false)
@@ -2756,7 +2797,18 @@ public final class MLXModelService: @unchecked Sendable {
                 serialRequestRecorded = true
                 StatsAggregator.shared.requestSucceeded(reason: "stop")
                 StatsAggregator.shared.requestCompleted()
-                return (modelID, result.0, result.1, result.2, nil, nil, 0, 0, 0, false, dflash2FallbackTelemetry)
+                return AFMMLXChatGenerationResultWithTelemetry(
+                    modelID: modelID,
+                    content: result.0,
+                    promptTokens: result.1,
+                    completionTokens: result.2,
+                    tokenLogprobs: nil,
+                    toolCalls: nil,
+                    cachedTokens: 0,
+                    promptTime: 0,
+                    generateTime: 0,
+                    stoppedBySequence: false,
+                    speculativeTelemetry: dflash2FallbackTelemetry)
             }
         }
 
@@ -2832,7 +2884,18 @@ public final class MLXModelService: @unchecked Sendable {
                     promptTime: result.3,
                     maxTokens: effectiveMaxTokens)
                 serialRequestRecorded = true
-                return (modelID, result.0, result.1, result.2, nil, nil, 0, result.3, result.4, false, result.5)
+                return AFMMLXChatGenerationResultWithTelemetry(
+                    modelID: modelID,
+                    content: result.0,
+                    promptTokens: result.1,
+                    completionTokens: result.2,
+                    tokenLogprobs: nil,
+                    toolCalls: nil,
+                    cachedTokens: 0,
+                    promptTime: result.3,
+                    generateTime: result.4,
+                    stoppedBySequence: false,
+                    speculativeTelemetry: result.5)
             }
             if requestRequiresDFlash2 {
                 throw MLXServiceError.loadFailed(
@@ -2873,7 +2936,18 @@ public final class MLXModelService: @unchecked Sendable {
                 serialRequestRecorded = true
                 StatsAggregator.shared.requestSucceeded(reason: "stop")
                 StatsAggregator.shared.requestCompleted()
-                return (modelID, mtpResult.0, mtpResult.1, mtpResult.2, nil, nil, 0, 0, 0, false, dflash2FallbackTelemetry)
+                return AFMMLXChatGenerationResultWithTelemetry(
+                    modelID: modelID,
+                    content: mtpResult.0,
+                    promptTokens: mtpResult.1,
+                    completionTokens: mtpResult.2,
+                    tokenLogprobs: nil,
+                    toolCalls: nil,
+                    cachedTokens: 0,
+                    promptTime: 0,
+                    generateTime: 0,
+                    stoppedBySequence: false,
+                    speculativeTelemetry: dflash2FallbackTelemetry)
             }
         }
 
@@ -2917,7 +2991,18 @@ public final class MLXModelService: @unchecked Sendable {
                 serialRequestRecorded = true
                 StatsAggregator.shared.requestSucceeded(reason: "stop")
                 StatsAggregator.shared.requestCompleted()
-                return (modelID, e3Result.0, e3Result.1, e3Result.2, nil, nil, 0, 0, 0, false, dflash2FallbackTelemetry)
+                return AFMMLXChatGenerationResultWithTelemetry(
+                    modelID: modelID,
+                    content: e3Result.0,
+                    promptTokens: e3Result.1,
+                    completionTokens: e3Result.2,
+                    tokenLogprobs: nil,
+                    toolCalls: nil,
+                    cachedTokens: 0,
+                    promptTime: 0,
+                    generateTime: 0,
+                    stoppedBySequence: false,
+                    speculativeTelemetry: dflash2FallbackTelemetry)
             }
         }
 
@@ -3113,7 +3198,18 @@ public final class MLXModelService: @unchecked Sendable {
             StatsAggregator.shared.requestCompleted()
             serialRequestRecorded = true
 
-            return (modelID, finalContent, promptTokens, completionTokens, nil, responseToolCalls, 0, promptTime, generateTime, stoppedBySequence, dflash2FallbackTelemetry)
+            return AFMMLXChatGenerationResultWithTelemetry(
+                modelID: modelID,
+                content: finalContent,
+                promptTokens: promptTokens,
+                completionTokens: completionTokens,
+                tokenLogprobs: nil,
+                toolCalls: responseToolCalls,
+                cachedTokens: 0,
+                promptTime: promptTime,
+                generateTime: generateTime,
+                stoppedBySequence: stoppedBySequence,
+                speculativeTelemetry: dflash2FallbackTelemetry)
         }
 
         let generated: String = try await container.perform { context in
@@ -3658,7 +3754,18 @@ public final class MLXModelService: @unchecked Sendable {
             StatsAggregator.shared.requestCompleted()
             serialRequestRecorded = true
 
-            return (modelID, finalContent, promptTokens, completionTokens, resolvedLogprobs, responseToolCalls, cachedTokenCount, promptTime, generateTime, stoppedBySequence, dflash2FallbackTelemetry)
+            return AFMMLXChatGenerationResultWithTelemetry(
+                modelID: modelID,
+                content: finalContent,
+                promptTokens: promptTokens,
+                completionTokens: completionTokens,
+                tokenLogprobs: resolvedLogprobs,
+                toolCalls: responseToolCalls,
+                cachedTokens: cachedTokenCount,
+                promptTime: promptTime,
+                generateTime: generateTime,
+                stoppedBySequence: stoppedBySequence,
+                speculativeTelemetry: dflash2FallbackTelemetry)
         }
 
     private func collectStreamingGeneration(
@@ -3680,7 +3787,7 @@ public final class MLXModelService: @unchecked Sendable {
         responseFormat: ResponseFormat?,
         chatTemplateKwargs: [String: AnyCodable]?,
         speculativeDecoding: SpeculativeDecodingOptions?
-    ) async throws -> (modelID: String, content: String, promptTokens: Int, completionTokens: Int, tokenLogprobs: [ResolvedLogprob]?, toolCalls: [ResponseToolCall]?, cachedTokens: Int, promptTime: Double, generateTime: Double, stoppedBySequence: Bool, speculativeTelemetry: AFMMLXSpeculativeTelemetry?) {
+    ) async throws -> AFMMLXChatGenerationResultWithTelemetry {
         let result = try await generateStreaming(
             model: model,
             messages: messages,
@@ -3731,7 +3838,7 @@ public final class MLXModelService: @unchecked Sendable {
             speculativeTelemetry = chunk.speculativeTelemetry ?? speculativeTelemetry
         }
 
-        return (
+        return AFMMLXChatGenerationResultWithTelemetry(
             modelID: result.modelID,
             content: content,
             promptTokens: promptTokens,

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -68,7 +68,7 @@ final class DFlash2Runtime: @unchecked Sendable {
     }
 }
 
-private struct DFlash2RequestPolicy {
+struct DFlash2RequestPolicy {
     let permitsRuntime: Bool
     let requiresRuntime: Bool
     let requestedBlockSize: Int?
@@ -1486,7 +1486,7 @@ public final class MLXModelService: @unchecked Sendable {
         return downloaded
     }
 
-    private func dflash2RequestPolicy(
+    func dflash2RequestPolicy(
         _ options: SpeculativeDecodingOptions?
     ) throws -> DFlash2RequestPolicy {
         let requirement = options?.requirement?.lowercased()

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -93,6 +93,7 @@ actor MLXModelExecutionCoordinator {
     private var activeSchedulerUsers = 0
     private var promotionInProgress = false
     private var schedulerInstalled = false
+    private var shutdownRequested = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
 
     func acquireGeneration() async -> Lease {
@@ -124,6 +125,7 @@ actor MLXModelExecutionCoordinator {
         while promotionInProgress {
             await waitForChange()
         }
+        guard !shutdownRequested else { return false }
         guard !schedulerInstalled else { return false }
 
         promotionInProgress = true
@@ -137,6 +139,14 @@ actor MLXModelExecutionCoordinator {
         self.schedulerInstalled = schedulerInstalled
         promotionInProgress = false
         signalChange()
+    }
+
+    func beginShutdown() async {
+        shutdownRequested = true
+        signalChange()
+        while promotionInProgress {
+            await waitForChange()
+        }
     }
 
     func beginSchedulerRemoval() async -> Bool {
@@ -706,6 +716,9 @@ public final class MLXModelService: @unchecked Sendable {
     /// Prevents the scheduler and serial `container.perform` generations from
     /// owning the same model at the same time during dynamic promotion.
     private let modelExecutionCoordinator = MLXModelExecutionCoordinator()
+
+    /// Deterministic test barrier between promotion ownership and construction.
+    var schedulerPromotionBarrier: (@Sendable () async -> Void)?
 
     /// Scheduled teardown work item (cancelled if new batch arrives).
     private var teardownWorkItem: DispatchWorkItem?
@@ -1729,14 +1742,24 @@ public final class MLXModelService: @unchecked Sendable {
             throw MLXServiceError.loadFailed(
                 "speculative_decoding.requirement must be preferred or required")
         }
-        if let maxDraftTokens = options?.maxDraftTokens, maxDraftTokens < 1 {
-            throw MLXServiceError.loadFailed(
-                "speculative_decoding.max_draft_tokens must be at least 1")
-        }
-        if let maxDraftTokens = options?.maxDraftTokens,
-           maxDraftTokens + 1 > dflash2BlockSize {
-            throw MLXServiceError.loadFailed(
-                "speculative_decoding.max_draft_tokens exceeds the loaded DFlash2 block limit \(dflash2BlockSize - 1)")
+        let requestedBlockSize: Int?
+        if let maxDraftTokens = options?.maxDraftTokens {
+            guard maxDraftTokens >= 1 else {
+                throw MLXServiceError.loadFailed(
+                    "speculative_decoding.max_draft_tokens must be at least 1")
+            }
+            guard maxDraftTokens < Int.max else {
+                throw MLXServiceError.loadFailed(
+                    "speculative_decoding.max_draft_tokens must be less than Int.max")
+            }
+            let loadedDraftLimit = dflash2BlockSize > 1 ? dflash2BlockSize - 1 : 0
+            guard maxDraftTokens <= loadedDraftLimit else {
+                throw MLXServiceError.loadFailed(
+                    "speculative_decoding.max_draft_tokens exceeds the loaded DFlash2 block limit \(loadedDraftLimit)")
+            }
+            requestedBlockSize = maxDraftTokens + 1
+        } else {
+            requestedBlockSize = nil
         }
 
         let mode = options?.mode?.lowercased()
@@ -1773,7 +1796,7 @@ public final class MLXModelService: @unchecked Sendable {
             permitsOtherRuntimes: reason == nil && !explicitlyDFlash2,
             requiresRuntime: !explicitlyDisabled
                 && (dflash2Requirement == .required || requirement == "required"),
-            requestedBlockSize: options?.maxDraftTokens.map { $0 + 1 },
+            requestedBlockSize: requestedBlockSize,
             denialReason: reason)
     }
 
@@ -2451,7 +2474,13 @@ public final class MLXModelService: @unchecked Sendable {
         }
         startedInBatchMode = true
         let ownsPromotion = await modelExecutionCoordinator.beginPromotion()
-        guard ownsPromotion else { return }
+        guard ownsPromotion else {
+            if shuttingDown { throw MLXServiceError.serviceShuttingDown }
+            return
+        }
+        if let barrier = withStateLock({ schedulerPromotionBarrier }) {
+            await barrier()
+        }
         guard let container = withStateLock({ currentContainer }) else {
             await modelExecutionCoordinator.finishPromotion(schedulerInstalled: false)
             throw MLXServiceError.noModelLoaded
@@ -2470,7 +2499,16 @@ public final class MLXModelService: @unchecked Sendable {
                 requiresFixedDecodeCohorts: requiresFixedDecodeCohorts
             )
         }
-        withStateLock { self.scheduler = sched }
+        let published = withStateLock { () -> Bool in
+            guard !isShuttingDown else { return false }
+            self.scheduler = sched
+            return true
+        }
+        if !published {
+            await sched.shutdown()
+            await modelExecutionCoordinator.finishPromotion(schedulerInstalled: false)
+            throw MLXServiceError.serviceShuttingDown
+        }
         await modelExecutionCoordinator.finishPromotion(schedulerInstalled: true)
         print("[\(ts())] Concurrent mode: up to \(limit) parallel generations\(prefixCaching ? " (prefix caching enabled)" : "")")
     }
@@ -2491,10 +2529,14 @@ public final class MLXModelService: @unchecked Sendable {
         teardownWorkItem = nil
         let ownsPromotion = await modelExecutionCoordinator.beginPromotion()
         if !ownsPromotion {
+            if shuttingDown { throw MLXServiceError.serviceShuttingDown }
             _activeBatchCount.withLock { $0 += 1 }
             teardownWorkItem?.cancel()
             teardownWorkItem = nil
             return
+        }
+        if let barrier = withStateLock({ schedulerPromotionBarrier }) {
+            await barrier()
         }
 
         // Promote: create scheduler
@@ -2518,8 +2560,15 @@ public final class MLXModelService: @unchecked Sendable {
             )
         }
 
-        withStateLock {
+        let published = withStateLock { () -> Bool in
+            guard !isShuttingDown else { return false }
             self.scheduler = sched
+            return true
+        }
+        if !published {
+            await sched.shutdown()
+            await modelExecutionCoordinator.finishPromotion(schedulerInstalled: false)
+            throw MLXServiceError.serviceShuttingDown
         }
         await modelExecutionCoordinator.finishPromotion(schedulerInstalled: true)
         _activeBatchCount.withLock { $0 += 1 }
@@ -3874,6 +3923,53 @@ public final class MLXModelService: @unchecked Sendable {
         preserveStructuralTags: Bool = false,
         requestId: String? = nil
     ) async throws -> (modelID: String, stream: AsyncThrowingStream<StreamChunk, Error>, promptTokens: Int, toolCallStartTag: String?, toolCallEndTag: String?, thinkStartTag: String?, thinkEndTag: String?) {
+        try await generateStreamingWithSchedulerAdmission(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: speculativeDecoding,
+            preserveStructuralTags: preserveStructuralTags,
+            requestId: requestId,
+            admission: .unreserved)
+    }
+
+    func generateStreamingWithSchedulerAdmission(
+        model: String,
+        messages: [AFMOpenAICompat.Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int? = nil,
+        minP: Double? = nil,
+        presencePenalty: Double? = nil,
+        seed: Int? = nil,
+        logprobs: Bool? = nil,
+        topLogprobs: Int? = nil,
+        tools: [RequestTool]? = nil,
+        parallelToolCalls: Bool? = nil,
+        stop: [String]? = nil,
+        responseFormat: ResponseFormat? = nil,
+        chatTemplateKwargs: [String: AnyCodable]? = nil,
+        speculativeDecoding: SpeculativeDecodingOptions? = nil,
+        preserveStructuralTags: Bool = false,
+        requestId: String? = nil,
+        admission: BatchSchedulerSubmissionAdmission
+    ) async throws -> (modelID: String, stream: AsyncThrowingStream<StreamChunk, Error>, promptTokens: Int, toolCallStartTag: String?, toolCallEndTag: String?, thinkStartTag: String?, thinkEndTag: String?) {
         let reqId = requestId ?? ""
         let operation = try beginOperation()
         var operationOwnedByStream = false
@@ -4053,7 +4149,8 @@ public final class MLXModelService: @unchecked Sendable {
                 stopSequences: (stop ?? []) + self.implicitStopSequences,
                 thinkStartTag: self.thinkStartTag,
                 thinkEndTag: self.thinkEndTag,
-                requestId: reqId
+                requestId: reqId,
+                admission: admission
             )
             var effectiveStream: AsyncThrowingStream<StreamChunk, Error>
             if templateOpenedThink, let thinkStart = self.thinkStartTag {
@@ -4904,7 +5001,9 @@ public final class MLXModelService: @unchecked Sendable {
     }
 
     public func shutdownAndReleaseResources(verbose: Bool = false, timeoutSeconds: TimeInterval = 30) async {
-        let scheduler = beginShutdown()
+        _ = beginShutdown()
+        await modelExecutionCoordinator.beginShutdown()
+        let scheduler = withStateLock { self.scheduler }
 
         // Shut down concurrent scheduler first (cancels pending + active)
         if let scheduler {

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -54,6 +54,27 @@ final class Eagle3Runtime: @unchecked Sendable {
     var active: Gemma4Eagle3Drafter? { lock.withLock { drafter } }
 }
 
+final class DFlash2Runtime: @unchecked Sendable {
+    static let shared = DFlash2Runtime()
+    private let lock = NSLock()
+    private var value: (draft: DFlash2DraftModel, blockSize: Int)?
+
+    func install(draft: DFlash2DraftModel, blockSize: Int) {
+        lock.withLock { value = (draft, blockSize) }
+    }
+    func clear() { lock.withLock { value = nil } }
+    var active: (draft: DFlash2DraftModel, blockSize: Int)? {
+        lock.withLock { value }
+    }
+}
+
+private struct DFlash2RequestPolicy {
+    let permitsRuntime: Bool
+    let requiresRuntime: Bool
+    let requestedBlockSize: Int?
+    let denialReason: String?
+}
+
 /// Resolved log probability entry with token strings (ready for API response).
 public struct ResolvedLogprob: Sendable {
     public let token: String
@@ -251,6 +272,10 @@ public final class MLXModelService: @unchecked Sendable {
     /// EAGLE3 speculative decoding (--eagle3 <drafter-path>). Activates only when the loaded model
     /// is a dense Gemma4 verifier and a drafter loads from the given path; otherwise falls back to AR.
     public var eagle3DrafterPath: String?
+    /// Opt-in DFlash 2 checkpoint directory or Hugging Face repository.
+    public var dflash2Drafter: String?
+    public var dflash2BlockSize: Int = 5
+    public var dflash2Requirement: AFMMLXDFlash2Requirement = .preferred
     /// Server-level default JSON schema from `--guided-json` CLI flag.
     /// Applied to requests that don't specify their own response_format. (#97)
     public var defaultGuidedJsonSchema: ResponseFormat?
@@ -1434,6 +1459,68 @@ public final class MLXModelService: @unchecked Sendable {
         return sidecar
     }
 
+    private func resolveDFlash2Directory(
+        progress: (@Sendable (Progress) -> Void)?,
+        stage: (@Sendable (MLXLoadStage) -> Void)?
+    ) async throws -> URL? {
+        guard let resource = dflash2Drafter?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !resource.isEmpty else { return nil }
+        if let local = resolver.localFilesystemURLIfExists(
+            NSString(string: resource).expandingTildeInPath) {
+            guard FileManager.default.fileExists(
+                atPath: local.appendingPathComponent("config.json").path) else {
+                throw MLXServiceError.loadFailed(
+                    "DFlash2 drafter directory has no config.json: \(local.path)")
+            }
+            return local
+        }
+        if let cached = resolver.localModelDirectory(repoId: resource) {
+            return cached
+        }
+        stage?(.downloading)
+        print("[\(ts())] [DFlash2] downloading drafter: \(resource)")
+        try await downloadModel(modelID: resource, progress: progress)
+        guard let downloaded = resolver.localModelDirectory(repoId: resource) else {
+            throw MLXServiceError.modelNotFoundInCache(resource)
+        }
+        return downloaded
+    }
+
+    private func dflash2RequestPolicy(
+        _ options: SpeculativeDecodingOptions?
+    ) throws -> DFlash2RequestPolicy {
+        let requirement = options?.requirement?.lowercased()
+        guard requirement == nil || requirement == "preferred" || requirement == "required" else {
+            throw MLXServiceError.loadFailed(
+                "speculative_decoding.requirement must be preferred or required")
+        }
+        if let maxDraftTokens = options?.maxDraftTokens, maxDraftTokens < 1 {
+            let required = dflash2Requirement == .required || requirement == "required"
+            return DFlash2RequestPolicy(
+                permitsRuntime: false,
+                requiresRuntime: required,
+                requestedBlockSize: nil,
+                denialReason: "max_draft_tokens must be at least 1")
+        }
+
+        let mode = options?.mode?.lowercased()
+        let modePermits = mode == nil || mode == "auto" || mode == "dflash2"
+        let drafterMatches = options?.drafter == nil || options?.drafter == dflash2Drafter
+        let reason: String?
+        if !modePermits {
+            reason = "request selected speculative mode \(mode ?? "off")"
+        } else if !drafterMatches {
+            reason = "per-request drafter does not match the server-loaded drafter"
+        } else {
+            reason = nil
+        }
+        return DFlash2RequestPolicy(
+            permitsRuntime: reason == nil,
+            requiresRuntime: dflash2Requirement == .required || requirement == "required",
+            requestedBlockSize: options?.maxDraftTokens.map { $0 + 1 },
+            denialReason: reason)
+    }
+
     private func mtpQuantization(for sidecarPath: String) -> (
         groupSize: Int, bits: Int, mode: QuantizationMode
     ) {
@@ -1475,6 +1562,18 @@ public final class MLXModelService: @unchecked Sendable {
         guard !modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw MLXServiceError.invalidModel(rawModel)
         }
+        let speculativeSelections = [
+            mtpEnabled,
+            eagle3DrafterPath?.isEmpty == false,
+            dflash2Drafter?.isEmpty == false,
+        ].filter { $0 }.count
+        guard speculativeSelections <= 1 else {
+            throw MLXServiceError.loadFailed(
+                "Choose only one speculative runtime: MTP, EAGLE3, or DFlash2")
+        }
+        guard dflash2Drafter == nil || dflash2BlockSize >= 2 else {
+            throw MLXServiceError.loadFailed("DFlash2 block size must be at least 2")
+        }
         stage?(.checkingCache)
 
         if let cached = withStateLock({ () -> (String, ModelContainer)? in
@@ -1490,6 +1589,8 @@ public final class MLXModelService: @unchecked Sendable {
             stage?(.ready)
             return cached.0
         }
+        DFlash2Runtime.shared.clear()
+        Eagle3Runtime.shared.clear()
 
         // Loading priority:
         // 1. Absolute/relative path — use directly (no cache or download)
@@ -1723,6 +1824,46 @@ public final class MLXModelService: @unchecked Sendable {
                     }
                 } else {
                     print("[\(ts())] [EAGLE3] no config.json at \(drafterPath) — EAGLE3 disabled (AR decode)")
+                }
+            }
+            if dflash2Drafter != nil {
+                do {
+                    guard maxConcurrent < 2 else {
+                        throw MLXServiceError.loadFailed(
+                            "DFlash2 currently requires serial scheduling; remove --concurrent")
+                    }
+                    guard !enablePrefixCaching else {
+                        throw MLXServiceError.loadFailed(
+                            "DFlash2 prefix snapshots are not yet integrated; disable --enable-prefix-caching")
+                    }
+                    guard let draftDirectory = try await resolveDFlash2Directory(
+                        progress: progress, stage: stage) else {
+                        throw MLXServiceError.loadFailed("DFlash2 drafter was not resolved")
+                    }
+                    let draftConfig = try AFMMLXDFlash2Configuration(directory: draftDirectory)
+                    let targetData = try Data(contentsOf: directory.appendingPathComponent("config.json"))
+                    guard let targetMetadata = try JSONSerialization.jsonObject(
+                        with: targetData) as? [String: Any] else {
+                        throw MLXServiceError.loadFailed("Target config.json is not an object")
+                    }
+                    try draftConfig.validateTarget(metadata: targetMetadata)
+                    let block = try draftConfig.effectiveBlockSize(requested: dflash2BlockSize)
+                    let draft = try DFlash2DraftModel.load(directory: draftDirectory.path)
+                    let targetCompatible = try await loaded.perform { context in
+                        guard let target = context.model as? any DFlash2Target else { return false }
+                        _ = try DFlash2Generator(target: target, draft: draft, blockSize: block)
+                        return true
+                    }
+                    guard targetCompatible else {
+                        throw MLXServiceError.loadFailed(
+                            "Loaded target runtime does not expose DFlash2 hidden-state and rollback hooks")
+                    }
+                    DFlash2Runtime.shared.install(draft: draft, blockSize: block)
+                    print("[\(ts())] [DFlash2] ready from \(draftDirectory.path) (block \(block))")
+                } catch {
+                    DFlash2Runtime.shared.clear()
+                    if dflash2Requirement == .required { throw error }
+                    print("[\(ts())] [DFlash2] unavailable (\(error)); using autoregressive decoding")
                 }
             }
             // Detect think start/end tags from tokenizer vocabulary
@@ -2086,7 +2227,8 @@ public final class MLXModelService: @unchecked Sendable {
         parallelToolCalls: Bool? = nil,
         stop: [String]? = nil,
         responseFormat: ResponseFormat? = nil,
-        chatTemplateKwargs: [String: AnyCodable]? = nil
+        chatTemplateKwargs: [String: AnyCodable]? = nil,
+        speculativeDecoding: SpeculativeDecodingOptions? = nil
     ) async throws -> (modelID: String, content: String, promptTokens: Int, completionTokens: Int, tokenLogprobs: [ResolvedLogprob]?, toolCalls: [ResponseToolCall]?, cachedTokens: Int, promptTime: Double, generateTime: Double, stoppedBySequence: Bool) {
         try beginOperation()
         defer { endOperation() }
@@ -2177,6 +2319,73 @@ public final class MLXModelService: @unchecked Sendable {
                 StatsAggregator.shared.requestSucceeded(reason: "stop")
                 StatsAggregator.shared.requestCompleted()
                 return (modelID, result.0, result.1, result.2, nil, nil, 0, 0, 0, false)
+            }
+        }
+
+
+        // ---- DFlash2 one-pass parallel draft/verify path ----
+        let dflash2Policy = try dflash2RequestPolicy(speculativeDecoding)
+        let requestRequiresDFlash2 = dflash2Policy.requiresRuntime
+        let dflash2Active = dflash2Policy.permitsRuntime
+            ? DFlash2Runtime.shared.active : nil
+        let dflash2Eligible = dflash2Active != nil
+            && (temperature ?? 0) <= 0.0
+            && (tools?.isEmpty ?? true)
+            && responseFormat == nil
+            && !wantLogprobs
+            && (stop?.isEmpty ?? true)
+        if requestRequiresDFlash2, dflash2Active == nil {
+            throw MLXServiceError.loadFailed(
+                "DFlash2 is required but unavailable: \(dflash2Policy.denialReason ?? "no compatible runtime is active")")
+        }
+        if requestRequiresDFlash2, dflash2Active != nil, !dflash2Eligible {
+            throw MLXServiceError.loadFailed(
+                "DFlash2 is required but this request uses sampling, tools, grammar, logprobs, or stop sequences")
+        }
+        if dflash2Eligible, let installed = dflash2Active {
+            if let result = try await container.perform({ context -> (String, Int, Int)? in
+                guard let target = context.model as? any DFlash2Target else { return nil }
+                let lmInput = try await context.processor.prepare(input: scratch.userInput)
+                if self.isMultimodalInput(lmInput) { return nil }
+                let promptIDs = self.extractTokenArray(lmInput)
+                guard !promptIDs.isEmpty else { return nil }
+                let eos = Set((context.tokenizer.eosTokenId).map { [$0] } ?? [])
+                let generator = try DFlash2Generator(
+                    target: target,
+                    draft: installed.draft,
+                    blockSize: dflash2Policy.requestedBlockSize.map {
+                        min(installed.blockSize, $0)
+                    } ?? installed.blockSize)
+                let generated = generator.generate(
+                    promptIDs: promptIDs,
+                    maxTokens: effectiveMaxTokens,
+                    stopTokenIDs: eos,
+                    shouldStop: { Task.isCancelled })
+                let ids = generated.tokenIDs
+                let textIDs = (ids.last.map { eos.contains($0) } ?? false)
+                    ? Array(ids.dropLast()) : ids
+                let stats = generated.statistics
+                StatsAggregator.shared.addSpeculative(
+                    strategy: "dflash2",
+                    draftedTokens: stats.draftedTokens,
+                    acceptedDraftTokens: stats.acceptedDraftTokens,
+                    verificationCycles: stats.verificationCycles,
+                    draftSeconds: stats.draftSeconds,
+                    verificationSeconds: stats.verificationSeconds,
+                    rollbackSeconds: stats.rollbackSeconds)
+                if debugLogging {
+                    print("[\(ts())] [DFlash2] \(ids.count) tokens, \(stats.verificationCycles) cycles, mean acceptance \(String(format: "%.2f", stats.meanAcceptanceLength))")
+                }
+                return (context.tokenizer.decode(tokens: textIDs), promptIDs.count, ids.count)
+            }) {
+                serialRequestRecorded = true
+                StatsAggregator.shared.requestSucceeded(reason: "stop")
+                StatsAggregator.shared.requestCompleted()
+                return (modelID, result.0, result.1, result.2, nil, nil, 0, 0, 0, false)
+            }
+            if requestRequiresDFlash2 {
+                throw MLXServiceError.loadFailed(
+                    "DFlash2 is required but the prepared input is empty, multimodal, or target-incompatible")
             }
         }
 
@@ -3034,6 +3243,7 @@ public final class MLXModelService: @unchecked Sendable {
         stop: [String]? = nil,
         responseFormat: ResponseFormat? = nil,
         chatTemplateKwargs: [String: AnyCodable]? = nil,
+        speculativeDecoding: SpeculativeDecodingOptions? = nil,
         preserveStructuralTags: Bool = false,
         requestId: String? = nil
     ) async throws -> (modelID: String, stream: AsyncThrowingStream<StreamChunk, Error>, promptTokens: Int, toolCallStartTag: String?, toolCallEndTag: String?, thinkStartTag: String?, thinkEndTag: String?) {
@@ -3227,9 +3437,19 @@ public final class MLXModelService: @unchecked Sendable {
             loadedSupportsDSpark = false
         }
         let dsparkStreamEligible = specGreedyStream && loadedSupportsDSpark
+        let dflash2Policy = try dflash2RequestPolicy(speculativeDecoding)
+        let requestRequiresDFlash2 = dflash2Policy.requiresRuntime
+        let dflash2StreamEligible = specGreedyStream
+            && dflash2Policy.permitsRuntime
+            && DFlash2Runtime.shared.active != nil
         let eagle3StreamEligible = specGreedyStream && Eagle3Runtime.shared.active != nil
         let mtpStreamEligible = specGreedyStream && mtpBinding != nil
-        if dsparkStreamEligible || eagle3StreamEligible || mtpStreamEligible {
+        if requestRequiresDFlash2,
+           !dflash2StreamEligible {
+            throw MLXServiceError.loadFailed(
+                "DFlash2 is required but unavailable: \(dflash2Policy.denialReason ?? "streaming request modifiers require autoregressive decoding")")
+        }
+        if dsparkStreamEligible || dflash2StreamEligible || eagle3StreamEligible || mtpStreamEligible {
             // Prep prompt ids under the lock; nil => multimodal/empty/wrong-model => fall back to AR.
             // Also detect a template-opened think block (last prompt tokens contain thinkStart): for
             // thinking models whose chat template begins reasoning in the prompt, the generated
@@ -3242,6 +3462,7 @@ public final class MLXModelService: @unchecked Sendable {
                     && !((context.model as? DeepseekV4Model)?.supportsEmbeddedDSpark == true)
                 { return nil }
                 if eagle3StreamEligible && !(context.model is Gemma4Model) { return nil }
+                if dflash2StreamEligible && !(context.model is any DFlash2Target) { return nil }
                 let ids = self.extractTokenArray(lmInput)
                 if ids.isEmpty { return nil }
                 var opened = false
@@ -3259,7 +3480,8 @@ public final class MLXModelService: @unchecked Sendable {
                 let promptIds = prep.ids
                 let openedThink = prep.openedThink
                 let useDSpark = dsparkStreamEligible
-                let useEagle3 = !useDSpark && eagle3StreamEligible
+                let useDFlash2 = !useDSpark && dflash2StreamEligible
+                let useEagle3 = !useDSpark && !useDFlash2 && eagle3StreamEligible
                 let maxTok = effectiveMaxTokens
                 let dbg = debugLogging
                 let thinkStartTag = self.thinkStartTag
@@ -3295,6 +3517,30 @@ public final class MLXModelService: @unchecked Sendable {
                                     _ = generator.generate(
                                         promptIds: promptIds, maxTokens: maxTok,
                                         eosIds: eos, onToken: emit)
+                                } else if useDFlash2,
+                                          let installed = DFlash2Runtime.shared.active,
+                                          let target = context.model as? any DFlash2Target {
+                                    let generator = try DFlash2Generator(
+                                        target: target,
+                                        draft: installed.draft,
+                                        blockSize: dflash2Policy.requestedBlockSize.map {
+                                            min(installed.blockSize, $0)
+                                        } ?? installed.blockSize)
+                                    let result = generator.generate(
+                                        promptIDs: promptIds,
+                                        maxTokens: maxTok,
+                                        stopTokenIDs: eos,
+                                        shouldStop: { Task.isCancelled },
+                                        onToken: emit)
+                                    let stats = result.statistics
+                                    StatsAggregator.shared.addSpeculative(
+                                        strategy: "dflash2",
+                                        draftedTokens: stats.draftedTokens,
+                                        acceptedDraftTokens: stats.acceptedDraftTokens,
+                                        verificationCycles: stats.verificationCycles,
+                                        draftSeconds: stats.draftSeconds,
+                                        verificationSeconds: stats.verificationSeconds,
+                                        rollbackSeconds: stats.rollbackSeconds)
                                 } else if useEagle3, let drafter = Eagle3Runtime.shared.active,
                                    let model = context.model as? Gemma4Model {
                                     let block = ProcessInfo.processInfo.environment["AFM_EAGLE3_BLOCK"].flatMap { Int($0) } ?? 2
@@ -3311,7 +3557,8 @@ public final class MLXModelService: @unchecked Sendable {
                             let gt = Date.timeIntervalSinceReferenceDate - t0
                             if dbg {
                                 let tps = gt > 0 ? Double(outCount) / gt : 0
-                                let engine = useDSpark ? "DSpARK" : (useEagle3 ? "EAGLE3" : "MTP")
+                                let engine = useDSpark ? "DSpARK"
+                                    : (useDFlash2 ? "DFlash2" : (useEagle3 ? "EAGLE3" : "MTP"))
                                 print("[\(ts())] [\(engine)] streamed \(outCount) tok in \(String(format: "%.2f", gt))s (\(String(format: "%.1f", tps)) tok/s)")
                             }
                             continuation.yield(StreamChunk(text: "", promptTokens: promptIds.count,
@@ -3334,6 +3581,10 @@ public final class MLXModelService: @unchecked Sendable {
                 streamOwnsTempFiles = true
                 endOperationOnExit = false
                 return (modelID, stream, promptTokens, nil, nil, self.thinkStartTag, self.thinkEndTag)
+            }
+            if requestRequiresDFlash2 {
+                throw MLXServiceError.loadFailed(
+                    "DFlash2 is required but the prepared streaming input is empty, multimodal, or target-incompatible")
             }
         }
 
@@ -3905,6 +4156,8 @@ public final class MLXModelService: @unchecked Sendable {
                 currentMTPBinding = nil
             }
         }
+        DFlash2Runtime.shared.clear()
+        Eagle3Runtime.shared.clear()
 
         if gpuInitialized {
             // Ensure queued GPU work is complete before clearing recycled buffers.

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -317,6 +317,7 @@ public enum MLXServiceError: Error, LocalizedError {
     case noMetalDevice
     case serviceShuttingDown
     case serverBusy(Int)
+    case invalidSchedulerReservation
 
     public var errorDescription: String? {
         switch self {
@@ -336,6 +337,8 @@ public enum MLXServiceError: Error, LocalizedError {
             return "MLX service is shutting down"
         case .serverBusy(let max):
             return "Server at capacity (\(max) concurrent requests). Please retry shortly."
+        case .invalidSchedulerReservation:
+            return "Scheduler reservation does not belong to the active scheduler request"
         }
     }
 }
@@ -723,18 +726,26 @@ public final class MLXModelService: @unchecked Sendable {
     /// Scheduled teardown work item (cancelled if new batch arrives).
     private var teardownWorkItem: DispatchWorkItem?
 
-    /// Atomically reserve a concurrent slot. Returns true if reserved (or serial mode).
-    public func tryReserveSlot() -> Bool {
-        withStateLock({ scheduler })?.tryReserve() ?? true
+    /// Atomically acquire scheduler capacity, or identify the serial path.
+    public func tryReserveSlot() -> AFMMLXSchedulerAdmission {
+        guard let scheduler = withStateLock({ scheduler }) else { return .serial }
+        guard let reservation = scheduler.tryReserve() else { return .unavailable }
+        return .reserved(reservation)
     }
-    /// Wait for a concurrent slot with timeout. Returns true if reserved (or serial mode).
-    public func waitForSlot(timeout: TimeInterval = 30) async -> Bool {
-        guard let sched = withStateLock({ scheduler }) else { return true }
-        return await sched.waitForSlot(timeout: timeout)
+    /// Wait for scheduler capacity, or identify the serial path.
+    public func waitForSlot(
+        timeout: TimeInterval = 30
+    ) async -> AFMMLXSchedulerAdmission {
+        guard let scheduler = withStateLock({ scheduler }) else { return .serial }
+        guard let reservation = await scheduler.waitForSlot(timeout: timeout) else {
+            return .unavailable
+        }
+        return .reserved(reservation)
     }
-    /// Release a reserved slot (call if request fails before generation starts).
-    public func releaseSlot() {
-        withStateLock({ scheduler })?.releaseReservation()
+    /// Release only the matching reservation from the active scheduler.
+    @discardableResult
+    public func releaseSlot(_ reservation: AFMMLXSchedulerReservation) -> Bool {
+        withStateLock({ scheduler })?.releaseReservation(reservation) ?? false
     }
 
     var schedulerAdmissionSnapshot: BatchSchedulerAdmissionState.Snapshot? {
@@ -743,6 +754,16 @@ public final class MLXModelService: @unchecked Sendable {
 
     var installedScheduler: BatchScheduler? {
         withStateLock { scheduler }
+    }
+
+    func replaceInstalledSchedulerForTesting(
+        with replacement: BatchScheduler?
+    ) -> BatchScheduler? {
+        withStateLock {
+            let previous = scheduler
+            scheduler = replacement
+            return previous
+        }
     }
     public init(resolver: MLXCacheResolver) {
         _ = Self.registerModelFactoriesOnce
@@ -4001,6 +4022,9 @@ public final class MLXModelService: @unchecked Sendable {
             if releaseSchedulerExecutionOnExit {
                 Task { await self.modelExecutionCoordinator.releaseSchedulerGeneration() }
             }
+        }
+        if hasSerialExecutionLease, case .reserved = admission {
+            throw MLXServiceError.invalidSchedulerReservation
         }
 
         let promptText = buildPrompt(from: messages)

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -1562,12 +1562,12 @@ public final class MLXModelService: @unchecked Sendable {
         guard let temperature, temperature <= 0 else {
             return SpeculativeRequestCompatibility(denialReason: "sampling")
         }
-        if let topP, topP < 1
+        if (topP ?? 1) < 1
             || (topK ?? 0) > 0
             || (minP ?? 0) > 0 {
             return SpeculativeRequestCompatibility(denialReason: "sampling")
         }
-        if let repetitionPenalty, abs(repetitionPenalty - 1) > 0.000_001
+        if abs((repetitionPenalty ?? 1) - 1) > 0.000_001
             || abs(presencePenalty ?? 0) > 0.000_001 {
             return SpeculativeRequestCompatibility(denialReason: "penalties")
         }

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -1583,6 +1583,14 @@ public final class MLXModelService: @unchecked Sendable {
         return nil
     }
 
+    func dflash2UnavailableReason(
+        policy: DFlash2RequestPolicy,
+        runtimeFallbackReason: String?,
+        defaultReason: String
+    ) -> String {
+        policy.denialReason ?? runtimeFallbackReason ?? defaultReason
+    }
+
     func dflash2WasRequested(
         _ options: SpeculativeDecodingOptions?,
         configuredDrafter: String?
@@ -2427,8 +2435,12 @@ public final class MLXModelService: @unchecked Sendable {
         let dflash2Eligible = dflash2Active != nil
             && speculativeCompatibility.isEligible
         if requestRequiresDFlash2, dflash2Active == nil {
+            let reason = dflash2UnavailableReason(
+                policy: dflash2Policy,
+                runtimeFallbackReason: dflash2State?.fallbackReason,
+                defaultReason: "no compatible runtime is active")
             throw MLXServiceError.loadFailed(
-                "DFlash2 is required but unavailable: \(dflash2Policy.denialReason ?? "no compatible runtime is active")")
+                "DFlash2 is required but unavailable: \(reason)")
         }
         if requestRequiresDFlash2, !dflash2Eligible {
             throw MLXServiceError.loadFailed(
@@ -3679,8 +3691,12 @@ public final class MLXModelService: @unchecked Sendable {
             && specGreedyStream && mtpBinding != nil
         if requestRequiresDFlash2,
            !dflash2StreamEligible {
+            let reason = dflash2UnavailableReason(
+                policy: dflash2Policy,
+                runtimeFallbackReason: dflash2State?.fallbackReason,
+                defaultReason: "streaming request modifiers require autoregressive decoding")
             throw MLXServiceError.loadFailed(
-                "DFlash2 is required but unavailable: \(dflash2Policy.denialReason ?? "streaming request modifiers require autoregressive decoding")")
+                "DFlash2 is required but unavailable: \(reason)")
         }
         if dsparkStreamEligible || dflash2StreamEligible || eagle3StreamEligible || mtpStreamEligible {
             // Prep prompt ids under the lock; nil => multimodal/empty/wrong-model => fall back to AR.

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -84,11 +84,13 @@ actor MLXModelExecutionCoordinator {
 
     struct Snapshot: Equatable, Sendable {
         let activeSerialGenerations: Int
+        let activeSchedulerUsers: Int
         let promotionInProgress: Bool
         let schedulerInstalled: Bool
     }
 
     private var activeSerialGenerations = 0
+    private var activeSchedulerUsers = 0
     private var promotionInProgress = false
     private var schedulerInstalled = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
@@ -97,7 +99,10 @@ actor MLXModelExecutionCoordinator {
         while promotionInProgress {
             await waitForChange()
         }
-        guard !schedulerInstalled else { return .scheduler }
+        if schedulerInstalled {
+            activeSchedulerUsers += 1
+            return .scheduler
+        }
         activeSerialGenerations += 1
         return .serial
     }
@@ -105,6 +110,12 @@ actor MLXModelExecutionCoordinator {
     func releaseSerialGeneration() {
         precondition(activeSerialGenerations > 0)
         activeSerialGenerations -= 1
+        signalChange()
+    }
+
+    func releaseSchedulerGeneration() {
+        precondition(activeSchedulerUsers > 0)
+        activeSchedulerUsers -= 1
         signalChange()
     }
 
@@ -128,11 +139,21 @@ actor MLXModelExecutionCoordinator {
         signalChange()
     }
 
-    func beginSchedulerRemoval() async {
+    func beginSchedulerRemoval() async -> Bool {
         while promotionInProgress {
             await waitForChange()
         }
+        guard schedulerInstalled else { return false }
         promotionInProgress = true
+        while activeSchedulerUsers > 0 {
+            await waitForChange()
+        }
+        return true
+    }
+
+    func cancelSchedulerRemoval() {
+        promotionInProgress = false
+        signalChange()
     }
 
     func finishSchedulerRemoval() {
@@ -144,6 +165,7 @@ actor MLXModelExecutionCoordinator {
     func snapshot() -> Snapshot {
         Snapshot(
             activeSerialGenerations: activeSerialGenerations,
+            activeSchedulerUsers: activeSchedulerUsers,
             promotionInProgress: promotionInProgress,
             schedulerInstalled: schedulerInstalled)
     }
@@ -2415,10 +2437,20 @@ public final class MLXModelService: @unchecked Sendable {
             guard sched.activeSlotCount == 0 else { return }
         }
 
-        await modelExecutionCoordinator.beginSchedulerRemoval()
+        guard await modelExecutionCoordinator.beginSchedulerRemoval() else { return }
+        guard _activeBatchCount.withLock({ $0 == 0 }),
+              let sched = withStateLock({ scheduler }),
+              sched.activeSlotCount == 0
+        else {
+            await modelExecutionCoordinator.cancelSchedulerRemoval()
+            return
+        }
+        await sched.shutdown()
         withStateLock {
-            self.scheduler = nil
-            self.maxConcurrent = 0
+            if self.scheduler === sched {
+                self.scheduler = nil
+                self.maxConcurrent = 0
+            }
         }
         await modelExecutionCoordinator.finishSchedulerRemoval()
         print("[\(ts())] Auto-teardown: returned to serial mode")
@@ -2478,7 +2510,8 @@ public final class MLXModelService: @unchecked Sendable {
         let mtpBinding = runtime.mtpBinding
         let dflash2State = runtime.dflash2State
         let executionLease = await modelExecutionCoordinator.acquireGeneration()
-        guard case .serial = executionLease else {
+        if case .scheduler = executionLease {
+            await modelExecutionCoordinator.releaseSchedulerGeneration()
             throw MLXServiceError.loadFailed(
                 "Direct generation is unavailable while the batch scheduler owns the model")
         }
@@ -3553,9 +3586,13 @@ public final class MLXModelService: @unchecked Sendable {
             hasSerialExecutionLease = false
         }
         var releaseSerialExecutionOnExit = hasSerialExecutionLease
+        let releaseSchedulerExecutionOnExit = !hasSerialExecutionLease
         defer {
             if releaseSerialExecutionOnExit {
                 Task { await self.modelExecutionCoordinator.releaseSerialGeneration() }
+            }
+            if releaseSchedulerExecutionOnExit {
+                Task { await self.modelExecutionCoordinator.releaseSchedulerGeneration() }
             }
         }
 
@@ -4539,10 +4576,15 @@ public final class MLXModelService: @unchecked Sendable {
     public func shutdownAndReleaseResources(verbose: Bool = false, timeoutSeconds: TimeInterval = 30) async {
         // Shut down concurrent scheduler first (cancels pending + active)
         if let scheduler = self.scheduler {
-            await modelExecutionCoordinator.beginSchedulerRemoval()
-            await scheduler.shutdown()
-            withStateLock { self.scheduler = nil }
-            await modelExecutionCoordinator.finishSchedulerRemoval()
+            if await modelExecutionCoordinator.beginSchedulerRemoval() {
+                await scheduler.shutdown()
+                withStateLock {
+                    if self.scheduler === scheduler {
+                        self.scheduler = nil
+                    }
+                }
+                await modelExecutionCoordinator.finishSchedulerRemoval()
+            }
         }
 
         let start = Date()

--- a/Sources/AFMKitMLX/Models/StatsAggregator.swift
+++ b/Sources/AFMKitMLX/Models/StatsAggregator.swift
@@ -132,6 +132,7 @@ public final class StatsAggregator: @unchecked Sendable {
         public var cacheMissesTotal: UInt64 = 0
         public var speculativeDraftedTokensTotal: UInt64 = 0
         public var speculativeAcceptedTokensTotal: UInt64 = 0
+        public var speculativeEmittedTokensTotal: UInt64 = 0
         public var speculativeVerificationCyclesTotal: UInt64 = 0
         public var speculativeDraftSecondsTotal: Double = 0
         public var speculativeVerificationSecondsTotal: Double = 0
@@ -269,6 +270,7 @@ public final class StatsAggregator: @unchecked Sendable {
         strategy: String,
         draftedTokens: Int,
         acceptedDraftTokens: Int,
+        emittedTokens: Int,
         verificationCycles: Int,
         draftSeconds: Double,
         verificationSeconds: Double,
@@ -277,6 +279,7 @@ public final class StatsAggregator: @unchecked Sendable {
         counters.withLock { counters in
             counters.speculativeDraftedTokensTotal &+= UInt64(max(0, draftedTokens))
             counters.speculativeAcceptedTokensTotal &+= UInt64(max(0, acceptedDraftTokens))
+            counters.speculativeEmittedTokensTotal &+= UInt64(max(0, emittedTokens))
             counters.speculativeVerificationCyclesTotal &+= UInt64(max(0, verificationCycles))
             counters.speculativeDraftSecondsTotal += max(0, draftSeconds)
             counters.speculativeVerificationSecondsTotal += max(0, verificationSeconds)
@@ -444,6 +447,7 @@ public final class StatsAggregator: @unchecked Sendable {
         public let cacheMissesTotal: UInt64
         public let speculativeDraftedTokensTotal: UInt64
         public let speculativeAcceptedTokensTotal: UInt64
+        public let speculativeEmittedTokensTotal: UInt64
         public let speculativeVerificationCyclesTotal: UInt64
         public let speculativeDraftSecondsTotal: Double
         public let speculativeVerificationSecondsTotal: Double
@@ -498,6 +502,7 @@ public final class StatsAggregator: @unchecked Sendable {
             cacheMissesTotal: c.cacheMissesTotal,
             speculativeDraftedTokensTotal: c.speculativeDraftedTokensTotal,
             speculativeAcceptedTokensTotal: c.speculativeAcceptedTokensTotal,
+            speculativeEmittedTokensTotal: c.speculativeEmittedTokensTotal,
             speculativeVerificationCyclesTotal: c.speculativeVerificationCyclesTotal,
             speculativeDraftSecondsTotal: c.speculativeDraftSecondsTotal,
             speculativeVerificationSecondsTotal: c.speculativeVerificationSecondsTotal,

--- a/Sources/AFMKitMLX/Models/StatsAggregator.swift
+++ b/Sources/AFMKitMLX/Models/StatsAggregator.swift
@@ -130,6 +130,13 @@ public final class StatsAggregator: @unchecked Sendable {
         public var requestsCompletedTotal: UInt64 = 0
         public var cacheHitsTotal: UInt64 = 0
         public var cacheMissesTotal: UInt64 = 0
+        public var speculativeDraftedTokensTotal: UInt64 = 0
+        public var speculativeAcceptedTokensTotal: UInt64 = 0
+        public var speculativeVerificationCyclesTotal: UInt64 = 0
+        public var speculativeDraftSecondsTotal: Double = 0
+        public var speculativeVerificationSecondsTotal: Double = 0
+        public var speculativeRollbackSecondsTotal: Double = 0
+        public var speculativeCyclesByStrategy: [String: UInt64] = [:]
         /// vLLM's `request_success_total{finished_reason=...}`. Keyed by
         /// the finished_reason string ("stop", "length", "abort", "error").
         public var requestSuccessByReason: [String: UInt64] = [:]
@@ -256,6 +263,27 @@ public final class StatsAggregator: @unchecked Sendable {
     public func addPromptTokens(_ n: Int) {
         guard n > 0 else { return }
         counters.withLock { $0.promptTokensTotal &+= UInt64(n) }
+    }
+
+    public func addSpeculative(
+        strategy: String,
+        draftedTokens: Int,
+        acceptedDraftTokens: Int,
+        verificationCycles: Int,
+        draftSeconds: Double,
+        verificationSeconds: Double,
+        rollbackSeconds: Double
+    ) {
+        counters.withLock { counters in
+            counters.speculativeDraftedTokensTotal &+= UInt64(max(0, draftedTokens))
+            counters.speculativeAcceptedTokensTotal &+= UInt64(max(0, acceptedDraftTokens))
+            counters.speculativeVerificationCyclesTotal &+= UInt64(max(0, verificationCycles))
+            counters.speculativeDraftSecondsTotal += max(0, draftSeconds)
+            counters.speculativeVerificationSecondsTotal += max(0, verificationSeconds)
+            counters.speculativeRollbackSecondsTotal += max(0, rollbackSeconds)
+            counters.speculativeCyclesByStrategy[strategy, default: 0] &+= UInt64(
+                max(0, verificationCycles))
+        }
     }
 
     public func requestStarted() {
@@ -414,6 +442,13 @@ public final class StatsAggregator: @unchecked Sendable {
         public let requestsCompletedTotal: UInt64
         public let cacheHitsTotal: UInt64
         public let cacheMissesTotal: UInt64
+        public let speculativeDraftedTokensTotal: UInt64
+        public let speculativeAcceptedTokensTotal: UInt64
+        public let speculativeVerificationCyclesTotal: UInt64
+        public let speculativeDraftSecondsTotal: Double
+        public let speculativeVerificationSecondsTotal: Double
+        public let speculativeRollbackSecondsTotal: Double
+        public let speculativeCyclesByStrategy: [String: UInt64]
         public let requestSuccessByReason: [String: UInt64]
         public let e2eLatency: Histogram
         public let queueTime: Histogram
@@ -461,6 +496,13 @@ public final class StatsAggregator: @unchecked Sendable {
             requestsCompletedTotal: c.requestsCompletedTotal,
             cacheHitsTotal: c.cacheHitsTotal,
             cacheMissesTotal: c.cacheMissesTotal,
+            speculativeDraftedTokensTotal: c.speculativeDraftedTokensTotal,
+            speculativeAcceptedTokensTotal: c.speculativeAcceptedTokensTotal,
+            speculativeVerificationCyclesTotal: c.speculativeVerificationCyclesTotal,
+            speculativeDraftSecondsTotal: c.speculativeDraftSecondsTotal,
+            speculativeVerificationSecondsTotal: c.speculativeVerificationSecondsTotal,
+            speculativeRollbackSecondsTotal: c.speculativeRollbackSecondsTotal,
+            speculativeCyclesByStrategy: c.speculativeCyclesByStrategy,
             requestSuccessByReason: c.requestSuccessByReason,
             e2eLatency: h.e2eLatency,
             queueTime: h.queueTime,

--- a/Sources/AFMKitMLX/Models/ToolCallStreamingRuntime.swift
+++ b/Sources/AFMKitMLX/Models/ToolCallStreamingRuntime.swift
@@ -201,12 +201,15 @@ public final class ToolCallStreamingRuntime {
         if incrementalEmittedFirst {
             let parsed = parseIncrementalToolCalls(includeTrailingPartial: false)
             var events = [ToolCallStreamingEvent]()
-            if needsIncrementalArgumentClose {
+            let closeArguments = incrementalParamCount == 0
+                ? "{}"
+                : (needsIncrementalArgumentClose ? "}" : nil)
+            if let closeArguments {
                 events.append(.delta(StreamDeltaToolCall(
                     index: incrementalToolIndex,
                     id: nil,
                     type: nil,
-                    function: StreamDeltaFunction(name: nil, arguments: "}")
+                    function: StreamDeltaFunction(name: nil, arguments: closeArguments)
                 )))
             }
             for tc in parsed {
@@ -292,7 +295,21 @@ public final class ToolCallStreamingRuntime {
             tools: tools
         )
         let fixedToolCall = applyFixToolArgs(responseToolCall)
-        return MLXModelService.coerceArgumentTypes(fixedToolCall, tools: tools)
+        let coerced = MLXModelService.coerceArgumentTypes(fixedToolCall, tools: tools)
+        guard coerced.function.arguments
+            .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return coerced
+        }
+        return ResponseToolCall(
+            index: coerced.index,
+            id: coerced.id,
+            type: coerced.type,
+            function: ResponseToolCallFunction(
+                name: coerced.function.name,
+                arguments: "{}"
+            )
+        )
     }
 
     private func scanIncrementalMarkers() -> [ToolCallStreamingEvent] {

--- a/Sources/AFMOpenAICompat/OpenAIRequest.swift
+++ b/Sources/AFMOpenAICompat/OpenAIRequest.swift
@@ -120,17 +120,23 @@ public struct SpeculativeDecodingOptions: Codable, Sendable, Equatable {
     public let requirement: String?
     public let drafter: String?
     public let maxDraftTokens: Int?
+    /// Internal execution constraint used by server-owned workflows such as
+    /// deterministic batch dispatch. It is intentionally not part of the
+    /// OpenAI-compatible wire representation.
+    public var forceAutoregressiveReason: String? = nil
 
     public init(
         mode: String? = nil,
         requirement: String? = nil,
         drafter: String? = nil,
-        maxDraftTokens: Int? = nil
+        maxDraftTokens: Int? = nil,
+        forceAutoregressiveReason: String? = nil
     ) {
         self.mode = mode
         self.requirement = requirement
         self.drafter = drafter
         self.maxDraftTokens = maxDraftTokens
+        self.forceAutoregressiveReason = forceAutoregressiveReason
     }
 
     public enum CodingKeys: String, CodingKey {

--- a/Sources/AFMOpenAICompat/OpenAIRequest.swift
+++ b/Sources/AFMOpenAICompat/OpenAIRequest.swift
@@ -28,6 +28,7 @@ public struct ChatCompletionRequest: Codable, Sendable {
     public let chatTemplateKwargs: [String: AnyCodable]?
     /// Official DeepSeek 0731 reasoning control: low, high, or max.
     public let reasoningEffort: String?
+    public let speculativeDecoding: SpeculativeDecodingOptions?
 
     public enum CodingKeys: String, CodingKey {
         case model
@@ -55,6 +56,7 @@ public struct ChatCompletionRequest: Codable, Sendable {
         case responseFormat = "response_format"
         case chatTemplateKwargs = "chat_template_kwargs"
         case reasoningEffort = "reasoning_effort"
+        case speculativeDecoding = "speculative_decoding"
     }
 
     /// Whether the final SSE chunk should carry a `usage` block. Mirrors OpenAI's
@@ -81,7 +83,7 @@ public struct ChatCompletionRequest: Codable, Sendable {
         return result.isEmpty ? nil : result
     }
 
-    public init(model: String?, messages: [Message], temperature: Double?, maxTokens: Int?, maxCompletionTokens: Int?, topP: Double?, repetitionPenalty: Double?, repeatPenalty: Double?, frequencyPenalty: Double?, presencePenalty: Double?, topK: Int?, minP: Double?, seed: Int?, logprobs: Bool?, topLogprobs: Int?, stop: [String]?, stream: Bool?, streamOptions: StreamOptions?, user: String?, tools: [RequestTool]?, toolChoice: ToolChoice?, parallelToolCalls: Bool?, responseFormat: ResponseFormat?, chatTemplateKwargs: [String: AnyCodable]?, reasoningEffort: String? = nil) {
+    public init(model: String?, messages: [Message], temperature: Double?, maxTokens: Int?, maxCompletionTokens: Int?, topP: Double?, repetitionPenalty: Double?, repeatPenalty: Double?, frequencyPenalty: Double?, presencePenalty: Double?, topK: Int?, minP: Double?, seed: Int?, logprobs: Bool?, topLogprobs: Int?, stop: [String]?, stream: Bool?, streamOptions: StreamOptions?, user: String?, tools: [RequestTool]?, toolChoice: ToolChoice?, parallelToolCalls: Bool?, responseFormat: ResponseFormat?, chatTemplateKwargs: [String: AnyCodable]?, reasoningEffort: String? = nil, speculativeDecoding: SpeculativeDecodingOptions? = nil) {
         self.model = model
         self.messages = messages
         self.temperature = temperature
@@ -107,6 +109,35 @@ public struct ChatCompletionRequest: Codable, Sendable {
         self.responseFormat = responseFormat
         self.chatTemplateKwargs = chatTemplateKwargs
         self.reasoningEffort = reasoningEffort
+        self.speculativeDecoding = speculativeDecoding
+    }
+}
+
+/// Optional, provider-neutral speculative-decoding request controls.
+/// Servers may reject `required` when the selected provider cannot honor it.
+public struct SpeculativeDecodingOptions: Codable, Sendable, Equatable {
+    public let mode: String?
+    public let requirement: String?
+    public let drafter: String?
+    public let maxDraftTokens: Int?
+
+    public init(
+        mode: String? = nil,
+        requirement: String? = nil,
+        drafter: String? = nil,
+        maxDraftTokens: Int? = nil
+    ) {
+        self.mode = mode
+        self.requirement = requirement
+        self.drafter = drafter
+        self.maxDraftTokens = maxDraftTokens
+    }
+
+    public enum CodingKeys: String, CodingKey {
+        case mode
+        case requirement
+        case drafter
+        case maxDraftTokens = "max_draft_tokens"
     }
 }
 

--- a/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
+++ b/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
@@ -281,6 +281,50 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
         chatTemplateKwargs: [String: AnyCodable]?,
         speculativeDecoding: SpeculativeDecodingOptions?
     ) async throws -> AFMMLXChatGenerationResult {
+        let enriched = try await generateWithTelemetry(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: speculativeDecoding)
+        return enriched.result
+    }
+
+    func generateWithTelemetry(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?
+    ) async throws -> AFMMLXChatGenerationResultWithTelemetry {
         let request = try AFMRequest(
             openAIMessages: messages,
             generationConfig: generationConfig(
@@ -311,7 +355,7 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
         let speculativeTelemetry = metadata[AFMMLXSpeculativeTelemetry.metadataKey]
             .flatMap(AFMMLXSpeculativeTelemetry.init(metadataValue:))
         let responseModelID = metadata.string("modelID") ?? normalizeModel(model)
-        return (
+        return AFMMLXChatGenerationResultWithTelemetry(
             modelID: responseModelID,
             content: rawContent(
                 text: response.text,

--- a/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
+++ b/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
@@ -308,6 +308,8 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
         let promptTime = metadata.double("promptTime") ?? 0
         let generateTime = metadata.double("generateTime") ?? 0
         let stoppedBySequence = metadata.bool("stoppedBySequence") ?? false
+        let speculativeTelemetry = metadata[AFMMLXSpeculativeTelemetry.metadataKey]
+            .flatMap(AFMMLXSpeculativeTelemetry.init(metadataValue:))
         let responseModelID = metadata.string("modelID") ?? normalizeModel(model)
         return (
             modelID: responseModelID,
@@ -326,7 +328,8 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
             cachedTokens: response.usage.cachedInputTokens,
             promptTime: promptTime,
             generateTime: generateTime,
-            stoppedBySequence: stoppedBySequence
+            stoppedBySequence: stoppedBySequence,
+            speculativeTelemetry: speculativeTelemetry
         )
     }
 
@@ -485,6 +488,7 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
                 var promptTime: Double = 0
                 var generateTime: Double = 0
                 var stoppedBySequence = false
+                var speculativeTelemetry: AFMMLXSpeculativeTelemetry?
                 var insideReasoning = false
                 var toolIndices = [String: Int]()
 
@@ -536,6 +540,10 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
                             generateTime = metadata.double("generateTime") ?? generateTime
                             stoppedBySequence =
                                 metadata.bool("stoppedBySequence") ?? stoppedBySequence
+                            if let value = metadata[AFMMLXSpeculativeTelemetry.metadataKey] {
+                                speculativeTelemetry = AFMMLXSpeculativeTelemetry(
+                                    metadataValue: value)
+                            }
                         case .completed:
                             if insideReasoning {
                                 continuation.yield(StreamChunk(text: endTag ?? ""))
@@ -549,7 +557,8 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
                                     cachedTokens: cachedTokens,
                                     promptTime: promptTime,
                                     generateTime: generateTime,
-                                    stoppedBySequence: stoppedBySequence
+                                    stoppedBySequence: stoppedBySequence,
+                                    speculativeTelemetry: speculativeTelemetry
                                 )
                             )
                         case .custom:

--- a/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
+++ b/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
@@ -590,7 +590,8 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
             AFMMLXModel(
                 modelID: AFMModelID(rawValue: model),
                 resolver: resolver,
-                attachedService: service!))
+                attachedService: service!,
+                schedulerAdmissionOwnership: .callerReserved))
     }
 
     private static func profile(

--- a/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
+++ b/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
@@ -467,7 +467,8 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
                 stop: stop,
                 responseFormat: responseFormat,
                 chatTemplateKwargs: chatTemplateKwargs,
-                speculativeDecoding: speculativeDecoding
+                speculativeDecoding: speculativeDecoding,
+                preserveStructuralTags: preserveStructuralTags
             )
         )
         let modelID = normalizeModel(model)
@@ -631,7 +632,8 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
         stop: [String]?,
         responseFormat: ResponseFormat?,
         chatTemplateKwargs: [String: AnyCodable]?,
-        speculativeDecoding: SpeculativeDecodingOptions?
+        speculativeDecoding: SpeculativeDecodingOptions?,
+        preserveStructuralTags: Bool? = nil
     ) -> GenerationConfig {
         var metadata = [String: AFMJSONValue]()
         switch toolChoice {
@@ -669,6 +671,10 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
                 speculative["forceAutoregressiveReason"] = .string(forceAutoregressiveReason)
             }
             metadata["speculativeDecoding"] = .object(speculative)
+        }
+        if let preserveStructuralTags {
+            metadata[AFMMLXRequestMetadata.preserveStructuralTags] =
+                .bool(preserveStructuralTags)
         }
         return GenerationConfig(
             temperature: temperature,

--- a/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
+++ b/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
@@ -237,6 +237,50 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
         responseFormat: ResponseFormat?,
         chatTemplateKwargs: [String: AnyCodable]?
     ) async throws -> AFMMLXChatGenerationResult {
+        try await generate(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: nil
+        )
+    }
+
+    func generate(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?
+    ) async throws -> AFMMLXChatGenerationResult {
         let request = try AFMRequest(
             openAIMessages: messages,
             generationConfig: generationConfig(
@@ -255,7 +299,8 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
                 parallelToolCalls: parallelToolCalls,
                 stop: stop,
                 responseFormat: responseFormat,
-                chatTemplateKwargs: chatTemplateKwargs
+                chatTemplateKwargs: chatTemplateKwargs,
+                speculativeDecoding: speculativeDecoding
             )
         )
         let response = try await afmModel(for: model).respond(to: request)
@@ -352,6 +397,54 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
         preserveStructuralTags: Bool,
         requestId: String?
     ) async throws -> AFMMLXChatStreamingResult {
+        try await generateStreaming(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: nil,
+            preserveStructuralTags: preserveStructuralTags,
+            requestId: requestId
+        )
+    }
+
+    func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?,
+        preserveStructuralTags: Bool,
+        requestId: String?
+    ) async throws -> AFMMLXChatStreamingResult {
         let request = try AFMRequest(
             openAIMessages: messages,
             generationConfig: generationConfig(
@@ -370,7 +463,8 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
                 parallelToolCalls: parallelToolCalls,
                 stop: stop,
                 responseFormat: responseFormat,
-                chatTemplateKwargs: chatTemplateKwargs
+                chatTemplateKwargs: chatTemplateKwargs,
+                speculativeDecoding: speculativeDecoding
             )
         )
         let modelID = normalizeModel(model)
@@ -526,7 +620,8 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
         parallelToolCalls: Bool?,
         stop: [String]?,
         responseFormat: ResponseFormat?,
-        chatTemplateKwargs: [String: AnyCodable]?
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?
     ) -> GenerationConfig {
         var metadata = [String: AFMJSONValue]()
         switch toolChoice {
@@ -545,6 +640,22 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
             metadata["chatTemplateKwargs"] = .object(
                 chatTemplateKwargs.mapValues(\.afmJSONValue)
             )
+        }
+        if let speculativeDecoding {
+            var speculative = [String: AFMJSONValue]()
+            if let mode = speculativeDecoding.mode {
+                speculative["mode"] = .string(mode)
+            }
+            if let requirement = speculativeDecoding.requirement {
+                speculative["requirement"] = .string(requirement)
+            }
+            if let drafter = speculativeDecoding.drafter {
+                speculative["drafter"] = .string(drafter)
+            }
+            if let maxDraftTokens = speculativeDecoding.maxDraftTokens {
+                speculative["maxDraftTokens"] = .integer(maxDraftTokens)
+            }
+            metadata["speculativeDecoding"] = .object(speculative)
         }
         return GenerationConfig(
             temperature: temperature,

--- a/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
+++ b/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
@@ -13,8 +13,9 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
     private let defaultChatTemplateKwargs: [String: AnyCodable]?
     private let forceDisableThinking: Bool
     private let slotLock = NSLock()
+    private let fixedSchedulerID = UUID()
     private let fixedMaxConcurrent: Int
-    private var fixedSlotsReserved = 0
+    private var fixedReservationIDs = Set<UUID>()
 
     init(
         service: MLXModelService,
@@ -72,35 +73,43 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
         service?.resolvedToolCallParser(logBypass: logBypass)
     }
 
-    func tryReserveSlot() -> Bool {
+    func tryReserveSlot() -> AFMMLXSchedulerAdmission {
         if let service { return service.tryReserveSlot() }
-        slotLock.lock()
-        defer { slotLock.unlock() }
-        guard fixedSlotsReserved < fixedMaxConcurrent else { return false }
-        fixedSlotsReserved += 1
-        return true
+        return slotLock.withLock {
+            guard fixedReservationIDs.count < fixedMaxConcurrent else {
+                return .unavailable
+            }
+            let reservation = AFMMLXSchedulerReservation(
+                schedulerID: fixedSchedulerID)
+            fixedReservationIDs.insert(reservation.reservationID)
+            return .reserved(reservation)
+        }
     }
 
-    func waitForSlot(timeout: TimeInterval) async -> Bool {
+    func waitForSlot(
+        timeout: TimeInterval
+    ) async -> AFMMLXSchedulerAdmission {
         if let service { return await service.waitForSlot(timeout: timeout) }
         if timeout <= 0 { return tryReserveSlot() }
         let deadline = ContinuousClock.now + .seconds(timeout)
         while ContinuousClock.now < deadline {
-            if Task.isCancelled { return false }
-            if tryReserveSlot() { return true }
+            if Task.isCancelled { return .unavailable }
+            let admission = tryReserveSlot()
+            if admission.isAdmitted { return admission }
             try? await Task.sleep(for: .milliseconds(10))
         }
-        return false
+        return .unavailable
     }
 
-    func releaseSlot() {
+    @discardableResult
+    func releaseSlot(_ reservation: AFMMLXSchedulerReservation) -> Bool {
         if let service {
-            service.releaseSlot()
-            return
+            return service.releaseSlot(reservation)
         }
-        slotLock.lock()
-        fixedSlotsReserved = max(0, fixedSlotsReserved - 1)
-        slotLock.unlock()
+        guard reservation.schedulerID == fixedSchedulerID else { return false }
+        return slotLock.withLock {
+            fixedReservationIDs.remove(reservation.reservationID) != nil
+        }
     }
 
     func tokenize(text: String) async throws -> [Int] {
@@ -492,6 +501,107 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
         preserveStructuralTags: Bool,
         requestId: String?
     ) async throws -> AFMMLXChatStreamingResult {
+        try await generateStreamingWithAdmission(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: speculativeDecoding,
+            preserveStructuralTags: preserveStructuralTags,
+            requestId: requestId,
+            schedulerAdmission: nil)
+    }
+
+    func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?,
+        preserveStructuralTags: Bool,
+        requestId: String?,
+        schedulerAdmission: AFMMLXSchedulerAdmission
+    ) async throws -> AFMMLXChatStreamingResult {
+        try await generateStreamingWithAdmission(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: speculativeDecoding,
+            preserveStructuralTags: preserveStructuralTags,
+            requestId: requestId,
+            schedulerAdmission: schedulerAdmission)
+    }
+
+    private func generateStreamingWithAdmission(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?,
+        preserveStructuralTags: Bool,
+        requestId: String?,
+        schedulerAdmission: AFMMLXSchedulerAdmission?
+    ) async throws -> AFMMLXChatStreamingResult {
+        if schedulerAdmission?.isAdmitted == false {
+            throw AFMError.unavailable("MLX scheduler is at capacity")
+        }
         let request = try AFMRequest(
             openAIMessages: messages,
             generationConfig: generationConfig(
@@ -516,15 +626,19 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
             )
         )
         let modelID = normalizeModel(model)
-        let eventStream = afmModel(for: model).streamResponse(to: request)
+        let eventStream = afmModel(
+            for: model,
+            schedulerAdmission: schedulerAdmission
+        ).streamResponse(to: request)
         let startTag = thinkStartTag
         let endTag = thinkEndTag
+        let fixedReservation = service == nil ? schedulerAdmission?.reservation : nil
 
         let stream = AsyncThrowingStream<StreamChunk, Error> { continuation in
             let task = Task {
                 defer {
-                    if self.service == nil {
-                        self.releaseSlot()
+                    if let fixedReservation {
+                        self.releaseSlot(fixedReservation)
                     }
                 }
                 var promptTokens = 0
@@ -629,14 +743,19 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
         )
     }
 
-    private func afmModel(for model: String) -> AnyAFMModel {
+    private func afmModel(
+        for model: String,
+        schedulerAdmission: AFMMLXSchedulerAdmission? = nil
+    ) -> AnyAFMModel {
         if let fixedModel { return fixedModel }
         return AnyAFMModel(
             AFMMLXModel(
                 modelID: AFMModelID(rawValue: model),
                 resolver: resolver,
                 attachedService: service!,
-                schedulerAdmissionOwnership: .callerReserved))
+                schedulerAdmissionOwnership: schedulerAdmission.map {
+                    .caller($0)
+                } ?? .model))
     }
 
     private static func profile(

--- a/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
+++ b/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
@@ -664,6 +664,9 @@ final class AFMKitMLXChatServingAdapter: AFMMLXOpenAIChatServing, AFMTextTokeniz
             if let maxDraftTokens = speculativeDecoding.maxDraftTokens {
                 speculative["maxDraftTokens"] = .integer(maxDraftTokens)
             }
+            if let forceAutoregressiveReason = speculativeDecoding.forceAutoregressiveReason {
+                speculative["forceAutoregressiveReason"] = .string(forceAutoregressiveReason)
+            }
             metadata["speculativeDecoding"] = .object(speculative)
         }
         return GenerationConfig(

--- a/Sources/AFMServer/Controllers/BatchAPIController.swift
+++ b/Sources/AFMServer/Controllers/BatchAPIController.swift
@@ -294,10 +294,14 @@ struct BatchAPIController: RouteCollection {
                 logprobs: chatReq.logprobs,
                 topLogprobs: chatReq.topLogprobs,
                 tools: chatReq.tools,
+                toolChoice: chatReq.toolChoice,
                 parallelToolCalls: chatReq.parallelToolCalls,
                 stop: chatReq.stop,
                 responseFormat: chatReq.responseFormat,
-                chatTemplateKwargs: chatReq.effectiveChatTemplateKwargs
+                chatTemplateKwargs: chatReq.effectiveChatTemplateKwargs,
+                speculativeDecoding: chatReq.speculativeDecoding,
+                preserveStructuralTags: false,
+                requestId: nil
             )
             reservationTransferred = true
 

--- a/Sources/AFMServer/Controllers/BatchAPIController.swift
+++ b/Sources/AFMServer/Controllers/BatchAPIController.swift
@@ -299,7 +299,8 @@ struct BatchAPIController: RouteCollection {
                 stop: chatReq.stop,
                 responseFormat: chatReq.responseFormat,
                 chatTemplateKwargs: chatReq.effectiveChatTemplateKwargs,
-                speculativeDecoding: chatReq.speculativeDecoding,
+                speculativeDecoding: AFMMLXBatchSpeculativePolicy.forceAutoregressive(
+                    chatReq.speculativeDecoding),
                 preserveStructuralTags: false,
                 requestId: nil
             )

--- a/Sources/AFMServer/Controllers/BatchAPIController.swift
+++ b/Sources/AFMServer/Controllers/BatchAPIController.swift
@@ -260,7 +260,8 @@ struct BatchAPIController: RouteCollection {
 
         do {
             // Reserve slot
-            guard service.tryReserveSlot() else {
+            let schedulerAdmission = service.tryReserveSlot()
+            guard schedulerAdmission.isAdmitted else {
                 let result = BatchResultLine(
                     id: resultId, customId: inputLine.customId,
                     response: nil,
@@ -271,8 +272,9 @@ struct BatchAPIController: RouteCollection {
             }
             var reservationTransferred = false
             defer {
-                if !reservationTransferred {
-                    service.releaseSlot()
+                if !reservationTransferred,
+                   let reservation = schedulerAdmission.reservation {
+                    service.releaseSlot(reservation)
                 }
             }
 
@@ -302,7 +304,8 @@ struct BatchAPIController: RouteCollection {
                 speculativeDecoding: AFMMLXBatchSpeculativePolicy.forceAutoregressive(
                     chatReq.speculativeDecoding),
                 preserveStructuralTags: false,
-                requestId: nil
+                requestId: nil,
+                schedulerAdmission: schedulerAdmission
             )
             reservationTransferred = true
 

--- a/Sources/AFMServer/Controllers/BatchCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/BatchCompletionsController.swift
@@ -205,10 +205,14 @@ struct BatchCompletionsController: RouteCollection {
                 logprobs: chatReq.logprobs,
                 topLogprobs: chatReq.topLogprobs,
                 tools: chatReq.tools,
+                toolChoice: chatReq.toolChoice,
                 parallelToolCalls: chatReq.parallelToolCalls,
                 stop: chatReq.stop,
                 responseFormat: effectiveResponseFormat,
-                chatTemplateKwargs: chatReq.effectiveChatTemplateKwargs
+                chatTemplateKwargs: chatReq.effectiveChatTemplateKwargs,
+                speculativeDecoding: chatReq.speculativeDecoding,
+                preserveStructuralTags: false,
+                requestId: nil
             )
             reservationTransferred = true
 

--- a/Sources/AFMServer/Controllers/BatchCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/BatchCompletionsController.swift
@@ -173,7 +173,8 @@ struct BatchCompletionsController: RouteCollection {
         let isStreaming = chatReq.stream ?? false
 
         do {
-            guard service.tryReserveSlot() else {
+            let schedulerAdmission = service.tryReserveSlot()
+            guard schedulerAdmission.isAdmitted else {
                 let errorEvent = makeErrorEvent(customId: customId, message: "Server at capacity", type: "server_error", encoder: encoder)
                 continuation.yield(errorEvent)
                 decrementAndFinishIfDone(activeCount: activeCount, continuation: continuation)
@@ -181,8 +182,9 @@ struct BatchCompletionsController: RouteCollection {
             }
             var reservationTransferred = false
             defer {
-                if !reservationTransferred {
-                    service.releaseSlot()
+                if !reservationTransferred,
+                   let reservation = schedulerAdmission.reservation {
+                    service.releaseSlot(reservation)
                 }
             }
 
@@ -213,7 +215,8 @@ struct BatchCompletionsController: RouteCollection {
                 speculativeDecoding: AFMMLXBatchSpeculativePolicy.forceAutoregressive(
                     chatReq.speculativeDecoding),
                 preserveStructuralTags: false,
-                requestId: nil
+                requestId: nil,
+                schedulerAdmission: schedulerAdmission
             )
             reservationTransferred = true
 

--- a/Sources/AFMServer/Controllers/BatchCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/BatchCompletionsController.swift
@@ -210,7 +210,8 @@ struct BatchCompletionsController: RouteCollection {
                 stop: chatReq.stop,
                 responseFormat: effectiveResponseFormat,
                 chatTemplateKwargs: chatReq.effectiveChatTemplateKwargs,
-                speculativeDecoding: chatReq.speculativeDecoding,
+                speculativeDecoding: AFMMLXBatchSpeculativePolicy.forceAutoregressive(
+                    chatReq.speculativeDecoding),
                 preserveStructuralTags: false,
                 requestId: nil
             )

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -263,6 +263,7 @@ struct MLXChatCompletionsController: RouteCollection {
                     stop: effectiveStop,
                     responseFormat: effectiveResponseFormat,
                     chatTemplateKwargs: chatRequest.effectiveChatTemplateKwargs,
+                    speculativeDecoding: chatRequest.speculativeDecoding,
                     preserveStructuralTags: !extractThinking,
                     requestId: reqId
                 )
@@ -379,7 +380,8 @@ struct MLXChatCompletionsController: RouteCollection {
                     parallelToolCalls: chatRequest.parallelToolCalls,
                     stop: effectiveStop,
                     responseFormat: effectiveResponseFormat,
-                    chatTemplateKwargs: chatRequest.effectiveChatTemplateKwargs
+                    chatTemplateKwargs: chatRequest.effectiveChatTemplateKwargs,
+                    speculativeDecoding: chatRequest.speculativeDecoding
                 )
             }
             let completionTok = result.completionTokens
@@ -609,6 +611,7 @@ struct MLXChatCompletionsController: RouteCollection {
                     stop: effectiveStop,
                     responseFormat: effectiveResponseFormat,
                     chatTemplateKwargs: chatRequest.effectiveChatTemplateKwargs,
+                    speculativeDecoding: chatRequest.speculativeDecoding,
                     preserveStructuralTags: !extractThinking,
                     requestId: streamReqId
                 )

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -241,7 +241,7 @@ struct MLXChatCompletionsController: RouteCollection {
                 print("[\(Self.timestamp())] [HTTPPipeline] req=\(reqId) json_parse=\(String(format: "%.1f", jsonMs))ms slot_wait=\(String(format: "%.1f", slotMs))ms total=\(String(format: "%.1f", totalMs))ms")
             }
 
-            let result: AFMMLXChatGenerationResult
+            let result: AFMMLXChatGenerationResultWithTelemetry
             if service.maxConcurrent >= 2 {
                 // Batch mode: route through scheduler for batched decode
                 let streamResult: AFMMLXChatStreamingResult = try await service.generateStreaming(
@@ -355,7 +355,7 @@ struct MLXChatCompletionsController: RouteCollection {
 
                 // Tool-call argument coercion is handled in convertToolCall (pre-serialization)
                 // and in the streaming vendor path. No additional pass needed here.
-                result = (
+                result = AFMMLXChatGenerationResultWithTelemetry(
                     modelID: streamResult.modelID,
                     content: fullText,
                     promptTokens: promptTokens,
@@ -369,8 +369,8 @@ struct MLXChatCompletionsController: RouteCollection {
                     speculativeTelemetry: speculativeTelemetry
                 )
             } else {
-                // Serial mode: use existing generate() path
-                result = try await service.generate(
+                // Serial mode: retain speculative telemetry for response headers.
+                result = try await service.generateWithTelemetry(
                     model: modelID,
                     messages: chatRequest.messages,
                     temperature: effectiveTemp,

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -178,7 +178,9 @@ struct MLXChatCompletionsController: RouteCollection {
             // Reserve a concurrent slot — waits up to 4 minutes for a slot to free up.
             // RotatingKVCache models (Gemma 4) fall back to serial execution, so
             // queued requests can wait a long time when all slots are occupied.
-            guard await service.waitForSlot(timeout: Self.slotQueueTimeout) else {
+            let schedulerAdmission = await service.waitForSlot(
+                timeout: Self.slotQueueTimeout)
+            guard schedulerAdmission.isAdmitted else {
                 let peer = req.peerAddress?.description ?? "unknown"
                 let ua = req.headers.first(name: .userAgent) ?? "unknown"
                 req.logger.warning("Connection refused: at capacity after \(Int(Self.slotQueueTimeout))s wait (\(service.maxConcurrent)/\(service.maxConcurrent)) — client=\(peer) ua=\(ua)")
@@ -192,6 +194,13 @@ struct MLXChatCompletionsController: RouteCollection {
                 ))
                 return response
             }
+            var schedulerAdmissionTransferred = false
+            defer {
+                if !schedulerAdmissionTransferred,
+                   let reservation = schedulerAdmission.reservation {
+                    service.releaseSlot(reservation)
+                }
+            }
 
             // Reset peak memory before each request so usage.peak_memory_gib
             // reflects this request only (matches mlx_lm's mx.reset_peak_memory())
@@ -201,14 +210,17 @@ struct MLXChatCompletionsController: RouteCollection {
             let extractThinking = !rawOutput || isWebUI
 
             if chatRequest.stream == true && streamingEnabled {
-                return try await createStreamingResponse(req: req, chatRequest: chatRequest, extractThinking: extractThinking, effectiveResponseFormat: effectiveResponseFormat, grammarDowngraded: grammarDowngraded, requestId: reqId)
+                let response = try await createStreamingResponse(
+                    req: req,
+                    chatRequest: chatRequest,
+                    extractThinking: extractThinking,
+                    effectiveResponseFormat: effectiveResponseFormat,
+                    grammarDowngraded: grammarDowngraded,
+                    requestId: reqId,
+                    schedulerAdmission: schedulerAdmission)
+                schedulerAdmissionTransferred = true
+                return response
             }
-
-            // In concurrent mode, non-streaming requests currently bypass the
-            // BatchScheduler decode loop, so the controller must release the
-            // reservation itself. Streaming requests are released by the
-            // scheduler when the stream finishes.
-            defer { service.releaseSlot() }
 
             // AFM Profile: start GPU monitoring if client requests it
             let profileHeader = req.headers.first(name: "X-AFM-Profile")?.lowercased()
@@ -265,8 +277,10 @@ struct MLXChatCompletionsController: RouteCollection {
                     chatTemplateKwargs: chatRequest.effectiveChatTemplateKwargs,
                     speculativeDecoding: chatRequest.speculativeDecoding,
                     preserveStructuralTags: !extractThinking,
-                    requestId: reqId
+                    requestId: reqId,
+                    schedulerAdmission: schedulerAdmission
                 )
+                schedulerAdmissionTransferred = true
 
                 // Collect stream into complete response
                 var fullText = ""
@@ -521,7 +535,15 @@ struct MLXChatCompletionsController: RouteCollection {
         }
     }
 
-    private func createStreamingResponse(req: Request, chatRequest: ChatCompletionRequest, extractThinking: Bool, effectiveResponseFormat: ResponseFormat?, grammarDowngraded: Bool = false, requestId: String = "") async throws -> Response {
+    private func createStreamingResponse(
+        req: Request,
+        chatRequest: ChatCompletionRequest,
+        extractThinking: Bool,
+        effectiveResponseFormat: ResponseFormat?,
+        grammarDowngraded: Bool = false,
+        requestId: String = "",
+        schedulerAdmission: AFMMLXSchedulerAdmission
+    ) async throws -> Response {
         let httpResponse = Response(status: .ok)
         httpResponse.headers.add(name: .contentType, value: "text/event-stream")
         httpResponse.headers.add(name: .cacheControl, value: "no-cache")
@@ -567,6 +589,13 @@ struct MLXChatCompletionsController: RouteCollection {
             // when the SSE body finishes.
             StatsAggregator.shared.connectionStarted()
             defer { StatsAggregator.shared.connectionEnded() }
+            var schedulerAdmissionTransferred = false
+            defer {
+                if !schedulerAdmissionTransferred,
+                   let reservation = schedulerAdmission.reservation {
+                    service.releaseSlot(reservation)
+                }
+            }
             let encoder = JSONEncoder()
             var fullContent = ""
             let started = Date()
@@ -621,8 +650,10 @@ struct MLXChatCompletionsController: RouteCollection {
                     chatTemplateKwargs: chatRequest.effectiveChatTemplateKwargs,
                     speculativeDecoding: chatRequest.speculativeDecoding,
                     preserveStructuralTags: !extractThinking,
-                    requestId: streamReqId
+                    requestId: streamReqId,
+                    schedulerAdmission: schedulerAdmission
                 )
+                schedulerAdmissionTransferred = true
                 try Task.checkCancellation()
                 // Emit an initial assistant delta so clients always open a response container.
                 let initialChunk = ChatCompletionStreamResponse(

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -280,7 +280,9 @@ struct MLXChatCompletionsController: RouteCollection {
                 var stoppedBySequence = false
                 var speculativeTelemetry: AFMMLXSpeculativeTelemetry?
 
+                try Task.checkCancellation()
                 for try await chunk in streamResult.stream {
+                    try Task.checkCancellation()
                     fullText += chunk.text
                     if let lp = chunk.logprobs { allLogprobs.append(contentsOf: lp) }
                     if let tc = chunk.toolCalls { finalToolCalls = tc }
@@ -294,6 +296,7 @@ struct MLXChatCompletionsController: RouteCollection {
                         speculativeTelemetry = telemetry
                     }
                 }
+                try Task.checkCancellation()
 
                 // FIX: Vendor ToolCallProcessor can append XML tag remnants to tool names
                 // for zero-parameter calls (e.g. "todoread</function"). Strip them.
@@ -620,6 +623,7 @@ struct MLXChatCompletionsController: RouteCollection {
                     preserveStructuralTags: !extractThinking,
                     requestId: streamReqId
                 )
+                try Task.checkCancellation()
                 // Emit an initial assistant delta so clients always open a response container.
                 let initialChunk = ChatCompletionStreamResponse(
                     id: streamId,
@@ -746,6 +750,7 @@ struct MLXChatCompletionsController: RouteCollection {
 
                 var pendingRawTag: String? = nil
                 for try await streamChunk in res.stream {
+                    try Task.checkCancellation()
                     let piece = streamChunk.text
 
                     // Capture real token counts and timing from the info chunk
@@ -1141,6 +1146,10 @@ struct MLXChatCompletionsController: RouteCollection {
                         }
                     }
                 }
+                // AsyncThrowingStream reports cancellation while awaiting the
+                // next element as normal end-of-stream. Re-check the consumer
+                // task before translating that termination into stop + usage.
+                try Task.checkCancellation()
 
                 // Handle incomplete tool call (model hit max tokens mid-tool-call)
                 if let toolRuntime {

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -278,6 +278,7 @@ struct MLXChatCompletionsController: RouteCollection {
                 var promptTime: Double = 0
                 var generateTime: Double = 0
                 var stoppedBySequence = false
+                var speculativeTelemetry: AFMMLXSpeculativeTelemetry?
 
                 for try await chunk in streamResult.stream {
                     fullText += chunk.text
@@ -289,6 +290,9 @@ struct MLXChatCompletionsController: RouteCollection {
                     if let pt = chunk.promptTime { promptTime = pt }
                     if let gt = chunk.generateTime { generateTime = gt }
                     if let sbs = chunk.stoppedBySequence { stoppedBySequence = sbs }
+                    if let telemetry = chunk.speculativeTelemetry {
+                        speculativeTelemetry = telemetry
+                    }
                 }
 
                 // FIX: Vendor ToolCallProcessor can append XML tag remnants to tool names
@@ -358,7 +362,8 @@ struct MLXChatCompletionsController: RouteCollection {
                     cachedTokens: cachedTokens,
                     promptTime: promptTime,
                     generateTime: generateTime,
-                    stoppedBySequence: stoppedBySequence
+                    stoppedBySequence: stoppedBySequence,
+                    speculativeTelemetry: speculativeTelemetry
                 )
             } else {
                 // Serial mode: use existing generate() path

--- a/Sources/AFMServer/Controllers/MetricsController.swift
+++ b/Sources/AFMServer/Controllers/MetricsController.swift
@@ -172,6 +172,11 @@ struct MetricsController: RouteCollection {
             s.speculativeAcceptedTokensTotal
         )
         counter(
+            "afm:speculative_emitted_tokens_total",
+            "Total output tokens committed by speculative verification.",
+            s.speculativeEmittedTokensTotal
+        )
+        counter(
             "afm:speculative_verification_cycles_total",
             "Total speculative target-verification cycles.",
             s.speculativeVerificationCyclesTotal

--- a/Sources/AFMServer/Controllers/MetricsController.swift
+++ b/Sources/AFMServer/Controllers/MetricsController.swift
@@ -78,6 +78,11 @@ struct MetricsController: RouteCollection {
             out += "# TYPE \(name) counter\n"
             out += "\(name)\(modelLabel) \(value)\n"
         }
+        func floatingCounter(_ name: String, _ help: String, _ value: Double) {
+            out += "# HELP \(name) \(help)\n"
+            out += "# TYPE \(name) counter\n"
+            out += "\(name)\(modelLabel) \(formatDouble(value))\n"
+        }
 
         // ─── Gauges ─────────────────────────────────────────────────────────
         gauge(
@@ -156,6 +161,42 @@ struct MetricsController: RouteCollection {
             "Total number of prefix cache misses (radix tree) since server start.",
             s.cacheMissesTotal
         )
+        counter(
+            "afm:speculative_drafted_tokens_total",
+            "Total tokens proposed by speculative drafters.",
+            s.speculativeDraftedTokensTotal
+        )
+        counter(
+            "afm:speculative_accepted_tokens_total",
+            "Total proposed tokens accepted by target verification.",
+            s.speculativeAcceptedTokensTotal
+        )
+        counter(
+            "afm:speculative_verification_cycles_total",
+            "Total speculative target-verification cycles.",
+            s.speculativeVerificationCyclesTotal
+        )
+        floatingCounter(
+            "afm:speculative_draft_seconds_total",
+            "Cumulative speculative drafting time in seconds.",
+            s.speculativeDraftSecondsTotal
+        )
+        floatingCounter(
+            "afm:speculative_verification_seconds_total",
+            "Cumulative target verification time in seconds.",
+            s.speculativeVerificationSecondsTotal
+        )
+        floatingCounter(
+            "afm:speculative_rollback_seconds_total",
+            "Cumulative target cache restore/replay time in seconds.",
+            s.speculativeRollbackSecondsTotal
+        )
+        out += "# HELP afm:speculative_strategy_cycles_total Speculative verification cycles by strategy.\n"
+        out += "# TYPE afm:speculative_strategy_cycles_total counter\n"
+        for strategy in s.speculativeCyclesByStrategy.keys.sorted() {
+            let value = s.speculativeCyclesByStrategy[strategy] ?? 0
+            out += "afm:speculative_strategy_cycles_total{\(modelLabelOnly),strategy=\"\(labelEscape(strategy))\"} \(value)\n"
+        }
 
         // request_success_total{finished_reason=...} — vLLM-style labeled counter.
         out += "# HELP afm:request_success_total Count of successfully processed requests, broken out by finished_reason (stop|length|tool_calls|abort|error|...).\n"

--- a/Sources/AFMServer/Controllers/OpenAPIController.swift
+++ b/Sources/AFMServer/Controllers/OpenAPIController.swift
@@ -126,7 +126,7 @@ struct OpenAPIController: RouteCollection {
               "response_format": { "$ref": "#/components/schemas/ResponseFormat" },
               "speculative_decoding": {
                 "type": "object",
-                "description": "Optional provider-neutral speculative decoding controls. Preferred mode may fall back; required mode returns an error when unavailable or incompatible.",
+                "description": "Optional provider-neutral speculative decoding controls. DFlash 2 requires explicit temperature 0 and serial text generation without sampling modifiers or non-neutral penalties. Omitted temperature retains the normal sampling default. Preferred mode falls back to autoregressive decoding for incompatible, prefix-cache, concurrent, or batch requests; required mode returns an error before output. Mode off disables every speculative runtime for the request.",
                 "properties": {
                   "mode": { "type": "string", "enum": ["auto", "off", "dflash2"] },
                   "requirement": { "type": "string", "enum": ["preferred", "required"] },

--- a/Sources/AFMServer/Controllers/OpenAPIController.swift
+++ b/Sources/AFMServer/Controllers/OpenAPIController.swift
@@ -128,11 +128,12 @@ struct OpenAPIController: RouteCollection {
                 "type": "object",
                 "description": "Optional provider-neutral speculative decoding controls. Preferred mode may fall back; required mode returns an error when unavailable or incompatible.",
                 "properties": {
-                  "mode": { "type": "string", "description": "Provider/runtime mode such as auto, off, or dflash2." },
+                  "mode": { "type": "string", "enum": ["auto", "off", "dflash2"] },
                   "requirement": { "type": "string", "enum": ["preferred", "required"] },
-                  "drafter": { "type": "string", "description": "Drafter resource identifier or server-local path." },
+                  "drafter": { "type": "string", "description": "Must match the DFlash 2 drafter loaded at server startup; request-time drafter switching is rejected." },
                   "max_draft_tokens": { "type": "integer", "minimum": 1 }
-                }
+                },
+                "additionalProperties": false
               }
             }
           },

--- a/Sources/AFMServer/Controllers/OpenAPIController.swift
+++ b/Sources/AFMServer/Controllers/OpenAPIController.swift
@@ -123,7 +123,17 @@ struct OpenAPIController: RouteCollection {
               "tools": { "type": "array", "items": { "$ref": "#/components/schemas/Tool" } },
               "tool_choice": { "description": "auto | none | required | { type: 'function', function: { name } }" },
               "parallel_tool_calls": { "type": "boolean", "description": "When false, the server emits at most one tool call per assistant turn." },
-              "response_format": { "$ref": "#/components/schemas/ResponseFormat" }
+              "response_format": { "$ref": "#/components/schemas/ResponseFormat" },
+              "speculative_decoding": {
+                "type": "object",
+                "description": "Optional provider-neutral speculative decoding controls. Preferred mode may fall back; required mode returns an error when unavailable or incompatible.",
+                "properties": {
+                  "mode": { "type": "string", "description": "Provider/runtime mode such as auto, off, or dflash2." },
+                  "requirement": { "type": "string", "enum": ["preferred", "required"] },
+                  "drafter": { "type": "string", "description": "Drafter resource identifier or server-local path." },
+                  "max_draft_tokens": { "type": "integer", "minimum": 1 }
+                }
+              }
             }
           },
           "Message": {

--- a/Tests/MacLocalAPITests/AFMDwarfStarCheckpointTests.swift
+++ b/Tests/MacLocalAPITests/AFMDwarfStarCheckpointTests.swift
@@ -40,6 +40,110 @@ final class AFMDwarfStarCheckpointTests: XCTestCase {
         XCTAssertFalse(AFMDwarfStarCheckpointCatalog.isGGUF(at: model))
     }
 
+    func testBoundedGGUFHeaderProbeRejectsUnsupportedArchitectureBeforeDownload() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let model = directory.appendingPathComponent("unsupported.gguf")
+        try writeMinimalGGUF(to: model, architecture: "qwen3")
+        let header = try Data(contentsOf: model)
+
+        let architecture = AFMDwarfStarCheckpointCatalog.ggufArchitecture(in: header)
+        XCTAssertEqual(architecture, "qwen3")
+        XCTAssertThrowsError(
+            try AFMDwarfStarHubSelector.validateArchitecture(
+                architecture,
+                path: "unsupported.gguf"
+            )
+        ) { error in
+            guard case AFMDwarfStarHubSelectionError.unsupportedArchitecture(
+                let path,
+                let actual
+            ) = error else {
+                return XCTFail("unexpected error: \(error)")
+            }
+            XCTAssertEqual(path, "unsupported.gguf")
+            XCTAssertEqual(actual, "qwen3")
+            XCTAssertTrue(error.localizedDescription.contains("deepseek4"))
+        }
+    }
+
+    func testBoundedGGUFRangeProbeRejectsFullResponseBeforeReadingBody() async throws {
+        IgnoredRangeURLProtocol.reset()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [IgnoredRangeURLProtocol.self]
+        let delegate = AFMDwarfStarBoundedRangeDataDelegate(maximumBytes: 16)
+        let session = URLSession(
+            configuration: configuration,
+            delegate: delegate,
+            delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+        var request = URLRequest(url: URL(string: "https://example.invalid/model.gguf")!)
+        request.setValue("bytes=0-15", forHTTPHeaderField: "Range")
+
+        do {
+            _ = try await delegate.run(request: request, session: session)
+            XCTFail("expected a server that ignores Range to be rejected")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("did not honor"))
+        }
+
+        XCTAssertEqual(IgnoredRangeURLProtocol.lastRange, "bytes=0-15")
+        XCTAssertEqual(delegate.acceptedByteCount, 0)
+    }
+
+    func testDwarfStarHubCacheLockCoordinatesAcrossProcesses() async throws {
+        let python = URL(fileURLWithPath: "/usr/bin/python3")
+        guard FileManager.default.isExecutableFile(atPath: python.path) else {
+            throw XCTSkip("/usr/bin/python3 is required for the cross-process lock test")
+        }
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let artifact = directory
+            .appendingPathComponent("models--org--model/blobs/blob-key")
+        let lockFile = AFMDwarfStarHubCacheCoordinator.lockFileURL(
+            cacheDirectory: directory,
+            artifact: artifact
+        )
+        let acquiredMarker = directory.appendingPathComponent("python-acquired")
+        let releaseMarker = directory.appendingPathComponent("python-release")
+        let script = """
+        import fcntl, os, sys, time
+        lock_path, acquired, release = sys.argv[1:]
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+        with open(lock_path, "w") as handle:
+            fcntl.flock(handle, fcntl.LOCK_EX)
+            open(acquired, "w").close()
+            while not os.path.exists(release):
+                time.sleep(0.01)
+        """
+        let process = Process()
+        process.executableURL = python
+        process.arguments = [
+            "-c", script, lockFile.path, acquiredMarker.path, releaseMarker.path
+        ]
+        try process.run()
+        defer {
+            if process.isRunning { process.terminate() }
+        }
+
+        try await waitForFile(acquiredMarker)
+        let started = ContinuousClock.now
+        let waiter = Task {
+            try await AFMDwarfStarHubCacheCoordinator.withArtifactLock(
+                cacheDirectory: directory,
+                artifact: artifact
+            ) {}
+            return ContinuousClock.now - started
+        }
+        try await Task.sleep(for: .milliseconds(150))
+        try Data().write(to: releaseMarker)
+        let elapsed = try await waiter.value
+        process.waitUntilExit()
+
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertGreaterThanOrEqual(elapsed, .milliseconds(100))
+    }
+
     func testExternalAFMCheckpointHeadersCanBeCataloged() throws {
         let environment = ProcessInfo.processInfo.environment
         guard environment["AFM_DWARFSTAR_REAL_CHECKPOINT_TEST"] == "1" else {
@@ -219,6 +323,16 @@ final class AFMDwarfStarCheckpointTests: XCTestCase {
         return root
     }
 
+    private func waitForFile(_ url: URL) async throws {
+        let deadline = ContinuousClock.now + .seconds(5)
+        while !FileManager.default.fileExists(atPath: url.path) {
+            guard ContinuousClock.now < deadline else {
+                throw CocoaError(.fileReadUnknown)
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
     private func writeMinimalGGUF(to url: URL, architecture: String) throws {
         var data = Data("GGUF".utf8)
         data.appendLittleEndian(UInt32(3))
@@ -365,6 +479,40 @@ final class AFMDwarfStarCheckpointTests: XCTestCase {
             tensorDataOffset: tensorDataOffset,
             relativeOffsetPositions: positions)
     }
+}
+
+private final class IgnoredRangeURLProtocol: URLProtocol, @unchecked Sendable {
+    private static let stateLock = NSLock()
+    nonisolated(unsafe) private static var recordedRange: String?
+
+    static var lastRange: String? {
+        stateLock.withLock { recordedRange }
+    }
+
+    static func reset() {
+        stateLock.withLock { recordedRange = nil }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.stateLock.withLock {
+            Self.recordedRange = request.value(forHTTPHeaderField: "Range")
+        }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Length": "1048576"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(repeating: 0x5a, count: 1_048_576))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }
 
 private extension Data {

--- a/Tests/MacLocalAPITests/AFMKitMLXReasoningPropagationTests.swift
+++ b/Tests/MacLocalAPITests/AFMKitMLXReasoningPropagationTests.swift
@@ -35,7 +35,14 @@ final class AFMKitMLXReasoningPropagationTests: XCTestCase {
 
         func respond(to request: AFMRequest) async throws -> AFMModelResponse {
             await capture.append(request)
-            return AFMModelResponse(text: "captured", reasoning: "thought")
+            return AFMModelResponse(
+                text: "captured",
+                reasoning: "thought",
+                metadata: [
+                    AFMMLXSpeculativeTelemetry.metadataKey:
+                        Self.telemetry.metadataValue,
+                ]
+            )
         }
 
         func streamResponse(
@@ -44,10 +51,18 @@ final class AFMKitMLXReasoningPropagationTests: XCTestCase {
             AsyncThrowingStream { continuation in
                 Task {
                     await capture.append(request)
+                    continuation.yield(.metadata([
+                        AFMMLXSpeculativeTelemetry.metadataKey:
+                            Self.telemetry.metadataValue,
+                    ]))
+                    continuation.yield(.completed(.stop))
                     continuation.finish()
                 }
             }
         }
+
+        static let telemetry = AFMMLXSpeculativeTelemetry.fallback(
+            strategy: "dflash2", reason: "disabled")
     }
 
     func testStartupReasoningDefaultsReachAFMRequestMetadata() async throws {
@@ -80,6 +95,7 @@ final class AFMKitMLXReasoningPropagationTests: XCTestCase {
         XCTAssertEqual(adapter.thinkStartTag, "<think>")
         XCTAssertEqual(adapter.thinkEndTag, "</think>")
         XCTAssertEqual(result.content, "<think>thought</think>captured")
+        XCTAssertEqual(result.speculativeTelemetry, CapturingModel.telemetry)
     }
 
     func testRequestReasoningEffortOverridesStartupDefault() async throws {
@@ -161,13 +177,17 @@ final class AFMKitMLXReasoningPropagationTests: XCTestCase {
             preserveStructuralTags: false,
             requestId: "spec-test"
         )
-        for try await _ in result.stream {}
+        var streamedTelemetry: AFMMLXSpeculativeTelemetry?
+        for try await chunk in result.stream {
+            streamedTelemetry = chunk.speculativeTelemetry ?? streamedTelemetry
+        }
 
         let request = await capture.request(at: 0)
         XCTAssertEqual(
             request.metadata["speculativeDecoding"],
             .object(["mode": .string("off")])
         )
+        XCTAssertEqual(streamedTelemetry, CapturingModel.telemetry)
     }
 
     private func makeAdapter(

--- a/Tests/MacLocalAPITests/AFMKitMLXReasoningPropagationTests.swift
+++ b/Tests/MacLocalAPITests/AFMKitMLXReasoningPropagationTests.swift
@@ -16,14 +16,18 @@ final class AFMKitMLXReasoningPropagationTests: XCTestCase {
     }
 
     private struct CapturingModel: AFMModel {
-        let descriptor = AFMModelDescriptor(
-            providerID: "test.capture",
-            modelID: "capture",
-            displayName: "Capture",
-            capabilities: [.text, .reasoning],
-            metadata: ["maxConcurrent": .integer(1)]
-        )
         let capture: RequestCapture
+        let maxConcurrent: Int
+
+        var descriptor: AFMModelDescriptor {
+            AFMModelDescriptor(
+                providerID: "test.capture",
+                modelID: "capture",
+                displayName: "Capture",
+                capabilities: [.text, .reasoning],
+                metadata: ["maxConcurrent": .integer(maxConcurrent)]
+            )
+        }
 
         func availability() async -> AFMModelAvailability { .available }
 
@@ -187,15 +191,69 @@ final class AFMKitMLXReasoningPropagationTests: XCTestCase {
             request.metadata["speculativeDecoding"],
             .object(["mode": .string("off")])
         )
+        XCTAssertEqual(
+            request.metadata[AFMMLXRequestMetadata.preserveStructuralTags],
+            .bool(false))
         XCTAssertEqual(streamedTelemetry, CapturingModel.telemetry)
+    }
+
+    func testStreamingStructuralTagsHaveSerialConcurrentParity() async throws {
+        let serialCapture = RequestCapture()
+        let concurrentCapture = RequestCapture()
+        let serial = makeAdapter(
+            capture: serialCapture,
+            defaults: [:],
+            maxConcurrent: 1)
+        let concurrent = makeAdapter(
+            capture: concurrentCapture,
+            defaults: [:],
+            maxConcurrent: 4)
+
+        for adapter in [serial, concurrent] {
+            let result = try await adapter.generateStreaming(
+                model: "capture",
+                messages: [Message(role: "user", content: "hello")],
+                temperature: nil,
+                maxTokens: 8,
+                topP: nil,
+                repetitionPenalty: nil,
+                topK: nil,
+                minP: nil,
+                presencePenalty: nil,
+                seed: nil,
+                logprobs: nil,
+                topLogprobs: nil,
+                tools: nil,
+                toolChoice: nil,
+                parallelToolCalls: nil,
+                stop: nil,
+                responseFormat: nil,
+                chatTemplateKwargs: nil,
+                speculativeDecoding: nil,
+                preserveStructuralTags: true,
+                requestId: nil)
+            for try await _ in result.stream {}
+        }
+
+        let serialRequest = await serialCapture.request(at: 0)
+        let concurrentRequest = await concurrentCapture.request(at: 0)
+        XCTAssertEqual(
+            serialRequest.metadata[AFMMLXRequestMetadata.preserveStructuralTags],
+            .bool(true))
+        XCTAssertEqual(
+            concurrentRequest.metadata[AFMMLXRequestMetadata.preserveStructuralTags],
+            .bool(true))
     }
 
     private func makeAdapter(
         capture: RequestCapture,
-        defaults: [String: AnyCodable]
+        defaults: [String: AnyCodable],
+        maxConcurrent: Int = 1
     ) -> AFMKitMLXChatServingAdapter {
         AFMKitMLXChatServingAdapter(
-            model: AnyAFMModel(CapturingModel(capture: capture)),
+            model: AnyAFMModel(CapturingModel(
+                capture: capture,
+                maxConcurrent: maxConcurrent)),
             modelID: "capture",
             defaultChatTemplateKwargs: defaults
         )

--- a/Tests/MacLocalAPITests/AFMKitMLXReasoningPropagationTests.swift
+++ b/Tests/MacLocalAPITests/AFMKitMLXReasoningPropagationTests.swift
@@ -263,8 +263,8 @@ final class AFMKitMLXReasoningPropagationTests: XCTestCase {
         adapter: AFMKitMLXChatServingAdapter,
         kwargs: [String: AnyCodable]?,
         speculativeDecoding: SpeculativeDecodingOptions? = nil
-    ) async throws -> AFMMLXChatGenerationResult {
-        try await adapter.generate(
+    ) async throws -> AFMMLXChatGenerationResultWithTelemetry {
+        try await adapter.generateWithTelemetry(
             model: "capture",
             messages: [Message(role: "user", content: "hello")],
             temperature: nil,

--- a/Tests/MacLocalAPITests/AFMKitMLXReasoningPropagationTests.swift
+++ b/Tests/MacLocalAPITests/AFMKitMLXReasoningPropagationTests.swift
@@ -42,7 +42,10 @@ final class AFMKitMLXReasoningPropagationTests: XCTestCase {
             to request: AFMRequest
         ) -> AsyncThrowingStream<AFMGenerationEvent, Error> {
             AsyncThrowingStream { continuation in
-                continuation.finish()
+                Task {
+                    await capture.append(request)
+                    continuation.finish()
+                }
             }
         }
     }
@@ -104,6 +107,69 @@ final class AFMKitMLXReasoningPropagationTests: XCTestCase {
         )
     }
 
+    func testSpeculativeControlsReachAFMRequestMetadata() async throws {
+        let capture = RequestCapture()
+        let adapter = makeAdapter(capture: capture, defaults: [:])
+        let speculative = SpeculativeDecodingOptions(
+            mode: "dflash2",
+            requirement: "required",
+            drafter: "incoai/example",
+            maxDraftTokens: 4
+        )
+
+        _ = try await generate(
+            adapter: adapter,
+            kwargs: nil,
+            speculativeDecoding: speculative
+        )
+
+        let request = await capture.request(at: 0)
+        XCTAssertEqual(
+            request.metadata["speculativeDecoding"],
+            .object([
+                "mode": .string("dflash2"),
+                "requirement": .string("required"),
+                "drafter": .string("incoai/example"),
+                "maxDraftTokens": .integer(4),
+            ])
+        )
+    }
+
+    func testStreamingSpeculativeControlsReachAFMRequestMetadata() async throws {
+        let capture = RequestCapture()
+        let adapter = makeAdapter(capture: capture, defaults: [:])
+        let result = try await adapter.generateStreaming(
+            model: "capture",
+            messages: [Message(role: "user", content: "hello")],
+            temperature: nil,
+            maxTokens: 8,
+            topP: nil,
+            repetitionPenalty: nil,
+            topK: nil,
+            minP: nil,
+            presencePenalty: nil,
+            seed: nil,
+            logprobs: nil,
+            topLogprobs: nil,
+            tools: nil,
+            toolChoice: nil,
+            parallelToolCalls: nil,
+            stop: nil,
+            responseFormat: nil,
+            chatTemplateKwargs: nil,
+            speculativeDecoding: SpeculativeDecodingOptions(mode: "off"),
+            preserveStructuralTags: false,
+            requestId: "spec-test"
+        )
+        for try await _ in result.stream {}
+
+        let request = await capture.request(at: 0)
+        XCTAssertEqual(
+            request.metadata["speculativeDecoding"],
+            .object(["mode": .string("off")])
+        )
+    }
+
     private func makeAdapter(
         capture: RequestCapture,
         defaults: [String: AnyCodable]
@@ -117,7 +183,8 @@ final class AFMKitMLXReasoningPropagationTests: XCTestCase {
 
     private func generate(
         adapter: AFMKitMLXChatServingAdapter,
-        kwargs: [String: AnyCodable]?
+        kwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions? = nil
     ) async throws -> AFMMLXChatGenerationResult {
         try await adapter.generate(
             model: "capture",
@@ -133,10 +200,12 @@ final class AFMKitMLXReasoningPropagationTests: XCTestCase {
             logprobs: nil,
             topLogprobs: nil,
             tools: nil,
+            toolChoice: nil,
             parallelToolCalls: nil,
             stop: nil,
             responseFormat: nil,
-            chatTemplateKwargs: kwargs
+            chatTemplateKwargs: kwargs,
+            speculativeDecoding: speculativeDecoding
         )
     }
 }

--- a/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
@@ -242,6 +242,21 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
                 SpeculativeDecodingOptions(mode: "dflash2", requirement: "required")))
         XCTAssertTrue(required.requiresRuntime)
         XCTAssertEqual(required.denialReason, "batch")
+        XCTAssertEqual(service.dflash2UnavailableReason(
+            policy: required,
+            runtimeFallbackReason: "prefix_cache",
+            defaultReason: "unavailable"), "batch")
+
+        let runtimePermitted = try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(mode: "dflash2", requirement: "required"))
+        XCTAssertEqual(service.dflash2UnavailableReason(
+            policy: runtimePermitted,
+            runtimeFallbackReason: "prefix_cache",
+            defaultReason: "unavailable"), "prefix_cache")
+        XCTAssertEqual(service.dflash2UnavailableReason(
+            policy: runtimePermitted,
+            runtimeFallbackReason: "concurrency",
+            defaultReason: "unavailable"), "concurrency")
     }
 
     func testPromptOpenedReasoningBoundaryIsRestoredForNonStreamingOutput() {

--- a/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
@@ -103,7 +103,7 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
         XCTAssertEqual(runtime.dflash2Requirement, .required)
     }
 
-    func testProviderMaxDraftTokensValidatesIntegerBoundariesBeforeAddition() {
+    func testProviderMaxDraftTokensValidatesIntegerBoundariesBeforeAddition() throws {
         let largestValid = AFMProviderConfiguration(values: [
             "speculativeDecoding": .object([
                 "mode": .string("dflash2"),
@@ -117,12 +117,37 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
             ]),
         ])
 
-        XCTAssertEqual(
-            AFMMLXRuntimeConfiguration(providerConfiguration: largestValid).dflash2BlockSize,
-            Int.max)
-        XCTAssertEqual(
-            AFMMLXRuntimeConfiguration(providerConfiguration: overflowing).dflash2BlockSize,
-            5)
+        let largestValidRuntime = AFMMLXRuntimeConfiguration(
+            providerConfiguration: largestValid)
+        XCTAssertEqual(largestValidRuntime.dflash2BlockSize, Int.max)
+        XCTAssertNoThrow(try largestValidRuntime.validateForStartup())
+
+        let overflowingRuntime = AFMMLXRuntimeConfiguration(
+            providerConfiguration: overflowing)
+        XCTAssertThrowsError(try overflowingRuntime.validateForStartup()) { error in
+            XCTAssertTrue(error.localizedDescription.contains(
+                "speculative_decoding.max_draft_tokens must be less than Int.max"))
+        }
+    }
+
+    func testRuntimeLoadRejectsOverflowingProviderMaxDraftTokensBeforeModelLoad() async {
+        let configuration = AFMProviderConfiguration(values: [
+            "speculativeDecoding": .object([
+                "mode": .string("dflash2"),
+                "maxDraftTokens": .integer(Int.max),
+            ]),
+        ])
+        let runtime = AFMMLXRuntime(
+            modelID: "tests/startup-validation",
+            providerConfiguration: configuration)
+
+        do {
+            _ = try await runtime.load()
+            XCTFail("expected startup validation failure")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains(
+                "speculative_decoding.max_draft_tokens must be less than Int.max"))
+        }
     }
 
     func testRequestPolicyFallsBackOrRequiresBeforeEmission() throws {

--- a/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
@@ -1,0 +1,332 @@
+import XCTest
+import AFMKitCore
+import MLX
+import MLXLMCommon
+@testable import AFMKitMLX
+@testable import AFMOpenAICompat
+
+final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
+    func testSelectorParametersUseCheckpointCompatibleNestedKeys() throws {
+        let model = try tinyDraftModel()
+        let keys = Set(model.parameters().flattened().map(\.0))
+        XCTAssertTrue(keys.contains("candidate_selector.hidden_projection.weight"))
+        XCTAssertTrue(keys.contains("candidate_selector.predecessor_codebook.weight"))
+        XCTAssertTrue(keys.contains("candidate_selector.successor_codebook.weight"))
+    }
+
+    func testGreedyGenerationRemainsTargetEquivalentAndCancellable() throws {
+        let draft = try tinyDraftModel()
+        let target = DeterministicDFlash2Target()
+        let generator = try DFlash2Generator(target: target, draft: draft, blockSize: 4)
+
+        let result = generator.generate(promptIDs: [1], maxTokens: 4)
+        XCTAssertEqual(result.tokenIDs, [5, 6, 7, 8])
+        XCTAssertEqual(result.statistics.emittedTokens, 4)
+        XCTAssertGreaterThan(result.statistics.verificationCycles, 0)
+
+        let cancelled = generator.generate(
+            promptIDs: [1], maxTokens: 4, shouldStop: { true })
+        XCTAssertEqual(cancelled.tokenIDs, [])
+    }
+
+    private func tinyDraftModel() throws -> DFlash2DraftModel {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let metadata: [String: Any] = [
+            "architectures": ["DFlash2DraftModel"],
+            "is_causal": false,
+            "hidden_size": 16,
+            "intermediate_size": 32,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "vocab_size": 32,
+            "num_target_layers": 2,
+            "rms_norm_eps": 0.000001,
+            "rope_theta": 1_000_000,
+            "dflash_config": [
+                "target_layer_ids": [1],
+                "block_size": 4,
+                "mask_token_id": 31,
+                "conv_kernel_size": 2,
+                "conv_group_size": 8,
+                "selector_rank": 4,
+                "selector_top_k": 4,
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: metadata)
+            .write(to: directory.appendingPathComponent("config.json"))
+
+        let config = try DFlash2DraftConfiguration.load(directory: directory.path)
+        return DFlash2DraftModel(config)
+    }
+
+    func testProviderNeutralStartupConfigurationMapsToMLXRuntime() {
+        let configuration = AFMProviderConfiguration(values: [
+            "speculativeDecoding": .object([
+                "mode": .string("dflash2"),
+                "drafter": .string("incoai/example"),
+                "maxDraftTokens": .integer(4),
+                "requirement": .string("required"),
+            ]),
+        ])
+
+        let runtime = AFMMLXRuntimeConfiguration(providerConfiguration: configuration)
+        XCTAssertEqual(runtime.dflash2Drafter, "incoai/example")
+        XCTAssertEqual(runtime.dflash2BlockSize, 5)
+        XCTAssertEqual(runtime.dflash2Requirement, .required)
+    }
+
+    func testRequestPolicyFallsBackOrRequiresBeforeEmission() throws {
+        let service = MLXModelService(resolver: MLXCacheResolver())
+        service.dflash2Drafter = "incoai/loaded"
+
+        let disabled = try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(mode: "off"))
+        XCTAssertFalse(disabled.permitsRuntime)
+        XCTAssertFalse(disabled.requiresRuntime)
+
+        let mismatch = try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(
+                mode: "dflash2", requirement: "required", drafter: "incoai/other"))
+        XCTAssertFalse(mismatch.permitsRuntime)
+        XCTAssertTrue(mismatch.requiresRuntime)
+        XCTAssertNotNil(mismatch.denialReason)
+
+        let invalidCount = try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(mode: "dflash2", maxDraftTokens: 0))
+        XCTAssertFalse(invalidCount.permitsRuntime)
+        XCTAssertEqual(invalidCount.denialReason, "max_draft_tokens must be at least 1")
+
+        XCTAssertThrowsError(try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(requirement: "best-effort")))
+    }
+
+    func testQwenReleasedContractValidatesByMetadata() throws {
+        let config = try AFMMLXDFlash2Configuration(metadata: draftMetadata(
+            hidden: 5_120,
+            targetLayers: 64,
+            vocabulary: 248_320,
+            block: 8,
+            mask: 248_070,
+            targetLayerIDs: [5, 19, 33, 47, 61]))
+
+        try config.validateTarget(metadata: [
+            "model_type": "qwen3_5",
+            "text_config": [
+                "model_type": "qwen3_5_text",
+                "hidden_size": 5_120,
+                "num_hidden_layers": 64,
+                "vocab_size": 248_320,
+            ],
+        ])
+        XCTAssertEqual(try config.effectiveBlockSize(requested: 5), 5)
+        XCTAssertEqual(try config.effectiveBlockSize(requested: 20), 8)
+    }
+
+    func testMuseReleasedContractValidatesByMetadata() throws {
+        let config = try AFMMLXDFlash2Configuration(metadata: draftMetadata(
+            hidden: 6_656,
+            targetLayers: 52,
+            vocabulary: 202_048,
+            block: 16,
+            mask: 201_818,
+            targetLayerIDs: [1, 13, 25, 37, 49]))
+
+        try config.validateTarget(metadata: [
+            "model_type": "muse_glimmer",
+            "text_config": [
+                "model_type": "muse_glimmer_text",
+                "hidden_size": 6_656,
+                "num_hidden_layers": 52,
+                "vocab_size": 202_048,
+            ],
+        ])
+    }
+
+    func testRepositoryNameCannotMakeLegacyDFlashLookLikeDFlash2() {
+        var metadata = draftMetadata(
+            hidden: 5_120,
+            targetLayers: 64,
+            vocabulary: 248_320,
+            block: 8,
+            mask: 248_070,
+            targetLayerIDs: [5, 19, 33, 47, 61])
+        metadata["architectures"] = ["DFlashDraftModel"]
+
+        XCTAssertThrowsError(try AFMMLXDFlash2Configuration(metadata: metadata)) {
+            XCTAssertEqual(
+                $0 as? AFMMLXDFlash2ConfigurationError,
+                .unsupportedArchitecture(["DFlashDraftModel"]))
+        }
+    }
+
+    func testRejectsNonTwoTapConvolutionMetadata() {
+        var metadata = draftMetadata(
+            hidden: 5_120,
+            targetLayers: 64,
+            vocabulary: 248_320,
+            block: 8,
+            mask: 248_070,
+            targetLayerIDs: [5, 19, 33, 47, 61])
+        var dflash = metadata["dflash_config"] as? [String: Any] ?? [:]
+        dflash["conv_kernel_size"] = 3
+        metadata["dflash_config"] = dflash
+
+        XCTAssertThrowsError(try AFMMLXDFlash2Configuration(metadata: metadata))
+    }
+
+    func testTargetShapeMismatchFailsBeforeWeightsLoad() throws {
+        let config = try AFMMLXDFlash2Configuration(metadata: draftMetadata(
+            hidden: 5_120,
+            targetLayers: 64,
+            vocabulary: 248_320,
+            block: 8,
+            mask: 248_070,
+            targetLayerIDs: [5, 19, 33, 47, 61]))
+
+        XCTAssertThrowsError(try config.validateTarget(metadata: [
+            "model_type": "qwen3_5",
+            "text_config": [
+                "model_type": "qwen3_5_text",
+                "hidden_size": 5_120,
+                "num_hidden_layers": 64,
+                "vocab_size": 202_048,
+            ],
+        ]))
+    }
+
+    func testOpenAIRequestDecodesNeutralSpeculativeControls() throws {
+        let data = Data(#"""
+        {
+          "model":"target",
+          "messages":[{"role":"user","content":"hello"}],
+          "speculative_decoding":{
+            "mode":"dflash2",
+            "requirement":"required",
+            "drafter":"incoai/example",
+            "max_draft_tokens":4
+          }
+        }
+        """#.utf8)
+        let request = try JSONDecoder().decode(ChatCompletionRequest.self, from: data)
+        XCTAssertEqual(request.speculativeDecoding?.mode, "dflash2")
+        XCTAssertEqual(request.speculativeDecoding?.requirement, "required")
+        XCTAssertEqual(request.speculativeDecoding?.drafter, "incoai/example")
+        XCTAssertEqual(request.speculativeDecoding?.maxDraftTokens, 4)
+    }
+
+    func testDFlash2FallsBackForStringStopsAndSampling() {
+        let withStops = AFMMLXSpeculativeGenerationDecision.evaluate(
+            mode: .dflash2,
+            installedRuntime: .dflash2,
+            temperature: 0,
+            hasUnsupportedGenerationModifiers: false,
+            hasReasoningOutput: false,
+            hasImages: false,
+            hasStopSequences: true)
+        XCTAssertEqual(withStops.path, .fallback)
+        XCTAssertEqual(withStops.reason, .stopSequences)
+
+        let sampled = AFMMLXSpeculativeGenerationDecision.evaluate(
+            mode: .dflash2,
+            installedRuntime: .dflash2,
+            temperature: 0.7,
+            hasUnsupportedGenerationModifiers: false,
+            hasReasoningOutput: false,
+            hasImages: false,
+            hasStopSequences: false)
+        XCTAssertEqual(sampled.path, .fallback)
+        XCTAssertEqual(sampled.reason, .samplingEnabled)
+    }
+
+    func testNeutralTelemetryDerivesMeanAcceptanceLength() {
+        let telemetry = AFMMLXSpeculativeTelemetry(
+            strategy: "dflash2",
+            draftedTokens: 8,
+            acceptedDraftTokens: 6,
+            emittedTokens: 8,
+            verificationCycles: 4,
+            draftTime: 0.1,
+            verificationTime: 0.2,
+            rollbackTime: 0.03)
+        XCTAssertEqual(telemetry.meanAcceptanceLength, 1.5)
+    }
+
+    private func draftMetadata(
+        hidden: Int,
+        targetLayers: Int,
+        vocabulary: Int,
+        block: Int,
+        mask: Int,
+        targetLayerIDs: [Int]
+    ) -> [String: Any] {
+        [
+            "architectures": ["DFlash2DraftModel"],
+            "model_type": "qwen3",
+            "is_causal": false,
+            "hidden_size": hidden,
+            "intermediate_size": hidden * 3,
+            "num_hidden_layers": 5,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "vocab_size": vocabulary,
+            "num_target_layers": targetLayers,
+            "dflash_config": [
+                "target_layer_ids": targetLayerIDs,
+                "block_size": block,
+                "mask_token_id": mask,
+                "conv_kernel_size": 2,
+                "conv_group_size": 16,
+                "selector_rank": 256,
+                "selector_top_k": 16,
+            ],
+        ]
+    }
+}
+
+private final class DeterministicDFlash2Target: DFlash2Target {
+    var position = 0
+    let dflash2HiddenSize = 16
+    let dflash2LayerCount = 2
+    let dflash2VocabularySize = 32
+
+    func dflash2NewCache() -> [any KVCache] {
+        position = 0
+        return []
+    }
+
+    func dflash2Embed(_ tokenIDs: MLXArray) -> MLXArray {
+        MLXArray.zeros([1, tokenIDs.dim(1), dflash2HiddenSize])
+    }
+
+    func dflash2Project(_ hidden: MLXArray) -> MLXArray {
+        MLXArray.zeros([1, hidden.dim(1), dflash2VocabularySize])
+    }
+
+    func dflash2Forward(
+        _ tokenIDs: MLXArray,
+        captureLayerIDs: [Int],
+        cache: [any KVCache]
+    ) -> DFlash2TargetOutput {
+        let length = tokenIDs.dim(1)
+        let logits = MLXArray.zeros([1, length, dflash2VocabularySize])
+        for index in 0 ..< length {
+            logits[0, index, 5 + position + index] = MLXArray(Float(100))
+        }
+        position += length
+        return DFlash2TargetOutput(
+            hidden: MLXArray.zeros([1, length, dflash2HiddenSize * captureLayerIDs.count]),
+            logits: logits)
+    }
+
+    func dflash2CaptureCache(_ cache: [any KVCache]) -> Any { position }
+
+    func dflash2RestoreCache(_ snapshot: Any, into cache: [any KVCache]) {
+        position = snapshot as? Int ?? position
+    }
+}

--- a/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
@@ -103,6 +103,28 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
         XCTAssertEqual(runtime.dflash2Requirement, .required)
     }
 
+    func testProviderMaxDraftTokensValidatesIntegerBoundariesBeforeAddition() {
+        let largestValid = AFMProviderConfiguration(values: [
+            "speculativeDecoding": .object([
+                "mode": .string("dflash2"),
+                "maxDraftTokens": .integer(Int.max - 1),
+            ]),
+        ])
+        let overflowing = AFMProviderConfiguration(values: [
+            "speculativeDecoding": .object([
+                "mode": .string("dflash2"),
+                "maxDraftTokens": .integer(Int.max),
+            ]),
+        ])
+
+        XCTAssertEqual(
+            AFMMLXRuntimeConfiguration(providerConfiguration: largestValid).dflash2BlockSize,
+            Int.max)
+        XCTAssertEqual(
+            AFMMLXRuntimeConfiguration(providerConfiguration: overflowing).dflash2BlockSize,
+            5)
+    }
+
     func testRequestPolicyFallsBackOrRequiresBeforeEmission() throws {
         let service = MLXModelService(resolver: MLXCacheResolver())
         service.dflash2Drafter = "incoai/loaded"
@@ -137,6 +159,23 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
             SpeculativeDecodingOptions(mode: "eagle3")))
         XCTAssertThrowsError(try service.dflash2RequestPolicy(
             SpeculativeDecodingOptions(mode: "off", requirement: "required")))
+    }
+
+    func testRequestPolicyValidatesIntegerBoundariesBeforeAddition() throws {
+        let service = MLXModelService(resolver: MLXCacheResolver())
+        service.dflash2Drafter = "incoai/loaded"
+        service.dflash2BlockSize = Int.max
+
+        let boundary = try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(
+                mode: "dflash2",
+                maxDraftTokens: Int.max - 1))
+        XCTAssertEqual(boundary.requestedBlockSize, Int.max)
+
+        XCTAssertThrowsError(try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(
+                mode: "dflash2",
+                maxDraftTokens: Int.max)))
     }
 
     func testServiceSamplingCompatibilityPreservesNormalDefaultsAndPenalties() {

--- a/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
@@ -20,18 +20,37 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
         let target = DeterministicDFlash2Target()
         let generator = try DFlash2Generator(target: target, draft: draft, blockSize: 4)
 
-        let result = generator.generate(promptIDs: [1], maxTokens: 4)
+        let result = try generator.generate(promptIDs: [1], maxTokens: 4)
         XCTAssertEqual(result.tokenIDs, [5, 6, 7, 8])
         XCTAssertEqual(result.statistics.emittedTokens, 4)
         XCTAssertGreaterThan(result.statistics.verificationCycles, 0)
 
-        let cancelled = generator.generate(
-            promptIDs: [1], maxTokens: 4, shouldStop: { true })
-        XCTAssertEqual(cancelled.tokenIDs, [])
+        XCTAssertThrowsError(try generator.generate(
+            promptIDs: [1], maxTokens: 4, shouldStop: { true })) {
+            XCTAssertTrue($0 is CancellationError)
+        }
+
+        var partiallyEmitted = 0
+        XCTAssertThrowsError(try generator.generate(
+            promptIDs: [1],
+            maxTokens: 4,
+            onToken: { _ in
+                partiallyEmitted += 1
+                return partiallyEmitted < 2
+            })) {
+            XCTAssertTrue($0 is CancellationError)
+        }
+        XCTAssertEqual(partiallyEmitted, 2)
+
+        let secondaryEOS = try generator.generate(
+            promptIDs: [1], maxTokens: 4, stopTokenIDs: [7])
+        XCTAssertEqual(secondaryEOS.tokenIDs, [5, 6])
+        XCTAssertEqual(secondaryEOS.statistics.emittedTokens, 2)
     }
 
     private func tinyDraftModel() throws -> DFlash2DraftModel {
-        let directory = FileManager.default.temporaryDirectory
+        let directory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(".build/test-artifacts", isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -91,12 +110,14 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
         let disabled = try service.dflash2RequestPolicy(
             SpeculativeDecodingOptions(mode: "off"))
         XCTAssertFalse(disabled.permitsRuntime)
+        XCTAssertFalse(disabled.permitsOtherRuntimes)
         XCTAssertFalse(disabled.requiresRuntime)
 
         service.dflash2Requirement = .required
         let explicitlyDisabled = try service.dflash2RequestPolicy(
             SpeculativeDecodingOptions(mode: "off"))
         XCTAssertFalse(explicitlyDisabled.permitsRuntime)
+        XCTAssertFalse(explicitlyDisabled.permitsOtherRuntimes)
         XCTAssertFalse(explicitlyDisabled.requiresRuntime)
 
         XCTAssertThrowsError(try service.dflash2RequestPolicy(
@@ -116,6 +137,144 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
             SpeculativeDecodingOptions(mode: "eagle3")))
         XCTAssertThrowsError(try service.dflash2RequestPolicy(
             SpeculativeDecodingOptions(mode: "off", requirement: "required")))
+    }
+
+    func testServiceSamplingCompatibilityPreservesNormalDefaultsAndPenalties() {
+        let service = MLXModelService(resolver: MLXCacheResolver())
+
+        XCTAssertEqual(
+            service.speculativeRequestCompatibility(
+                temperature: nil, topP: nil, repetitionPenalty: nil,
+                topK: nil, minP: nil, presencePenalty: nil,
+                hasTools: false, hasResponseFormat: false,
+                wantsLogprobs: false, hasStopSequences: false).denialReason,
+            "sampling")
+        XCTAssertTrue(service.speculativeRequestCompatibility(
+            temperature: 0, topP: 1, repetitionPenalty: 1,
+            topK: 0, minP: 0, presencePenalty: 0,
+            hasTools: false, hasResponseFormat: false,
+            wantsLogprobs: false, hasStopSequences: false).isEligible)
+        XCTAssertEqual(service.speculativeRequestCompatibility(
+            temperature: 0, topP: 1, repetitionPenalty: 1.1,
+            topK: 0, minP: 0, presencePenalty: 0,
+            hasTools: false, hasResponseFormat: false,
+            wantsLogprobs: false, hasStopSequences: false).denialReason, "penalties")
+        XCTAssertEqual(service.speculativeRequestCompatibility(
+            temperature: 0, topP: 1, repetitionPenalty: 1,
+            topK: 0, minP: 0, presencePenalty: 0.4,
+            hasTools: false, hasResponseFormat: false,
+            wantsLogprobs: false, hasStopSequences: false).denialReason, "penalties")
+    }
+
+    func testExplicitPreferredAndOffDoNotSelectOtherSpeculativeRuntimes() throws {
+        let service = MLXModelService(resolver: MLXCacheResolver())
+        service.dflash2Drafter = "incoai/loaded"
+
+        let preferred = try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(requirement: "preferred"))
+        XCTAssertTrue(preferred.permitsRuntime)
+        XCTAssertFalse(preferred.permitsOtherRuntimes)
+
+        let off = try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(mode: "off"))
+        XCTAssertFalse(off.permitsRuntime)
+        XCTAssertFalse(off.permitsOtherRuntimes)
+        XCTAssertEqual(off.denialReason, "disabled")
+    }
+
+    func testServiceBuildsCompleteEOSSet() {
+        let eos = MLXModelService.completeEOSTokenIDs(
+            configuredTokenIDs: [10, 11],
+            tokenizerTokenID: 12,
+            extraTokens: ["<end>", "<missing>"],
+            tokenID: { $0 == "<end>" ? 13 : nil })
+        XCTAssertEqual(eos, [10, 11, 12, 13])
+    }
+
+    func testServiceInstancesHaveIndependentDFlashRuntimeScopes() {
+        let first = MLXModelService(resolver: MLXCacheResolver())
+        let second = MLXModelService(resolver: MLXCacheResolver())
+        XCTAssertNotEqual(first.dflash2RuntimeScopeID, second.dflash2RuntimeScopeID)
+
+        first.dflash2Drafter = "incoai/first"
+        second.dflash2Drafter = "incoai/second"
+        XCTAssertNoThrow(try first.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(drafter: "incoai/first")))
+        XCTAssertNoThrow(try second.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(drafter: "incoai/second")))
+        XCTAssertThrowsError(try first.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(drafter: "incoai/second")))
+    }
+
+    func testPrefixConcurrencyAndBatchFallbackReasonsAreStable() throws {
+        let service = MLXModelService(resolver: MLXCacheResolver())
+        service.dflash2Drafter = "incoai/loaded"
+        service.enablePrefixCaching = true
+        XCTAssertEqual(service.dflash2StartupFallbackReason(), "prefix_cache")
+        service.maxConcurrent = 2
+        XCTAssertEqual(service.dflash2StartupFallbackReason(), "concurrency")
+
+        let forced = AFMMLXBatchSpeculativePolicy.forceAutoregressive(
+            SpeculativeDecodingOptions(mode: "dflash2", requirement: "preferred"))
+        let preferred = try service.dflash2RequestPolicy(forced)
+        XCTAssertFalse(preferred.permitsRuntime)
+        XCTAssertFalse(preferred.permitsOtherRuntimes)
+        XCTAssertFalse(preferred.requiresRuntime)
+        XCTAssertEqual(preferred.denialReason, "batch")
+
+        let required = try service.dflash2RequestPolicy(
+            AFMMLXBatchSpeculativePolicy.forceAutoregressive(
+                SpeculativeDecodingOptions(mode: "dflash2", requirement: "required")))
+        XCTAssertTrue(required.requiresRuntime)
+        XCTAssertEqual(required.denialReason, "batch")
+    }
+
+    func testPromptOpenedReasoningBoundaryIsRestoredForNonStreamingOutput() {
+        let restored = MLXModelService.restorePromptOpenedReasoningBoundary(
+            generatedText: "private reasoning</think>visible answer",
+            promptSuffix: "assistant\n<think>\n",
+            startTag: "<think>",
+            endTag: "</think>")
+        var translator = MLXStreamEventTranslator(
+            thinkStartTag: "<think>",
+            thinkEndTag: "</think>",
+            maximumResponseTokens: nil)
+        let events = translator.consume(StreamChunk(text: restored)) + translator.finish()
+        let visible = events.compactMap { event -> String? in
+            guard case .responseText(_, let delta, _) = event else { return nil }
+            return delta
+        }.joined()
+        let reasoning = events.compactMap { event -> String? in
+            guard case .reasoningText(_, let delta, _) = event else { return nil }
+            return delta
+        }.joined()
+        XCTAssertEqual(reasoning, "private reasoning")
+        XCTAssertEqual(visible, "visible answer")
+    }
+
+    func testSpeculativeCompletionPopulatesBaseRequestTelemetry() {
+        let service = MLXModelService(resolver: MLXCacheResolver())
+        StatsAggregator.shared.reset()
+        defer { StatsAggregator.shared.reset() }
+        StatsAggregator.shared.requestStarted()
+        service.recordSpeculativeRequestCompletion(
+            queuedAt: Date(timeIntervalSince1970: 100),
+            completedAt: Date(timeIntervalSince1970: 100.3),
+            promptTokens: 12,
+            completionTokens: 4,
+            promptTime: 0.1,
+            maxTokens: 10)
+
+        let snapshot = StatsAggregator.shared.snapshot()
+        XCTAssertEqual(snapshot.promptTokensTotal, 12)
+        XCTAssertEqual(snapshot.genTokensTotal, 4)
+        XCTAssertEqual(snapshot.requestsStartedTotal, 1)
+        XCTAssertEqual(snapshot.requestsCompletedTotal, 1)
+        XCTAssertEqual(snapshot.requestSuccessByReason["stop"], 1)
+        XCTAssertEqual(snapshot.promptTokens.count, 1)
+        XCTAssertEqual(snapshot.generationTokens.count, 1)
+        XCTAssertEqual(snapshot.prefillTime.count, 1)
+        XCTAssertEqual(snapshot.decodeTime.count, 1)
     }
 
     func testQwenReleasedContractValidatesByMetadata() throws {
@@ -276,6 +435,58 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
         XCTAssertThrowsError(try config.validateWeights(in: directory)) {
             XCTAssertTrue($0.localizedDescription.contains("fc.weight"))
         }
+    }
+
+    func testSharedRuntimePreflightPreservesValidatedTargetContract() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(".build/test-artifacts", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let target = root.appendingPathComponent("target", isDirectory: true)
+        let draft = root.appendingPathComponent("draft", isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: draft, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var draftObject = draftMetadata(
+            hidden: 16,
+            targetLayers: 2,
+            vocabulary: 32,
+            block: 4,
+            mask: 31,
+            targetLayerIDs: [1])
+        draftObject["eos_token_id"] = 30
+        draftObject["pad_token_id"] = 30
+        try JSONSerialization.data(withJSONObject: draftObject, options: [.sortedKeys])
+            .write(to: draft.appendingPathComponent("config.json"))
+        let configuration = try AFMMLXDFlash2Configuration(metadata: draftObject)
+        try writeSafetensorHeader(
+            shapes: configuration.expectedTensorShapes(),
+            to: draft.appendingPathComponent("model.safetensors"))
+
+        let targetObject: [String: Any] = [
+            "model_type": "qwen3_5",
+            "generation_config": ["eos_token_id": [30]],
+            "text_config": [
+                "model_type": "qwen3_5_text",
+                "hidden_size": 16,
+                "num_hidden_layers": 2,
+                "vocab_size": 32,
+                "max_position_embeddings": 262_144,
+                "eos_token_id": 30,
+                "rope_parameters": ["rope_theta": 10_000_000],
+            ],
+        ]
+        let targetData = try JSONSerialization.data(
+            withJSONObject: targetObject, options: [.sortedKeys])
+        try targetData.write(to: target.appendingPathComponent("config.json"))
+
+        let preflight = try AFMMLXDFlash2PreflightValidator.validate(
+            targetDirectory: target,
+            drafterDirectory: draft,
+            requestedBlockSize: 3)
+        XCTAssertEqual(preflight.blockSize, 3)
+        XCTAssertEqual(preflight.targetConfigurationData, targetData)
+        XCTAssertEqual(preflight.configuration.hiddenSize, 16)
     }
 
     func testOpenAIRequestDecodesNeutralSpeculativeControls() throws {

--- a/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
@@ -201,9 +201,10 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
         let eos = MLXModelService.completeEOSTokenIDs(
             configuredTokenIDs: [10, 11],
             tokenizerTokenID: 12,
+            unknownTokenID: 14,
             extraTokens: ["<end>", "<missing>"],
             tokenID: { $0 == "<end>" ? 13 : nil })
-        XCTAssertEqual(eos, [10, 11, 12, 13])
+        XCTAssertEqual(eos, [10, 11, 12, 13, 14])
     }
 
     func testServiceInstancesHaveIndependentDFlashRuntimeScopes() {
@@ -333,28 +334,24 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
     }
 
     func testMuseReleasedContractValidatesByMetadata() throws {
-        let config = try AFMMLXDFlash2Configuration(metadata: draftMetadata(
-            hidden: 6_656,
-            targetLayers: 52,
-            vocabulary: 202_048,
-            block: 16,
-            mask: 201_818,
-            targetLayerIDs: [1, 13, 25, 37, 49]))
+        let target = museTargetMetadata()
+        let config = try AFMMLXDFlash2Configuration(
+            metadata: museAssistantMetadata(), targetMetadata: target)
 
-        try config.validateTarget(metadata: [
-            "model_type": "muse_glimmer",
-            "text_config": [
-                "model_type": "muse_glimmer_text",
-                "hidden_size": 6_656,
-                "num_hidden_layers": 52,
-                "vocab_size": 202_048,
-                "max_position_embeddings": 131_072,
-                "bos_token_id": 200_000,
-                "eos_token_id": 200_001,
-                "sliding_window": 2_048,
-                "rope_parameters": ["rope_theta": 500_000],
-            ],
-        ])
+        XCTAssertEqual(config.draftArchitecture, "MuseGlimmerAssistantModel")
+        XCTAssertEqual(config.targetLayers, 52)
+        XCTAssertEqual(config.vocabularySize, 202_048)
+        XCTAssertEqual(config.targetLayerIDs, [1, 13, 25, 37, 49])
+        XCTAssertEqual(config.checkpointBlockSize, 16)
+        XCTAssertEqual(config.convolutionKernelSize, 0)
+        XCTAssertEqual(config.selectorRank, 0)
+        XCTAssertEqual(config.expectedTensorShapes().count, 53)
+        XCTAssertNotNil(config.expectedTensorShapes()["encoder.fc.weight"])
+        XCTAssertNil(config.expectedTensorShapes()["candidate_selector.hidden_projection.weight"])
+        try config.validateTarget(metadata: target)
+
+        XCTAssertThrowsError(try AFMMLXDFlash2Configuration(
+            metadata: museAssistantMetadata()))
     }
 
     func testRepositoryNameCannotMakeLegacyDFlashLookLikeDFlash2() {
@@ -667,6 +664,55 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
                 "conv_group_size": 16,
                 "selector_rank": 256,
                 "selector_top_k": 16,
+            ],
+        ]
+    }
+
+    private func museAssistantMetadata() -> [String: Any] {
+        [
+            "architectures": ["MuseGlimmerAssistantModel"],
+            "attention_dropout": 0,
+            "block_size": 16,
+            "bos_token_id": 200_000,
+            "dtype": "bfloat16",
+            "eos_token_id": 200_001,
+            "head_dim": 128,
+            "hidden_act": "silu",
+            "hidden_size": 6_656,
+            "intermediate_size": 19_968,
+            "layer_types": Array(repeating: "sliding_attention", count: 5),
+            "mask_token_id": 201_818,
+            "max_position_embeddings": 131_072,
+            "model_type": "muse_glimmer_assistant",
+            "num_attention_heads": 32,
+            "num_hidden_layers": 5,
+            "num_key_value_heads": 8,
+            "pad_token_id": 200_018,
+            "rms_norm_eps": 0.00001,
+            "rope_parameters": [
+                "rope_theta": 500_000.0,
+                "rope_type": "default",
+            ],
+            "sliding_window": 2_048,
+            "target_layer_ids": [1, 13, 25, 37, 49],
+            "transformers_version": "5.15.0.dev0",
+        ]
+    }
+
+    private func museTargetMetadata() -> [String: Any] {
+        [
+            "model_type": "muse_glimmer",
+            "text_config": [
+                "model_type": "muse_glimmer_text",
+                "hidden_size": 6_656,
+                "num_hidden_layers": 52,
+                "vocab_size": 202_048,
+                "max_position_embeddings": 131_072,
+                "bos_token_id": 200_000,
+                "eos_token_id": 200_001,
+                "pad_token_id": 200_018,
+                "sliding_window": 2_048,
+                "rope_parameters": ["rope_theta": 500_000],
             ],
         ]
     }

--- a/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import AFMKit
 import AFMKitCore
 import MLX
 import MLXLMCommon
@@ -46,7 +47,10 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
             "vocab_size": 32,
             "num_target_layers": 2,
             "rms_norm_eps": 0.000001,
-            "rope_theta": 1_000_000,
+            "max_position_embeddings": 4_096,
+            "layer_types": ["sliding_attention"],
+            "sliding_window": 2_048,
+            "rope_parameters": ["rope_theta": 1_000_000],
             "dflash_config": [
                 "target_layer_ids": [1],
                 "block_size": 4,
@@ -89,20 +93,25 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
         XCTAssertFalse(disabled.permitsRuntime)
         XCTAssertFalse(disabled.requiresRuntime)
 
-        let mismatch = try service.dflash2RequestPolicy(
-            SpeculativeDecodingOptions(
-                mode: "dflash2", requirement: "required", drafter: "incoai/other"))
-        XCTAssertFalse(mismatch.permitsRuntime)
-        XCTAssertTrue(mismatch.requiresRuntime)
-        XCTAssertNotNil(mismatch.denialReason)
+        service.dflash2Requirement = .required
+        let explicitlyDisabled = try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(mode: "off"))
+        XCTAssertFalse(explicitlyDisabled.permitsRuntime)
+        XCTAssertFalse(explicitlyDisabled.requiresRuntime)
 
-        let invalidCount = try service.dflash2RequestPolicy(
-            SpeculativeDecodingOptions(mode: "dflash2", maxDraftTokens: 0))
-        XCTAssertFalse(invalidCount.permitsRuntime)
-        XCTAssertEqual(invalidCount.denialReason, "max_draft_tokens must be at least 1")
+        XCTAssertThrowsError(try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(
+                mode: "dflash2", requirement: "required", drafter: "incoai/other")))
+
+        XCTAssertThrowsError(try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(mode: "dflash2", maxDraftTokens: 0)))
 
         XCTAssertThrowsError(try service.dflash2RequestPolicy(
             SpeculativeDecodingOptions(requirement: "best-effort")))
+        XCTAssertThrowsError(try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(mode: "eagle3")))
+        XCTAssertThrowsError(try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(mode: "off", requirement: "required")))
     }
 
     func testQwenReleasedContractValidatesByMetadata() throws {
@@ -121,6 +130,9 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
                 "hidden_size": 5_120,
                 "num_hidden_layers": 64,
                 "vocab_size": 248_320,
+                "max_position_embeddings": 262_144,
+                "eos_token_id": 248_044,
+                "rope_parameters": ["rope_theta": 10_000_000],
             ],
         ])
         XCTAssertEqual(try config.effectiveBlockSize(requested: 5), 5)
@@ -143,6 +155,11 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
                 "hidden_size": 6_656,
                 "num_hidden_layers": 52,
                 "vocab_size": 202_048,
+                "max_position_embeddings": 131_072,
+                "bos_token_id": 200_000,
+                "eos_token_id": 200_001,
+                "sliding_window": 2_048,
+                "rope_parameters": ["rope_theta": 500_000],
             ],
         ])
     }
@@ -195,8 +212,66 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
                 "hidden_size": 5_120,
                 "num_hidden_layers": 64,
                 "vocab_size": 202_048,
+                "max_position_embeddings": 262_144,
+                "eos_token_id": 248_044,
+                "rope_parameters": ["rope_theta": 10_000_000],
             ],
         ]))
+    }
+
+    func testRejectsMismatchedTargetContextAndTokenizerContract() throws {
+        let config = try AFMMLXDFlash2Configuration(metadata: draftMetadata(
+            hidden: 5_120,
+            targetLayers: 64,
+            vocabulary: 248_320,
+            block: 8,
+            mask: 248_070,
+            targetLayerIDs: [5, 19, 33, 47, 61]))
+        let target: [String: Any] = [
+            "model_type": "qwen3_5",
+            "text_config": [
+                "model_type": "qwen3_5_text",
+                "hidden_size": 5_120,
+                "num_hidden_layers": 64,
+                "vocab_size": 248_320,
+                "max_position_embeddings": 262_144,
+                "eos_token_id": 7,
+                "rope_parameters": ["rope_theta": 10_000_000],
+            ],
+        ]
+
+        XCTAssertThrowsError(try config.validateTarget(metadata: target)) {
+            XCTAssertTrue($0.localizedDescription.contains("eos_token_id"))
+        }
+    }
+
+    func testSafetensorShapesValidateBeforeWeightLoad() throws {
+        let config = try AFMMLXDFlash2Configuration(metadata: draftMetadata(
+            hidden: 16,
+            targetLayers: 2,
+            vocabulary: 32,
+            block: 4,
+            mask: 31,
+            targetLayerIDs: [1]))
+        let directory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(".build/test-artifacts", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        var shapes = config.expectedTensorShapes()
+        shapes["candidate_selector.predecessor_codebook"] =
+            shapes.removeValue(forKey: "candidate_selector.predecessor_codebook.weight")
+        shapes["candidate_selector.successor_codebook"] =
+            shapes.removeValue(forKey: "candidate_selector.successor_codebook.weight")
+        try writeSafetensorHeader(shapes: shapes, to: directory.appendingPathComponent("model.safetensors"))
+        XCTAssertNoThrow(try config.validateWeights(in: directory))
+
+        shapes["fc.weight"] = [15, 16]
+        try writeSafetensorHeader(shapes: shapes, to: directory.appendingPathComponent("model.safetensors"))
+        XCTAssertThrowsError(try config.validateWeights(in: directory)) {
+            XCTAssertTrue($0.localizedDescription.contains("fc.weight"))
+        }
     }
 
     func testOpenAIRequestDecodesNeutralSpeculativeControls() throws {
@@ -217,6 +292,30 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
         XCTAssertEqual(request.speculativeDecoding?.requirement, "required")
         XCTAssertEqual(request.speculativeDecoding?.drafter, "incoai/example")
         XCTAssertEqual(request.speculativeDecoding?.maxDraftTokens, 4)
+    }
+
+    func testAFMRequestDecodesNeutralSpeculativeControls() throws {
+        let request = try AFMRequest(
+            openAIMessages: [Message(role: "user", content: "hello")],
+            generationConfig: GenerationConfig(metadata: [
+                "speculativeDecoding": .object([
+                    "mode": .string("dflash2"),
+                    "requirement": .string("required"),
+                    "drafter": .string("incoai/example"),
+                    "maxDraftTokens": .integer(4),
+                ]),
+            ])
+        )
+
+        XCTAssertEqual(
+            request.speculativeDecodingOptions(),
+            SpeculativeDecodingOptions(
+                mode: "dflash2",
+                requirement: "required",
+                drafter: "incoai/example",
+                maxDraftTokens: 4
+            )
+        )
     }
 
     func testDFlash2FallsBackForStringStopsAndSampling() {
@@ -270,12 +369,21 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
             "is_causal": false,
             "hidden_size": hidden,
             "intermediate_size": hidden * 3,
-            "num_hidden_layers": 5,
+            "num_hidden_layers": targetLayerIDs.count,
             "num_attention_heads": 32,
             "num_key_value_heads": 8,
             "head_dim": 128,
             "vocab_size": vocabulary,
             "num_target_layers": targetLayers,
+            "max_position_embeddings": targetLayers == 52 ? 131_072 : 262_144,
+            "layer_types": Array(repeating: "sliding_attention", count: targetLayerIDs.count),
+            "sliding_window": 2_048,
+            "rope_parameters": [
+                "rope_theta": targetLayers == 52 ? 500_000 : 10_000_000,
+            ],
+            "bos_token_id": targetLayers == 52 ? 200_000 : NSNull(),
+            "eos_token_id": targetLayers == 52 ? 200_001 : 248_044,
+            "pad_token_id": targetLayers == 52 ? 200_018 : 248_044,
             "dflash_config": [
                 "target_layer_ids": targetLayerIDs,
                 "block_size": block,
@@ -286,6 +394,18 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
                 "selector_top_k": 16,
             ],
         ]
+    }
+
+    private func writeSafetensorHeader(shapes: [String: [Int]], to url: URL) throws {
+        let object = shapes.mapValues { shape -> [String: Any] in
+            ["dtype": "BF16", "shape": shape, "data_offsets": [0, 0]]
+        }
+        var header = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        while !header.count.isMultiple(of: 8) { header.append(0x20) }
+        var size = UInt64(header.count).littleEndian
+        var data = Data(bytes: &size, count: MemoryLayout<UInt64>.size)
+        data.append(header)
+        try data.write(to: url)
     }
 }
 

--- a/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
@@ -105,6 +105,10 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
 
         XCTAssertThrowsError(try service.dflash2RequestPolicy(
             SpeculativeDecodingOptions(mode: "dflash2", maxDraftTokens: 0)))
+        XCTAssertNoThrow(try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(mode: "dflash2", maxDraftTokens: 4)))
+        XCTAssertThrowsError(try service.dflash2RequestPolicy(
+            SpeculativeDecodingOptions(mode: "dflash2", maxDraftTokens: 5)))
 
         XCTAssertThrowsError(try service.dflash2RequestPolicy(
             SpeculativeDecodingOptions(requirement: "best-effort")))
@@ -136,7 +140,7 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
             ],
         ])
         XCTAssertEqual(try config.effectiveBlockSize(requested: 5), 5)
-        XCTAssertEqual(try config.effectiveBlockSize(requested: 20), 8)
+        XCTAssertThrowsError(try config.effectiveBlockSize(requested: 20))
     }
 
     func testMuseReleasedContractValidatesByMetadata() throws {
@@ -353,6 +357,36 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
             verificationTime: 0.2,
             rollbackTime: 0.03)
         XCTAssertEqual(telemetry.meanAcceptanceLength, 1.5)
+        XCTAssertEqual(
+            AFMMLXSpeculativeTelemetry(metadataValue: telemetry.metadataValue),
+            telemetry
+        )
+
+        StatsAggregator.shared.reset()
+        StatsAggregator.shared.addSpeculative(
+            strategy: telemetry.strategy,
+            draftedTokens: telemetry.draftedTokens,
+            acceptedDraftTokens: telemetry.acceptedDraftTokens,
+            emittedTokens: telemetry.emittedTokens,
+            verificationCycles: telemetry.verificationCycles,
+            draftSeconds: telemetry.draftTime,
+            verificationSeconds: telemetry.verificationTime,
+            rollbackSeconds: telemetry.rollbackTime
+        )
+        let snapshot = StatsAggregator.shared.snapshot()
+        XCTAssertEqual(snapshot.speculativeDraftedTokensTotal, 8)
+        XCTAssertEqual(snapshot.speculativeAcceptedTokensTotal, 6)
+        XCTAssertEqual(snapshot.speculativeEmittedTokensTotal, 8)
+        XCTAssertEqual(snapshot.speculativeVerificationCyclesTotal, 4)
+        StatsAggregator.shared.reset()
+
+        let fallback = AFMMLXSpeculativeTelemetry.fallback(
+            strategy: "dflash2", reason: "incompatible_request")
+        XCTAssertEqual(fallback.fallbackReason, "incompatible_request")
+        XCTAssertEqual(
+            AFMMLXSpeculativeTelemetry(metadataValue: fallback.metadataValue),
+            fallback
+        )
     }
 
     private func draftMetadata(

--- a/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
@@ -164,6 +164,21 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
             topK: 0, minP: 0, presencePenalty: 0.4,
             hasTools: false, hasResponseFormat: false,
             wantsLogprobs: false, hasStopSequences: false).denialReason, "penalties")
+        XCTAssertEqual(service.speculativeRequestCompatibility(
+            temperature: 0, topP: nil, repetitionPenalty: nil,
+            topK: 20, minP: nil, presencePenalty: nil,
+            hasTools: false, hasResponseFormat: false,
+            wantsLogprobs: false, hasStopSequences: false).denialReason, "sampling")
+        XCTAssertEqual(service.speculativeRequestCompatibility(
+            temperature: 0, topP: nil, repetitionPenalty: nil,
+            topK: nil, minP: 0.05, presencePenalty: nil,
+            hasTools: false, hasResponseFormat: false,
+            wantsLogprobs: false, hasStopSequences: false).denialReason, "sampling")
+        XCTAssertEqual(service.speculativeRequestCompatibility(
+            temperature: 0, topP: nil, repetitionPenalty: nil,
+            topK: nil, minP: nil, presencePenalty: 0.4,
+            hasTools: false, hasResponseFormat: false,
+            wantsLogprobs: false, hasStopSequences: false).denialReason, "penalties")
     }
 
     func testExplicitPreferredAndOffDoNotSelectOtherSpeculativeRuntimes() throws {

--- a/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXDFlash2ConfigurationTests.swift
@@ -345,7 +345,7 @@ final class AFMMLXDFlash2ConfigurationTests: XCTestCase {
         XCTAssertEqual(config.checkpointBlockSize, 16)
         XCTAssertEqual(config.convolutionKernelSize, 0)
         XCTAssertEqual(config.selectorRank, 0)
-        XCTAssertEqual(config.expectedTensorShapes().count, 53)
+        XCTAssertEqual(config.expectedTensorShapes().count, 58)
         XCTAssertNotNil(config.expectedTensorShapes()["encoder.fc.weight"])
         XCTAssertNil(config.expectedTensorShapes()["candidate_selector.hidden_projection.weight"])
         try config.validateTarget(metadata: target)

--- a/Tests/MacLocalAPITests/AFMMLXProviderTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXProviderTests.swift
@@ -6,6 +6,25 @@ import MLXLMCommon
 import XCTest
 
 final class AFMMLXProviderTests: XCTestCase {
+    func testSchedulerStreamAccumulatorBuildsNonStreamingResponse() {
+        var accumulator = AFMMLXResponseAccumulator(modelID: "test/model")
+        accumulator.consume(.responseText(action: .append, text: "hello", tokenCount: 1))
+        accumulator.consume(.reasoningText(action: .append, text: "thinking", tokenCount: 1))
+        accumulator.consume(.usage(.init(inputTokens: 4, cachedInputTokens: 2, outputTokens: 2)))
+        accumulator.consume(.metadata(["promptTime": .number(0.25)]))
+        accumulator.consume(.completed(.length))
+
+        let response = accumulator.response
+        XCTAssertEqual(response.text, "hello")
+        XCTAssertEqual(response.reasoning, "thinking")
+        XCTAssertEqual(response.usage.inputTokens, 4)
+        XCTAssertEqual(response.usage.cachedInputTokens, 2)
+        XCTAssertEqual(response.usage.outputTokens, 2)
+        XCTAssertEqual(response.finishReason, .length)
+        XCTAssertEqual(response.metadata["modelID"], .string("test/model"))
+        XCTAssertEqual(response.metadata["promptTime"], .number(0.25))
+    }
+
     func testTranslatorCoercesCompleteVendorToolDeltaUsingSchema() throws {
         let tools = [
             RequestTool(

--- a/Tests/MacLocalAPITests/AFMMLXProviderTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXProviderTests.swift
@@ -25,6 +25,28 @@ final class AFMMLXProviderTests: XCTestCase {
         XCTAssertEqual(response.metadata["promptTime"], .number(0.25))
     }
 
+    func testSchedulerResponseNormalizationMatchesSerialReasoningPath() {
+        let raw = "  <think>\n  inspect state  \n</think>\n  final answer  \n"
+        let serial = AFMMLXModel.normalizedGeneratedResponse(
+            raw,
+            startTag: "<think>",
+            endTag: "</think>")
+        var translator = MLXStreamEventTranslator(
+            thinkStartTag: "<think>",
+            thinkEndTag: "</think>",
+            maximumResponseTokens: nil)
+        var accumulator = AFMMLXResponseAccumulator(modelID: "test/model")
+
+        for event in translator.consume(StreamChunk(text: raw)) + translator.finish() {
+            accumulator.consume(event)
+        }
+
+        XCTAssertEqual(accumulator.response.text, serial.text)
+        XCTAssertEqual(accumulator.response.reasoning, serial.reasoning)
+        XCTAssertEqual(accumulator.response.text, "final answer")
+        XCTAssertEqual(accumulator.response.reasoning, "inspect state")
+    }
+
     func testTranslatorCoercesCompleteVendorToolDeltaUsingSchema() throws {
         let tools = [
             RequestTool(

--- a/Tests/MacLocalAPITests/AFMMLXProviderTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXProviderTests.swift
@@ -370,7 +370,7 @@ final class AFMMLXProviderTests: XCTestCase {
         XCTAssertEqual(arguments["days"] as? Int, 5)
     }
 
-    func testAFMKitOwnsChatGenerationResultShape() {
+    func testLegacyChatGenerationResultConstructionAndDestructuringRemainCompatible() {
         let result: AFMMLXChatGenerationResult = (
             modelID: "test/model",
             content: "ok",
@@ -381,12 +381,61 @@ final class AFMMLXProviderTests: XCTestCase {
             cachedTokens: 0,
             promptTime: 0,
             generateTime: 0,
-            stoppedBySequence: false,
-            speculativeTelemetry: nil
+            stoppedBySequence: false
+        )
+        let (
+            modelID,
+            content,
+            promptTokens,
+            completionTokens,
+            tokenLogprobs,
+            toolCalls,
+            cachedTokens,
+            promptTime,
+            generateTime,
+            stoppedBySequence
+        ) = result
+
+        XCTAssertEqual(modelID, "test/model")
+        XCTAssertEqual(content, "ok")
+        XCTAssertEqual(promptTokens, 1)
+        XCTAssertEqual(completionTokens, 1)
+        XCTAssertNil(tokenLogprobs)
+        XCTAssertNil(toolCalls)
+        XCTAssertEqual(cachedTokens, 0)
+        XCTAssertEqual(promptTime, 0)
+        XCTAssertEqual(generateTime, 0)
+        XCTAssertFalse(stoppedBySequence)
+    }
+
+    func testLegacyChatGeneratorConformanceUsesDefaultTelemetryAPI() async throws {
+        let generator = LegacyChatGenerator()
+        requireOpenAIChatGenerationContract(generator)
+
+        let result = try await generator.generateWithTelemetry(
+            model: "test/model",
+            messages: [],
+            temperature: nil,
+            maxTokens: nil,
+            topP: nil,
+            repetitionPenalty: nil,
+            topK: nil,
+            minP: nil,
+            presencePenalty: nil,
+            seed: nil,
+            logprobs: nil,
+            topLogprobs: nil,
+            tools: nil,
+            toolChoice: nil,
+            parallelToolCalls: nil,
+            stop: nil,
+            responseFormat: nil,
+            chatTemplateKwargs: nil,
+            speculativeDecoding: nil
         )
 
         XCTAssertEqual(result.modelID, "test/model")
-        XCTAssertEqual(result.content, "ok")
+        XCTAssertNil(result.speculativeTelemetry)
     }
 
     func testDescriptorInfersCapabilitiesFromModelAssets() throws {
@@ -756,5 +805,75 @@ final class AFMMLXProviderTests: XCTestCase {
 
     private func writeJSON(_ value: [String: Any], to url: URL) throws {
         try JSONSerialization.data(withJSONObject: value).write(to: url)
+    }
+}
+
+private struct LegacyChatGenerator: AFMMLXOpenAIChatGenerating {
+    func generate(
+        model: String,
+        messages: [AFMOpenAICompat.Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?
+    ) async throws -> AFMMLXChatGenerationResult {
+        (
+            modelID: model,
+            content: "legacy",
+            promptTokens: 1,
+            completionTokens: 1,
+            tokenLogprobs: nil,
+            toolCalls: nil,
+            cachedTokens: 0,
+            promptTime: 0,
+            generateTime: 0,
+            stoppedBySequence: false
+        )
+    }
+
+    func generateStreaming(
+        model: String,
+        messages: [AFMOpenAICompat.Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        preserveStructuralTags: Bool,
+        requestId: String?
+    ) async throws -> AFMMLXChatStreamingResult {
+        let stream = AsyncThrowingStream<StreamChunk, Error> { continuation in
+            continuation.finish()
+        }
+        return (
+            modelID: model,
+            stream: stream,
+            promptTokens: 0,
+            toolCallStartTag: nil,
+            toolCallEndTag: nil,
+            thinkStartTag: nil,
+            thinkEndTag: nil
+        )
     }
 }

--- a/Tests/MacLocalAPITests/AFMMLXProviderTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXProviderTests.swift
@@ -340,7 +340,8 @@ final class AFMMLXProviderTests: XCTestCase {
             cachedTokens: 0,
             promptTime: 0,
             generateTime: 0,
-            stoppedBySequence: false
+            stoppedBySequence: false,
+            speculativeTelemetry: nil
         )
 
         XCTAssertEqual(result.modelID, "test/model")

--- a/Tests/MacLocalAPITests/AFMMLXRuntimeTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXRuntimeTests.swift
@@ -5,6 +5,15 @@ import AFMOpenAICompat
 import XCTest
 
 final class AFMMLXRuntimeTests: XCTestCase {
+    func testConcurrentRuntimeRoutesNonStreamingAndPrewarmThroughSchedulerStream() {
+        XCTAssertEqual(
+            AFMMLXGenerationRoute.resolve(maxConcurrent: 8),
+            .schedulerStream
+        )
+        XCTAssertEqual(AFMMLXGenerationRoute.resolve(maxConcurrent: 1), .serial)
+        XCTAssertEqual(AFMMLXGenerationRoute.resolve(maxConcurrent: 0), .serial)
+    }
+
     func testEngineConfigurationCarriesKernelSelection() {
         XCTAssertEqual(EngineConfig(mlxKernels: "ds4").mlxKernels, "ds4")
     }

--- a/Tests/MacLocalAPITests/AFMMLXRuntimeTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXRuntimeTests.swift
@@ -5,6 +5,8 @@ import AFMOpenAICompat
 import XCTest
 
 final class AFMMLXRuntimeTests: XCTestCase {
+    private struct ExpectedFailure: Error {}
+
     func testConcurrentRuntimeRoutesNonStreamingAndPrewarmThroughSchedulerStream() {
         XCTAssertEqual(
             AFMMLXGenerationRoute.resolve(maxConcurrent: 8),
@@ -12,6 +14,61 @@ final class AFMMLXRuntimeTests: XCTestCase {
         )
         XCTAssertEqual(AFMMLXGenerationRoute.resolve(maxConcurrent: 1), .serial)
         XCTAssertEqual(AFMMLXGenerationRoute.resolve(maxConcurrent: 0), .serial)
+    }
+
+    func testSchedulerBackedRespondReleasesOperationAfterCompletion() async throws {
+        let service = MLXModelService(resolver: MLXCacheResolver())
+        let operation = try service.beginOperation()
+        XCTAssertEqual(service.activeOperationCount, 1)
+        let upstream = AsyncThrowingStream<StreamChunk, Error> { continuation in
+            continuation.yield(StreamChunk(text: "done"))
+            continuation.finish()
+        }
+
+        let stream = MLXModelService.ownOperation(upstream, operation: operation)
+        for try await _ in stream {}
+
+        XCTAssertEqual(service.activeOperationCount, 0)
+    }
+
+    func testSchedulerBackedPrewarmReleasesOperationAfterFailure() async throws {
+        let service = MLXModelService(resolver: MLXCacheResolver())
+        let operation = try service.beginOperation()
+        let upstream = AsyncThrowingStream<StreamChunk, Error> { continuation in
+            continuation.finish(throwing: ExpectedFailure())
+        }
+
+        do {
+            for try await _ in MLXModelService.ownOperation(
+                upstream,
+                operation: operation) {}
+            XCTFail("prewarm stream should surface its failure")
+        } catch is ExpectedFailure {
+            // Expected.
+        }
+
+        XCTAssertEqual(service.activeOperationCount, 0)
+    }
+
+    func testUnloadWaitsForSchedulerBackedOperationCleanup() async throws {
+        let service = MLXModelService(resolver: MLXCacheResolver())
+        let operation = try service.beginOperation()
+        let (upstream, continuation) = AsyncThrowingStream<StreamChunk, Error>.makeStream()
+        let stream = MLXModelService.ownOperation(upstream, operation: operation)
+        let consumer = Task {
+            for try await _ in stream {}
+        }
+        let unload = Task {
+            await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+        }
+
+        try await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(service.activeOperationCount, 1)
+        continuation.finish()
+        try await consumer.value
+        await unload.value
+
+        XCTAssertEqual(service.activeOperationCount, 0)
     }
 
     func testEngineConfigurationCarriesKernelSelection() {

--- a/Tests/MacLocalAPITests/AFMMLXRuntimeTests.swift
+++ b/Tests/MacLocalAPITests/AFMMLXRuntimeTests.swift
@@ -7,6 +7,20 @@ import XCTest
 final class AFMMLXRuntimeTests: XCTestCase {
     private struct ExpectedFailure: Error {}
 
+    func testGPUCapturePolicyRejectsConcurrentModeOnly() {
+        XCTAssertEqual(
+            AFMMLXGPUCapturePolicy.incompatibility(
+                maxConcurrent: 8,
+                capturePath: "/tmp/capture.gputrace"),
+            AFMMLXGPUCapturePolicy.concurrentIncompatibility)
+        XCTAssertNil(AFMMLXGPUCapturePolicy.incompatibility(
+            maxConcurrent: 1,
+            capturePath: "/tmp/capture.gputrace"))
+        XCTAssertNil(AFMMLXGPUCapturePolicy.incompatibility(
+            maxConcurrent: 8,
+            capturePath: nil))
+    }
+
     func testConcurrentRuntimeRoutesNonStreamingAndPrewarmThroughSchedulerStream() {
         XCTAssertEqual(
             AFMMLXGenerationRoute.resolve(maxConcurrent: 8),

--- a/Tests/MacLocalAPITests/BatchDispatchTests.swift
+++ b/Tests/MacLocalAPITests/BatchDispatchTests.swift
@@ -36,6 +36,8 @@ private final class FakeBatchService: AFMMLXOpenAIChatServing, @unchecked Sendab
 
     // Tracking
     private let _lock = NSLock()
+    private let schedulerID = UUID()
+    private var reservationIDs = Set<UUID>()
     private(set) var ensureBatchModeCallCount = 0
     private(set) var releaseBatchReferenceCallCount = 0
     private(set) var generateStreamingCallCount = 0
@@ -60,16 +62,25 @@ private final class FakeBatchService: AFMMLXOpenAIChatServing, @unchecked Sendab
     func normalizeModel(_ raw: String) -> String { raw }
     func resolvedToolCallParser(logBypass: Bool) -> String? { toolCallParser }
 
-    func tryReserveSlot() -> Bool {
+    func tryReserveSlot() -> AFMMLXSchedulerAdmission {
         _lock.withLock {
             reserveSlotCallCount += 1
-            return !shouldFailReserveSlot
+            guard !shouldFailReserveSlot else { return .unavailable }
+            let reservation = AFMMLXSchedulerReservation(schedulerID: schedulerID)
+            reservationIDs.insert(reservation.reservationID)
+            return .reserved(reservation)
         }
     }
 
-    func releaseSlot() {
-        _lock.withLock {
+    @discardableResult
+    func releaseSlot(_ reservation: AFMMLXSchedulerReservation) -> Bool {
+        guard reservation.schedulerID == schedulerID else { return false }
+        return _lock.withLock {
+            guard reservationIDs.remove(reservation.reservationID) != nil else {
+                return false
+            }
             releaseSlotCallCount += 1
+            return true
         }
     }
 
@@ -226,6 +237,62 @@ private final class FakeBatchService: AFMMLXOpenAIChatServing, @unchecked Sendab
             stop: stop,
             responseFormat: responseFormat,
             chatTemplateKwargs: chatTemplateKwargs)
+    }
+
+    func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?,
+        preserveStructuralTags: Bool,
+        requestId: String?,
+        schedulerAdmission: AFMMLXSchedulerAdmission
+    ) async throws -> AFMMLXChatStreamingResult {
+        let result = try await generateStreaming(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            speculativeDecoding: speculativeDecoding,
+            preserveStructuralTags: preserveStructuralTags,
+            requestId: requestId)
+        if case .reserved(let reservation) = schedulerAdmission {
+            guard reservation.schedulerID == schedulerID,
+                  _lock.withLock({ reservationIDs.remove(reservation.reservationID) != nil })
+            else {
+                throw MLXServiceError.invalidSchedulerReservation
+            }
+        }
+        return result
     }
 
     static func makeStreamingResult(chunks: [StreamChunk]) -> AFMMLXChatStreamingResult {

--- a/Tests/MacLocalAPITests/BatchDispatchTests.swift
+++ b/Tests/MacLocalAPITests/BatchDispatchTests.swift
@@ -115,7 +115,7 @@ private final class FakeBatchService: AFMMLXOpenAIChatServing, @unchecked Sendab
     ) async throws -> AFMMLXChatGenerationResult {
         (modelID: model, content: "Hello", promptTokens: 10, completionTokens: 5,
          tokenLogprobs: nil, toolCalls: nil, cachedTokens: 0, promptTime: 0.01,
-         generateTime: 0.02, stoppedBySequence: false)
+         generateTime: 0.02, stoppedBySequence: false, speculativeTelemetry: nil)
     }
 
     func generateStreaming(

--- a/Tests/MacLocalAPITests/BatchDispatchTests.swift
+++ b/Tests/MacLocalAPITests/BatchDispatchTests.swift
@@ -116,7 +116,7 @@ private final class FakeBatchService: AFMMLXOpenAIChatServing, @unchecked Sendab
     ) async throws -> AFMMLXChatGenerationResult {
         (modelID: model, content: "Hello", promptTokens: 10, completionTokens: 5,
          tokenLogprobs: nil, toolCalls: nil, cachedTokens: 0, promptTime: 0.01,
-         generateTime: 0.02, stoppedBySequence: false, speculativeTelemetry: nil)
+         generateTime: 0.02, stoppedBySequence: false)
     }
 
     func generateStreaming(

--- a/Tests/MacLocalAPITests/BatchDispatchTests.swift
+++ b/Tests/MacLocalAPITests/BatchDispatchTests.swift
@@ -39,6 +39,7 @@ private final class FakeBatchService: AFMMLXOpenAIChatServing, @unchecked Sendab
     private(set) var ensureBatchModeCallCount = 0
     private(set) var releaseBatchReferenceCallCount = 0
     private(set) var generateStreamingCallCount = 0
+    private(set) var lastSpeculativeDecoding: SpeculativeDecodingOptions?
     private(set) var reserveSlotCallCount = 0
     private(set) var releaseSlotCallCount = 0
 
@@ -171,6 +172,60 @@ private final class FakeBatchService: AFMMLXOpenAIChatServing, @unchecked Sendab
             responseFormat: responseFormat,
             chatTemplateKwargs: chatTemplateKwargs
         )
+    }
+
+    func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?,
+        preserveStructuralTags: Bool,
+        requestId: String?
+    ) async throws -> AFMMLXChatStreamingResult {
+        _lock.withLock {
+            lastSpeculativeDecoding = speculativeDecoding
+        }
+        if speculativeDecoding?.forceAutoregressiveReason != nil,
+           speculativeDecoding?.requirement?.lowercased() == "required" {
+            throw NSError(
+                domain: "AFMMLXSpeculativeDecoding",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey:
+                    "Required speculative decoding conflicts with batch autoregressive execution"])
+        }
+        return try await generateStreaming(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs)
     }
 
     static func makeStreamingResult(chunks: [StreamChunk]) -> AFMMLXChatStreamingResult {
@@ -1163,6 +1218,42 @@ final class BatchCompletionsControllerTests: XCTestCase {
         ) { res async in
             XCTAssertContains(res.body.string, "data: [DONE]")
         }
+    }
+
+    func testPreferredSpeculativeRequestIsForcedAutoregressive() async throws {
+        let json = """
+        {"requests":[{"custom_id":"preferred","body":{"model":"m","temperature":0,"messages":[{"role":"user","content":"hi"}],"speculative_decoding":{"mode":"dflash2","requirement":"preferred"}}}]}
+        """
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/batch/completions", headers: headers, body: ByteBuffer(string: json)
+        ) { res async in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertContains(res.body.string, "\"preferred\"")
+        }
+
+        XCTAssertEqual(service.lastSpeculativeDecoding?.mode, "dflash2")
+        XCTAssertEqual(service.lastSpeculativeDecoding?.requirement, "preferred")
+        XCTAssertEqual(service.lastSpeculativeDecoding?.forceAutoregressiveReason, "batch")
+    }
+
+    func testRequiredSpeculativeRequestReportsBatchConflict() async throws {
+        let json = """
+        {"requests":[{"custom_id":"required","body":{"model":"m","temperature":0,"messages":[{"role":"user","content":"hi"}],"speculative_decoding":{"mode":"dflash2","requirement":"required"}}}]}
+        """
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/batch/completions", headers: headers, body: ByteBuffer(string: json)
+        ) { res async in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertContains(res.body.string, "batch autoregressive execution")
+        }
+
+        XCTAssertEqual(service.lastSpeculativeDecoding?.forceAutoregressiveReason, "batch")
     }
 
     func testNonStreamingResponseContainsCustomId() async throws {

--- a/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
+++ b/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
@@ -151,10 +151,11 @@ struct ConcurrentBatchTests {
         #expect(admission.snapshot == .init(inFlightCount: 1, reservedCount: 0))
 
         admission.finish()
-        #expect(admission.tryReserve())
+        let reservation = admission.tryReserve()
+        #expect(reservation != nil)
         #expect(admission.snapshot == .init(inFlightCount: 1, reservedCount: 1))
         #expect(!admission.reserveForUnreservedSubmission())
-        #expect(admission.consumeReservationForSubmission())
+        #expect(admission.consumeReservationForSubmission(reservation!))
         #expect(admission.snapshot == .init(inFlightCount: 1, reservedCount: 0))
     }
 

--- a/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
+++ b/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
@@ -142,18 +142,19 @@ struct ConcurrentBatchTests {
         #expect(BatchScheduler.defaultAdmissionWindowNanoseconds <= 20_000_000)
     }
 
-    @Test("Scheduler submit self-reserves when promotion bypassed controller admission")
-    func promotionTimeSubmissionReservesCapacity() {
+    @Test("Scheduler submission admission keeps reserved and unreserved capacity separate")
+    func schedulerSubmissionAdmissionIsExplicit() {
         let admission = BatchSchedulerAdmissionState(maxConcurrent: 1)
 
-        #expect(admission.consumeReservationOrReserveForSubmission())
-        #expect(!admission.consumeReservationOrReserveForSubmission())
+        #expect(admission.reserveForUnreservedSubmission())
+        #expect(!admission.reserveForUnreservedSubmission())
         #expect(admission.snapshot == .init(inFlightCount: 1, reservedCount: 0))
 
         admission.finish()
         #expect(admission.tryReserve())
         #expect(admission.snapshot == .init(inFlightCount: 1, reservedCount: 1))
-        #expect(admission.consumeReservationOrReserveForSubmission())
+        #expect(!admission.reserveForUnreservedSubmission())
+        #expect(admission.consumeReservationForSubmission())
         #expect(admission.snapshot == .init(inFlightCount: 1, reservedCount: 0))
     }
 

--- a/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
+++ b/Tests/MacLocalAPITests/ConcurrentBatchTests.swift
@@ -142,6 +142,21 @@ struct ConcurrentBatchTests {
         #expect(BatchScheduler.defaultAdmissionWindowNanoseconds <= 20_000_000)
     }
 
+    @Test("Scheduler submit self-reserves when promotion bypassed controller admission")
+    func promotionTimeSubmissionReservesCapacity() {
+        let admission = BatchSchedulerAdmissionState(maxConcurrent: 1)
+
+        #expect(admission.consumeReservationOrReserveForSubmission())
+        #expect(!admission.consumeReservationOrReserveForSubmission())
+        #expect(admission.snapshot == .init(inFlightCount: 1, reservedCount: 0))
+
+        admission.finish()
+        #expect(admission.tryReserve())
+        #expect(admission.snapshot == .init(inFlightCount: 1, reservedCount: 1))
+        #expect(admission.consumeReservationOrReserveForSubmission())
+        #expect(admission.snapshot == .init(inFlightCount: 1, reservedCount: 0))
+    }
+
     @Test("Gemma 4 defers staggered arrivals until the active cohort drains")
     func gemma4DefersStaggeredAdmissions() {
         #expect(BatchScheduler.shouldDeferStaggeredAdmissions(

--- a/Tests/MacLocalAPITests/DFlash2ProductionPathTests.swift
+++ b/Tests/MacLocalAPITests/DFlash2ProductionPathTests.swift
@@ -211,6 +211,45 @@ final class DFlash2ProductionPathTests: XCTestCase {
         await coordinator.releaseSerialGeneration()
     }
 
+    func testDFlash2FastPathDiagnosticsInitializeAndCleanupOnce() {
+        var events: [String] = []
+        var finishedMetrics: MLXGenerationDiagnosticsMetrics?
+        let scope = MLXGenerationDiagnosticsScope {
+            events.append("start")
+            return { metrics in
+                events.append("finish")
+                finishedMetrics = metrics
+            }
+        }
+
+        XCTAssertEqual(events, ["start"])
+        XCTAssertFalse(scope.isFinished)
+
+        let metrics = MLXGenerationDiagnosticsMetrics(
+            promptTokens: 7,
+            completionTokens: 3,
+            promptTime: 0.25,
+            generateTime: 0.5)
+        scope.finish(metrics: metrics)
+        scope.finish(metrics: .init())
+
+        XCTAssertEqual(events, ["start", "finish"])
+        XCTAssertEqual(finishedMetrics, metrics)
+        XCTAssertTrue(scope.isFinished)
+    }
+
+    func testDFlash2FastPathDiagnosticsCleanupOnAbandonedScope() {
+        var cleanupCount = 0
+        var scope: MLXGenerationDiagnosticsScope? = MLXGenerationDiagnosticsScope {
+            return { _ in cleanupCount += 1 }
+        }
+
+        XCTAssertFalse(scope!.isFinished)
+        scope = nil
+
+        XCTAssertEqual(cleanupCount, 1)
+    }
+
     private func makeDFlash2Draft(
         hidden: Int,
         targetLayers: Int,

--- a/Tests/MacLocalAPITests/DFlash2ProductionPathTests.swift
+++ b/Tests/MacLocalAPITests/DFlash2ProductionPathTests.swift
@@ -173,6 +173,42 @@ final class DFlash2ProductionPathTests: XCTestCase {
         snapshot = await coordinator.snapshot()
         XCTAssertEqual(snapshot.activeSerialGenerations, 0)
         XCTAssertTrue(snapshot.schedulerInstalled)
+        await coordinator.releaseSchedulerGeneration()
+    }
+
+    func testSchedulerRemovalWaitsForUsersAndBlocksSerialOverlap() async throws {
+        let coordinator = MLXModelExecutionCoordinator()
+        let ownsPromotion = await coordinator.beginPromotion()
+        XCTAssertTrue(ownsPromotion)
+        await coordinator.finishPromotion(schedulerInstalled: true)
+        guard case .scheduler = await coordinator.acquireGeneration() else {
+            return XCTFail("generation should hold a scheduler-user lease")
+        }
+
+        let removal = Task { await coordinator.beginSchedulerRemoval() }
+        try await waitUntil {
+            await coordinator.snapshot().promotionInProgress
+        }
+        let blockedGeneration = Task { await coordinator.acquireGeneration() }
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        var snapshot = await coordinator.snapshot()
+        XCTAssertEqual(snapshot.activeSchedulerUsers, 1)
+        XCTAssertTrue(snapshot.schedulerInstalled)
+        XCTAssertTrue(snapshot.promotionInProgress)
+
+        await coordinator.releaseSchedulerGeneration()
+        let ownsRemoval = await removal.value
+        XCTAssertTrue(ownsRemoval)
+        snapshot = await coordinator.snapshot()
+        XCTAssertEqual(snapshot.activeSchedulerUsers, 0)
+        XCTAssertTrue(snapshot.schedulerInstalled)
+
+        await coordinator.finishSchedulerRemoval()
+        guard case .serial = await blockedGeneration.value else {
+            return XCTFail("serial execution must begin only after scheduler removal finishes")
+        }
+        await coordinator.releaseSerialGeneration()
     }
 
     private func makeDFlash2Draft(

--- a/Tests/MacLocalAPITests/DFlash2ProductionPathTests.swift
+++ b/Tests/MacLocalAPITests/DFlash2ProductionPathTests.swift
@@ -158,7 +158,9 @@ final class DFlash2ProductionPathTests: XCTestCase {
             await coordinator.snapshot().promotionInProgress
         }
         let blockedGeneration = Task { await coordinator.acquireGeneration() }
-        try await Task.sleep(nanoseconds: 20_000_000)
+        try await waitUntil {
+            await coordinator.snapshot().waitingGenerationAcquisitions == 1
+        }
         var snapshot = await coordinator.snapshot()
         XCTAssertEqual(snapshot.activeSerialGenerations, 1)
         XCTAssertTrue(snapshot.promotionInProgress)
@@ -190,7 +192,9 @@ final class DFlash2ProductionPathTests: XCTestCase {
             await coordinator.snapshot().promotionInProgress
         }
         let blockedGeneration = Task { await coordinator.acquireGeneration() }
-        try await Task.sleep(nanoseconds: 20_000_000)
+        try await waitUntil {
+            await coordinator.snapshot().waitingGenerationAcquisitions == 1
+        }
 
         var snapshot = await coordinator.snapshot()
         XCTAssertEqual(snapshot.activeSchedulerUsers, 1)

--- a/Tests/MacLocalAPITests/DFlash2ProductionPathTests.swift
+++ b/Tests/MacLocalAPITests/DFlash2ProductionPathTests.swift
@@ -1,0 +1,433 @@
+import Foundation
+import MLX
+import MLXLMCommon
+@testable import AFMKitMLX
+@testable import MLXLLM
+@testable import MLXVLM
+import XCTest
+
+final class DFlash2ProductionPathTests: XCTestCase {
+    func testReleasedMuseAssistantFactoryLoadsCheckpointNames() throws {
+        let directory = try makeArtifactDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let metadata = museAssistantMetadata(hidden: 8, targetLayerIDs: [1])
+        try writeJSON(metadata, to: directory.appendingPathComponent("config.json"))
+        let config = try DFlash2DraftConfiguration.load(
+            directory: directory.path, targetLayers: 2, vocabularySize: 16)
+        let source = DFlashDraftModel(config)
+        var weights = Dictionary(uniqueKeysWithValues: source.parameters().flattened())
+        weights["encoder.fc.weight"] = weights.removeValue(forKey: "fc.weight")
+        weights["encoder.output_norm_enc.weight"] = weights.removeValue(
+            forKey: "hidden_norm.weight")
+        try save(
+            arrays: weights,
+            url: directory.appendingPathComponent("model.safetensors"))
+
+        let loaded = try DFlashDraftModelFactory.load(
+            directory: directory.path, targetLayers: 2, vocabularySize: 16)
+        XCTAssertTrue(loaded is DFlashDraftModel)
+        let output = loaded.callAsFunction(
+            noiseEmbedding: MLXArray.zeros([1, 2, 8]),
+            targetHidden: MLXArray.zeros([1, 1, 8]))
+        MLX.eval(output)
+        XCTAssertEqual(output.shape, [1, 2, 8])
+        XCTAssertTrue(output.asArray(Float.self).allSatisfy(\.isFinite))
+    }
+
+    func testProductionQwenFactoryTargetRunsDFlashGeneration() async throws {
+        let target = try await makeQwenTarget()
+        let draft = try makeDFlash2Draft(
+            hidden: 16, targetLayers: 1, vocabulary: 32, targetLayerIDs: [0])
+        let generator = try DFlash2Generator(target: target, draft: draft, blockSize: 2)
+
+        let result = try generator.generate(promptIDs: [1, 2], maxTokens: 2)
+
+        XCTAssertEqual(result.tokenIDs.count, 2)
+        XCTAssertTrue(result.tokenIDs.allSatisfy { 0 ..< 32 ~= $0 })
+        XCTAssertEqual(result.statistics.verificationCycles, 1)
+    }
+
+    func testProductionMuseFactoryTargetRunsDFlashGeneration() async throws {
+        let target = try await makeMuseTarget()
+        let draft = try makeDFlash2Draft(
+            hidden: 8, targetLayers: 2, vocabulary: 16, targetLayerIDs: [1])
+        let generator = try DFlash2Generator(target: target, draft: draft, blockSize: 2)
+
+        let result = try generator.generate(promptIDs: [1, 2], maxTokens: 2)
+
+        XCTAssertEqual(result.tokenIDs.count, 2)
+        XCTAssertTrue(result.tokenIDs.allSatisfy { 0 ..< 16 ~= $0 })
+        XCTAssertEqual(result.statistics.verificationCycles, 1)
+    }
+
+    func testRotatingCacheSnapshotRestoresWrappedStorageAndCircularIndex() {
+        let cache = RotatingKVCache(maxSize: 2_048, keep: 0)
+        for token in 0 ..< 2_055 {
+            let value = MLXArray(Float(token)).reshaped(1, 1, 1, 1)
+            _ = cache.update(keys: value, values: value + 10_000)
+            if token.isMultiple(of: 256) {
+                MLX.eval(cache.state)
+            }
+        }
+        MLX.eval(cache.state)
+
+        let expectedMetaState = cache.metaState
+        let expectedState = cache.state.map { $0.asArray(Float.self) }
+        let snapshot = DFlash2CacheSnapshot.capture([cache])
+
+        for token in 0 ..< 17 {
+            let value = MLXArray(Float(50_000 + token)).reshaped(1, 1, 1, 1)
+            _ = cache.update(keys: value, values: value)
+        }
+        MLX.eval(cache.state)
+        XCTAssertNotEqual(cache.metaState, expectedMetaState)
+
+        DFlash2CacheSnapshot.restore(snapshot, into: [cache])
+        MLX.eval(cache.state)
+        XCTAssertEqual(cache.metaState, expectedMetaState)
+        XCTAssertEqual(cache.state.map { $0.asArray(Float.self) }, expectedState)
+
+        let next = MLXArray(Float(99_999)).reshaped(1, 1, 1, 1)
+        _ = cache.update(keys: next, values: next)
+        XCTAssertEqual(Int(cache.metaState[3]), 2_056)
+        XCTAssertEqual(Int(cache.metaState[4]), 8)
+    }
+
+    func testCancellationAfterDraftDoesNotRestoreOrReplay() throws {
+        let target = TrackingDFlashTarget()
+        let draft = try ScriptedDFlashDraft(proposals: [6, 7, 8])
+        let generator = try DFlash2Generator(target: target, draft: draft, blockSize: 4)
+        var cancellationChecks = 0
+
+        XCTAssertThrowsError(try generator.generate(
+            promptIDs: [1],
+            maxTokens: 4,
+            shouldStop: {
+                cancellationChecks += 1
+                return cancellationChecks == 3
+            })) {
+            XCTAssertTrue($0 is CancellationError)
+        }
+        XCTAssertEqual(target.forwardLengths, [1])
+        XCTAssertEqual(target.restoreCount, 0)
+    }
+
+    func testCancellationAfterVerificationDoesNotRestoreOrReplay() throws {
+        let target = TrackingDFlashTarget()
+        let draft = try ScriptedDFlashDraft(proposals: [6, 7, 8])
+        let generator = try DFlash2Generator(target: target, draft: draft, blockSize: 4)
+        var cancellationChecks = 0
+
+        XCTAssertThrowsError(try generator.generate(
+            promptIDs: [1],
+            maxTokens: 4,
+            shouldStop: {
+                cancellationChecks += 1
+                return cancellationChecks == 4
+            })) {
+            XCTAssertTrue($0 is CancellationError)
+        }
+        XCTAssertEqual(target.forwardLengths, [1, 4])
+        XCTAssertEqual(target.restoreCount, 0)
+    }
+
+    func testUnknownTerminalStopsAcceptanceReplayAndTelemetryAtBoundary() throws {
+        let target = TrackingDFlashTarget()
+        let draft = try ScriptedDFlashDraft(proposals: [6, 7, 8])
+        let generator = try DFlash2Generator(target: target, draft: draft, blockSize: 4)
+
+        let result = try generator.generate(
+            promptIDs: [1], maxTokens: 4, stopTokenIDs: [7])
+
+        XCTAssertEqual(result.tokenIDs, [5, 6])
+        XCTAssertEqual(result.statistics.acceptedDraftTokens, 2)
+        XCTAssertEqual(result.statistics.emittedTokens, 2)
+        XCTAssertEqual(target.forwardLengths, [1, 4, 3])
+        XCTAssertEqual(target.restoreCount, 1)
+    }
+
+    func testBatchPromotionDrainsSerialOwnerAndBlocksNewSerialWork() async throws {
+        let coordinator = MLXModelExecutionCoordinator()
+        guard case .serial = await coordinator.acquireGeneration() else {
+            return XCTFail("initial generation should own the serial model path")
+        }
+
+        let promotion = Task { await coordinator.beginPromotion() }
+        try await waitUntil {
+            await coordinator.snapshot().promotionInProgress
+        }
+        let blockedGeneration = Task { await coordinator.acquireGeneration() }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        var snapshot = await coordinator.snapshot()
+        XCTAssertEqual(snapshot.activeSerialGenerations, 1)
+        XCTAssertTrue(snapshot.promotionInProgress)
+
+        await coordinator.releaseSerialGeneration()
+        let ownsPromotion = await promotion.value
+        XCTAssertTrue(ownsPromotion)
+        await coordinator.finishPromotion(schedulerInstalled: true)
+        guard case .scheduler = await blockedGeneration.value else {
+            return XCTFail("generation should route through the installed scheduler")
+        }
+        snapshot = await coordinator.snapshot()
+        XCTAssertEqual(snapshot.activeSerialGenerations, 0)
+        XCTAssertTrue(snapshot.schedulerInstalled)
+    }
+
+    private func makeDFlash2Draft(
+        hidden: Int,
+        targetLayers: Int,
+        vocabulary: Int,
+        targetLayerIDs: [Int]
+    ) throws -> DFlash2DraftModel {
+        let directory = try makeArtifactDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let metadata: [String: Any] = [
+            "architectures": ["DFlash2DraftModel"],
+            "is_causal": false,
+            "hidden_size": hidden,
+            "intermediate_size": hidden * 2,
+            "num_hidden_layers": targetLayerIDs.count,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": hidden / 2,
+            "vocab_size": vocabulary,
+            "num_target_layers": targetLayers,
+            "rms_norm_eps": 0.000001,
+            "max_position_embeddings": 4_096,
+            "layer_types": Array(repeating: "sliding_attention", count: targetLayerIDs.count),
+            "sliding_window": 2_048,
+            "rope_parameters": ["rope_theta": 1_000_000],
+            "dflash_config": [
+                "target_layer_ids": targetLayerIDs,
+                "block_size": 4,
+                "mask_token_id": vocabulary - 1,
+                "conv_kernel_size": 2,
+                "conv_group_size": 4,
+                "selector_rank": 4,
+                "selector_top_k": 4,
+            ],
+        ]
+        try writeJSON(metadata, to: directory.appendingPathComponent("config.json"))
+        return DFlash2DraftModel(try DFlash2DraftConfiguration.load(directory: directory.path))
+    }
+
+    private func makeQwenTarget() async throws -> Qwen3_5MoEModel {
+        let metadata: [String: Any] = [
+            "model_type": "qwen3_5",
+            "text_config": [
+                "model_type": "qwen3_5_text",
+                "hidden_size": 16,
+                "num_hidden_layers": 1,
+                "intermediate_size": 32,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 8,
+                "vocab_size": 32,
+                "full_attention_interval": 1,
+                "num_experts": 0,
+                "rope_parameters": [
+                    "rope_theta": 1_000_000,
+                    "partial_rotary_factor": 1,
+                ],
+            ],
+        ]
+        let model = try await LLMTypeRegistry.shared.createModel(
+            configuration: JSONSerialization.data(withJSONObject: metadata),
+            modelType: "qwen3_5")
+        guard let target = model as? Qwen3_5MoEModel else {
+            throw NSError(
+                domain: "DFlash2ProductionPathTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Qwen registry returned \(type(of: model))"])
+        }
+        return target
+    }
+
+    private func makeMuseTarget() async throws -> MuseGlimmer {
+        let metadata: [String: Any] = [
+            "model_type": "muse_glimmer",
+            "text_config": [
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "head_dim": 4,
+                "vocab_size": 16,
+                "layer_types": ["sliding_attention", "full_attention"],
+                "layer_rope_theta": [500_000.0, 0.0],
+                "sliding_window": 4,
+            ],
+            "vision_config": [
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "patch_size": 2,
+                "patch_temporal": 1,
+                "merge_size": 1,
+                "pos_emb_height": 2,
+                "pos_emb_width": 2,
+                "layer_types": ["full_attention"],
+            ],
+            "image_token_id": 14,
+            "video_token_id": 15,
+            "out_hidden_size": 8,
+            "projector_hidden_size": 8,
+        ]
+        let model = try await VLMTypeRegistry.shared.createModel(
+            configuration: JSONSerialization.data(withJSONObject: metadata),
+            modelType: "muse_glimmer")
+        guard let target = model as? MuseGlimmer else {
+            throw NSError(
+                domain: "DFlash2ProductionPathTests",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Muse registry returned \(type(of: model))"])
+        }
+        return target
+    }
+
+    private func museAssistantMetadata(
+        hidden: Int,
+        targetLayerIDs: [Int]
+    ) -> [String: Any] {
+        [
+            "architectures": ["MuseGlimmerAssistantModel"],
+            "block_size": 4,
+            "head_dim": hidden / 2,
+            "hidden_size": hidden,
+            "intermediate_size": hidden * 2,
+            "layer_types": Array(repeating: "sliding_attention", count: targetLayerIDs.count),
+            "mask_token_id": 15,
+            "max_position_embeddings": 4_096,
+            "model_type": "muse_glimmer_assistant",
+            "num_attention_heads": 2,
+            "num_hidden_layers": targetLayerIDs.count,
+            "num_key_value_heads": 1,
+            "rms_norm_eps": 0.00001,
+            "rope_parameters": ["rope_theta": 500_000.0],
+            "sliding_window": 2_048,
+            "target_layer_ids": targetLayerIDs,
+        ]
+    }
+
+    private func makeArtifactDirectory() throws -> URL {
+        let directory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(".build/test-artifacts", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func writeJSON(_ object: [String: Any], to url: URL) throws {
+        try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]).write(to: url)
+    }
+
+    private func waitUntil(
+        timeoutNanoseconds: UInt64 = 1_000_000_000,
+        condition: @escaping () async -> Bool
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while !(await condition()) {
+            if DispatchTime.now().uptimeNanoseconds >= deadline {
+                XCTFail("condition did not become true before timeout")
+                return
+            }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+    }
+}
+
+private final class ScriptedDFlashDraft: DFlashDraftingModel {
+    let config: DFlash2DraftConfiguration
+    private let proposals: [Int]
+
+    init(proposals: [Int]) throws {
+        self.proposals = proposals
+        let directory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(".build/test-artifacts", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let metadata: [String: Any] = [
+            "architectures": ["MuseGlimmerAssistantModel"],
+            "block_size": 4,
+            "head_dim": 8,
+            "hidden_size": 16,
+            "intermediate_size": 32,
+            "layer_types": ["sliding_attention"],
+            "mask_token_id": 31,
+            "max_position_embeddings": 4_096,
+            "model_type": "muse_glimmer_assistant",
+            "num_attention_heads": 2,
+            "num_hidden_layers": 1,
+            "num_key_value_heads": 2,
+            "rms_norm_eps": 0.00001,
+            "rope_parameters": ["rope_theta": 500_000.0],
+            "sliding_window": 2_048,
+            "target_layer_ids": [1],
+        ]
+        try JSONSerialization.data(withJSONObject: metadata).write(
+            to: directory.appendingPathComponent("config.json"))
+        self.config = try DFlash2DraftConfiguration.load(
+            directory: directory.path, targetLayers: 2, vocabularySize: 32)
+    }
+
+    func callAsFunction(noiseEmbedding: MLXArray, targetHidden: MLXArray) -> MLXArray {
+        MLXArray.zeros(noiseEmbedding.shape)
+    }
+
+    func select(hidden: MLXArray, logits: MLXArray, anchor: Int) -> [Int] {
+        Array(proposals.prefix(hidden.dim(1)))
+    }
+}
+
+private final class TrackingDFlashTarget: DFlash2Target {
+    let dflash2HiddenSize = 16
+    let dflash2LayerCount = 2
+    let dflash2VocabularySize = 32
+    private var position = 0
+    private(set) var forwardLengths: [Int] = []
+    private(set) var restoreCount = 0
+
+    func dflash2NewCache() -> [any KVCache] {
+        position = 0
+        forwardLengths = []
+        restoreCount = 0
+        return []
+    }
+
+    func dflash2Embed(_ tokenIDs: MLXArray) -> MLXArray {
+        MLXArray.zeros([1, tokenIDs.dim(1), dflash2HiddenSize])
+    }
+
+    func dflash2Project(_ hidden: MLXArray) -> MLXArray {
+        MLXArray.zeros([1, hidden.dim(1), dflash2VocabularySize])
+    }
+
+    func dflash2Forward(
+        _ tokenIDs: MLXArray,
+        captureLayerIDs: [Int],
+        cache: [any KVCache]
+    ) -> DFlash2TargetOutput {
+        let length = tokenIDs.dim(1)
+        forwardLengths.append(length)
+        let logits = MLXArray.zeros([1, length, dflash2VocabularySize])
+        for index in 0 ..< length {
+            logits[0, index, 5 + position + index] = MLXArray(Float(100))
+        }
+        position += length
+        return DFlash2TargetOutput(
+            hidden: MLXArray.zeros([1, length, dflash2HiddenSize * captureLayerIDs.count]),
+            logits: logits)
+    }
+
+    func dflash2CaptureCache(_ cache: [any KVCache]) -> Any { position }
+
+    func dflash2RestoreCache(_ snapshot: Any, into cache: [any KVCache]) {
+        restoreCount += 1
+        position = snapshot as? Int ?? position
+    }
+}

--- a/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
+++ b/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
@@ -1129,6 +1129,8 @@ private final class FakeMLXChatService: AFMMLXOpenAIChatServing, @unchecked Send
     private let streamingResult: AFMMLXChatStreamingResult
     private let streamingHandler: (([Message]) -> AFMMLXChatStreamingResult)?
     private let stateLock = NSLock()
+    private let schedulerID = UUID()
+    private var reservationIDs = Set<UUID>()
     private(set) var recordedGenerateToolNames: [[String]] = []
     private(set) var recordedStreamingToolNames: [[String]] = []
     private(set) var recordedGenerateToolChoices: [String] = []
@@ -1200,8 +1202,21 @@ private final class FakeMLXChatService: AFMMLXOpenAIChatServing, @unchecked Send
 
     func normalizeModel(_ raw: String) -> String { raw }
     func resolvedToolCallParser(logBypass: Bool) -> String? { toolCallParser }
-    func tryReserveSlot() -> Bool { true }
-    func releaseSlot() {}
+    func tryReserveSlot() -> AFMMLXSchedulerAdmission {
+        guard maxConcurrent >= 2 else { return .serial }
+        return stateLock.withLock {
+            let reservation = AFMMLXSchedulerReservation(schedulerID: schedulerID)
+            reservationIDs.insert(reservation.reservationID)
+            return .reserved(reservation)
+        }
+    }
+    @discardableResult
+    func releaseSlot(_ reservation: AFMMLXSchedulerReservation) -> Bool {
+        guard reservation.schedulerID == schedulerID else { return false }
+        return stateLock.withLock {
+            reservationIDs.remove(reservation.reservationID) != nil
+        }
+    }
     func ensureBatchMode(concurrency: Int) async throws {}
     func releaseBatchReference() {}
     func cancelBatchSlots(ids: Set<UUID>) async {}
@@ -1344,6 +1359,61 @@ private final class FakeMLXChatService: AFMMLXOpenAIChatServing, @unchecked Send
             responseFormat: responseFormat,
             chatTemplateKwargs: chatTemplateKwargs
         )
+    }
+
+    func generateStreaming(
+        model: String,
+        messages: [Message],
+        temperature: Double?,
+        maxTokens: Int?,
+        topP: Double?,
+        repetitionPenalty: Double?,
+        topK: Int?,
+        minP: Double?,
+        presencePenalty: Double?,
+        seed: Int?,
+        logprobs: Bool?,
+        topLogprobs: Int?,
+        tools: [RequestTool]?,
+        toolChoice: ToolChoice?,
+        parallelToolCalls: Bool?,
+        stop: [String]?,
+        responseFormat: ResponseFormat?,
+        chatTemplateKwargs: [String: AnyCodable]?,
+        speculativeDecoding: SpeculativeDecodingOptions?,
+        preserveStructuralTags: Bool,
+        requestId: String?,
+        schedulerAdmission: AFMMLXSchedulerAdmission
+    ) async throws -> AFMMLXChatStreamingResult {
+        let result = try await generateStreaming(
+            model: model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            topP: topP,
+            repetitionPenalty: repetitionPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            seed: seed,
+            logprobs: logprobs,
+            topLogprobs: topLogprobs,
+            tools: tools,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            stop: stop,
+            responseFormat: responseFormat,
+            chatTemplateKwargs: chatTemplateKwargs,
+            preserveStructuralTags: preserveStructuralTags,
+            requestId: requestId)
+        if case .reserved(let reservation) = schedulerAdmission {
+            guard reservation.schedulerID == schedulerID,
+                  stateLock.withLock({ reservationIDs.remove(reservation.reservationID) != nil })
+            else {
+                throw MLXServiceError.invalidSchedulerReservation
+            }
+        }
+        return result
     }
 
     func generateStreaming(

--- a/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
+++ b/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
@@ -464,7 +464,8 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
                 cachedTokens: 0,
                 promptTime: 0.02,
                 generateTime: 0.01,
-                stoppedBySequence: false
+                stoppedBySequence: false,
+                speculativeTelemetry: nil
             ),
             streamingResult: makeStreamingResult(chunks: [])
         )
@@ -533,7 +534,8 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
                 cachedTokens: 0,
                 promptTime: 0.02,
                 generateTime: 0.01,
-                stoppedBySequence: false
+                stoppedBySequence: false,
+                speculativeTelemetry: nil
             ),
             streamingResult: makeStreamingResult(chunks: [])
         )
@@ -693,7 +695,8 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
                 cachedTokens: 0,
                 promptTime: 0.01,
                 generateTime: 0.01,
-                stoppedBySequence: false
+                stoppedBySequence: false,
+                speculativeTelemetry: nil
             ),
             streamingResult: makeStreamingResult(chunks: [])
         )
@@ -1055,7 +1058,8 @@ private final class FakeMLXChatService: AFMMLXOpenAIChatServing, @unchecked Send
             cachedTokens: 0,
             promptTime: 0,
             generateTime: 0,
-            stoppedBySequence: false
+            stoppedBySequence: false,
+            speculativeTelemetry: nil
         )
         self.streamingResult = streamingResult
         self.streamingHandler = nil
@@ -1086,7 +1090,8 @@ private final class FakeMLXChatService: AFMMLXOpenAIChatServing, @unchecked Send
             cachedTokens: 0,
             promptTime: 0,
             generateTime: 0,
-            stoppedBySequence: false
+            stoppedBySequence: false,
+            speculativeTelemetry: nil
         )
         self.streamingResult = FakeMLXChatService.emptyStreamingResult
         self.streamingHandler = streamingHandler

--- a/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
+++ b/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
@@ -548,8 +548,7 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
                 cachedTokens: 0,
                 promptTime: 0.02,
                 generateTime: 0.01,
-                stoppedBySequence: false,
-                speculativeTelemetry: nil
+                stoppedBySequence: false
             ),
             streamingResult: makeStreamingResult(chunks: [])
         )
@@ -618,8 +617,7 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
                 cachedTokens: 0,
                 promptTime: 0.02,
                 generateTime: 0.01,
-                stoppedBySequence: false,
-                speculativeTelemetry: nil
+                stoppedBySequence: false
             ),
             streamingResult: makeStreamingResult(chunks: [])
         )
@@ -779,8 +777,7 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
                 cachedTokens: 0,
                 promptTime: 0.01,
                 generateTime: 0.01,
-                stoppedBySequence: false,
-                speculativeTelemetry: nil
+                stoppedBySequence: false
             ),
             streamingResult: makeStreamingResult(chunks: [])
         )
@@ -1164,8 +1161,7 @@ private final class FakeMLXChatService: AFMMLXOpenAIChatServing, @unchecked Send
             cachedTokens: 0,
             promptTime: 0,
             generateTime: 0,
-            stoppedBySequence: false,
-            speculativeTelemetry: nil
+            stoppedBySequence: false
         )
         self.streamingResult = streamingResult
         self.streamingHandler = nil
@@ -1196,8 +1192,7 @@ private final class FakeMLXChatService: AFMMLXOpenAIChatServing, @unchecked Send
             cachedTokens: 0,
             promptTime: 0,
             generateTime: 0,
-            stoppedBySequence: false,
-            speculativeTelemetry: nil
+            stoppedBySequence: false
         )
         self.streamingResult = FakeMLXChatService.emptyStreamingResult
         self.streamingHandler = streamingHandler

--- a/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
+++ b/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
@@ -116,6 +116,90 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
         XCTAssertEqual(service.recordedPreserveStructuralTags, [true])
     }
 
+    func testStreamingCancellationAfterPartialOutputDoesNotEmitStopOrUsage() async throws {
+        app.middleware.use(RequestIDMiddleware())
+        let probe = StreamingCancellationProbe()
+        let inflightRegistry = app.inflightRegistry
+        let stream = AsyncThrowingStream<StreamChunk, Error> { continuation in
+            let producer = Task {
+                do {
+                    while await inflightRegistry.count == 0 {
+                        try await Task.sleep(nanoseconds: 5_000_000)
+                    }
+                    continuation.yield(StreamChunk(text: "partial"))
+                    probe.markYielded()
+                    try await Task.sleep(nanoseconds: 5_000_000_000)
+                    continuation.yield(StreamChunk(
+                        text: "",
+                        promptTokens: 12,
+                        completionTokens: 20,
+                        cachedTokens: 0,
+                        promptTime: 0.1,
+                        generateTime: 5
+                    ))
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in
+                probe.markTerminated()
+                producer.cancel()
+            }
+        }
+        let service = FakeMLXChatService(
+            streamingResult: (
+                modelID: "test-model",
+                stream: stream,
+                promptTokens: 12,
+                toolCallStartTag: nil,
+                toolCallEndTag: nil,
+                thinkStartTag: nil,
+                thinkEndTag: nil
+            )
+        )
+        try MLXChatCompletionsController(
+            modelID: "test-model",
+            service: service,
+            temperature: nil,
+            repetitionPenalty: nil
+        ).boot(routes: app)
+        try CancelController().boot(routes: app)
+
+        let body = try requestBody(stream: true)
+        var headers = requestHeaders(for: body)
+        headers.replaceOrAdd(name: "X-Request-ID", value: "partial-cancel")
+        let cancelTester = try app.testable()
+        let tester = try app.testable(method: .running(port: 0))
+        let responseTask = Task {
+            try await tester.sendRequest(
+                .POST,
+                "/v1/chat/completions",
+                headers: headers,
+                body: body
+            )
+        }
+
+        for _ in 0..<200 where !probe.yielded {
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTAssertTrue(probe.yielded)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let cancelResponse = try await cancelTester.sendRequest(
+            .POST,
+            "/v1/chat/completions/partial-cancel/cancel"
+        )
+        XCTAssertEqual(cancelResponse.status, .ok)
+        XCTAssertContains(cancelResponse.body.string, "\"cancelled\":true")
+
+        let response = try await responseTask.value.body.string
+        XCTAssertContains(response, "partial")
+        XCTAssertContains(response, "\"finish_reason\":\"cancelled\"")
+        XCTAssertFalse(response.contains("\"finish_reason\":\"stop\""))
+        XCTAssertFalse(response.contains("\"usage\":{"))
+        XCTAssertTrue(probe.terminated)
+    }
+
     func testStreamingControllerSerializesCompletedBatchToolCalls() async throws {
         let toolCall = ResponseToolCall(
             index: 0,
@@ -1002,6 +1086,28 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
       }
     ]
     """
+}
+
+private final class StreamingCancellationProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didYield = false
+    private var didTerminate = false
+
+    func markYielded() {
+        lock.withLock { didYield = true }
+    }
+
+    func markTerminated() {
+        lock.withLock { didTerminate = true }
+    }
+
+    var yielded: Bool {
+        lock.withLock { didYield }
+    }
+
+    var terminated: Bool {
+        lock.withLock { didTerminate }
+    }
 }
 
 private final class FakeMLXChatService: AFMMLXOpenAIChatServing, @unchecked Sendable {

--- a/Tests/MacLocalAPITests/MLXSchedulerLifecycleTests.swift
+++ b/Tests/MacLocalAPITests/MLXSchedulerLifecycleTests.swift
@@ -11,6 +11,115 @@ import Tokenizers
 import XCTest
 
 final class MLXSchedulerLifecycleTests: XCTestCase {
+    private struct ExpectedLoadFailure: Error {}
+
+    func testCallerReservedLoadFailureReleasesReservation() async throws {
+        let service = try await makeScheduledService(maxConcurrent: 2)
+        XCTAssertTrue(service.tryReserveSlot())
+        let model = AFMMLXModel(
+            modelID: AFMModelID(rawValue: Self.modelID),
+            attachedService: service,
+            schedulerAdmissionOwnership: .callerReserved,
+            testingStreamingLoad: { throw ExpectedLoadFailure() })
+
+        do {
+            for try await _ in model.streamResponse(to: AFMRequest(messages: [])) {}
+            XCTFail("expected load failure")
+        } catch is ExpectedLoadFailure {
+            // Expected.
+        }
+
+        XCTAssertEqual(
+            service.schedulerAdmissionSnapshot,
+            .init(inFlightCount: 0, reservedCount: 0))
+        await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+    }
+
+    func testCallerReservedRespondLoadFailureReleasesReservation() async throws {
+        let service = try await makeScheduledService(maxConcurrent: 2)
+        XCTAssertTrue(service.tryReserveSlot())
+        let model = AFMMLXModel(
+            modelID: AFMModelID(rawValue: Self.modelID),
+            attachedService: service,
+            schedulerAdmissionOwnership: .callerReserved)
+        _ = service.beginShutdown()
+
+        do {
+            _ = try await model.respond(to: AFMRequest(messages: []))
+            XCTFail("expected shutdown load failure")
+        } catch {
+            guard case .loadingFailed = error as? AFMError else {
+                return XCTFail("unexpected error: \(error)")
+            }
+        }
+
+        XCTAssertEqual(
+            service.schedulerAdmissionSnapshot,
+            .init(inFlightCount: 0, reservedCount: 0))
+        await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+    }
+
+    func testCallerReservedLoadCancellationReleasesReservation() async throws {
+        let service = try await makeScheduledService(maxConcurrent: 2)
+        XCTAssertTrue(service.tryReserveSlot())
+        let probe = SchedulerCancellationProbe()
+        let model = AFMMLXModel(
+            modelID: AFMModelID(rawValue: Self.modelID),
+            attachedService: service,
+            schedulerAdmissionOwnership: .callerReserved,
+            testingStreamingLoad: { try await probe.run() })
+        let stream = model.streamResponse(to: AFMRequest(messages: []))
+        let consumer = Task {
+            do {
+                for try await _ in stream {}
+            } catch {
+                // Cancellation is the expected terminal state.
+            }
+        }
+
+        await probe.waitUntilEntered()
+        consumer.cancel()
+        await consumer.value
+        try await waitUntil {
+            service.schedulerAdmissionSnapshot
+                == .init(inFlightCount: 0, reservedCount: 0)
+        }
+
+        await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+    }
+
+    func testUnreservedSubmissionCannotConsumeAnotherRequestsReservation() {
+        let admission = BatchSchedulerAdmissionState(maxConcurrent: 1)
+
+        XCTAssertTrue(admission.tryReserve())
+        XCTAssertFalse(admission.reserveForUnreservedSubmission())
+        XCTAssertEqual(
+            admission.snapshot,
+            .init(inFlightCount: 1, reservedCount: 1))
+        XCTAssertTrue(admission.consumeReservationForSubmission())
+        XCTAssertEqual(
+            admission.snapshot,
+            .init(inFlightCount: 1, reservedCount: 0))
+    }
+
+    func testReservedAndUnreservedSubmissionsRemainIndependentWhenInterleaved() {
+        let admission = BatchSchedulerAdmissionState(maxConcurrent: 2)
+
+        XCTAssertTrue(admission.tryReserve())
+        XCTAssertTrue(admission.reserveForUnreservedSubmission())
+        XCTAssertEqual(
+            admission.snapshot,
+            .init(inFlightCount: 2, reservedCount: 1))
+        XCTAssertTrue(admission.consumeReservationForSubmission())
+        XCTAssertEqual(
+            admission.snapshot,
+            .init(inFlightCount: 2, reservedCount: 0))
+        admission.finish(count: 2)
+        XCTAssertEqual(
+            admission.snapshot,
+            .init(inFlightCount: 0, reservedCount: 0))
+    }
+
     func testAttachedAdapterTransfersControllerReservationWithoutDuplicatingIt() async throws {
         let service = try await makeScheduledService(maxConcurrent: 2)
         let adapter = AFMKitMLXChatServingAdapter(service: service)
@@ -56,6 +165,65 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
         await service.shutdownAndReleaseResources(timeoutSeconds: 1)
     }
 
+    func testDirectGenerationCannotStealReservedAdapterCapacity() async throws {
+        let service = try await makeScheduledService(maxConcurrent: 2)
+        XCTAssertTrue(service.tryReserveSlot())
+        XCTAssertTrue(service.tryReserveSlot())
+
+        do {
+            _ = try await service.generate(
+                model: Self.modelID,
+                messages: [.init(role: "user", content: "direct")],
+                temperature: 0,
+                maxTokens: 1,
+                topP: nil,
+                repetitionPenalty: nil,
+                seed: 11)
+            XCTFail("unreserved generation should not consume reserved capacity")
+        } catch {
+            guard case .serverBusy = error as? MLXServiceError else {
+                return XCTFail("unexpected error: \(error)")
+            }
+        }
+        XCTAssertEqual(
+            service.schedulerAdmissionSnapshot,
+            .init(inFlightCount: 2, reservedCount: 2))
+
+        let adapter = AFMKitMLXChatServingAdapter(service: service)
+        let result = try await adapter.generateStreaming(
+            model: Self.modelID,
+            messages: [.init(role: "user", content: "reserved")],
+            temperature: 0,
+            maxTokens: 1,
+            topP: nil,
+            repetitionPenalty: nil,
+            topK: nil,
+            minP: nil,
+            presencePenalty: nil,
+            seed: 7,
+            logprobs: nil,
+            topLogprobs: nil,
+            tools: nil,
+            toolChoice: nil,
+            parallelToolCalls: nil,
+            stop: nil,
+            responseFormat: nil,
+            chatTemplateKwargs: nil,
+            speculativeDecoding: nil,
+            preserveStructuralTags: false,
+            requestId: "reserved-adapter")
+        for try await _ in result.stream {}
+        XCTAssertEqual(
+            service.schedulerAdmissionSnapshot,
+            .init(inFlightCount: 1, reservedCount: 1))
+
+        service.releaseSlot()
+        XCTAssertEqual(
+            service.schedulerAdmissionSnapshot,
+            .init(inFlightCount: 0, reservedCount: 0))
+        await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+    }
+
     func testDirectGenerateCollectsSchedulerStreamWithoutDoubleAdmission() async throws {
         let service = try await makeScheduledService(maxConcurrent: 2)
 
@@ -89,6 +257,36 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
         }
 
         await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+    }
+
+    func testShutdownInvalidatesPromotionBeforeSchedulerPublication() async throws {
+        let service = makeLoadedService()
+        service.maxConcurrent = 2
+        let barrier = SchedulerPromotionBarrier()
+        service.schedulerPromotionBarrier = { await barrier.suspend() }
+        let promotion = Task {
+            try await service.initScheduler()
+        }
+
+        await barrier.waitUntilEntered()
+        let shutdown = Task {
+            await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+        }
+        try await waitUntil { service.shuttingDown }
+        XCTAssertNil(service.installedScheduler)
+
+        await barrier.release()
+        do {
+            try await promotion.value
+            XCTFail("promotion should be invalidated by shutdown")
+        } catch {
+            guard case MLXServiceError.serviceShuttingDown = error else {
+                return XCTFail("unexpected error: \(error)")
+            }
+        }
+        await shutdown.value
+
+        XCTAssertNil(service.installedScheduler)
     }
 
     func testGPUCaptureRejectsSchedulerInstallationWithoutConsumingCapture() async throws {
@@ -235,6 +433,64 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
             guard case MLXServiceError.serviceShuttingDown = error else {
                 return XCTFail("unexpected error: \(error)", file: file, line: line)
             }
+        }
+    }
+}
+
+private actor SchedulerCancellationProbe {
+    private var entered = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func run() async throws {
+        entered = true
+        let waiters = enteredWaiters
+        enteredWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+        try await Task.sleep(for: .seconds(60))
+    }
+
+    func waitUntilEntered() async {
+        if entered { return }
+        await withCheckedContinuation { continuation in
+            enteredWaiters.append(continuation)
+        }
+    }
+}
+
+private actor SchedulerPromotionBarrier {
+    private var entered = false
+    private var released = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func suspend() async {
+        entered = true
+        let waiters = enteredWaiters
+        enteredWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+        if released { return }
+        await withCheckedContinuation { continuation in
+            releaseWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilEntered() async {
+        if entered { return }
+        await withCheckedContinuation { continuation in
+            enteredWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        released = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
         }
     }
 }

--- a/Tests/MacLocalAPITests/MLXSchedulerLifecycleTests.swift
+++ b/Tests/MacLocalAPITests/MLXSchedulerLifecycleTests.swift
@@ -448,7 +448,7 @@ private actor SchedulerCancellationProbe {
         for waiter in waiters {
             waiter.resume()
         }
-        try await Task.sleep(for: .seconds(60))
+        try await Task.sleep(for: .seconds(5))
     }
 
     func waitUntilEntered() async {

--- a/Tests/MacLocalAPITests/MLXSchedulerLifecycleTests.swift
+++ b/Tests/MacLocalAPITests/MLXSchedulerLifecycleTests.swift
@@ -1,0 +1,278 @@
+import AFMKit
+import AFMOpenAICompat
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+import Tokenizers
+@testable import AFMKitMLX
+@testable import AFMServer
+import XCTest
+
+final class MLXSchedulerLifecycleTests: XCTestCase {
+    func testAttachedAdapterTransfersControllerReservationWithoutDuplicatingIt() async throws {
+        let service = try await makeScheduledService(maxConcurrent: 2)
+        let adapter = AFMKitMLXChatServingAdapter(service: service)
+
+        let reserved = await adapter.waitForSlot(timeout: 0)
+        XCTAssertTrue(reserved)
+        XCTAssertEqual(
+            service.schedulerAdmissionSnapshot,
+            .init(inFlightCount: 1, reservedCount: 1))
+
+        let result = try await adapter.generateStreaming(
+            model: Self.modelID,
+            messages: [.init(role: "user", content: "hello")],
+            temperature: 0,
+            maxTokens: 1,
+            topP: nil,
+            repetitionPenalty: nil,
+            topK: nil,
+            minP: nil,
+            presencePenalty: nil,
+            seed: 7,
+            logprobs: nil,
+            topLogprobs: nil,
+            tools: nil,
+            toolChoice: nil,
+            parallelToolCalls: nil,
+            stop: nil,
+            responseFormat: nil,
+            chatTemplateKwargs: nil,
+            speculativeDecoding: nil,
+            preserveStructuralTags: false,
+            requestId: "attached-controller")
+
+        try await waitUntil {
+            service.schedulerAdmissionSnapshot
+                == .init(inFlightCount: 1, reservedCount: 0)
+        }
+        for try await _ in result.stream {}
+        XCTAssertEqual(
+            service.schedulerAdmissionSnapshot,
+            .init(inFlightCount: 0, reservedCount: 0))
+
+        await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+    }
+
+    func testDirectGenerateCollectsSchedulerStreamWithoutDoubleAdmission() async throws {
+        let service = try await makeScheduledService(maxConcurrent: 2)
+
+        let result = try await service.generate(
+            model: Self.modelID,
+            messages: [.init(role: "user", content: "hello")],
+            temperature: 0,
+            maxTokens: 1,
+            topP: nil,
+            repetitionPenalty: nil,
+            seed: 11)
+
+        XCTAssertEqual(result.modelID, Self.modelID)
+        XCTAssertLessThanOrEqual(result.completionTokens, 1)
+        XCTAssertEqual(
+            service.schedulerAdmissionSnapshot,
+            .init(inFlightCount: 0, reservedCount: 0))
+
+        await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+    }
+
+    func testShutdownClosesOperationAdmissionBeforeSchedulerRemoval() async throws {
+        let service = try await makeScheduledService(maxConcurrent: 2)
+
+        XCTAssertNotNil(service.beginShutdown())
+        XCTAssertTrue(service.shuttingDown)
+        XCTAssertThrowsError(try service.beginOperation()) { error in
+            guard case MLXServiceError.serviceShuttingDown = error else {
+                return XCTFail("unexpected error: \(error)")
+            }
+        }
+
+        await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+    }
+
+    func testSchedulerShutdownBalancesPendingAndActiveRequestAccounting() async throws {
+        StatsAggregator.shared.reset()
+        defer { StatsAggregator.shared.reset() }
+
+        let service = try await makeScheduledService(
+            maxConcurrent: 2,
+            requiresFixedDecodeCohorts: true)
+        let scheduler = try XCTUnwrap(service.installedScheduler)
+        let parameters = GenerateParameters(maxTokens: 100_000, temperature: 0)
+        let input = LMInput(tokens: MLXArray([1, 2, 3]))
+        let activeStream = scheduler.submit(
+            input: input,
+            parameters: parameters,
+            promptTokens: 3,
+            requestId: "active")
+
+        try await waitUntil { scheduler.pendingRequestCount == 0 }
+        let pendingStream = scheduler.submit(
+            input: input,
+            parameters: parameters,
+            promptTokens: 3,
+            requestId: "pending")
+        try await waitUntil { scheduler.pendingRequestCount == 1 }
+
+        let before = StatsAggregator.shared.snapshot()
+        XCTAssertEqual(before.requestsStartedTotal, 2)
+        XCTAssertEqual(before.numRunning, 1)
+        XCTAssertEqual(before.numWaiting, 1)
+
+        await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+
+        await assertShutdown(stream: activeStream)
+        await assertShutdown(stream: pendingStream)
+        let after = StatsAggregator.shared.snapshot()
+        XCTAssertEqual(after.requestsStartedTotal, 2)
+        XCTAssertEqual(after.requestsCompletedTotal, 2)
+        XCTAssertEqual(after.requestSuccessByReason["abort"], 2)
+        XCTAssertEqual(
+            scheduler.admissionSnapshot,
+            .init(inFlightCount: 0, reservedCount: 0))
+        XCTAssertEqual(scheduler.pendingRequestCount, 0)
+    }
+
+    private static let modelID = "tests/tiny-scheduler"
+
+    private func makeScheduledService(
+        maxConcurrent: Int,
+        requiresFixedDecodeCohorts: Bool? = nil
+    ) async throws -> MLXModelService {
+        let fixture = makeModelFixture()
+        let container = ModelContainer(context: .init(
+            configuration: fixture.configuration,
+            model: fixture.model,
+            processor: fixture.processor,
+            tokenizer: fixture.tokenizer))
+        let architecture = AFMMLXModelArchitecturePreflight(
+            modelID: Self.modelID,
+            modelType: "llama",
+            canonicalModelType: "llama",
+            isVisionConfiguration: false,
+            requiresVisionModelFactory: false)
+        let service = MLXModelService(
+            resolver: MLXCacheResolver(),
+            testingModelID: Self.modelID,
+            container: container,
+            architecture: architecture)
+        service.maxConcurrent = maxConcurrent
+        try await service.initScheduler(
+            requiresFixedDecodeCohorts: requiresFixedDecodeCohorts)
+        return service
+    }
+
+    private func makeModelFixture() -> (
+        model: LlamaModel,
+        tokenizer: SchedulerTestTokenizer,
+        processor: SchedulerTestInputProcessor,
+        configuration: ModelConfiguration
+    ) {
+        let tokenizer = SchedulerTestTokenizer()
+        let processor = SchedulerTestInputProcessor()
+        let model = LlamaModel(LlamaConfiguration(
+            hiddenSize: 16,
+            hiddenLayers: 1,
+            intermediateSize: 32,
+            attentionHeads: 2,
+            rmsNormEps: 0.00001,
+            vocabularySize: 32,
+            kvHeads: 1))
+        eval(model)
+        let configuration = ModelConfiguration(id: Self.modelID)
+        return (model, tokenizer, processor, configuration)
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 1,
+        condition: @escaping @Sendable () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while !condition() {
+            guard ContinuousClock.now < deadline else {
+                XCTFail("scheduler state did not settle before timeout")
+                throw NSError(
+                    domain: "MLXSchedulerLifecycleTests",
+                    code: 1)
+            }
+            try await Task.sleep(for: .milliseconds(1))
+        }
+    }
+
+    private func assertShutdown(
+        stream: AsyncThrowingStream<StreamChunk, Error>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            for try await _ in stream {}
+            XCTFail("expected shutdown error", file: file, line: line)
+        } catch {
+            guard case MLXServiceError.serviceShuttingDown = error else {
+                return XCTFail("unexpected error: \(error)", file: file, line: line)
+            }
+        }
+    }
+}
+
+private struct SchedulerTestInputProcessor: UserInputProcessor {
+    func prepare(input: UserInput) async throws -> LMInput {
+        LMInput(tokens: MLXArray([1, 2, 3]))
+    }
+}
+
+private struct SchedulerTestTokenizer: Tokenizer {
+    var bosToken: String? { nil }
+    var bosTokenId: Int? { nil }
+    var eosToken: String? { nil }
+    var eosTokenId: Int? { nil }
+    var unknownToken: String? { nil }
+    var unknownTokenId: Int? { nil }
+    var hasChatTemplate: Bool { true }
+
+    func tokenize(text: String) -> [String] { [text] }
+    func encode(text: String) -> [Int] { [1, 2, 3] }
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { encode(text: text) }
+    func decode(tokens: [Int], skipSpecialTokens: Bool) -> String {
+        tokens.filter { !skipSpecialTokens || $0 != eosTokenId }.map(String.init).joined(separator: " ")
+    }
+    func convertTokenToId(_ token: String) -> Int? { token == eosToken ? eosTokenId : nil }
+    func convertIdToToken(_ id: Int) -> String? { id == eosTokenId ? eosToken : String(id) }
+
+    func applyChatTemplate(messages: [Tokenizers.Message]) throws -> [Int] { [1, 2, 3] }
+    func applyChatTemplate(
+        messages: [Tokenizers.Message],
+        tools: [Tokenizers.ToolSpec]?
+    ) throws -> [Int] { [1, 2, 3] }
+    func applyChatTemplate(
+        messages: [Tokenizers.Message],
+        tools: [Tokenizers.ToolSpec]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [1, 2, 3] }
+    func applyChatTemplate(
+        messages: [Tokenizers.Message],
+        chatTemplate: Tokenizers.ChatTemplateArgument
+    ) throws -> [Int] { [1, 2, 3] }
+    func applyChatTemplate(
+        messages: [Tokenizers.Message],
+        chatTemplate: String
+    ) throws -> [Int] { [1, 2, 3] }
+    func applyChatTemplate(
+        messages: [Tokenizers.Message],
+        chatTemplate: Tokenizers.ChatTemplateArgument?,
+        addGenerationPrompt: Bool,
+        truncation: Bool,
+        maxLength: Int?,
+        tools: [Tokenizers.ToolSpec]?
+    ) throws -> [Int] { [1, 2, 3] }
+    func applyChatTemplate(
+        messages: [Tokenizers.Message],
+        chatTemplate: Tokenizers.ChatTemplateArgument?,
+        addGenerationPrompt: Bool,
+        truncation: Bool,
+        maxLength: Int?,
+        tools: [Tokenizers.ToolSpec]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [1, 2, 3] }
+}

--- a/Tests/MacLocalAPITests/MLXSchedulerLifecycleTests.swift
+++ b/Tests/MacLocalAPITests/MLXSchedulerLifecycleTests.swift
@@ -332,6 +332,58 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
         XCTAssertNil(service.installedScheduler)
     }
 
+    func testShutdownClosesAdmissionBeforeSetupBlockedByActiveDecode() async throws {
+        let decodeBarrier = SchedulerDecodeBarrier()
+        let setupBarrier = SchedulerPromotionBarrier()
+        let service = try await makeScheduledService(
+            maxConcurrent: 2,
+            decodeBarrier: { decodeBarrier.block() })
+        addTeardownBlock {
+            decodeBarrier.release()
+            await setupBarrier.release()
+        }
+        let scheduler = try XCTUnwrap(service.installedScheduler)
+        let activeStream = scheduler.submit(
+            input: LMInput(tokens: MLXArray([1, 2, 3])),
+            parameters: GenerateParameters(maxTokens: 100_000, temperature: 0),
+            promptTokens: 3,
+            requestId: "active-decode")
+        await decodeBarrier.waitUntilEntered()
+
+        let reservation = try reserved(service.tryReserveSlot())
+        service.schedulerSetupBarrier = { await setupBarrier.suspend() }
+        let setup = Task<Void, Error> { @Sendable [service, reservation] in
+            defer { service.releaseSlot(reservation) }
+            _ = try await service.generateStreamingWithSchedulerAdmission(
+                model: Self.modelID,
+                messages: [.init(role: "user", content: "blocked setup")],
+                temperature: 0,
+                maxTokens: 1,
+                topP: nil,
+                repetitionPenalty: nil,
+                admission: .reserved(reservation))
+        }
+        await setupBarrier.waitUntilEntered()
+        await setupBarrier.release()
+
+        let shutdown = Task {
+            await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+        }
+        try await waitUntil { scheduler.isAdmissionClosed }
+        decodeBarrier.release()
+
+        do {
+            try await setup.value
+            XCTFail("setup queued behind decode should observe shutdown")
+        } catch {
+            guard case MLXServiceError.serviceShuttingDown = error else {
+                return XCTFail("unexpected setup error: \(error)")
+            }
+        }
+        await shutdown.value
+        await assertShutdown(stream: activeStream)
+    }
+
     func testGPUCaptureRejectsSchedulerInstallationWithoutConsumingCapture() async throws {
         let service = makeLoadedService()
         service.maxConcurrent = 2
@@ -351,10 +403,7 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
             "/tmp/should-not-capture.gputrace")
     }
 
-    func testSchedulerShutdownBalancesPendingAndActiveRequestAccounting() async throws {
-        StatsAggregator.shared.reset()
-        defer { StatsAggregator.shared.reset() }
-
+    func testSchedulerShutdownDrainsPendingAndActiveRequests() async throws {
         let service = try await makeScheduledService(
             maxConcurrent: 2,
             requiresFixedDecodeCohorts: true)
@@ -375,19 +424,10 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
             requestId: "pending")
         try await waitUntil { scheduler.pendingRequestCount == 1 }
 
-        let before = StatsAggregator.shared.snapshot()
-        XCTAssertEqual(before.requestsStartedTotal, 2)
-        XCTAssertEqual(before.numRunning, 1)
-        XCTAssertEqual(before.numWaiting, 1)
-
         await service.shutdownAndReleaseResources(timeoutSeconds: 1)
 
         await assertShutdown(stream: activeStream)
         await assertShutdown(stream: pendingStream)
-        let after = StatsAggregator.shared.snapshot()
-        XCTAssertEqual(after.requestsStartedTotal, 2)
-        XCTAssertEqual(after.requestsCompletedTotal, 2)
-        XCTAssertEqual(after.requestSuccessByReason["abort"], 2)
         XCTAssertEqual(
             scheduler.admissionSnapshot,
             .init(inFlightCount: 0, reservedCount: 0))
@@ -398,10 +438,12 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
 
     private func makeScheduledService(
         maxConcurrent: Int,
-        requiresFixedDecodeCohorts: Bool? = nil
+        requiresFixedDecodeCohorts: Bool? = nil,
+        decodeBarrier: (@Sendable () -> Void)? = nil
     ) async throws -> MLXModelService {
         let service = makeLoadedService()
         service.maxConcurrent = maxConcurrent
+        service.schedulerDecodeBarrier = decodeBarrier
         try await service.initScheduler(
             requiresFixedDecodeCohorts: requiresFixedDecodeCohorts)
         return service
@@ -550,6 +592,55 @@ private actor SchedulerPromotionBarrier {
         releaseWaiters.removeAll()
         for waiter in waiters {
             waiter.resume()
+        }
+    }
+}
+
+private final class SchedulerDecodeBarrier: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private var entered = false
+    private var released = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func block() {
+        let state = lock.withLock { () -> (Bool, [CheckedContinuation<Void, Never>]) in
+            guard !entered else { return (false, []) }
+            entered = true
+            let waiters = enteredWaiters
+            enteredWaiters.removeAll()
+            return (!released, waiters)
+        }
+        for waiter in state.1 {
+            waiter.resume()
+        }
+        if state.0 {
+            releaseSemaphore.wait()
+        }
+    }
+
+    func waitUntilEntered() async {
+        if lock.withLock({ entered }) { return }
+        await withCheckedContinuation { continuation in
+            let resumeImmediately = lock.withLock { () -> Bool in
+                if entered { return true }
+                enteredWaiters.append(continuation)
+                return false
+            }
+            if resumeImmediately {
+                continuation.resume()
+            }
+        }
+    }
+
+    func release() {
+        let shouldSignal = lock.withLock { () -> Bool in
+            guard !released else { return false }
+            released = true
+            return entered
+        }
+        if shouldSignal {
+            releaseSemaphore.signal()
         }
     }
 }

--- a/Tests/MacLocalAPITests/MLXSchedulerLifecycleTests.swift
+++ b/Tests/MacLocalAPITests/MLXSchedulerLifecycleTests.swift
@@ -91,6 +91,25 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
         await service.shutdownAndReleaseResources(timeoutSeconds: 1)
     }
 
+    func testGPUCaptureRejectsSchedulerInstallationWithoutConsumingCapture() async throws {
+        let service = makeLoadedService()
+        service.maxConcurrent = 2
+        service.gpuCapturePath = "/tmp/should-not-capture.gputrace"
+
+        do {
+            try await service.initScheduler()
+            XCTFail("concurrent GPU capture should be rejected")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains(
+                AFMMLXGPUCapturePolicy.concurrentIncompatibility))
+        }
+
+        XCTAssertNil(service.installedScheduler)
+        XCTAssertEqual(
+            service.gpuCapturePath,
+            "/tmp/should-not-capture.gputrace")
+    }
+
     func testSchedulerShutdownBalancesPendingAndActiveRequestAccounting() async throws {
         StatsAggregator.shared.reset()
         defer { StatsAggregator.shared.reset() }
@@ -140,6 +159,14 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
         maxConcurrent: Int,
         requiresFixedDecodeCohorts: Bool? = nil
     ) async throws -> MLXModelService {
+        let service = makeLoadedService()
+        service.maxConcurrent = maxConcurrent
+        try await service.initScheduler(
+            requiresFixedDecodeCohorts: requiresFixedDecodeCohorts)
+        return service
+    }
+
+    private func makeLoadedService() -> MLXModelService {
         let fixture = makeModelFixture()
         let container = ModelContainer(context: .init(
             configuration: fixture.configuration,
@@ -152,15 +179,11 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
             canonicalModelType: "llama",
             isVisionConfiguration: false,
             requiresVisionModelFactory: false)
-        let service = MLXModelService(
+        return MLXModelService(
             resolver: MLXCacheResolver(),
             testingModelID: Self.modelID,
             container: container,
             architecture: architecture)
-        service.maxConcurrent = maxConcurrent
-        try await service.initScheduler(
-            requiresFixedDecodeCohorts: requiresFixedDecodeCohorts)
-        return service
     }
 
     private func makeModelFixture() -> (

--- a/Tests/MacLocalAPITests/MLXSchedulerLifecycleTests.swift
+++ b/Tests/MacLocalAPITests/MLXSchedulerLifecycleTests.swift
@@ -15,11 +15,11 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
 
     func testCallerReservedLoadFailureReleasesReservation() async throws {
         let service = try await makeScheduledService(maxConcurrent: 2)
-        XCTAssertTrue(service.tryReserveSlot())
+        let reservation = try reserved(service.tryReserveSlot())
         let model = AFMMLXModel(
             modelID: AFMModelID(rawValue: Self.modelID),
             attachedService: service,
-            schedulerAdmissionOwnership: .callerReserved,
+            schedulerAdmissionOwnership: .caller(.reserved(reservation)),
             testingStreamingLoad: { throw ExpectedLoadFailure() })
 
         do {
@@ -37,11 +37,11 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
 
     func testCallerReservedRespondLoadFailureReleasesReservation() async throws {
         let service = try await makeScheduledService(maxConcurrent: 2)
-        XCTAssertTrue(service.tryReserveSlot())
+        let reservation = try reserved(service.tryReserveSlot())
         let model = AFMMLXModel(
             modelID: AFMModelID(rawValue: Self.modelID),
             attachedService: service,
-            schedulerAdmissionOwnership: .callerReserved)
+            schedulerAdmissionOwnership: .caller(.reserved(reservation)))
         _ = service.beginShutdown()
 
         do {
@@ -61,12 +61,12 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
 
     func testCallerReservedLoadCancellationReleasesReservation() async throws {
         let service = try await makeScheduledService(maxConcurrent: 2)
-        XCTAssertTrue(service.tryReserveSlot())
+        let reservation = try reserved(service.tryReserveSlot())
         let probe = SchedulerCancellationProbe()
         let model = AFMMLXModel(
             modelID: AFMModelID(rawValue: Self.modelID),
             attachedService: service,
-            schedulerAdmissionOwnership: .callerReserved,
+            schedulerAdmissionOwnership: .caller(.reserved(reservation)),
             testingStreamingLoad: { try await probe.run() })
         let stream = model.streamResponse(to: AFMRequest(messages: []))
         let consumer = Task {
@@ -91,12 +91,13 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
     func testUnreservedSubmissionCannotConsumeAnotherRequestsReservation() {
         let admission = BatchSchedulerAdmissionState(maxConcurrent: 1)
 
-        XCTAssertTrue(admission.tryReserve())
+        let reservation = admission.tryReserve()
+        XCTAssertNotNil(reservation)
         XCTAssertFalse(admission.reserveForUnreservedSubmission())
         XCTAssertEqual(
             admission.snapshot,
             .init(inFlightCount: 1, reservedCount: 1))
-        XCTAssertTrue(admission.consumeReservationForSubmission())
+        XCTAssertTrue(admission.consumeReservationForSubmission(reservation!))
         XCTAssertEqual(
             admission.snapshot,
             .init(inFlightCount: 1, reservedCount: 0))
@@ -105,12 +106,13 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
     func testReservedAndUnreservedSubmissionsRemainIndependentWhenInterleaved() {
         let admission = BatchSchedulerAdmissionState(maxConcurrent: 2)
 
-        XCTAssertTrue(admission.tryReserve())
+        let reservation = admission.tryReserve()
+        XCTAssertNotNil(reservation)
         XCTAssertTrue(admission.reserveForUnreservedSubmission())
         XCTAssertEqual(
             admission.snapshot,
             .init(inFlightCount: 2, reservedCount: 1))
-        XCTAssertTrue(admission.consumeReservationForSubmission())
+        XCTAssertTrue(admission.consumeReservationForSubmission(reservation!))
         XCTAssertEqual(
             admission.snapshot,
             .init(inFlightCount: 2, reservedCount: 0))
@@ -124,8 +126,8 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
         let service = try await makeScheduledService(maxConcurrent: 2)
         let adapter = AFMKitMLXChatServingAdapter(service: service)
 
-        let reserved = await adapter.waitForSlot(timeout: 0)
-        XCTAssertTrue(reserved)
+        let schedulerAdmission = await adapter.waitForSlot(timeout: 0)
+        XCTAssertTrue(schedulerAdmission.isAdmitted)
         XCTAssertEqual(
             service.schedulerAdmissionSnapshot,
             .init(inFlightCount: 1, reservedCount: 1))
@@ -151,7 +153,8 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
             chatTemplateKwargs: nil,
             speculativeDecoding: nil,
             preserveStructuralTags: false,
-            requestId: "attached-controller")
+            requestId: "attached-controller",
+            schedulerAdmission: schedulerAdmission)
 
         try await waitUntil {
             service.schedulerAdmissionSnapshot
@@ -167,8 +170,9 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
 
     func testDirectGenerationCannotStealReservedAdapterCapacity() async throws {
         let service = try await makeScheduledService(maxConcurrent: 2)
-        XCTAssertTrue(service.tryReserveSlot())
-        XCTAssertTrue(service.tryReserveSlot())
+        let firstAdmission = service.tryReserveSlot()
+        _ = try reserved(firstAdmission)
+        let secondReservation = try reserved(service.tryReserveSlot())
 
         do {
             _ = try await service.generate(
@@ -211,17 +215,56 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
             chatTemplateKwargs: nil,
             speculativeDecoding: nil,
             preserveStructuralTags: false,
-            requestId: "reserved-adapter")
+            requestId: "reserved-adapter",
+            schedulerAdmission: firstAdmission)
         for try await _ in result.stream {}
         XCTAssertEqual(
             service.schedulerAdmissionSnapshot,
             .init(inFlightCount: 1, reservedCount: 1))
 
-        service.releaseSlot()
+        XCTAssertTrue(service.releaseSlot(secondReservation))
         XCTAssertEqual(
             service.schedulerAdmissionSnapshot,
             .init(inFlightCount: 0, reservedCount: 0))
         await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+    }
+
+    func testSerialAdmissionDoesNotCreateSchedulerReservation() {
+        let service = makeLoadedService()
+
+        XCTAssertEqual(service.tryReserveSlot(), .serial)
+        XCTAssertNil(service.schedulerAdmissionSnapshot)
+    }
+
+    func testReplacementAndForeignSchedulerCannotReleaseReservation() async throws {
+        let firstService = try await makeScheduledService(maxConcurrent: 2)
+        let secondService = try await makeScheduledService(maxConcurrent: 2)
+        let firstReservation = try reserved(firstService.tryReserveSlot())
+        let secondReservation = try reserved(secondService.tryReserveSlot())
+
+        XCTAssertFalse(secondService.releaseSlot(firstReservation))
+        XCTAssertFalse(firstService.releaseSlot(secondReservation))
+        let firstScheduler = try XCTUnwrap(firstService.installedScheduler)
+        let secondScheduler = try XCTUnwrap(secondService.installedScheduler)
+        XCTAssertTrue(
+            firstService.replaceInstalledSchedulerForTesting(with: secondScheduler)
+                === firstScheduler)
+        defer {
+            _ = firstService.replaceInstalledSchedulerForTesting(with: firstScheduler)
+        }
+        XCTAssertFalse(firstService.releaseSlot(firstReservation))
+        XCTAssertEqual(
+            firstService.schedulerAdmissionSnapshot,
+            .init(inFlightCount: 1, reservedCount: 1))
+        XCTAssertEqual(
+            secondService.schedulerAdmissionSnapshot,
+            .init(inFlightCount: 1, reservedCount: 1))
+
+        _ = firstService.replaceInstalledSchedulerForTesting(with: firstScheduler)
+        XCTAssertTrue(firstService.releaseSlot(firstReservation))
+        XCTAssertTrue(secondService.releaseSlot(secondReservation))
+        await firstService.shutdownAndReleaseResources(timeoutSeconds: 1)
+        await secondService.shutdownAndReleaseResources(timeoutSeconds: 1)
     }
 
     func testDirectGenerateCollectsSchedulerStreamWithoutDoubleAdmission() async throws {
@@ -377,11 +420,15 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
             canonicalModelType: "llama",
             isVisionConfiguration: false,
             requiresVisionModelFactory: false)
-        return MLXModelService(
+        let service = MLXModelService(
             resolver: MLXCacheResolver(),
             testingModelID: Self.modelID,
             container: container,
             architecture: architecture)
+        addTeardownBlock {
+            await service.shutdownAndReleaseResources(timeoutSeconds: 1)
+        }
+        return service
     }
 
     private func makeModelFixture() -> (
@@ -434,6 +481,18 @@ final class MLXSchedulerLifecycleTests: XCTestCase {
                 return XCTFail("unexpected error: \(error)", file: file, line: line)
             }
         }
+    }
+
+    private func reserved(
+        _ admission: AFMMLXSchedulerAdmission,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> AFMMLXSchedulerReservation {
+        guard case .reserved(let reservation) = admission else {
+            XCTFail("expected scheduler reservation, got \(admission)", file: file, line: line)
+            throw NSError(domain: "MLXSchedulerLifecycleTests", code: 2)
+        }
+        return reservation
     }
 }
 

--- a/Tests/MacLocalAPITests/MLXStreamEventTranslatorTests.swift
+++ b/Tests/MacLocalAPITests/MLXStreamEventTranslatorTests.swift
@@ -116,6 +116,36 @@ final class MLXStreamEventTranslatorTests: XCTestCase {
         XCTAssertEqual(completionReason(from: events), .toolCalls)
     }
 
+    func testCompletedZeroParameterToolCallStreamsEmptyJSONObject() {
+        var translator = MLXStreamEventTranslator(
+            thinkStartTag: nil,
+            thinkEndTag: nil,
+            maximumResponseTokens: 100
+        )
+        var events = translator.consume(.init(
+            text: "",
+            toolCalls: [
+                .init(
+                    index: 0,
+                    id: "call_list",
+                    type: "function",
+                    function: .init(name: "list_projects", arguments: "")
+                )
+            ]
+        ))
+        events += translator.finish()
+
+        let argumentDeltas = events.compactMap { event -> String? in
+            guard case .toolCall(_, .argumentsDelta(let arguments)) = event else {
+                return nil
+            }
+            return arguments
+        }
+        XCTAssertEqual(argumentDeltas, ["{}"])
+        XCTAssertEqual(completedToolCall(from: events)?.arguments, "{}")
+        XCTAssertEqual(completionReason(from: events), .toolCalls)
+    }
+
     func testMaximumTokenUsageProducesLengthCompletion() {
         var translator = MLXStreamEventTranslator(
             thinkStartTag: nil,

--- a/Tests/MacLocalAPITests/MLXStreamEventTranslatorTests.swift
+++ b/Tests/MacLocalAPITests/MLXStreamEventTranslatorTests.swift
@@ -151,6 +151,37 @@ final class MLXStreamEventTranslatorTests: XCTestCase {
         XCTAssertEqual(usage?.outputTokens, 1)
     }
 
+    func testSpeculativeTelemetryProducesVersionedMetadataEvent() {
+        let telemetry = AFMMLXSpeculativeTelemetry(
+            strategy: "dflash2",
+            draftedTokens: 8,
+            acceptedDraftTokens: 6,
+            emittedTokens: 8,
+            verificationCycles: 4,
+            draftTime: 0.1,
+            verificationTime: 0.2,
+            rollbackTime: 0.03
+        )
+        var translator = MLXStreamEventTranslator(
+            thinkStartTag: nil,
+            thinkEndTag: nil,
+            maximumResponseTokens: 10
+        )
+
+        let events = translator.consume(
+            StreamChunk(text: "", speculativeTelemetry: telemetry)
+        )
+        let metadata = events.compactMap { event -> [String: AFMJSONValue]? in
+            guard case .metadata(let metadata) = event else { return nil }
+            return metadata
+        }.last
+
+        XCTAssertEqual(
+            metadata?[AFMMLXSpeculativeTelemetry.metadataKey],
+            telemetry.metadataValue
+        )
+    }
+
     private func text(from events: [AFMGenerationEvent]) -> String {
         events.compactMap {
             guard case .responseText(_, let text, _) = $0 else { return nil }

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -5,6 +5,7 @@ import XCTest
 import XCTVapor
 
 @testable import AFMKit
+@testable import AFMKitMLX
 @testable import AFMServer
 
 /// Tests for T1.6 (tokenize / count_tokens request decoding) and T1.7
@@ -115,12 +116,35 @@ struct TokenizeAndOpenAPITests {
         let properties = chat?["properties"] as? [String: Any]
         let speculative = properties?["speculative_decoding"] as? [String: Any]
         let speculativeProperties = speculative?["properties"] as? [String: Any]
+        let mode = speculativeProperties?["mode"] as? [String: Any]
 
         #expect(speculative?["type"] as? String == "object")
-        #expect(speculativeProperties?["mode"] != nil)
+        #expect(speculative?["additionalProperties"] as? Bool == false)
+        #expect(mode?["enum"] as? [String] == ["auto", "off", "dflash2"])
         #expect(speculativeProperties?["requirement"] != nil)
         #expect(speculativeProperties?["drafter"] != nil)
         #expect(speculativeProperties?["max_draft_tokens"] != nil)
+    }
+
+    @Test("T1.7 metrics export speculative emitted tokens")
+    func metricsExportSpeculativeEmittedTokens() {
+        StatsAggregator.shared.reset()
+        defer { StatsAggregator.shared.reset() }
+        StatsAggregator.shared.addSpeculative(
+            strategy: "dflash2",
+            draftedTokens: 5,
+            acceptedDraftTokens: 3,
+            emittedTokens: 4,
+            verificationCycles: 2,
+            draftSeconds: 0.1,
+            verificationSeconds: 0.2,
+            rollbackSeconds: 0.03
+        )
+
+        let metrics = MetricsController.renderPrometheus(
+            StatsAggregator.shared.snapshot())
+        #expect(metrics.contains(
+            "afm:speculative_emitted_tokens_total{model_name=\"\"} 4"))
     }
 
     @Test("T1.7 docs page references /openapi.json on same origin")

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -105,6 +105,24 @@ struct TokenizeAndOpenAPITests {
         }
     }
 
+    @Test("T1.7 chat schema declares neutral speculative decoding controls")
+    func openAPIDeclaresSpeculativeDecodingControls() throws {
+        let parsed = try JSONSerialization.jsonObject(
+            with: Data(OpenAPIController.specJSON.utf8)) as? [String: Any]
+        let components = parsed?["components"] as? [String: Any]
+        let schemas = components?["schemas"] as? [String: Any]
+        let chat = schemas?["ChatCompletionRequest"] as? [String: Any]
+        let properties = chat?["properties"] as? [String: Any]
+        let speculative = properties?["speculative_decoding"] as? [String: Any]
+        let speculativeProperties = speculative?["properties"] as? [String: Any]
+
+        #expect(speculative?["type"] as? String == "object")
+        #expect(speculativeProperties?["mode"] != nil)
+        #expect(speculativeProperties?["requirement"] != nil)
+        #expect(speculativeProperties?["drafter"] != nil)
+        #expect(speculativeProperties?["max_draft_tokens"] != nil)
+    }
+
     @Test("T1.7 docs page references /openapi.json on same origin")
     func docsHTMLReferencesSpec() {
         let html = OpenAPIController.docsHTML

--- a/Tests/MacLocalAPITests/ToolCallStreamingRuntimeTests.swift
+++ b/Tests/MacLocalAPITests/ToolCallStreamingRuntimeTests.swift
@@ -65,6 +65,26 @@ struct ToolCallStreamingRuntimeTests {
         #expect(!deltas.contains(#"{"location":"Sydney","unit":"fahrenheit"}"#))
     }
 
+    @Test("completed zero-parameter XML call emits valid empty JSON arguments")
+    func zeroParameterXMLCallEmitsEmptyJSONObject() throws {
+        let runtime = ToolCallStreamingRuntime(
+            toolCallStartTag: "<tool_call>",
+            toolCallEndTag: "</tool_call>",
+            toolCallParser: "afm_adaptive_xml",
+            tools: [makeTool(name: "list_projects", properties: [:])],
+            applyFixToolArgs: { $0 },
+            remapSingleKey: { key, _ in key }
+        )
+
+        _ = runtime.process(piece: "<tool_call>")
+        let function = runtime.process(piece: "<function=list_projects>")
+        let end = runtime.process(piece: "</function></tool_call>")
+        let events = function.events + end.events
+
+        #expect(replacement(from: events)?.function.arguments == "{}")
+        #expect(emittedArgumentDeltas(events).joined() == "{}")
+    }
+
     @Test("runtime ignores duplicate JSON fallback after XML parameter deltas")
     func ignoresDuplicateJSONFallbackAfterXMLParameterDeltas() throws {
         let runtime = ToolCallStreamingRuntime(

--- a/docs/decode-optimizations.md
+++ b/docs/decode-optimizations.md
@@ -150,11 +150,20 @@ afm mlx -m mlx-community/Muse-Glimmer-30B-4bit \
   --dflash2 incoai/Muse-Glimmer-30B-DFlash2 --port 9999
 ```
 
-The supported fast path is greedy, serial, text-only generation without tools,
-grammar, logprobs, or string stop sequences. Streaming and non-streaming use
-the same draft/verify generator. Prefix-cache and concurrent/batch execution
-remain autoregressive in preferred mode. `--dflash2-required` converts any
-unsupported request or runtime conflict into an error before output begins.
+The supported fast path is explicit-greedy (`"temperature": 0`), serial,
+text-only generation without sampling controls, non-neutral repetition or
+presence penalties, tools, grammar, logprobs, or string stop sequences. An
+omitted temperature retains AFM's normal `0.6` default and is therefore a
+sampling request; preferred mode uses AR and required mode rejects it before
+output. Streaming and non-streaming use the same draft/verify generator and
+the complete configured/tokenizer EOS set; terminal EOS tokens are not emitted
+or counted as completion tokens.
+
+Prefix-cache, concurrent, and multiplex/job batch execution remain
+autoregressive in preferred mode. Batch requests never run serial DFlash2.
+`--dflash2-required` converts any unsupported request or runtime conflict into
+an error before output begins. Cancellation propagates through the generator;
+cancelled work is not recorded as a successful partial completion.
 
 Requests may explicitly disable a loaded runtime or require it:
 
@@ -171,17 +180,20 @@ Requests may explicitly disable a loaded runtime or require it:
 }
 ```
 
-Use `"mode": "off"` for per-request autoregressive decoding. A request cannot
-load or switch drafters; an optional `drafter` value must match the resource
-selected at startup. AFM exports neutral draft, accepted, emitted, cycle, and
-phase-time counters under `/metrics`, and AFMKit receives the same summary in
+Use `"mode": "off"` for per-request autoregressive decoding. It suppresses all
+loaded speculative runtimes, including DFlash2, DSpARK, MTP, and EAGLE3. An
+explicit preferred/required DFlash2 request also cannot silently fall through
+to another speculative runtime. A request cannot load or switch drafters; an
+optional `drafter` value must match the resource selected at startup. AFM
+exports neutral draft, accepted, emitted, cycle, and phase-time counters under
+`/metrics`, and AFMKit receives the same summary in
 `afm.speculative_decoding.v1` response metadata/events.
 
 The current generator is correctness-first: greedy output is target-equivalent
 in synthetic qualification and bounded live smoke tests on both released pairs,
-but draft KV caching, speculative prefix snapshots, sampling rejection, and
-batched verification are deferred. No local Qwen/Muse speedup claim has been
-qualified.
+but draft KV caching, speculative prefix snapshots, sampling support, and
+batched verification are deferred behind the fallback/error policy above. No
+local Qwen/Muse speedup claim has been qualified.
 
 ---
 

--- a/docs/decode-optimizations.md
+++ b/docs/decode-optimizations.md
@@ -13,30 +13,32 @@ export MACAFM_MLX_MODEL_CACHE=/Volumes/Crucial4TB/models/vesta-test-cache
 
 ## Which flag for which model? (start here)
 
-afm has exactly **two** speculative-decoding options — one per model family. Both are
-quality-preserving (bit-exact to greedy on short generations; near-greedy on long ones) and need
-a specific drafter/checkpoint.
+AFM has three MLX speculative-decoding options plus DwarfStar DSpark. Each
+requires a compatible target and drafter or sidecar.
 
 | Running… | Use | Speedup | Needs |
 |----------|-----|---------|-------|
 | **Qwen3.6-27B** | `--mtp` | **~+52%** | checkpoint with the MTP head: `Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed` (has `mtp.safetensors`) |
 | **Gemma4-31B (dense)** | `--eagle3 <drafter-dir>` | **~+30%** | the `RedHatAI/gemma-4-31B-it-speculator.eagle3` drafter |
-| anything else (incl. **Gemma4 MoE 26B-A4B**) | — | none | no speculative option — use normal decode |
+| **Qwen3.8-27B** | `--dflash2 <repo-or-dir>` | no local speed result | `incoai/Qwen3.8-27B-DFlash2` |
+| **Muse-Glimmer-30B** | `--dflash2 <repo-or-dir>` | no local speed result | `incoai/Muse-Glimmer-30B-DFlash2` |
+| anything else (incl. **Gemma4 MoE 26B-A4B**) | — | none | use normal decode |
 
 ```bash
 # Qwen3.6  → MTP
 afm mlx -m Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed --mtp --port 9999
 # Gemma4-31B dense → EAGLE3
 afm mlx -m mlx-community/gemma-4-31b-it-4bit --eagle3 <eagle3-drafter-dir> --port 9999
+# Qwen3.8-27B → DFlash 2
+afm mlx -m mlx-community/Qwen3.8-27B-4bit \
+  --dflash2 incoai/Qwen3.8-27B-DFlash2 --port 9999
 ```
 
-Both engage only for greedy (`temperature: 0`), text-only requests (streaming or not); anything
-else silently uses normal autoregressive decode. Full details per feature below.
+These paths engage only for supported greedy, serial requests. DFlash 2 has an
+explicit preferred/required policy described below.
 
-**Evaluated but NOT shipped** (so you don't go looking): Gemma4 MoE spec-decode (all methods slower
-than AR), the Gemma4 "assistant"-MTP that llama.cpp uses (~+9% in MLX — not worth it; llama.cpp's
-GGUF/Metal version is a different engine, ~+39% on M4 Pro), DFlash (negative). On M4 Pro the practical
-spec-decode ceiling is ~+40% in any engine — afm's lossless EAGLE3/MTP are at or near it.
+Legacy DFlash and DFlash 2 are distinct checkpoint contracts. Only checkpoints
+declaring `DFlash2DraftModel` are accepted by `--dflash2`.
 
 ---
 
@@ -129,7 +131,61 @@ depth-2-bonus structure from mlx-lm PR #990).
 
 ---
 
-## 3. Long-context SDPA (automatic — no flag)
+## 3. DFlash 2 — Qwen 3.8 and Muse Glimmer
+
+**Flags:** `--dflash2 <repo-or-directory>`, `--dflash2-block <N>`, and
+`--dflash2-required`
+
+DFlash 2 performs one-pass parallel drafting with metadata-validated Qwen 3.8
+and Muse Glimmer target adapters. AFM validates the draft architecture, target
+dimensions, tokenizer/context/RoPE contract, feature taps, and all safetensor
+shapes before loading draft weights. Repository names are not used as proof of
+compatibility.
+
+```bash
+afm mlx -m mlx-community/Qwen3.8-27B-4bit \
+  --dflash2 incoai/Qwen3.8-27B-DFlash2 --port 9999
+
+afm mlx -m mlx-community/Muse-Glimmer-30B-4bit \
+  --dflash2 incoai/Muse-Glimmer-30B-DFlash2 --port 9999
+```
+
+The supported fast path is greedy, serial, text-only generation without tools,
+grammar, logprobs, or string stop sequences. Streaming and non-streaming use
+the same draft/verify generator. Prefix-cache and concurrent/batch execution
+remain autoregressive in preferred mode. `--dflash2-required` converts any
+unsupported request or runtime conflict into an error before output begins.
+
+Requests may explicitly disable a loaded runtime or require it:
+
+```json
+{
+  "model": "mlx-community/Qwen3.8-27B-4bit",
+  "messages": [{"role": "user", "content": "Explain speculative decoding."}],
+  "temperature": 0,
+  "speculative_decoding": {
+    "mode": "dflash2",
+    "requirement": "required",
+    "max_draft_tokens": 4
+  }
+}
+```
+
+Use `"mode": "off"` for per-request autoregressive decoding. A request cannot
+load or switch drafters; an optional `drafter` value must match the resource
+selected at startup. AFM exports neutral draft, accepted, emitted, cycle, and
+phase-time counters under `/metrics`, and AFMKit receives the same summary in
+`afm.speculative_decoding.v1` response metadata/events.
+
+The current generator is correctness-first: greedy output is target-equivalent
+in synthetic qualification and bounded live smoke tests on both released pairs,
+but draft KV caching, speculative prefix snapshots, sampling rejection, and
+batched verification are deferred. No local Qwen/Muse speedup claim has been
+qualified.
+
+---
+
+## 4. Long-context SDPA (automatic — no flag)
 
 The pinned mlx-swift 0.30.3 tree is patched with **0.31.3's adaptive-block 2-pass SDPA**
 (backported in `Scripts/patches/mlx-cpp-sdpa/`). This is applied at build time and needs no flag —
@@ -147,12 +203,12 @@ Applied automatically by the full build:
 
 ---
 
-## 4. Faster reasoning TTFT (automatic)
+## 5. Faster reasoning TTFT (automatic)
 
 Streaming responses now emit the `<think>` open tag eagerly, cutting reasoning **time-to-first-token
 ~610ms → ~346ms**. No flag — it just applies to streaming chat completions on thinking models.
 
-## 5. Metal-kernel prewarm (automatic)
+## 6. Metal-kernel prewarm (automatic)
 
 Metal kernels are prewarmed on server startup, so the **cold first token** is faster. No flag.
 
@@ -176,6 +232,7 @@ AFM_DEBUG=1 AFM_EAGLE3_PROFILE=1 afm mlx -m <gemma4-31b> --eagle3 <drafter> --po
 |---------|------|-------|---------|--------|
 | EAGLE3 | `--eagle3 <dir>` | dense Gemma4-31B | ~+30% decode | lossless (== greedy AR) |
 | MTP | `--mtp` | Qwen3.6 sidecar or Qwen3.8 matching head | serial decode acceleration | near-greedy (bit-exact on short gens) |
+| DFlash 2 | `--dflash2 <repo-or-dir>` | Qwen3.8-27B or Muse-Glimmer-30B | no local speed result | lossless greedy |
 | SDPA backport | (build-time) | any | ~+10% @16k | correct at all depths |
 | Eager think-tag | (auto) | thinking models | TTFT 610→346ms | unchanged |
 | Kernel prewarm | (auto) | any | faster cold token | unchanged |
@@ -187,8 +244,7 @@ AFM_DEBUG=1 AFM_EAGLE3_PROFILE=1 afm mlx -m <gemma4-31b> --eagle3 <drafter> --po
 | `AFM_DEBUG` | off | decode tok/s, cache, timing logs |
 | `AFM_EAGLE3_PROFILE` | off | EAGLE3 per-round verify/draft timing |
 
-All fast paths require: **greedy** (`temperature: 0`), text-only, no `tools` / `response_format` /
-`logprobs` / `stop` sequences. **Streaming and non-streaming are both supported.** Concurrent mode
-(`--concurrent N≥2`) routes through the batch scheduler and does **not** use MTP/EAGLE3 (serial only).
-Anything else uses normal autoregressive decode.
-EOF
+All fast paths require supported greedy requests. **Streaming and non-streaming
+are both supported.** Concurrent mode routes through the batch scheduler and
+does not run serial MTP/EAGLE3/DFlash 2. DFlash 2 preferred mode falls back to
+AR; required mode rejects the conflict before generation.


### PR DESCRIPTION
## Summary

- add metadata-driven DFlash 2 loading and greedy draft/verify support for the released Qwen 3.8 and Muse Glimmer target/drafter pairs
- route startup and request `off`/`preferred`/`required` controls through CLI, OpenAI-compatible HTTP, AFMKit, and the MLX provider
- bind validated runtime state to each service/model container and share one production/public compatibility preflight for metadata, RoPE/context/token IDs, and safetensor shapes
- preserve normal sampling defaults, construct the complete EOS set, propagate cancellation, retain reasoning boundaries, and publish normal plus speculative telemetry
- keep prefix, concurrent, and batch work deterministically autoregressive for preferred requests and reject required conflicts before speculative generation
- keep the MLX dependency implementation reproducible through the existing patch workflow

## Execution Policy

DFlash 2 is opt-in and off by default. The accelerated path supports explicit greedy, serial, text-only requests without tools, grammar, logprobs, sampling modifiers, non-neutral repetition/presence penalties, or explicit string stops. Preferred incompatible requests fall back to AR before emission; required requests reject. Request-level `off` suppresses every speculative runtime. Prefix caching and concurrent/batch scheduling remain AR-only; Muse batch requests do not execute serial DFlash.

## Independent Review Fixes

All ten review blockers are addressed: sampling semantics, complete EOS handling, request control over every speculative runtime, service-scoped runtime ownership, cancellation propagation, prompt-opened reasoning parsing, base request telemetry, Muse batch policy, shared runtime compatibility preflight, and service/production-path regression coverage.

## Validation

- Debug: `AFMMLXDFlash2ConfigurationTests` 23/23, `BatchCompletionsControllerTests` 17/17, `TokenizeAndOpenAPITests` 11/11, and `AFMMLXSpeculativeDecodingTests` 22/22
- final focused Release selection: 58/58 XCTest cases across DFlash2 service policy/runtime, batch routing, and streaming cancellation
- broader focused regression selection: 143 XCTest plus 78 Swift Testing cases, zero failures
- Qwen production path: omitted temperature and penalties use AR for preferred and reject required; explicit greedy DFlash reports normal usage/timings; reasoning is separated from visible content; partial SSE cancellation emits `cancelled` without stop/usage, stops speculative cycles, and leaves health green
- Qwen prefix conflict: preferred uses AR, required returns `prefix_cache`, speculative cycles remain zero
- Muse batch: two preferred rows complete through AR; required emits `batch.error` with reason `batch`; speculative cycles remain zero
- `Scripts/check-dflash2-vendor-patch.sh`, clean-vendor materialization comparison, and `git diff --check` pass
- all live and Release qualifications were serialized with `/Volumes/edata/dev/git/CODEX/vesta-mac/.agent-live-test-lock`; no AI judge ran

Raw evidence is retained under `.build/qualification/dflash2-review-fixes-20260820`; exact revisions and results are recorded in `Research/DFlash2/TRACE.md`.

## Limitations

- two broad Release attempts completed all 437 Swift Testing cases, then the XCTest process terminated with signal 11 in unrelated `MLXFoundationLanguageModelTests.testGenerationConfigDisablesThinkingByDefaultForReasoningModels` under macOS 27/Xcode 27 beta 3; the failure reproduces in isolation and no unrelated workaround is included
- no exhaustive live matrix, long-context/performance study, comprehensive, Promptfoo, or UI suite was run
- sampling, DFlash-aware prefix snapshots, and row-aligned concurrent/batch speculative verification remain intentionally unsupported behind deterministic fallback/error policy
- the correctness-first runtime replays target state and recomputes draft context; it does not implement the reference draft KV-cache optimization
- no local speed claim is made

## Vendor State

`vendor/mlx-swift-lm` remains dirty by design after the repository patch scripts materialize tracked patch definitions. The submodule pointer is unchanged, the materialized state matches a clean pinned-vendor application, and no upstream dependency repository was pushed.

## Summary by Sourcery

Integrate opt-in, metadata-driven DFlash 2 decoding with safe request routing, runtime validation, cancellation, and observability across the MLX stack.

New Features:
- Add opt-in, metadata-validated DFlash 2 speculative decoding for Qwen 3.8 and Muse Glimmer targets.
- Expose speculative-decoding startup and request controls across the CLI, OpenAI-compatible API, AFMKit, and MLX provider.
- Publish provider-neutral speculative decoding telemetry through responses, streams, Prometheus metrics, and AFMKit metadata.

Bug Fixes:
- Preserve normal sampling defaults while enforcing deterministic fallback or rejection for unsupported speculative requests.
- Improve EOS handling, reasoning-boundary preservation, cancellation behavior, scheduler admission, and service-scoped speculative runtime ownership.
- Prevent speculative decoding from conflicting with prefix caching, concurrent execution, and batch scheduling.

Enhancements:
- Add shared compatibility preflight for target and drafter metadata, tokenizer IDs, RoPE/context settings, and safetensor shapes.
- Add Qwen and Muse target adapters plus a correctness-first draft/verify runtime with cache rollback and replay.
- Improve scheduler lifecycle coordination, diagnostics cleanup, and streaming/non-streaming response parity.

Build:
- Materialize the DFlash 2 MLX vendor primitive through the existing patch workflow and add vendor patch validation.

Documentation:
- Document DFlash 2 usage, request policy, supported targets, limitations, and telemetry.

Tests:
- Add focused configuration, runtime, production-path, scheduler lifecycle, batch routing, streaming cancellation, API, telemetry, and regression coverage.

Chores:
- Add research architecture, decision, implementation-plan, source, test-matrix, and qualification trace documentation.