### PR TITLE
Add advanced terminal chat UI

### DIFF
--- a/.github/workflows/tui-tests.yml
+++ b/.github/workflows/tui-tests.yml
@@ -1,0 +1,28 @@
+name: Terminal UI tests
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/tui-tests.yml"
+      - "Package.swift"
+      - "Package.resolved"
+      - "Scripts/swiftpm-reliable.sh"
+      - "Scripts/test-tui.sh"
+      - "Sources/AFMTerminalUI/**"
+      - "Tests/TUIHarness/**"
+  workflow_dispatch:
+
+concurrency:
+  group: tui-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  focused-tui:
+    runs-on: macos-26
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Run snapshot and pseudo-terminal tests
+        run: Scripts/test-tui.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .build/
 Packages/
 Package.resolved
+!Tests/TUIHarness/Package.resolved
 *.xcworkspace
 *.xcodeproj
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # AFM - Apple Foundation Models API
 # Makefile for building and distributing the portable CLI
 
-.PHONY: build clean install uninstall portable dist test help submodules submodule-status webui verify-webui build-with-webui patch patch-check
+.PHONY: build clean install uninstall portable dist test test-tui help submodules submodule-status webui verify-webui build-with-webui patch patch-check
 
 PATCH_SH := Scripts/apply-mlx-patches.sh
 PATCH_STAMP := vendor/mlx-swift-lm/.patches-applied
@@ -106,6 +106,10 @@ test: build
 		echo "✅ Portability test passed" || echo "⚠️  Portability test failed"; \
 		rm -f "$$TEST_BIN"
 
+# Focused deterministic TUI snapshots plus real pseudo-terminal behavior.
+test-tui:
+	@Scripts/test-tui.sh
+
 # Development build (debug)
 debug: $(PATCH_STAMP)
 	@echo "🐛 Building debug version..."
@@ -133,6 +137,7 @@ help:
 	@echo "  uninstall       - Remove from /usr/local/bin"
 	@echo "  dist            - Create distribution package"
 	@echo "  test            - Test the binary and portability"
+	@echo "  test-tui        - Run focused TUI snapshots and pseudo-terminal tests"
 	@echo "  debug           - Build debug version"
 	@echo "  run             - Build and run debug server"
 	@echo "  submodules      - Initialize git submodules"

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ build: $(PATCH_STAMP)
 		-Xswiftc -disable-upcoming-feature \
 		-Xswiftc MemberImportVisibility
 	@AFM_BIN="$$(Scripts/find-afm-binary.sh release)"; \
+		Scripts/check-tree-sitter-highlighting.sh "$$AFM_BIN"; \
 		strip "$$AFM_BIN"; \
 		echo "✅ Build complete: $$AFM_BIN"; \
 		echo "📊 Size: $$(ls -lh "$$AFM_BIN" | awk '{print $$5}')"
@@ -109,6 +110,7 @@ test: build
 debug: $(PATCH_STAMP)
 	@echo "🐛 Building debug version..."
 	@Scripts/swiftpm-reliable.sh build
+	@Scripts/check-tree-sitter-highlighting.sh "$$(Scripts/find-afm-binary.sh debug)"
 	@echo "✅ Debug build complete: $$(Scripts/find-afm-binary.sh debug)"
 
 # Run the server (development)

--- a/Package.swift
+++ b/Package.swift
@@ -63,6 +63,11 @@ let package = Package(
             name: "AFMServer",
             targets: ["AFMServer"]
         ),
+        // Native terminal chat UI used by both Foundation and MLX modes.
+        .library(
+            name: "AFMTerminalUI",
+            targets: ["AFMTerminalUI"]
+        ),
         // The `afm` CLI executable (thin wrapper over AFMKit + AFMServer).
         .executable(
             name: "afm",
@@ -266,6 +271,13 @@ let package = Package(
                 .unsafeFlags(["-file-prefix-map", "\(packageDir)/="], .when(configuration: .release))
             ]
         ),
+        .target(
+            name: "AFMTerminalUI",
+            dependencies: [
+                "AFMKit",
+                "AFMOpenAICompat"
+            ]
+        ),
         // Thin CLI executable over AFMKit + AFMServer.
         .executableTarget(
             name: "AFMCLI",
@@ -273,6 +285,7 @@ let package = Package(
                 "AFMKit",
                 "AFMKitDwarfStar",
                 "AFMKitMLX",
+                "AFMTerminalUI",
                 "AFMServer",
                 .product(name: "Vapor", package: "vapor"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
@@ -322,6 +335,7 @@ let package = Package(
                 "AFMKitFoundationModels27DwarfStar",
                 "AFMKitServices",
                 "AFMServer",
+                "AFMTerminalUI",
                 .product(name: "Jinja", package: "swift-jinja"),
                 .product(name: "XCTVapor", package: "vapor"),
                 .product(name: "VaporTesting", package: "vapor"),

--- a/Package.swift
+++ b/Package.swift
@@ -77,6 +77,10 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.99.3"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
+        // Parse CommonMark/GFM into a real syntax tree for the native terminal UI.
+        // Rendering remains AFM-owned so ANSI output, math, diffs, and artifact
+        // actions behave consistently in Terminal.app and richer terminals.
+        .package(url: "https://github.com/swiftlang/swift-markdown.git", exact: "0.8.0"),
         // Development checkouts compile the patched vendor directly so local source edits
         // cannot be mistaken for successful stale builds. A plain downstream clone without
         // initialized submodules falls back to the pre-patched URL fork and remains portable.
@@ -275,7 +279,8 @@ let package = Package(
             name: "AFMTerminalUI",
             dependencies: [
                 "AFMKit",
-                "AFMOpenAICompat"
+                "AFMOpenAICompat",
+                .product(name: "Markdown", package: "swift-markdown")
             ]
         ),
         // Thin CLI executable over AFMKit + AFMServer.

--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,33 @@ let package = Package(
         // Rendering remains AFM-owned so ANSI output, math, diffs, and artifact
         // actions behave consistently in Terminal.app and richer terminals.
         .package(url: "https://github.com/swiftlang/swift-markdown.git", exact: "0.8.0"),
+        // Tree-sitter is compiled into the native TUI for grammar-aware ANSI
+        // highlighting. Every component is pinned so release builds cannot
+        // silently pick up a new runtime ABI or regenerated parser.
+        .package(url: "https://github.com/tree-sitter/tree-sitter.git", exact: "0.25.10"),
+        .package(url: "https://github.com/tree-sitter/swift-tree-sitter.git", exact: "0.25.0"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-bash.git", revision: "a06c2e4415e9bc0346c6b86d401879ffb44058f7"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-c.git", revision: "b780e47fc780ddc8da13afa35a3f4ed5c157823d"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-cpp.git", revision: "8b5b49eb196bec7040441bee33b2c9a4838d6967"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-c-sharp.git", revision: "9150f7d56bb47f1a809fa23623f1ba1413e93fa9"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-css.git", revision: "dda5cfc5722c429eaba1c910ca32c2c0c5bb1a3f"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-go.git", revision: "2346a3ab1bb3857b48b29d779a1ef9799a248cd7"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-html.git", revision: "73a3947324f6efddf9e17c0ea58d454843590cc0"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-java.git", revision: "e10607b45ff745f5f876bfa3e94fbcc6b44bdc11"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-javascript.git", revision: "58404d8cf191d69f2674a8fd507bd5776f46cb11"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-json.git", revision: "254c42a6476413b776221e03982ac8ae159eeb72"),
+        .package(url: "https://github.com/tree-sitter-grammars/tree-sitter-kotlin.git", revision: "3dea6dfa9c0129deb7c4315afbda806c85c41667"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-php.git", revision: "3fda2fb9577166c6399834917f9844f30370beea"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-python.git", revision: "26855eabccb19c6abf499fbc5b8dc7cc9ab8bc64"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-ruby.git", revision: "ad907a69da0c8a4f7a943a7fe012712208da6dee"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-rust.git", revision: "77a3747266f4d621d0757825e6b11edcbf991ca5"),
+        .package(url: "https://github.com/tree-sitter/tree-sitter-typescript.git", revision: "75b3874edb2dc714fb1fd77a32013d0f8699989f"),
+        .package(url: "https://github.com/alex-pinkus/tree-sitter-swift.git", revision: "31d17fe7e818a2048c808b5c6fdc2dc792f4f5b5"),
+        .package(url: "https://github.com/the-mikedavis/tree-sitter-diff.git", revision: "ada384ac7bfc1307f32de474620120add29998fb"),
+        .package(url: "https://github.com/DerekStride/tree-sitter-sql.git", revision: "851e9cb257ba7c66cc8c14214a31c44d2f1e954e"),
+        .package(url: "https://github.com/tree-sitter-grammars/tree-sitter-toml.git", revision: "64b56832c2cffe41758f28e05c756a3a98d16f41"),
+        .package(url: "https://github.com/tree-sitter-grammars/tree-sitter-yaml.git", revision: "a1c4812a73ec5e089de8e441fdea3a921e8d5079"),
+        .package(url: "https://github.com/tree-sitter-grammars/tree-sitter-markdown.git", revision: "a0a00f817d02412bd92c54d316f164d827b57b5c"),
         // Development checkouts compile the patched vendor directly so local source edits
         // cannot be mistaken for successful stale builds. A plain downstream clone without
         // initialized submodules falls back to the pre-patched URL fork and remains portable.
@@ -275,12 +302,52 @@ let package = Package(
                 .unsafeFlags(["-file-prefix-map", "\(packageDir)/="], .when(configuration: .release))
             ]
         ),
+        // Four upstream grammar manifests conditionally omit their external
+        // scanners when SwiftPM evaluates them from a parent package.  Keep
+        // the pinned scanner sources in an explicit target so an incomplete
+        // grammar can never survive the final executable link.
+        .target(
+            name: "AFMTreeSitterScanners",
+            dependencies: [
+                .product(name: "TreeSitter", package: "tree-sitter")
+            ],
+            path: "Sources/AFMTreeSitterScanners",
+            exclude: ["README.md", "LICENSES.md"],
+            publicHeadersPath: ".",
+            cSettings: [.headerSearchPath(".")],
+            linkerSettings: []
+        ),
         .target(
             name: "AFMTerminalUI",
             dependencies: [
                 "AFMKit",
                 "AFMOpenAICompat",
-                .product(name: "Markdown", package: "swift-markdown")
+                "AFMTreeSitterScanners",
+                .product(name: "Markdown", package: "swift-markdown"),
+                .product(name: "TreeSitter", package: "tree-sitter"),
+                .product(name: "SwiftTreeSitter", package: "swift-tree-sitter"),
+                .product(name: "TreeSitterBash", package: "tree-sitter-bash"),
+                .product(name: "TreeSitterC", package: "tree-sitter-c"),
+                .product(name: "TreeSitterCPP", package: "tree-sitter-cpp"),
+                .product(name: "TreeSitterCSharp", package: "tree-sitter-c-sharp"),
+                .product(name: "TreeSitterCSS", package: "tree-sitter-css"),
+                .product(name: "TreeSitterGo", package: "tree-sitter-go"),
+                .product(name: "TreeSitterHTML", package: "tree-sitter-html"),
+                .product(name: "TreeSitterJava", package: "tree-sitter-java"),
+                .product(name: "TreeSitterJavaScript", package: "tree-sitter-javascript"),
+                .product(name: "TreeSitterJSON", package: "tree-sitter-json"),
+                .product(name: "TreeSitterKotlin", package: "tree-sitter-kotlin"),
+                .product(name: "TreeSitterPHP", package: "tree-sitter-php"),
+                .product(name: "TreeSitterPython", package: "tree-sitter-python"),
+                .product(name: "TreeSitterRuby", package: "tree-sitter-ruby"),
+                .product(name: "TreeSitterRust", package: "tree-sitter-rust"),
+                .product(name: "TreeSitterTypeScript", package: "tree-sitter-typescript"),
+                .product(name: "TreeSitterSwift", package: "tree-sitter-swift"),
+                .product(name: "TreeSitterDiff", package: "tree-sitter-diff"),
+                .product(name: "TreeSitterSql", package: "tree-sitter-sql"),
+                .product(name: "TreeSitterTOML", package: "tree-sitter-toml"),
+                .product(name: "TreeSitterYAML", package: "tree-sitter-yaml"),
+                .product(name: "TreeSitterMarkdown", package: "tree-sitter-markdown")
             ]
         ),
         // Thin CLI executable over AFMKit + AFMServer.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ afm mlx -m Qwen3-0.6B-4bit --tui
 The terminal UI streams responses, separates optional reasoning, and renders both answers
 and visible reasoning through a native CommonMark/GFM renderer. Headings, nested/task lists,
 quotes, tables, links, inline formatting, fenced code, and raw HTML are presented as inert
-terminal output. Code has language-aware token highlighting and line numbers; unified diffs
+terminal output. Code uses source-compiled Tree-sitter grammars for semantic highlighting
+and line numbers ([details](docs/tui-syntax-highlighting.md)); unified diffs
 have distinct file, hunk, addition, and deletion styling. Inline and display LaTeX are rendered
 as readable Unicode math, including fractions, roots, super/subscripts, operators, Greek
 symbols, matrices, and cases. The UI also reports token and throughput statistics.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ It supports multiline editing, prompt history, cancellation, persisted/searchabl
 under `~/.afm/sessions`, transcript export, attachments, terminal-width-aware tables, themes,
 and safe actions for response artifacts. Use `/help` for the command palette.
 
+The navigation follows Codex CLI conventions. Normal chat output remains in Terminal
+scrollback. Press `Ctrl+T` to open the full transcript overlay, then scroll with a Mac
+trackpad or mouse wheel, arrows, Page Up/Down, Ctrl-U/Ctrl-D, or Home/End; press `Ctrl+T`
+again to close it. Add `--no-alt-screen` to keep overlays inline too. `/blocks` opens a
+session-wide code-block list: navigate with arrows or paging keys, press Enter for
+Copy/Save/Preview actions, and Escape to return. Numbered `/save`, `/copy`, and `/open`
+commands remain available for direct use.
+
 Code is never executed automatically. `/save` refuses overwrites unless `/save!` is used,
 and only an explicit `/open` previews HTML or JavaScript in the browser. iTerm2 and Kitty
 can display local images inline; Terminal.app uses an explicit `/image` Quick Look fallback.

--- a/README.md
+++ b/README.md
@@ -105,11 +105,17 @@ afm --tui
 afm mlx -m Qwen3-0.6B-4bit --tui
 ```
 
-The terminal UI streams responses, separates optional reasoning, renders Markdown,
-syntax-highlighted code, unified diffs, and readable LaTeX fallbacks, and reports token
-and throughput statistics. It supports multiline editing, prompt history, cancellation,
-persisted/searchable sessions under `~/.afm/sessions`, transcript export, attachments,
-themes, and safe actions for response artifacts. Use `/help` for the command palette.
+The terminal UI streams responses, separates optional reasoning, and renders both answers
+and visible reasoning through a native CommonMark/GFM renderer. Headings, nested/task lists,
+quotes, tables, links, inline formatting, fenced code, and raw HTML are presented as inert
+terminal output. Code has language-aware token highlighting and line numbers; unified diffs
+have distinct file, hunk, addition, and deletion styling. Inline and display LaTeX are rendered
+as readable Unicode math, including fractions, roots, super/subscripts, operators, Greek
+symbols, matrices, and cases. The UI also reports token and throughput statistics.
+
+It supports multiline editing, prompt history, cancellation, persisted/searchable sessions
+under `~/.afm/sessions`, transcript export, attachments, terminal-width-aware tables, themes,
+and safe actions for response artifacts. Use `/help` for the command palette.
 
 Code is never executed automatically. `/save` refuses overwrites unless `/save!` is used,
 and only an explicit `/open` previews HTML or JavaScript in the browser. iTerm2 and Kitty

--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ afm --tui
 afm mlx -m Qwen3-0.6B-4bit --tui
 ```
 
+TUI changes have a model-free regression harness. `make test-tui` runs stable
+Markdown/math/code snapshots and exercises keyboard input, terminal sizing,
+alternate-screen cleanup, and raw-mode restoration through a real macOS
+pseudo-terminal. If an intentional visual change updates the expected output,
+run `Scripts/test-tui.sh --record`, inspect the snapshot diff, then rerun
+`make test-tui` normally. The same focused suite runs automatically on relevant
+pull requests.
+
 The terminal UI streams responses, separates optional reasoning, and renders both answers
 and visible reasoning through a native CommonMark/GFM renderer. Headings, nested/task lists,
 quotes, tables, links, inline formatting, fenced code, and raw HTML are presented as inert

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ have distinct file, hunk, addition, and deletion styling. Inline and display LaT
 as readable Unicode math, including fractions, roots, super/subscripts, operators, Greek
 symbols, matrices, and cases. The UI also reports token and throughput statistics.
 
+Reasoning is collapsed by default into a live activity row with its phase, animated cursor,
+elapsed time, and generated character count. Press `Tab` during generation to expand or
+collapse the reasoning panel without interrupting the model. Use `/reasoning expanded`,
+`/reasoning collapsed`, `/reasoning off`, or `/reasoning last` to control it explicitly.
+
 It supports multiline editing, prompt history, cancellation, persisted/searchable sessions
 under `~/.afm/sessions`, transcript export, attachments, terminal-width-aware tables, themes,
 and safe actions for response artifacts. Use `/help` for the command palette.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,28 @@ Or use Apple’s on-device model:
 afm -w
 ```
 
+### Native terminal chat
+
+Use `--tui` when you want a private, full-screen chat without running an HTTP server:
+
+```bash
+# Apple Foundation Models
+afm --tui
+
+# Any supported MLX model (all normal sampling/runtime flags still apply)
+afm mlx -m Qwen3-0.6B-4bit --tui
+```
+
+The terminal UI streams responses, separates optional reasoning, renders Markdown,
+syntax-highlighted code, unified diffs, and readable LaTeX fallbacks, and reports token
+and throughput statistics. It supports multiline editing, prompt history, cancellation,
+persisted/searchable sessions under `~/.afm/sessions`, transcript export, attachments,
+themes, and safe actions for response artifacts. Use `/help` for the command palette.
+
+Code is never executed automatically. `/save` refuses overwrites unless `/save!` is used,
+and only an explicit `/open` previews HTML or JavaScript in the browser. iTerm2 and Kitty
+can display local images inline; Terminal.app uses an explicit `/image` Quick Look fallback.
+
 ## Choose your runtime
 
 | Runtime | Best for | Start it |

--- a/Scripts/check-tree-sitter-highlighting.sh
+++ b/Scripts/check-tree-sitter-highlighting.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="$ROOT_DIR/Package.swift"
+
+require_manifest_text() {
+    if ! grep -Fq "$1" "$MANIFEST"; then
+        echo "tree-sitter integrity: missing Package.swift pin: $1" >&2
+        exit 1
+    fi
+}
+
+check_digest() {
+    local expected="$1"
+    local relative="$2"
+    local actual
+    actual="$(shasum -a 256 "$ROOT_DIR/$relative" | awk '{print $1}')"
+    if [ "$actual" != "$expected" ]; then
+        echo "tree-sitter integrity: $relative does not match its pinned upstream source" >&2
+        exit 1
+    fi
+}
+
+require_manifest_text '.package(url: "https://github.com/tree-sitter/tree-sitter.git", exact: "0.25.10")'
+require_manifest_text '.package(url: "https://github.com/tree-sitter/swift-tree-sitter.git", exact: "0.25.0")'
+
+check_digest 18dae8c8c4f515f28a3dc7ffb5bda259b06013a752921dc411a2fad8ecf78988 Sources/AFMTreeSitterScanners/css_scanner.c
+check_digest b3d3f64284d97bf80749c026862427782cf7ecc0b7dc094e6698ab311c9a42c7 Sources/AFMTreeSitterScanners/javascript_scanner.c
+check_digest 6db82134ac2d4c90a1a1475487a625cface02662ebda9b7478cad9c7147e9afe Sources/AFMTreeSitterScanners/python_scanner.c
+check_digest a510c0ca699cf3853bd2192bf103e11132414bc002fe952a88a7106ffb5d44e9 Sources/AFMTreeSitterScanners/yaml_scanner.c
+check_digest 91e56c3f3ae6fad1803b739ce4eb4568a782a9aec710f733db2f3e38d407a4d5 Sources/AFMTreeSitterScanners/schema.core.c
+check_digest 180b893c8734778fd32f372dfbc27bd6ad1cd2221f26150b31256ff6716320d2 Sources/AFMTreeSitterScanners/tree_sitter/parser.h
+check_digest 5bdf6ed1a78e3409fd443e085ca967a64c188a5d082aaf7f819bccd53a471c94 Sources/AFMTreeSitterScanners/tree_sitter/array.h
+check_digest b29c1c9fb7cc82f58c84b376df1297d6e2737a1d655fd356db0859e3c29c2fea Sources/AFMTreeSitterScanners/tree_sitter/alloc.h
+
+if [ "$#" -gt 0 ]; then
+    BINARY="$1"
+    if [ ! -x "$BINARY" ]; then
+        echo "tree-sitter integrity: binary is not executable: $BINARY" >&2
+        exit 1
+    fi
+    SYMBOLS="$(nm -gU "$BINARY")"
+    for language in bash c cpp c_sharp css diff go html java javascript json kotlin markdown php python ruby rust sql swift toml tsx typescript yaml; do
+        if ! grep -q "_tree_sitter_${language}$" <<<"$SYMBOLS"; then
+            echo "tree-sitter integrity: linked binary is missing tree_sitter_${language}" >&2
+            exit 1
+        fi
+    done
+fi
+
+echo "tree-sitter integrity: pinned sources and linked grammars verified"

--- a/Scripts/test-tui.sh
+++ b/Scripts/test-tui.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+SCRATCH_DIR="$REPO_DIR/.build"
+
+if [ "${1:-}" = "--record" ]; then
+    export AFM_RECORD_TUI_SNAPSHOTS=1
+    shift
+fi
+
+if [ "$#" -ne 0 ]; then
+    echo "usage: Scripts/test-tui.sh [--record]" >&2
+    exit 64
+fi
+
+cd "$REPO_DIR"
+exec Scripts/swiftpm-reliable.sh test \
+    --package-path Tests/TUIHarness \
+    --scratch-path "$SCRATCH_DIR"

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -459,7 +459,7 @@ struct MlxCommand: ParsableCommand {
     var telegramAllow: String?
 
     @Option(name: .long, help: "Telegram reply format: markdown, plain, or html (default: markdown)")
-    var telegramFormat: TelegramReplyFormat = .markdown
+    var telegramFormat: TelegramReplyFormat?
 
     @Option(name: .long, help: "Require a specific prefix for Telegram messages, for example '/afm' (default: no prefix required)")
     var telegramRequirePrefix: String?
@@ -553,11 +553,18 @@ struct MlxCommand: ParsableCommand {
             throw ExitCode.failure
         }
 
+        let hasTelegramOptions = TUIInvocationPolicy.hasTelegramOptions(
+            botToken: telegramBotToken,
+            allowlist: telegramAllow,
+            replyFormat: telegramFormat?.rawValue,
+            requirePrefix: telegramRequirePrefix
+        )
         do {
             try TUIInvocationPolicy.validate(
                 tui: tui,
                 webUI: webui,
                 singlePrompt: singlePrompt != nil,
+                telegramOptions: hasTelegramOptions,
                 inputIsTTY: isatty(STDIN_FILENO) != 0,
                 outputIsTTY: isatty(STDOUT_FILENO) != 0
             )
@@ -587,10 +594,23 @@ struct MlxCommand: ParsableCommand {
             throw ExitCode.failure
         }
 
-        if (telegramBotToken != nil || telegramAllow != nil) && (singlePrompt != nil || isatty(STDIN_FILENO) == 0) {
+        if hasTelegramOptions && (singlePrompt != nil || isatty(STDIN_FILENO) == 0) {
             print("Error: --telegram requires server mode and cannot be used with -s or piped single-prompt input")
             throw ExitCode.failure
         }
+
+        let shellCWD = URL(
+            fileURLWithPath: ProcessInfo.processInfo.environment["PWD"]
+                ?? FileManager.default.currentDirectoryPath,
+            isDirectory: true
+        )
+        let resolvedMediaURLs: [URL]
+        do {
+            resolvedMediaURLs = try TUIMediaAttachmentPolicy.resolveAndValidate(media, cwd: shellCWD)
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+        let resolvedMedia = resolvedMediaURLs.map(\.path)
 
         emitCompatibilityWarnings()
 
@@ -797,7 +817,7 @@ struct MlxCommand: ParsableCommand {
                 engine: engineConfig,
                 generation: generation,
                 streaming: !noStreaming,
-                initialAttachments: try media.map { try TUIArtifactActions.resolvedURL($0) }
+                initialAttachments: resolvedMediaURLs
             ))
             return
         }
@@ -816,20 +836,6 @@ struct MlxCommand: ParsableCommand {
         let contextWindow = modelStore.descriptor(for: selectedModel).contextWindow
 
         try ensureMLXMetalLibraryAvailable(verbose: verbose)
-
-        // Resolve and validate --media paths early (before model load)
-        var resolvedMedia: [String] = []
-        let shellCWD = ProcessInfo.processInfo.environment["PWD"] ?? FileManager.default.currentDirectoryPath
-        for path in media {
-            let expanded = NSString(string: path).expandingTildeInPath
-            let absPath = expanded.hasPrefix("/") ? expanded : shellCWD + "/" + expanded
-            let resolved = URL(fileURLWithPath: absPath).standardized.path
-            guard FileManager.default.fileExists(atPath: resolved) else {
-                print("Error: Media file not found: \(path)")
-                throw ExitCode.failure
-            }
-            resolvedMedia.append(resolved)
-        }
 
         // An explicit prompt must win over redirected stdin. Profilers and
         // automation runners commonly attach a pipe that remains open.
@@ -877,7 +883,7 @@ struct MlxCommand: ParsableCommand {
             modelID: selectedModel,
             instructions: instructions,
             verbose: verbose || veryVerbose || vv,
-            replyFormat: telegramFormat,
+            replyFormat: telegramFormat ?? .markdown,
             requirePrefix: telegramRequirePrefix
         )
 
@@ -1161,7 +1167,7 @@ struct MlxCommand: ParsableCommand {
             modelID: modelID,
             instructions: instructions,
             verbose: verbose || veryVerbose || vv,
-            replyFormat: telegramFormat,
+            replyFormat: telegramFormat ?? .markdown,
             requirePrefix: telegramRequirePrefix)
 
         let model = AnyAFMModel(AFMDwarfStarModel(
@@ -1998,7 +2004,7 @@ struct RootCommand: ParsableCommand {
     var telegramAllow: String?
 
     @Option(name: .long, help: "Telegram reply format: markdown, plain, or html (default: markdown)")
-    var telegramFormat: TelegramReplyFormat = .markdown
+    var telegramFormat: TelegramReplyFormat?
 
     @Option(name: .long, help: "Require a specific prefix for Telegram messages, for example '/afm' (default: no prefix required)")
     var telegramRequirePrefix: String?
@@ -2042,7 +2048,13 @@ struct RootCommand: ParsableCommand {
             }
         }
 
-        if (telegramBotToken != nil || telegramAllow != nil) && (singlePrompt != nil || isatty(STDIN_FILENO) == 0) {
+        let hasTelegramOptions = TUIInvocationPolicy.hasTelegramOptions(
+            botToken: telegramBotToken,
+            allowlist: telegramAllow,
+            replyFormat: telegramFormat?.rawValue,
+            requirePrefix: telegramRequirePrefix
+        )
+        if hasTelegramOptions && (singlePrompt != nil || isatty(STDIN_FILENO) == 0) {
             throw ValidationError("--telegram requires server mode and cannot be used with -s or piped single-prompt input")
         }
 
@@ -2051,6 +2063,7 @@ struct RootCommand: ParsableCommand {
                 tui: tui,
                 webUI: webui,
                 singlePrompt: singlePrompt != nil,
+                telegramOptions: hasTelegramOptions,
                 inputIsTTY: isatty(STDIN_FILENO) != 0,
                 outputIsTTY: isatty(STDOUT_FILENO) != 0
             )
@@ -2060,9 +2073,6 @@ struct RootCommand: ParsableCommand {
 
         if tui {
             if gateway { throw ValidationError("--tui cannot be combined with --gateway") }
-            if telegramBotToken != nil || telegramAllow != nil {
-                throw ValidationError("--tui cannot be combined with Telegram server options")
-            }
             let responseFormat: ResponseFormat?
             if let guidedJson {
                 responseFormat = ResponseFormat(type: "json_schema", jsonSchema: try parseGuidedJsonSchema(guidedJson))
@@ -2112,7 +2122,7 @@ struct RootCommand: ParsableCommand {
         if gateway { args.append("--gateway") }
         if let telegramBotToken { args += ["--telegram-bot-token", telegramBotToken] }
         if let telegramAllow { args += ["--telegram-allow", telegramAllow] }
-        args += ["--telegram-format", telegramFormat.rawValue]
+        if let telegramFormat { args += ["--telegram-format", telegramFormat.rawValue] }
         if let telegramRequirePrefix { args += ["--telegram-require-prefix", telegramRequirePrefix] }
         if let adapter { args += ["--adapter", adapter] }
         if let temperature { args += ["--temperature", "\(temperature)"] }

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -241,6 +241,7 @@ struct MlxCommand: ParsableCommand {
           -V, --very-verbose: Log full requests/responses and all parameters
           -w, --webui: Enable WebUI and open in browser
           --tui: Run the native interactive terminal chat UI
+          --no-alt-screen: Disable alternate-screen overlays and keep the TUI inline
           --telegram-bot-token: Telegram bot token for remote AFM access
           --telegram-allow: Comma-separated allowlist of Telegram numeric user IDs
           --telegram-format: Telegram reply format: markdown, plain, or html
@@ -413,6 +414,9 @@ struct MlxCommand: ParsableCommand {
 
     @Flag(name: .long, help: "Run the advanced native terminal chat UI")
     var tui: Bool = false
+
+    @Flag(name: .long, help: "Disable alternate-screen overlays and keep the TUI inline")
+    var noAltScreen: Bool = false
 
     @Flag(name: [.customShort("g"), .long], help: "Gateway mode is not supported in afm mlx")
     var gateway: Bool = false
@@ -831,6 +835,7 @@ struct MlxCommand: ParsableCommand {
                 engine: engineConfig,
                 generation: generation,
                 streaming: !noStreaming,
+                useAlternateScreen: !noAltScreen,
                 initialAttachments: resolvedMediaURLs
             ))
             return
@@ -1823,6 +1828,7 @@ struct MacLocalAPI: ParsableCommand {
           -V, --very-verbose: Log full requests/responses
           -w, --webui: Enable WebUI and open in browser
           --tui: Run the native interactive terminal chat UI
+          --no-alt-screen: Disable alternate-screen overlays and keep the TUI inline
           --telegram-bot-token: Telegram bot token for remote AFM access
           --telegram-allow: Comma-separated allowlist of Telegram numeric user IDs
           --telegram-format: Telegram reply format: markdown, plain, or html
@@ -2011,6 +2017,9 @@ struct RootCommand: ParsableCommand {
     @Flag(name: .long, help: "Run the advanced native terminal chat UI")
     var tui: Bool = false
 
+    @Flag(name: .long, help: "Disable alternate-screen overlays and keep the TUI inline")
+    var noAltScreen: Bool = false
+
     @Option(name: .long, help: "Telegram bot token for remote AFM access")
     var telegramBotToken: String?
 
@@ -2108,7 +2117,8 @@ struct RootCommand: ParsableCommand {
                     stop: stop?.split(separator: ",").map(String.init),
                     responseFormat: responseFormat
                 ),
-                streaming: !noStreaming
+                streaming: !noStreaming,
+                useAlternateScreen: !noAltScreen
             ))
             return
         }

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -1,6 +1,7 @@
 import AFMKit
 import AFMKitDwarfStar
 import AFMServer
+import AFMTerminalUI
 import ArgumentParser
 import Foundation
 import Darwin
@@ -16,6 +17,22 @@ extension TelegramReplyFormat: ExpressibleByArgument {}
 // single-threaded with respect to the run loop, so the unsafety is contained.
 nonisolated(unsafe) private var globalServer: Server?
 nonisolated(unsafe) private var shouldKeepRunning = true
+
+private func runTerminalChat(_ configuration: TerminalChatConfiguration) throws {
+    let group = DispatchGroup()
+    let errorBox = SendableBox<Error?>(nil)
+    group.enter()
+    Task.detached {
+        do {
+            try await AFMTerminalChat(configuration: configuration).run()
+        } catch {
+            errorBox.value = error
+        }
+        group.leave()
+    }
+    group.wait()
+    if let error = errorBox.value { throw error }
+}
 
 // Signal handler function
 func handleShutdown(_ signal: Int32) {
@@ -209,6 +226,7 @@ struct MlxCommand: ParsableCommand {
           -v, --verbose: Enable verbose logging
           -V, --very-verbose: Log full requests/responses and all parameters
           -w, --webui: Enable WebUI and open in browser
+          --tui: Run the native interactive terminal chat UI
           --telegram-bot-token: Telegram bot token for remote AFM access
           --telegram-allow: Comma-separated allowlist of Telegram numeric user IDs
           --telegram-format: Telegram reply format: markdown, plain, or html
@@ -379,6 +397,9 @@ struct MlxCommand: ParsableCommand {
     @Flag(name: [.customShort("w"), .long], help: "Enable webui and open in default browser")
     var webui: Bool = false
 
+    @Flag(name: .long, help: "Run the advanced native terminal chat UI")
+    var tui: Bool = false
+
     @Flag(name: [.customShort("g"), .long], help: "Gateway mode is not supported in afm mlx")
     var gateway: Bool = false
 
@@ -532,6 +553,20 @@ struct MlxCommand: ParsableCommand {
             throw ExitCode.failure
         }
 
+        do {
+            try TUIInvocationPolicy.validate(
+                tui: tui,
+                webUI: webui,
+                singlePrompt: singlePrompt != nil,
+                pipedInput: isatty(STDIN_FILENO) == 0
+            )
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+        if tui && (raw || json || openclawConfig) {
+            throw ValidationError("--tui cannot be combined with --raw, --json, or --openclaw-config")
+        }
+
         // GPU capture: set MTL_CAPTURE_ENABLED before Metal device is created
         if let capturePath = gpuCapture {
             setenv("MTL_CAPTURE_ENABLED", "1", 1)
@@ -658,6 +693,9 @@ struct MlxCommand: ParsableCommand {
             throw ValidationError("--dspark-support requires --mlx-runtime dwarfstar or a DwarfStar executor checkpoint")
         }
         if runtimeBackend == .dwarfstar {
+            if tui {
+                throw ValidationError("--tui currently supports MLX directory checkpoints; DwarfStar GGUF terminal chat is not yet available")
+            }
             try runDwarfStar(
                 checkpointPath: localModelPath(resolvedModel),
                 modelStore: modelStore,
@@ -702,6 +740,64 @@ struct MlxCommand: ParsableCommand {
         let selectedModel = runtime.modelID
         let service = runtime.service
         service.kernelEngine = kernelEngine
+
+        if tui {
+            var metadata: [String: AFMJSONValue] = [:]
+            if !parsedKwargs.isEmpty {
+                metadata["chatTemplateKwargs"] = .object(
+                    try parsedKwargs.mapValues { try Self.afmJSONValue(from: $0) }
+                )
+            }
+            let engineConfig = EngineConfig(
+                instructions: instructions,
+                kvBits: kvBits,
+                enablePrefixCaching: enablePrefixCaching,
+                mlxKernels: kernelEngine.rawValue,
+                mtpEnabled: mtp,
+                mtpDepth: mtpDepth,
+                mtpModelID: mtpModel,
+                eagle3DrafterPath: eagle3,
+                enableGrammarConstraints: enableGrammarConstraints,
+                toolCallParser: toolCallParser,
+                maxConcurrent: concurrent ?? 0,
+                prefillStepSize: prefillStepSize,
+                kvEvictionPolicy: kvEviction ?? "none",
+                fixToolArguments: fixToolArgs,
+                forceVLM: vlm || !media.isEmpty,
+                cacheProfilePath: cacheProfilePath,
+                trace: vv,
+                gpuCapturePath: gpuCapture,
+                gpuTraceDuration: gpuTrace,
+                gpuProfile: gpuProfile || gpuProfileBw,
+                gpuProfileBandwidth: gpuProfileBw
+            )
+            let generation = GenerationConfig(
+                temperature: temperature,
+                maxTokens: maxTokens,
+                topP: topP,
+                topK: topK,
+                minP: minP,
+                repetitionPenalty: repetitionPenalty,
+                presencePenalty: presencePenalty,
+                seed: seed,
+                topLogprobs: maxLogprobs,
+                stop: stop?.split(separator: ",").map(String.init),
+                tools: try Self.parseToolsJSON(toolsJson),
+                responseFormat: defaultGuidedJsonSchema,
+                metadata: metadata
+            )
+            try ensureMLXMetalLibraryAvailable(verbose: verbose)
+            try runTerminalChat(TerminalChatConfiguration(
+                backend: .mlx(modelID: selectedModel),
+                backendName: "MLX",
+                modelName: selectedModel,
+                engine: engineConfig,
+                generation: generation,
+                streaming: !noStreaming,
+                initialAttachments: try media.map { try TUIArtifactActions.resolvedURL($0) }
+            ))
+            return
+        }
 
         if openclawConfig {
             let chosenPort = port ?? 9999
@@ -1703,6 +1799,7 @@ struct MacLocalAPI: ParsableCommand {
           -v, --verbose: Enable verbose logging
           -V, --very-verbose: Log full requests/responses
           -w, --webui: Enable WebUI and open in browser
+          --tui: Run the native interactive terminal chat UI
           --telegram-bot-token: Telegram bot token for remote AFM access
           --telegram-allow: Comma-separated allowlist of Telegram numeric user IDs
           --telegram-format: Telegram reply format: markdown, plain, or html
@@ -1888,6 +1985,9 @@ struct RootCommand: ParsableCommand {
     @Flag(name: [.customShort("w"), .long], help: "Enable webui and open in default browser")
     var webui: Bool = false
 
+    @Flag(name: .long, help: "Run the advanced native terminal chat UI")
+    var tui: Bool = false
+
     @Option(name: .long, help: "Telegram bot token for remote AFM access")
     var telegramBotToken: String?
 
@@ -1941,6 +2041,48 @@ struct RootCommand: ParsableCommand {
 
         if (telegramBotToken != nil || telegramAllow != nil) && (singlePrompt != nil || isatty(STDIN_FILENO) == 0) {
             throw ValidationError("--telegram requires server mode and cannot be used with -s or piped single-prompt input")
+        }
+
+        do {
+            try TUIInvocationPolicy.validate(
+                tui: tui,
+                webUI: webui,
+                singlePrompt: singlePrompt != nil,
+                pipedInput: isatty(STDIN_FILENO) == 0
+            )
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+
+        if tui {
+            if gateway { throw ValidationError("--tui cannot be combined with --gateway") }
+            if telegramBotToken != nil || telegramAllow != nil {
+                throw ValidationError("--tui cannot be combined with Telegram server options")
+            }
+            let responseFormat: ResponseFormat?
+            if let guidedJson {
+                responseFormat = ResponseFormat(type: "json_schema", jsonSchema: try parseGuidedJsonSchema(guidedJson))
+            } else {
+                responseFormat = nil
+            }
+            try runTerminalChat(TerminalChatConfiguration(
+                backend: .foundationModels,
+                backendName: "Foundation Models",
+                modelName: "apple-foundation-model",
+                engine: EngineConfig(
+                    instructions: instructions,
+                    adapter: adapter,
+                    permissiveGuardrails: permissiveGuardrails,
+                    foundationRandomness: randomness
+                ),
+                generation: GenerationConfig(
+                    temperature: temperature,
+                    stop: stop?.split(separator: ",").map(String.init),
+                    responseFormat: responseFormat
+                ),
+                streaming: !noStreaming
+            ))
+            return
         }
 
         // Handle single-prompt mode for backward compatibility

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -558,7 +558,8 @@ struct MlxCommand: ParsableCommand {
                 tui: tui,
                 webUI: webui,
                 singlePrompt: singlePrompt != nil,
-                pipedInput: isatty(STDIN_FILENO) == 0
+                inputIsTTY: isatty(STDIN_FILENO) != 0,
+                outputIsTTY: isatty(STDOUT_FILENO) != 0
             )
         } catch {
             throw ValidationError(error.localizedDescription)
@@ -748,6 +749,7 @@ struct MlxCommand: ParsableCommand {
                     try parsedKwargs.mapValues { try Self.afmJSONValue(from: $0) }
                 )
             }
+            let tuiLogprobs = TUILogprobConfiguration(maximum: maxLogprobs)
             let engineConfig = EngineConfig(
                 instructions: instructions,
                 kvBits: kvBits,
@@ -780,7 +782,8 @@ struct MlxCommand: ParsableCommand {
                 repetitionPenalty: repetitionPenalty,
                 presencePenalty: presencePenalty,
                 seed: seed,
-                topLogprobs: maxLogprobs,
+                logprobs: tuiLogprobs.enabled,
+                topLogprobs: tuiLogprobs.maximum,
                 stop: stop?.split(separator: ",").map(String.init),
                 tools: try Self.parseToolsJSON(toolsJson),
                 responseFormat: defaultGuidedJsonSchema,
@@ -2048,7 +2051,8 @@ struct RootCommand: ParsableCommand {
                 tui: tui,
                 webUI: webui,
                 singlePrompt: singlePrompt != nil,
-                pipedInput: isatty(STDIN_FILENO) == 0
+                inputIsTTY: isatty(STDIN_FILENO) != 0,
+                outputIsTTY: isatty(STDOUT_FILENO) != 0
             )
         } catch {
             throw ValidationError(error.localizedDescription)
@@ -2122,7 +2126,21 @@ struct RootCommand: ParsableCommand {
 
 // Manual dispatch for subcommands to avoid flag conflicts between root and subcommands.
 // Subcommands are still registered in RootCommand.configuration so they appear in -h.
-if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "dwarfstar-bench" {
+if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "__tui-preview" {
+    if CommandLine.arguments.count != 3 {
+        fputs("Invalid TUI preview invocation.\n", stderr)
+        exit(EXIT_FAILURE)
+    }
+    do {
+        let artifactURL = URL(fileURLWithPath: CommandLine.arguments[2]).standardizedFileURL
+        try MainActor.assumeIsolated {
+            try TUIBrowserPreview.run(artifactURL: artifactURL)
+        }
+    } catch {
+        fputs("Unable to open TUI preview: \(error.localizedDescription)\n", stderr)
+        exit(EXIT_FAILURE)
+    }
+} else if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "dwarfstar-bench" {
     let args = Array(CommandLine.arguments.dropFirst(2))
     do {
         var cmd = try DwarfStarBenchmarkCommand.parse(args)

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -427,7 +427,7 @@ struct MlxCommand: ParsableCommand {
     @Option(name: .long, help: "Presence penalty: flat additive penalty for tokens already generated (0.0 = disabled)")
     var presencePenalty: Double?
     @Option(name: .long, help: "Maximum tokens to generate per response (default: 8192)")
-    var maxTokens: Int?
+    var maxTokens: Int = MLXModelService.defaultMaximumResponseTokens
     @Option(name: .long, help: "Random seed for reproducible sampling (nil = non-deterministic)")
     var seed: Int?
     @Option(name: .long, help: "Maximum number of top log probabilities returned per token (default: 20)")

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -19,12 +19,26 @@ nonisolated(unsafe) private var globalServer: Server?
 nonisolated(unsafe) private var shouldKeepRunning = true
 
 private func runTerminalChat(_ configuration: TerminalChatConfiguration) throws {
+    let outputIsolation = try TerminalOutputIsolation()
+    defer { outputIsolation.restore() }
+    let terminal = TerminalIO(
+        inputFD: STDIN_FILENO,
+        outputFD: outputIsolation.terminalOutputFD
+    )
+    let capabilities = TerminalCapabilities.detect(
+        inputFD: STDIN_FILENO,
+        outputFD: outputIsolation.terminalOutputFD
+    )
     let group = DispatchGroup()
     let errorBox = SendableBox<Error?>(nil)
     group.enter()
     Task.detached {
         do {
-            try await AFMTerminalChat(configuration: configuration).run()
+            try await AFMTerminalChat(
+                configuration: configuration,
+                terminal: terminal,
+                capabilities: capabilities
+            ).run()
         } catch {
             errorBox.value = error
         }

--- a/Sources/AFMKit/AFMEngine.swift
+++ b/Sources/AFMKit/AFMEngine.swift
@@ -330,6 +330,19 @@ public actor AFMEngine {
         foundationService = nil
     }
 
+    /// Reset backend-owned conversational state and optionally restore a transcript.
+    /// Stateless backends receive complete request histories and require no action.
+    public func resetConversation(with history: [Message] = []) async throws {
+        guard case .foundationModels = backend else { return }
+        try await ensureFoundation()
+        if #available(macOS 26.0, *) {
+            guard let service = foundationService as? FoundationModelService else {
+                throw AFMEngineError.foundationModelsUnavailable
+            }
+            service.resetConversation(with: history)
+        }
+    }
+
     /// Generate a single (non-streaming) response for a chat transcript.
     public func respond(to messages: [Message], _ config: GenerationConfig = GenerationConfig()) async throws -> AFMResponse {
         switch backend {

--- a/Sources/AFMKit/AFMEngine.swift
+++ b/Sources/AFMKit/AFMEngine.swift
@@ -246,6 +246,77 @@ public enum AFMStreamEvent: Sendable {
 
 // MARK: - AFMEngine
 
+final class AFMEngineFoundationOperationGate: @unchecked Sendable {
+    struct Reservation: Sendable {
+        fileprivate let predecessor: Signal?
+        fileprivate let completion: Signal
+
+        func perform<T: Sendable>(
+            _ operation: @Sendable () async throws -> T
+        ) async throws -> T {
+            if let predecessor {
+                await predecessor.wait()
+            }
+            defer { completion.signal() }
+            try Task.checkCancellation()
+            return try await operation()
+        }
+    }
+
+    fileprivate final class Signal: @unchecked Sendable {
+        private let lock = NSLock()
+        private var signalled = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func wait() async {
+            await withCheckedContinuation { continuation in
+                lock.lock()
+                if signalled {
+                    lock.unlock()
+                    continuation.resume()
+                } else {
+                    waiters.append(continuation)
+                    lock.unlock()
+                }
+            }
+        }
+
+        func signal() {
+            lock.lock()
+            guard !signalled else {
+                lock.unlock()
+                return
+            }
+            signalled = true
+            let pending = waiters
+            waiters.removeAll()
+            lock.unlock()
+            for waiter in pending {
+                waiter.resume()
+            }
+        }
+    }
+
+    private let lock = NSLock()
+    private var tail: Signal?
+
+    func reserve() -> Reservation {
+        lock.lock()
+        defer { lock.unlock() }
+        let completion = Signal()
+        let reservation = Reservation(predecessor: tail, completion: completion)
+        tail = completion
+        return reservation
+    }
+}
+
+struct AFMEngineFoundationDriver: Sendable {
+    let beforeStreamTask: @Sendable () async -> Void
+    let resetConversation: @Sendable ([Message]) async throws -> Void
+    let respond: @Sendable ([Message], GenerationConfig) async throws -> String
+    let stream: @Sendable ([Message], GenerationConfig) async throws -> AsyncThrowingStream<String, Error>
+}
+
 /// A headless, embeddable entry point to afm's inference backends.
 ///
 /// `AFMEngine` is the programmatic equivalent of the `afm` CLI: construct it with a
@@ -259,8 +330,10 @@ public enum AFMStreamEvent: Sendable {
 /// print(reply.content)
 /// ```
 public actor AFMEngine {
-    public let backend: AFMBackend
+    public nonisolated let backend: AFMBackend
     private let engineConfig: EngineConfig
+    private nonisolated let foundationOperations = AFMEngineFoundationOperationGate()
+    private let foundationDriver: AFMEngineFoundationDriver?
 
     private let registeredModel: AnyAFMModel?
 
@@ -270,6 +343,7 @@ public actor AFMEngine {
     public init(backend: AFMBackend, config: EngineConfig = EngineConfig()) {
         self.backend = backend
         self.engineConfig = config
+        self.foundationDriver = nil
         switch backend {
         case .mlx(let modelID):
             self.registeredModel = try? AFMMLXProviderFactory().makeModel(
@@ -299,11 +373,22 @@ public actor AFMEngine {
     ) throws {
         backend = .provider(providerID: providerID, modelID: modelID)
         self.engineConfig = engineConfig
+        foundationDriver = nil
         registeredModel = try registry.makeModel(
             providerID: providerID,
             modelID: modelID,
             configuration: configuration
         )
+    }
+
+    init(
+        config: EngineConfig = EngineConfig(),
+        foundationDriver: AFMEngineFoundationDriver
+    ) {
+        backend = .foundationModels
+        engineConfig = config
+        self.foundationDriver = foundationDriver
+        registeredModel = nil
     }
 
     /// Load (download if needed) the model and prepare it for inference.
@@ -334,12 +419,9 @@ public actor AFMEngine {
     /// Stateless backends receive complete request histories and require no action.
     public func resetConversation(with history: [Message] = []) async throws {
         guard case .foundationModels = backend else { return }
-        try await ensureFoundation()
-        if #available(macOS 26.0, *) {
-            guard let service = foundationService as? FoundationModelService else {
-                throw AFMEngineError.foundationModelsUnavailable
-            }
-            try await service.resetConversation(with: history)
+        let reservation = foundationOperations.reserve()
+        try await reservation.perform { [self] in
+            try await self.performFoundationReset(with: history)
         }
     }
 
@@ -358,7 +440,10 @@ public actor AFMEngine {
                 modelResponse: try await registeredModel.respond(to: request)
             )
         case .foundationModels:
-            let text = try await foundationGenerate(messages: messages, config: config)
+            let reservation = foundationOperations.reserve()
+            let text = try await reservation.perform { [self] in
+                try await self.foundationGenerate(messages: messages, config: config)
+            }
             return AFMResponse(content: text)
         }
     }
@@ -369,7 +454,15 @@ public actor AFMEngine {
         to messages: [Message],
         _ config: GenerationConfig = GenerationConfig()
     ) -> AsyncThrowingStream<AFMStreamEvent, Error> {
-        AsyncThrowingStream { continuation in
+        let foundationReservation: AFMEngineFoundationOperationGate.Reservation?
+        if case .foundationModels = backend {
+            // Reserve before returning the stream. A reset invoked immediately after this
+            // public call must wait even if the stream's task has not started running yet.
+            foundationReservation = foundationOperations.reserve()
+        } else {
+            foundationReservation = nil
+        }
+        return AsyncThrowingStream { continuation in
             let task = Task {
                 do {
                     switch backend {
@@ -387,12 +480,18 @@ public actor AFMEngine {
                         }
                         continuation.finish()
                     case .foundationModels:
-                        let stream = try await foundationStream(messages: messages, config: config)
-                        for try await text in stream {
-                            try Task.checkCancellation()
-                            continuation.yield(.text(text, tokenCount: 0))
+                        guard let foundationReservation else {
+                            throw AFMEngineError.foundationModelsUnavailable
                         }
-                        continuation.yield(.completed(.stop))
+                        await self.prepareFoundationStreamTask()
+                        try await foundationReservation.perform { [self] in
+                            let stream = try await self.foundationStream(messages: messages, config: config)
+                            for try await text in stream {
+                                try Task.checkCancellation()
+                                continuation.yield(.text(text, tokenCount: 0))
+                            }
+                            continuation.yield(.completed(.stop))
+                        }
                         continuation.finish()
                     }
                 } catch {
@@ -409,10 +508,11 @@ public actor AFMEngine {
         to messages: [Message],
         _ config: GenerationConfig = GenerationConfig()
     ) -> AsyncThrowingStream<String, Error> {
-        AsyncThrowingStream { continuation in
+        let events = streamEvents(to: messages, config)
+        return AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    for try await event in streamEvents(to: messages, config) {
+                    for try await event in events {
                         if case .text(let text, _) = event, !text.isEmpty {
                             continuation.yield(text)
                         }
@@ -509,7 +609,28 @@ public actor AFMEngine {
         }
     }
 
+    private func performFoundationReset(with history: [Message]) async throws {
+        if let foundationDriver {
+            try await foundationDriver.resetConversation(history)
+            return
+        }
+        try await ensureFoundation()
+        if #available(macOS 26.0, *) {
+            guard let service = foundationService as? FoundationModelService else {
+                throw AFMEngineError.foundationModelsUnavailable
+            }
+            try await service.resetConversation(with: history)
+        }
+    }
+
+    private func prepareFoundationStreamTask() async {
+        await foundationDriver?.beforeStreamTask()
+    }
+
     private func foundationGenerate(messages: [Message], config: GenerationConfig) async throws -> String {
+        if let foundationDriver {
+            return try await foundationDriver.respond(messages, config)
+        }
         try await ensureFoundation()
         if #available(macOS 26.0, *) {
             guard let svc = foundationService as? FoundationModelService else {
@@ -541,6 +662,9 @@ public actor AFMEngine {
         messages: [Message],
         config: GenerationConfig
     ) async throws -> AsyncThrowingStream<String, Error> {
+        if let foundationDriver {
+            return try await foundationDriver.stream(messages, config)
+        }
         try await ensureFoundation()
         if #available(macOS 26.0, *) {
             guard let svc = foundationService as? FoundationModelService else {

--- a/Sources/AFMKit/AFMEngine.swift
+++ b/Sources/AFMKit/AFMEngine.swift
@@ -24,6 +24,7 @@ public struct EngineConfig: Sendable {
     public var instructions: String
     public var adapter: String?
     public var permissiveGuardrails: Bool
+    public var foundationRandomness: String?
     // MLX runtime knobs (ignored by the Foundation Models backend)
     public var kvBits: Int?
     public var enablePrefixCaching: Bool
@@ -50,6 +51,7 @@ public struct EngineConfig: Sendable {
         instructions: String = "You are a helpful assistant",
         adapter: String? = nil,
         permissiveGuardrails: Bool = false,
+        foundationRandomness: String? = nil,
         kvBits: Int? = nil,
         enablePrefixCaching: Bool = false,
         mlxKernels: String = "native",
@@ -74,6 +76,7 @@ public struct EngineConfig: Sendable {
         self.instructions = instructions
         self.adapter = adapter
         self.permissiveGuardrails = permissiveGuardrails
+        self.foundationRandomness = foundationRandomness
         self.kvBits = kvBits
         self.enablePrefixCaching = enablePrefixCaching
         self.mlxKernels = mlxKernels
@@ -371,8 +374,11 @@ public actor AFMEngine {
                         }
                         continuation.finish()
                     case .foundationModels:
-                        let text = try await foundationGenerate(messages: messages, config: config)
-                        continuation.yield(.text(text, tokenCount: 0))
+                        let stream = try await foundationStream(messages: messages, config: config)
+                        for try await text in stream {
+                            try Task.checkCancellation()
+                            continuation.yield(.text(text, tokenCount: 0))
+                        }
                         continuation.yield(.completed(.stop))
                         continuation.finish()
                     }
@@ -496,10 +502,56 @@ public actor AFMEngine {
             guard let svc = foundationService as? FoundationModelService else {
                 throw AFMEngineError.foundationModelsUnavailable
             }
+            if config.responseFormat?.type == "json_schema",
+               let schema = config.responseFormat?.jsonSchema {
+                return try await svc.generateGuidedResponse(
+                    for: messages,
+                    jsonSchema: schema,
+                    temperature: config.temperature,
+                    randomness: engineConfig.foundationRandomness,
+                    maxTokens: config.maxTokens,
+                    stop: config.stop
+                )
+            }
             return try await svc.generateResponse(
                 for: messages,
                 temperature: config.temperature,
-                randomness: nil,
+                randomness: engineConfig.foundationRandomness,
+                maxTokens: config.maxTokens,
+                stop: config.stop
+            )
+        }
+        throw AFMEngineError.foundationModelsUnavailable
+    }
+
+    private func foundationStream(
+        messages: [Message],
+        config: GenerationConfig
+    ) async throws -> AsyncThrowingStream<String, Error> {
+        try await ensureFoundation()
+        if #available(macOS 26.0, *) {
+            guard let svc = foundationService as? FoundationModelService else {
+                throw AFMEngineError.foundationModelsUnavailable
+            }
+            if config.responseFormat?.type == "json_schema",
+               let schema = config.responseFormat?.jsonSchema {
+                let text = try await svc.generateGuidedResponse(
+                    for: messages,
+                    jsonSchema: schema,
+                    temperature: config.temperature,
+                    randomness: engineConfig.foundationRandomness,
+                    maxTokens: config.maxTokens,
+                    stop: config.stop
+                )
+                return AsyncThrowingStream { continuation in
+                    continuation.yield(text)
+                    continuation.finish()
+                }
+            }
+            return svc.generateNativeStreamingResponse(
+                for: messages,
+                temperature: config.temperature,
+                randomness: engineConfig.foundationRandomness,
                 maxTokens: config.maxTokens,
                 stop: config.stop
             )

--- a/Sources/AFMKit/AFMEngine.swift
+++ b/Sources/AFMKit/AFMEngine.swift
@@ -339,7 +339,7 @@ public actor AFMEngine {
             guard let service = foundationService as? FoundationModelService else {
                 throw AFMEngineError.foundationModelsUnavailable
             }
-            service.resetConversation(with: history)
+            try await service.resetConversation(with: history)
         }
     }
 

--- a/Sources/AFMKitFoundationModels/FoundationModelService.swift
+++ b/Sources/AFMKitFoundationModels/FoundationModelService.swift
@@ -375,6 +375,41 @@ public class FoundationModelService: @unchecked Sendable {
         }
         return Transcript(entries: entries)
     }
+
+    static func acceptedTranscript(
+        from previousTranscript: Transcript,
+        prompt: String,
+        response: String,
+        options: GenerationOptions
+    ) -> Transcript {
+        var entries = Array(previousTranscript)
+        entries.append(.prompt(.init(
+            segments: [.text(.init(content: prompt))],
+            options: options
+        )))
+        entries.append(.response(.init(
+            assetIDs: [],
+            segments: [.text(.init(content: response))]
+        )))
+        return Transcript(entries: entries)
+    }
+
+    private func restoreAcceptedResponse(
+        previousTranscript: Transcript,
+        prompt: String,
+        response: String,
+        options: GenerationOptions
+    ) {
+        session = LanguageModelSession(
+            model: model,
+            transcript: Self.acceptedTranscript(
+                from: previousTranscript,
+                prompt: prompt,
+                response: response,
+                options: options
+            )
+        )
+    }
     #endif
     
     public func generateResponse(for messages: [Message], temperature: Double? = nil, randomness: String? = nil, maxTokens: Int? = nil, stop: [String]? = nil) async throws -> String {
@@ -387,8 +422,18 @@ public class FoundationModelService: @unchecked Sendable {
 
         do {
             let options = try createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
+            let previousTranscript = session.transcript
             let response = try await session.respond(to: prompt, options: options)
-            return applyStopSequences(to: response.content, stopSequences: stop)
+            let acceptedResponse = applyStopSequences(to: response.content, stopSequences: stop)
+            if acceptedResponse != response.content {
+                restoreAcceptedResponse(
+                    previousTranscript: previousTranscript,
+                    prompt: prompt,
+                    response: acceptedResponse,
+                    options: options
+                )
+            }
+            return acceptedResponse
         } catch is CancellationError {
             throw CancellationError()
         } catch {
@@ -457,10 +502,12 @@ public class FoundationModelService: @unchecked Sendable {
 
                 do {
                     let options = try self.createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
+                    let previousTranscript = session.transcript
                     // Use native streaming API — partialResponse.content is cumulative,
                     // so we must extract only the new delta each iteration.
                     let stream = session.streamResponse(to: prompt, options: options)
                     var previousContent = ""
+                    var acceptedResponse = ""
                     var stopFilter = FoundationStopSequenceFilter(stopSequences: stop)
                     for try await partialResponse in stream {
                         try Task.checkCancellation()
@@ -469,12 +516,26 @@ public class FoundationModelService: @unchecked Sendable {
                         if full.count > previousContent.count {
                             let delta = String(full.dropFirst(previousContent.count))
                             let output = stopFilter.consume(delta)
-                            if !output.isEmpty { continuation.yield(output) }
+                            if !output.isEmpty {
+                                acceptedResponse += output
+                                continuation.yield(output)
+                            }
                         }
                         previousContent = full
                     }
                     let finalOutput = stopFilter.finish()
-                    if !finalOutput.isEmpty { continuation.yield(finalOutput) }
+                    if !finalOutput.isEmpty {
+                        acceptedResponse += finalOutput
+                        continuation.yield(finalOutput)
+                    }
+                    if stopFilter.stopped {
+                        self.restoreAcceptedResponse(
+                            previousTranscript: previousTranscript,
+                            prompt: prompt,
+                            response: acceptedResponse,
+                            options: options
+                        )
+                    }
                     continuation.finish()
                 } catch is CancellationError {
                     continuation.finish(throwing: CancellationError())
@@ -521,8 +582,19 @@ public class FoundationModelService: @unchecked Sendable {
 
         do {
             let options = try createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
+            let previousTranscript = session.transcript
             let response = try await session.respond(to: prompt, schema: schema, options: options)
-            return applyStopSequences(to: response.content.jsonString, stopSequences: stop)
+            let rawResponse = response.content.jsonString
+            let acceptedResponse = applyStopSequences(to: rawResponse, stopSequences: stop)
+            if acceptedResponse != rawResponse {
+                restoreAcceptedResponse(
+                    previousTranscript: previousTranscript,
+                    prompt: prompt,
+                    response: acceptedResponse,
+                    options: options
+                )
+            }
+            return acceptedResponse
         } catch is CancellationError {
             throw CancellationError()
         } catch {
@@ -576,9 +648,11 @@ public class FoundationModelService: @unchecked Sendable {
 
                 do {
                     let options = try self.createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
+                    let previousTranscript = session.transcript
                     let stream = session.streamResponse(to: prompt, schema: schema, options: options)
                     var previousJson = ""
                     var processedPrefixCount = 0
+                    var acceptedResponse = ""
                     var stopFilter = FoundationStopSequenceFilter(stopSequences: stop)
                     for try await partialResponse in stream {
                         try Task.checkCancellation()
@@ -589,17 +663,34 @@ public class FoundationModelService: @unchecked Sendable {
                             let stablePrefix = String(currentJson.prefix(stablePrefixCount))
                             let delta = String(stablePrefix.dropFirst(processedPrefixCount))
                             let output = stopFilter.consume(delta)
-                            if !output.isEmpty { continuation.yield(output) }
+                            if !output.isEmpty {
+                                acceptedResponse += output
+                                continuation.yield(output)
+                            }
                             processedPrefixCount = stablePrefixCount
                         }
                         previousJson = currentJson
                     }
                     if !stopFilter.stopped, previousJson.count > processedPrefixCount {
                         let output = stopFilter.consume(String(previousJson.dropFirst(processedPrefixCount)))
-                        if !output.isEmpty { continuation.yield(output) }
+                        if !output.isEmpty {
+                            acceptedResponse += output
+                            continuation.yield(output)
+                        }
                     }
                     let finalOutput = stopFilter.finish()
-                    if !finalOutput.isEmpty { continuation.yield(finalOutput) }
+                    if !finalOutput.isEmpty {
+                        acceptedResponse += finalOutput
+                        continuation.yield(finalOutput)
+                    }
+                    if stopFilter.stopped {
+                        self.restoreAcceptedResponse(
+                            previousTranscript: previousTranscript,
+                            prompt: prompt,
+                            response: acceptedResponse,
+                            options: options
+                        )
+                    }
                     continuation.finish()
                 } catch is CancellationError {
                     continuation.finish(throwing: CancellationError())

--- a/Sources/AFMKitFoundationModels/FoundationModelService.swift
+++ b/Sources/AFMKitFoundationModels/FoundationModelService.swift
@@ -194,11 +194,58 @@ public enum FoundationModelError: Error, LocalizedError {
     }
 }
 
+struct FoundationStopSequenceFilter {
+    private let stopSequences: [String]
+    private var pending = ""
+    private(set) var stopped = false
+
+    init(stopSequences: [String]?) {
+        self.stopSequences = stopSequences?.filter { !$0.isEmpty } ?? []
+    }
+
+    mutating func consume(_ delta: String) -> String {
+        guard !stopped else { return "" }
+        guard !stopSequences.isEmpty else { return delta }
+        pending += delta
+
+        let earliest = stopSequences.compactMap { pending.range(of: $0) }
+            .min { $0.lowerBound < $1.lowerBound }
+        if let earliest {
+            let output = String(pending[..<earliest.lowerBound])
+            pending = ""
+            stopped = true
+            return output
+        }
+
+        let heldCount = stopSequences.reduce(0) { longest, sequence in
+            let maximum = min(pending.count, max(0, sequence.count - 1))
+            guard maximum > longest else { return longest }
+            for count in stride(from: maximum, through: longest + 1, by: -1) {
+                if pending.suffix(count) == sequence.prefix(count) { return count }
+            }
+            return longest
+        }
+        let emittedCount = pending.count - heldCount
+        let output = String(pending.prefix(emittedCount))
+        pending = String(pending.suffix(heldCount))
+        return output
+    }
+
+    mutating func finish() -> String {
+        guard !stopped else { return "" }
+        let output = pending
+        pending = ""
+        return output
+    }
+}
+
 @available(macOS 26.0, *)
 public class FoundationModelService: @unchecked Sendable {
     
     #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
     private var session: LanguageModelSession?
+    private let model: SystemLanguageModel
+    private let instructions: String
     #endif
     
     // Shared singleton instance
@@ -214,6 +261,8 @@ public class FoundationModelService: @unchecked Sendable {
     
     public init(instructions: String = "You are a helpful assistant", adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil, permissiveGuardrails: Bool) async throws {
         #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS && !DISABLE_FOUNDATION_MODELS
+        let fallbackModel = SystemLanguageModel(guardrails: permissiveGuardrails ? .permissiveContentTransformations : .default)
+        let selectedModel: SystemLanguageModel
         // Check if adapter path is provided
         if let adapterPath = adapter {
             do {
@@ -224,34 +273,30 @@ public class FoundationModelService: @unchecked Sendable {
                 // Validate adapter file exists and has correct extension
                 guard FileManager.default.fileExists(atPath: adapterURL.path) else {
                     print("Warning: Adapter file not found at '\(adapterPath)', falling back to default model")
-                    let model = SystemLanguageModel(guardrails: permissiveGuardrails ? .permissiveContentTransformations : .default)
-                    self.session = LanguageModelSession(model: model) {
-                        instructions
-                    }
+                    selectedModel = fallbackModel
+                    self.model = selectedModel
+                    self.instructions = instructions
+                    self.session = LanguageModelSession(model: selectedModel) { instructions }
                     return
                 }
                 
                 guard adapterURL.pathExtension.lowercased() == "fmadapter" else {
                     print("Warning: Adapter file must have .fmadapter extension, falling back to default model")
-                    let model = SystemLanguageModel(guardrails: permissiveGuardrails ? .permissiveContentTransformations : .default)
-                    self.session = LanguageModelSession(model: model) {
-                        instructions
-                    }
+                    selectedModel = fallbackModel
+                    self.model = selectedModel
+                    self.instructions = instructions
+                    self.session = LanguageModelSession(model: selectedModel) { instructions }
                     return
                 }
                 
                 // Try to load the adapter
                 let adapter = try SystemLanguageModel.Adapter(fileURL: adapterURL)
-                let customModel = SystemLanguageModel(adapter: adapter, guardrails: permissiveGuardrails ? .permissiveContentTransformations : .default)
+                selectedModel = SystemLanguageModel(adapter: adapter, guardrails: permissiveGuardrails ? .permissiveContentTransformations : .default)
                 
                 // Store adapter for reuse if this is the first time loading
                 if Self.sharedAdapter == nil {
                     Self.sharedAdapter = adapter
                     Self.sharedAdapterPath = adapterPath
-                }
-                
-                self.session = LanguageModelSession(model: customModel) {
-                    instructions
                 }
                 
                 print("✅ Successfully loaded LoRA adapter: \(adapterURL.lastPathComponent)")
@@ -261,18 +306,15 @@ public class FoundationModelService: @unchecked Sendable {
                 print("Falling back to default model")
                 
                 // Fallback to default model
-                let model = SystemLanguageModel(guardrails: permissiveGuardrails ? .permissiveContentTransformations : .default)
-                self.session = LanguageModelSession(model: model) {
-                    instructions
-                }
+                selectedModel = fallbackModel
             }
         } else {
             // No adapter specified, use default model
-            let model = SystemLanguageModel(guardrails: permissiveGuardrails ? .permissiveContentTransformations : .default)
-            self.session = LanguageModelSession(model: model) {
-                instructions
-            }
+            selectedModel = fallbackModel
         }
+        self.model = selectedModel
+        self.instructions = instructions
+        self.session = LanguageModelSession(model: selectedModel) { instructions }
         #else
         throw FoundationModelError.notAvailable
         #endif
@@ -281,23 +323,59 @@ public class FoundationModelService: @unchecked Sendable {
     // Private initializer for creating instances with shared adapter
     private init(instructions: String, useSharedAdapter: Bool, temperature: Double? = nil, randomness: String? = nil, permissiveGuardrails: Bool) async throws {
         #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
+        let selectedModel: SystemLanguageModel
         if useSharedAdapter, let sharedAdapter = Self.sharedAdapter {
             // Use the shared adapter
-            let customModel = SystemLanguageModel(adapter: sharedAdapter, guardrails: permissiveGuardrails ? .permissiveContentTransformations : .default)
-            self.session = LanguageModelSession(model: customModel) {
-                instructions
-            }
+            selectedModel = SystemLanguageModel(adapter: sharedAdapter, guardrails: permissiveGuardrails ? .permissiveContentTransformations : .default)
         } else {
             // No shared adapter available, use default model
-            let model = SystemLanguageModel(guardrails: permissiveGuardrails ? .permissiveContentTransformations : .default)
-            self.session = LanguageModelSession(model: model) {
-                instructions
-            }
+            selectedModel = SystemLanguageModel(guardrails: permissiveGuardrails ? .permissiveContentTransformations : .default)
         }
+        self.model = selectedModel
+        self.instructions = instructions
+        self.session = LanguageModelSession(model: selectedModel) { instructions }
         #else
         throw FoundationModelError.notAvailable
         #endif
     }
+
+    /// Replaces the stateful native session and optionally restores a saved conversation.
+    /// Callers must subsequently submit only messages that are not already in `history`.
+    public func resetConversation(with history: [Message] = []) {
+        #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
+        guard !history.isEmpty else {
+            session = LanguageModelSession(model: model) { instructions }
+            return
+        }
+        session = LanguageModelSession(model: model, transcript: transcript(from: history))
+        #endif
+    }
+
+    #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
+    private func transcript(from messages: [Message]) -> Transcript {
+        let restoredInstructions = messages
+            .filter { $0.role == "system" || $0.role == "developer" }
+            .map(\.textContent)
+            .filter { !$0.isEmpty }
+        let instructionText = ([instructions] + restoredInstructions).joined(separator: "\n\n")
+        var entries: [Transcript.Entry] = [
+            .instructions(.init(
+                segments: [.text(.init(content: instructionText))],
+                toolDefinitions: []
+            ))
+        ]
+        for message in messages where message.role != "system" && message.role != "developer" {
+            if message.role == "assistant" {
+                let segment = Transcript.Segment.text(.init(content: message.textContent))
+                entries.append(.response(.init(assetIDs: [], segments: [segment])))
+            } else {
+                let segment = Transcript.Segment.text(.init(content: formatMessagesAsPrompt([message])))
+                entries.append(.prompt(.init(segments: [segment])))
+            }
+        }
+        return Transcript(entries: entries)
+    }
+    #endif
     
     public func generateResponse(for messages: [Message], temperature: Double? = nil, randomness: String? = nil, maxTokens: Int? = nil, stop: [String]? = nil) async throws -> String {
         #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
@@ -311,6 +389,8 @@ public class FoundationModelService: @unchecked Sendable {
             let options = try createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
             let response = try await session.respond(to: prompt, options: options)
             return applyStopSequences(to: response.content, stopSequences: stop)
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             // Check for context window exceeded error and wrap it
             if let contextError = FoundationModelError.parseContextWindowError(error) {
@@ -381,36 +461,23 @@ public class FoundationModelService: @unchecked Sendable {
                     // so we must extract only the new delta each iteration.
                     let stream = session.streamResponse(to: prompt, options: options)
                     var previousContent = ""
-                    var stopped = false
+                    var stopFilter = FoundationStopSequenceFilter(stopSequences: stop)
                     for try await partialResponse in stream {
                         try Task.checkCancellation()
-                        if stopped { break }
+                        if stopFilter.stopped { break }
                         let full = partialResponse.content
                         if full.count > previousContent.count {
-                            var delta = String(full.dropFirst(previousContent.count))
-                            // Check if any stop sequence appears in the accumulated content
-                            if let stopSeqs = stop, !stopSeqs.isEmpty {
-                                let accumulated = previousContent + delta
-                                for seq in stopSeqs {
-                                    if let range = accumulated.range(of: seq) {
-                                        // Truncate delta to exclude stop sequence and everything after
-                                        let keepUpTo = range.lowerBound
-                                        let alreadyEmitted = accumulated.index(accumulated.startIndex, offsetBy: previousContent.count)
-                                        if keepUpTo > alreadyEmitted {
-                                            delta = String(accumulated[alreadyEmitted..<keepUpTo])
-                                            continuation.yield(delta)
-                                        }
-                                        stopped = true
-                                        break
-                                    }
-                                }
-                                if stopped { break }
-                            }
-                            continuation.yield(delta)
+                            let delta = String(full.dropFirst(previousContent.count))
+                            let output = stopFilter.consume(delta)
+                            if !output.isEmpty { continuation.yield(output) }
                         }
                         previousContent = full
                     }
+                    let finalOutput = stopFilter.finish()
+                    if !finalOutput.isEmpty { continuation.yield(finalOutput) }
                     continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish(throwing: CancellationError())
                 } catch {
                     if let contextError = FoundationModelError.parseContextWindowError(error) {
                         continuation.finish(throwing: contextError)
@@ -456,6 +523,8 @@ public class FoundationModelService: @unchecked Sendable {
             let options = try createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
             let response = try await session.respond(to: prompt, schema: schema, options: options)
             return applyStopSequences(to: response.content.jsonString, stopSequences: stop)
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             if let contextError = FoundationModelError.parseContextWindowError(error) {
                 throw contextError
@@ -488,7 +557,7 @@ public class FoundationModelService: @unchecked Sendable {
         stop: [String]? = nil
     ) -> AsyncThrowingStream<String, Error> {
         return AsyncThrowingStream { continuation in
-            Task {
+            let task = Task {
                 #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
                 guard let session = self.session else {
                     continuation.finish(throwing: FoundationModelError.sessionCreationFailed)
@@ -509,45 +578,31 @@ public class FoundationModelService: @unchecked Sendable {
                     let options = try self.createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
                     let stream = session.streamResponse(to: prompt, schema: schema, options: options)
                     var previousJson = ""
-                    var emittedPrefixCount = 0
-                    var stopped = false
+                    var processedPrefixCount = 0
+                    var stopFilter = FoundationStopSequenceFilter(stopSequences: stop)
                     for try await partialResponse in stream {
-                        if stopped { break }
+                        try Task.checkCancellation()
+                        if stopFilter.stopped { break }
                         let currentJson = partialResponse.content.jsonString
                         let stablePrefixCount = Self.commonPrefixLength(previousJson, currentJson)
-                        if stablePrefixCount > emittedPrefixCount {
+                        if stablePrefixCount > processedPrefixCount {
                             let stablePrefix = String(currentJson.prefix(stablePrefixCount))
-                            var delta = String(stablePrefix.dropFirst(emittedPrefixCount))
-                            if let stopSeqs = stop, !stopSeqs.isEmpty {
-                                let accumulated = stablePrefix
-                                for seq in stopSeqs {
-                                    if let range = accumulated.range(of: seq) {
-                                        let keepUpTo = range.lowerBound
-                                        let keepCount = accumulated.distance(from: accumulated.startIndex, to: keepUpTo)
-                                        if keepCount > emittedPrefixCount {
-                                            delta = String(accumulated.dropFirst(emittedPrefixCount).prefix(keepCount - emittedPrefixCount))
-                                            continuation.yield(delta)
-                                        }
-                                        stopped = true
-                                        break
-                                    }
-                                }
-                                if stopped { break }
-                            }
-                            if !delta.isEmpty {
-                                continuation.yield(delta)
-                            }
-                            emittedPrefixCount = stablePrefixCount
+                            let delta = String(stablePrefix.dropFirst(processedPrefixCount))
+                            let output = stopFilter.consume(delta)
+                            if !output.isEmpty { continuation.yield(output) }
+                            processedPrefixCount = stablePrefixCount
                         }
                         previousJson = currentJson
                     }
-                    if !stopped, previousJson.count > emittedPrefixCount {
-                        let finalSnapshot = self.applyStopSequences(to: previousJson, stopSequences: stop)
-                        if finalSnapshot.count > emittedPrefixCount {
-                            continuation.yield(String(finalSnapshot.dropFirst(emittedPrefixCount)))
-                        }
+                    if !stopFilter.stopped, previousJson.count > processedPrefixCount {
+                        let output = stopFilter.consume(String(previousJson.dropFirst(processedPrefixCount)))
+                        if !output.isEmpty { continuation.yield(output) }
                     }
+                    let finalOutput = stopFilter.finish()
+                    if !finalOutput.isEmpty { continuation.yield(finalOutput) }
                     continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish(throwing: CancellationError())
                 } catch {
                     if let contextError = FoundationModelError.parseContextWindowError(error) {
                         continuation.finish(throwing: contextError)
@@ -563,6 +618,7 @@ public class FoundationModelService: @unchecked Sendable {
                 continuation.finish(throwing: FoundationModelError.notAvailable)
                 #endif
             }
+            continuation.onTermination = { _ in task.cancel() }
         }
     }
 

--- a/Sources/AFMKitFoundationModels/FoundationModelService.swift
+++ b/Sources/AFMKitFoundationModels/FoundationModelService.swift
@@ -239,6 +239,70 @@ struct FoundationStopSequenceFilter {
     }
 }
 
+final class FoundationSessionOperationGate: @unchecked Sendable {
+    struct Reservation: Sendable {
+        fileprivate let predecessor: Signal?
+        fileprivate let completion: Signal
+
+        func perform<T: Sendable>(
+            _ operation: @Sendable () async throws -> T
+        ) async throws -> T {
+            if let predecessor {
+                await predecessor.wait()
+            }
+            defer { completion.signal() }
+            try Task.checkCancellation()
+            return try await operation()
+        }
+    }
+
+    fileprivate final class Signal: @unchecked Sendable {
+        private let lock = NSLock()
+        private var signalled = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func wait() async {
+            await withCheckedContinuation { continuation in
+                lock.lock()
+                if signalled {
+                    lock.unlock()
+                    continuation.resume()
+                } else {
+                    waiters.append(continuation)
+                    lock.unlock()
+                }
+            }
+        }
+
+        func signal() {
+            lock.lock()
+            guard !signalled else {
+                lock.unlock()
+                return
+            }
+            signalled = true
+            let pending = waiters
+            waiters.removeAll()
+            lock.unlock()
+            for waiter in pending {
+                waiter.resume()
+            }
+        }
+    }
+
+    private let lock = NSLock()
+    private var tail: Signal?
+
+    func reserve() -> Reservation {
+        lock.lock()
+        defer { lock.unlock() }
+        let completion = Signal()
+        let reservation = Reservation(predecessor: tail, completion: completion)
+        tail = completion
+        return reservation
+    }
+}
+
 @available(macOS 26.0, *)
 public class FoundationModelService: @unchecked Sendable {
     
@@ -247,6 +311,7 @@ public class FoundationModelService: @unchecked Sendable {
     private let model: SystemLanguageModel
     private let instructions: String
     #endif
+    private let sessionOperations = FoundationSessionOperationGate()
     
     // Shared singleton instance
     nonisolated(unsafe) static var shared: FoundationModelService?
@@ -341,14 +406,17 @@ public class FoundationModelService: @unchecked Sendable {
 
     /// Replaces the stateful native session and optionally restores a saved conversation.
     /// Callers must subsequently submit only messages that are not already in `history`.
-    public func resetConversation(with history: [Message] = []) {
-        #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
-        guard !history.isEmpty else {
-            session = LanguageModelSession(model: model) { instructions }
-            return
+    public func resetConversation(with history: [Message] = []) async throws {
+        let reservation = sessionOperations.reserve()
+        try await reservation.perform { [self] in
+            #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
+            guard !history.isEmpty else {
+                session = LanguageModelSession(model: model) { instructions }
+                return
+            }
+            session = LanguageModelSession(model: model, transcript: transcript(from: history))
+            #endif
         }
-        session = LanguageModelSession(model: model, transcript: transcript(from: history))
-        #endif
     }
 
     #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
@@ -414,38 +482,41 @@ public class FoundationModelService: @unchecked Sendable {
     
     public func generateResponse(for messages: [Message], temperature: Double? = nil, randomness: String? = nil, maxTokens: Int? = nil, stop: [String]? = nil) async throws -> String {
         #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
-        guard let session = session else {
-            throw FoundationModelError.sessionCreationFailed
-        }
+        let reservation = sessionOperations.reserve()
+        return try await reservation.perform { [self] in
+            guard let session = session else {
+                throw FoundationModelError.sessionCreationFailed
+            }
 
-        let prompt = formatMessagesAsPrompt(messages)
+            let prompt = formatMessagesAsPrompt(messages)
 
-        do {
-            let options = try createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
-            let previousTranscript = session.transcript
-            let response = try await session.respond(to: prompt, options: options)
-            let acceptedResponse = applyStopSequences(to: response.content, stopSequences: stop)
-            if acceptedResponse != response.content {
-                restoreAcceptedResponse(
-                    previousTranscript: previousTranscript,
-                    prompt: prompt,
-                    response: acceptedResponse,
-                    options: options
-                )
+            do {
+                let options = try createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
+                let previousTranscript = session.transcript
+                let response = try await session.respond(to: prompt, options: options)
+                let acceptedResponse = applyStopSequences(to: response.content, stopSequences: stop)
+                if acceptedResponse != response.content {
+                    restoreAcceptedResponse(
+                        previousTranscript: previousTranscript,
+                        prompt: prompt,
+                        response: acceptedResponse,
+                        options: options
+                    )
+                }
+                return acceptedResponse
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                // Check for context window exceeded error and wrap it
+                if let contextError = FoundationModelError.parseContextWindowError(error) {
+                    throw contextError
+                }
+                // Check for guardrail violation
+                if let guardrailError = FoundationModelError.parseGuardrailError(error) {
+                    throw guardrailError
+                }
+                throw FoundationModelError.responseGenerationFailed(error.localizedDescription)
             }
-            return acceptedResponse
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch {
-            // Check for context window exceeded error and wrap it
-            if let contextError = FoundationModelError.parseContextWindowError(error) {
-                throw contextError
-            }
-            // Check for guardrail violation
-            if let guardrailError = FoundationModelError.parseGuardrailError(error) {
-                throw guardrailError
-            }
-            throw FoundationModelError.responseGenerationFailed(error.localizedDescription)
         }
         #else
         throw FoundationModelError.notAvailable
@@ -475,10 +546,13 @@ public class FoundationModelService: @unchecked Sendable {
     /// Pre-warm the session for faster first response
     public func prewarm() async throws {
         #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
-        guard let session = session else {
-            throw FoundationModelError.sessionCreationFailed
+        let reservation = sessionOperations.reserve()
+        try await reservation.perform { [self] in
+            guard let session = session else {
+                throw FoundationModelError.sessionCreationFailed
+            }
+            try await session.prewarm()
         }
-        try await session.prewarm()
         #endif
     }
 
@@ -490,51 +564,52 @@ public class FoundationModelService: @unchecked Sendable {
         maxTokens: Int? = nil,
         stop: [String]? = nil
     ) -> AsyncThrowingStream<String, Error> {
+        let reservation = sessionOperations.reserve()
         return AsyncThrowingStream { continuation in
             let task = Task {
                 #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
-                guard let session = self.session else {
-                    continuation.finish(throwing: FoundationModelError.sessionCreationFailed)
-                    return
-                }
-
-                let prompt = self.formatMessagesAsPrompt(messages)
-
                 do {
-                    let options = try self.createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
-                    let previousTranscript = session.transcript
-                    // Use native streaming API — partialResponse.content is cumulative,
-                    // so we must extract only the new delta each iteration.
-                    let stream = session.streamResponse(to: prompt, options: options)
-                    var previousContent = ""
-                    var acceptedResponse = ""
-                    var stopFilter = FoundationStopSequenceFilter(stopSequences: stop)
-                    for try await partialResponse in stream {
-                        try Task.checkCancellation()
-                        if stopFilter.stopped { break }
-                        let full = partialResponse.content
-                        if full.count > previousContent.count {
-                            let delta = String(full.dropFirst(previousContent.count))
-                            let output = stopFilter.consume(delta)
-                            if !output.isEmpty {
-                                acceptedResponse += output
-                                continuation.yield(output)
-                            }
+                    try await reservation.perform { [self] in
+                        guard let session = session else {
+                            throw FoundationModelError.sessionCreationFailed
                         }
-                        previousContent = full
-                    }
-                    let finalOutput = stopFilter.finish()
-                    if !finalOutput.isEmpty {
-                        acceptedResponse += finalOutput
-                        continuation.yield(finalOutput)
-                    }
-                    if stopFilter.stopped {
-                        self.restoreAcceptedResponse(
-                            previousTranscript: previousTranscript,
-                            prompt: prompt,
-                            response: acceptedResponse,
-                            options: options
-                        )
+
+                        let prompt = formatMessagesAsPrompt(messages)
+                        let options = try createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
+                        let previousTranscript = session.transcript
+                        // Use native streaming API — partialResponse.content is cumulative,
+                        // so we must extract only the new delta each iteration.
+                        let stream = session.streamResponse(to: prompt, options: options)
+                        var previousContent = ""
+                        var acceptedResponse = ""
+                        var stopFilter = FoundationStopSequenceFilter(stopSequences: stop)
+                        for try await partialResponse in stream {
+                            try Task.checkCancellation()
+                            if stopFilter.stopped { break }
+                            let full = partialResponse.content
+                            if full.count > previousContent.count {
+                                let delta = String(full.dropFirst(previousContent.count))
+                                let output = stopFilter.consume(delta)
+                                if !output.isEmpty {
+                                    acceptedResponse += output
+                                    continuation.yield(output)
+                                }
+                            }
+                            previousContent = full
+                        }
+                        let finalOutput = stopFilter.finish()
+                        if !finalOutput.isEmpty {
+                            acceptedResponse += finalOutput
+                            continuation.yield(finalOutput)
+                        }
+                        if stopFilter.stopped {
+                            restoreAcceptedResponse(
+                                previousTranscript: previousTranscript,
+                                prompt: prompt,
+                                response: acceptedResponse,
+                                options: options
+                            )
+                        }
                     }
                     continuation.finish()
                 } catch is CancellationError {
@@ -567,47 +642,50 @@ public class FoundationModelService: @unchecked Sendable {
         stop: [String]? = nil
     ) async throws -> String {
         #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
-        guard let session = session else {
-            throw FoundationModelError.sessionCreationFailed
-        }
+        let reservation = sessionOperations.reserve()
+        return try await reservation.perform { [self] in
+            guard let session = session else {
+                throw FoundationModelError.sessionCreationFailed
+            }
 
-        let schema: GenerationSchema
-        do {
-            schema = try JSONSchemaConverter.convert(jsonSchema)
-        } catch {
-            throw FoundationModelError.schemaConversionFailed(error.localizedDescription)
-        }
+            let schema: GenerationSchema
+            do {
+                schema = try JSONSchemaConverter.convert(jsonSchema)
+            } catch {
+                throw FoundationModelError.schemaConversionFailed(error.localizedDescription)
+            }
 
-        let prompt = formatMessagesAsPrompt(messages)
+            let prompt = formatMessagesAsPrompt(messages)
 
-        do {
-            let options = try createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
-            let previousTranscript = session.transcript
-            let response = try await session.respond(to: prompt, schema: schema, options: options)
-            let rawResponse = response.content.jsonString
-            let acceptedResponse = applyStopSequences(to: rawResponse, stopSequences: stop)
-            if acceptedResponse != rawResponse {
-                restoreAcceptedResponse(
-                    previousTranscript: previousTranscript,
-                    prompt: prompt,
-                    response: acceptedResponse,
-                    options: options
-                )
+            do {
+                let options = try createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
+                let previousTranscript = session.transcript
+                let response = try await session.respond(to: prompt, schema: schema, options: options)
+                let rawResponse = response.content.jsonString
+                let acceptedResponse = applyStopSequences(to: rawResponse, stopSequences: stop)
+                if acceptedResponse != rawResponse {
+                    restoreAcceptedResponse(
+                        previousTranscript: previousTranscript,
+                        prompt: prompt,
+                        response: acceptedResponse,
+                        options: options
+                    )
+                }
+                return acceptedResponse
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                if let contextError = FoundationModelError.parseContextWindowError(error) {
+                    throw contextError
+                }
+                if let guardrailError = FoundationModelError.parseGuardrailError(error) {
+                    throw guardrailError
+                }
+                if let truncationError = FoundationModelError.parseStructuredTruncationError(error, maxTokens: maxTokens) {
+                    throw truncationError
+                }
+                throw FoundationModelError.responseGenerationFailed(error.localizedDescription)
             }
-            return acceptedResponse
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch {
-            if let contextError = FoundationModelError.parseContextWindowError(error) {
-                throw contextError
-            }
-            if let guardrailError = FoundationModelError.parseGuardrailError(error) {
-                throw guardrailError
-            }
-            if let truncationError = FoundationModelError.parseStructuredTruncationError(error, maxTokens: maxTokens) {
-                throw truncationError
-            }
-            throw FoundationModelError.responseGenerationFailed(error.localizedDescription)
         }
         #else
         throw FoundationModelError.notAvailable
@@ -628,68 +706,68 @@ public class FoundationModelService: @unchecked Sendable {
         maxTokens: Int? = nil,
         stop: [String]? = nil
     ) -> AsyncThrowingStream<String, Error> {
+        let reservation = sessionOperations.reserve()
         return AsyncThrowingStream { continuation in
             let task = Task {
                 #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
-                guard let session = self.session else {
-                    continuation.finish(throwing: FoundationModelError.sessionCreationFailed)
-                    return
-                }
-
-                let schema: GenerationSchema
                 do {
-                    schema = try JSONSchemaConverter.convert(jsonSchema)
-                } catch {
-                    continuation.finish(throwing: FoundationModelError.schemaConversionFailed(error.localizedDescription))
-                    return
-                }
+                    try await reservation.perform { [self] in
+                        guard let session = session else {
+                            throw FoundationModelError.sessionCreationFailed
+                        }
 
-                let prompt = self.formatMessagesAsPrompt(messages)
+                        let schema: GenerationSchema
+                        do {
+                            schema = try JSONSchemaConverter.convert(jsonSchema)
+                        } catch {
+                            throw FoundationModelError.schemaConversionFailed(error.localizedDescription)
+                        }
 
-                do {
-                    let options = try self.createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
-                    let previousTranscript = session.transcript
-                    let stream = session.streamResponse(to: prompt, schema: schema, options: options)
-                    var previousJson = ""
-                    var processedPrefixCount = 0
-                    var acceptedResponse = ""
-                    var stopFilter = FoundationStopSequenceFilter(stopSequences: stop)
-                    for try await partialResponse in stream {
-                        try Task.checkCancellation()
-                        if stopFilter.stopped { break }
-                        let currentJson = partialResponse.content.jsonString
-                        let stablePrefixCount = Self.commonPrefixLength(previousJson, currentJson)
-                        if stablePrefixCount > processedPrefixCount {
-                            let stablePrefix = String(currentJson.prefix(stablePrefixCount))
-                            let delta = String(stablePrefix.dropFirst(processedPrefixCount))
-                            let output = stopFilter.consume(delta)
+                        let prompt = formatMessagesAsPrompt(messages)
+                        let options = try createGenerationOptions(temperature: temperature, randomness: randomness, maxTokens: maxTokens)
+                        let previousTranscript = session.transcript
+                        let stream = session.streamResponse(to: prompt, schema: schema, options: options)
+                        var previousJson = ""
+                        var processedPrefixCount = 0
+                        var acceptedResponse = ""
+                        var stopFilter = FoundationStopSequenceFilter(stopSequences: stop)
+                        for try await partialResponse in stream {
+                            try Task.checkCancellation()
+                            if stopFilter.stopped { break }
+                            let currentJson = partialResponse.content.jsonString
+                            let stablePrefixCount = Self.commonPrefixLength(previousJson, currentJson)
+                            if stablePrefixCount > processedPrefixCount {
+                                let stablePrefix = String(currentJson.prefix(stablePrefixCount))
+                                let delta = String(stablePrefix.dropFirst(processedPrefixCount))
+                                let output = stopFilter.consume(delta)
+                                if !output.isEmpty {
+                                    acceptedResponse += output
+                                    continuation.yield(output)
+                                }
+                                processedPrefixCount = stablePrefixCount
+                            }
+                            previousJson = currentJson
+                        }
+                        if !stopFilter.stopped, previousJson.count > processedPrefixCount {
+                            let output = stopFilter.consume(String(previousJson.dropFirst(processedPrefixCount)))
                             if !output.isEmpty {
                                 acceptedResponse += output
                                 continuation.yield(output)
                             }
-                            processedPrefixCount = stablePrefixCount
                         }
-                        previousJson = currentJson
-                    }
-                    if !stopFilter.stopped, previousJson.count > processedPrefixCount {
-                        let output = stopFilter.consume(String(previousJson.dropFirst(processedPrefixCount)))
-                        if !output.isEmpty {
-                            acceptedResponse += output
-                            continuation.yield(output)
+                        let finalOutput = stopFilter.finish()
+                        if !finalOutput.isEmpty {
+                            acceptedResponse += finalOutput
+                            continuation.yield(finalOutput)
                         }
-                    }
-                    let finalOutput = stopFilter.finish()
-                    if !finalOutput.isEmpty {
-                        acceptedResponse += finalOutput
-                        continuation.yield(finalOutput)
-                    }
-                    if stopFilter.stopped {
-                        self.restoreAcceptedResponse(
-                            previousTranscript: previousTranscript,
-                            prompt: prompt,
-                            response: acceptedResponse,
-                            options: options
-                        )
+                        if stopFilter.stopped {
+                            restoreAcceptedResponse(
+                                previousTranscript: previousTranscript,
+                                prompt: prompt,
+                                response: acceptedResponse,
+                                options: options
+                            )
+                        }
                     }
                     continuation.finish()
                 } catch is CancellationError {

--- a/Sources/AFMKitFoundationModels/FoundationModelService.swift
+++ b/Sources/AFMKitFoundationModels/FoundationModelService.swift
@@ -366,7 +366,7 @@ public class FoundationModelService: @unchecked Sendable {
         stop: [String]? = nil
     ) -> AsyncThrowingStream<String, Error> {
         return AsyncThrowingStream { continuation in
-            Task {
+            let task = Task {
                 #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
                 guard let session = self.session else {
                     continuation.finish(throwing: FoundationModelError.sessionCreationFailed)
@@ -383,6 +383,7 @@ public class FoundationModelService: @unchecked Sendable {
                     var previousContent = ""
                     var stopped = false
                     for try await partialResponse in stream {
+                        try Task.checkCancellation()
                         if stopped { break }
                         let full = partialResponse.content
                         if full.count > previousContent.count {
@@ -423,6 +424,7 @@ public class FoundationModelService: @unchecked Sendable {
                 continuation.finish(throwing: FoundationModelError.notAvailable)
                 #endif
             }
+            continuation.onTermination = { _ in task.cancel() }
         }
     }
     

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -209,6 +209,8 @@ private final class StreamingScratch: @unchecked Sendable {
 }
 
 public final class MLXModelService: @unchecked Sendable {
+    /// Shared fallback for MLX callers that omit a per-request output limit.
+    public static let defaultMaximumResponseTokens = 8_192
     private struct ConstrainedDecodingSetup {
         let processor: GrammarLogitProcessor
         let mode: String
@@ -2125,7 +2127,9 @@ public final class MLXModelService: @unchecked Sendable {
         )
         defer { cleanupTempFiles(mediaTempFiles) }
         let wantLogprobs = logprobs == true
-        let effectiveMaxTokens = capMaxTokensForCapture(maxTokens ?? 2000)
+        let effectiveMaxTokens = capMaxTokensForCapture(
+            maxTokens ?? Self.defaultMaximumResponseTokens
+        )
 
         // Mutable generation state lives in a scratch box so the @Sendable
         // `container.perform` closure (Swift 6) can capture-and-mutate it.
@@ -3081,7 +3085,9 @@ public final class MLXModelService: @unchecked Sendable {
         }
         let promptTokens = estimateTokens(promptText)
         let wantLogprobs = logprobs == true
-        let effectiveMaxTokens = capMaxTokensForCapture(maxTokens ?? 2000)
+        let effectiveMaxTokens = capMaxTokensForCapture(
+            maxTokens ?? Self.defaultMaximumResponseTokens
+        )
         // /metrics: streaming-path queue timestamp. The actual
         // requestStarted/observe calls happen ONLY in the serial-path
         // task below (the batch path's stats are owned by BatchScheduler).

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -1599,7 +1599,7 @@ struct MLXChatCompletionsController: RouteCollection {
     /// Deliberately larger than mlx_lm.server's 512 so interactive clients that
     /// omit max_tokens don't get truncated thinking/code output; parity
     /// benchmarks should pass an explicit max_tokens on both servers.
-    static let defaultMaxCompletionTokens = 4096
+    static let defaultMaxCompletionTokens = MLXModelService.defaultMaximumResponseTokens
 
     static func resolveEffectiveMaxTokens(requested: Int?, serverDefault: Int?) -> Int {
         if let requested, requested > 0 { return requested }

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -549,7 +549,7 @@ public class Server: @unchecked Sendable {
                             top_p: 0.95,
                             min_p: 0.05,
                             stream: self.streamingEnabled,
-                            max_tokens: 2000
+                            max_tokens: MLXModelService.defaultMaximumResponseTokens
                         )
                     ),
                     total_slots: 1,

--- a/Sources/AFMTerminalUI/ArtifactActions.swift
+++ b/Sources/AFMTerminalUI/ArtifactActions.swift
@@ -29,26 +29,117 @@ public enum TUIArtifactActions {
     }
 
     public static func save(_ data: Data, to url: URL, overwrite: Bool = false) throws {
+        try save(data, to: url, overwrite: overwrite, beforeAtomicInstall: nil)
+    }
+
+    static func save(
+        _ data: Data,
+        to url: URL,
+        overwrite: Bool,
+        beforeAtomicInstall: (() throws -> Void)?
+    ) throws {
         let parent = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
-        var info = stat()
-        if lstat(url.path, &info) == 0 {
-            if !overwrite { throw TUIArtifactError.exists(url.path) }
-            guard (info.st_mode & S_IFMT) == S_IFREG else { throw TUIArtifactError.invalidPath(url.path) }
+
+        var existingDescriptor: Int32 = -1
+        if overwrite {
+            existingDescriptor = open(
+                url.path,
+                O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC
+            )
+            if existingDescriptor >= 0 {
+                do {
+                    try verifyRegularAndRestrictPermissions(
+                        descriptor: existingDescriptor,
+                        path: url.path
+                    )
+                } catch {
+                    close(existingDescriptor)
+                    throw error
+                }
+            } else if errno != ENOENT {
+                throw TUIArtifactError.invalidPath(url.path)
+            }
         }
-        let flags = O_WRONLY | O_CREAT | (overwrite ? O_TRUNC : O_EXCL) | O_NOFOLLOW
-        let descriptor = open(url.path, flags, S_IRUSR | S_IWUSR)
+        defer {
+            if existingDescriptor >= 0 { close(existingDescriptor) }
+        }
+
+        let temporary = parent.appendingPathComponent(".afm-write-\(UUID().uuidString).tmp")
+        let descriptor = open(
+            temporary.path,
+            O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+            S_IRUSR | S_IWUSR
+        )
         guard descriptor >= 0 else {
-            if errno == EEXIST { throw TUIArtifactError.exists(url.path) }
             throw TUIArtifactError.invalidPath(url.path)
         }
-        defer { close(descriptor) }
+        var descriptorIsOpen = true
+        defer {
+            if descriptorIsOpen { close(descriptor) }
+            _ = unlink(temporary.path)
+        }
+
+        do {
+            try verifyRegularAndRestrictPermissions(
+                descriptor: descriptor,
+                path: temporary.path
+            )
+            try write(data, to: descriptor)
+            guard fsync(descriptor) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            guard close(descriptor) == 0 else {
+                descriptorIsOpen = false
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            descriptorIsOpen = false
+        } catch {
+            throw error
+        }
+
+        try beforeAtomicInstall?()
+        if overwrite {
+            guard rename(temporary.path, url.path) == 0 else {
+                throw TUIArtifactError.invalidPath(url.path)
+            }
+        } else {
+            guard link(temporary.path, url.path) == 0 else {
+                if errno == EEXIST { throw TUIArtifactError.exists(url.path) }
+                throw TUIArtifactError.invalidPath(url.path)
+            }
+            guard unlink(temporary.path) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
+    }
+
+    private static func verifyRegularAndRestrictPermissions(
+        descriptor: Int32,
+        path: String
+    ) throws {
+        var info = stat()
+        guard fstat(descriptor, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              fchmod(descriptor, S_IRUSR | S_IWUSR) == 0 else {
+            throw TUIArtifactError.invalidPath(path)
+        }
+    }
+
+    private static func write(_ data: Data, to descriptor: Int32) throws {
         try data.withUnsafeBytes { bytes in
             guard let start = bytes.baseAddress else { return }
             var offset = 0
             while offset < bytes.count {
-                let count = Darwin.write(descriptor, start.advanced(by: offset), bytes.count - offset)
-                guard count > 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+                let count = Darwin.write(
+                    descriptor,
+                    start.advanced(by: offset),
+                    bytes.count - offset
+                )
+                if count < 0, errno == EINTR { continue }
+                guard count > 0 else {
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                }
                 offset += count
             }
         }

--- a/Sources/AFMTerminalUI/ArtifactActions.swift
+++ b/Sources/AFMTerminalUI/ArtifactActions.swift
@@ -1,0 +1,158 @@
+import Darwin
+import Foundation
+
+public enum TUIArtifactError: Error, LocalizedError, Equatable {
+    case exists(String), invalidPath(String), unsupportedBlock(String), commandFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .exists(let path): return "Refusing to overwrite existing file: \(path). Add ! to the command to confirm."
+        case .invalidPath(let path): return "Invalid output path: \(path)"
+        case .unsupportedBlock(let language): return "Only HTML and JavaScript blocks can be opened in a browser (got \(language.isEmpty ? "untyped code" : language))."
+        case .commandFailed(let reason): return reason
+        }
+    }
+}
+
+public enum TUIArtifactActions {
+    public static func resolvedURL(_ rawPath: String, cwd: URL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)) throws -> URL {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.contains("\0") else { throw TUIArtifactError.invalidPath(rawPath) }
+        let expanded = NSString(string: trimmed).expandingTildeInPath
+        let url = expanded.hasPrefix("/") ? URL(fileURLWithPath: expanded) : cwd.appendingPathComponent(expanded)
+        return url.standardizedFileURL
+    }
+
+    public static func save(_ data: Data, to url: URL, overwrite: Bool = false) throws {
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        var info = stat()
+        if lstat(url.path, &info) == 0 {
+            if !overwrite { throw TUIArtifactError.exists(url.path) }
+            guard (info.st_mode & S_IFMT) == S_IFREG else { throw TUIArtifactError.invalidPath(url.path) }
+        }
+        let flags = O_WRONLY | O_CREAT | (overwrite ? O_TRUNC : O_EXCL) | O_NOFOLLOW
+        let descriptor = open(url.path, flags, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else {
+            if errno == EEXIST { throw TUIArtifactError.exists(url.path) }
+            throw TUIArtifactError.invalidPath(url.path)
+        }
+        defer { close(descriptor) }
+        try data.withUnsafeBytes { bytes in
+            guard let start = bytes.baseAddress else { return }
+            var offset = 0
+            while offset < bytes.count {
+                let count = Darwin.write(descriptor, start.advanced(by: offset), bytes.count - offset)
+                guard count > 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+                offset += count
+            }
+        }
+    }
+
+    public static func copyToClipboard(_ text: String) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pbcopy")
+        let pipe = Pipe()
+        process.standardInput = pipe
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        pipe.fileHandleForWriting.write(Data(text.utf8))
+        try pipe.fileHandleForWriting.close()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { throw TUIArtifactError.commandFailed("pbcopy failed") }
+    }
+
+    public static func prepareBrowserArtifact(_ block: TUICodeBlock, temporaryRoot: URL = FileManager.default.temporaryDirectory) throws -> URL {
+        let language = block.language.lowercased()
+        guard ["html", "htm", "javascript", "js"].contains(language) else {
+            throw TUIArtifactError.unsupportedBlock(block.language)
+        }
+        let directory = temporaryRoot.appendingPathComponent("afm-tui-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+        let url = directory.appendingPathComponent("artifact.html")
+        let html: String
+        if ["html", "htm"].contains(language) {
+            let escaped = block.content
+                .replacingOccurrences(of: "&", with: "&amp;")
+                .replacingOccurrences(of: "\"", with: "&quot;")
+                .replacingOccurrences(of: "<", with: "&lt;")
+                .replacingOccurrences(of: ">", with: "&gt;")
+            html = """
+            <!doctype html><meta charset="utf-8">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:">
+            <title>AFM TUI HTML Preview</title>
+            <iframe sandbox="allow-scripts" srcdoc="\(escaped)" style="position:fixed;inset:0;width:100%;height:100%;border:0"></iframe>
+            """
+        } else {
+            html = """
+            <!doctype html><meta charset="utf-8">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:">
+            <title>AFM TUI JavaScript Preview</title>
+            <style>body{font:16px -apple-system;padding:2rem;color:#eee;background:#111}pre{white-space:pre-wrap}</style>
+            <div id="app"></div><script>\(block.content)</script>
+            """
+        }
+        try save(Data(html.utf8), to: url)
+        return url
+    }
+
+    public static func openInBrowser(_ block: TUICodeBlock) throws -> URL {
+        let url = try prepareBrowserArtifact(block)
+        try runOpen([url.path])
+        return url
+    }
+
+    public static func quickLook(_ rawPath: String) throws {
+        let url = try resolvedURL(rawPath)
+        guard FileManager.default.fileExists(atPath: url.path) else { throw TUIArtifactError.invalidPath(url.path) }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/qlmanage")
+        process.arguments = ["-p", url.path]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+    }
+
+    public static func inlineImageSequence(path rawPath: String, capabilities: TerminalCapabilities) throws -> String? {
+        guard capabilities.inlineImages != .none else { return nil }
+        let url = try resolvedURL(rawPath)
+        let values = try url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        guard values.isRegularFile == true, (values.fileSize ?? 0) <= 20_000_000 else { return nil }
+        if capabilities.inlineImages == .kitty, url.pathExtension.lowercased() != "png" { return nil }
+        let data = try Data(contentsOf: url)
+        let encoded = data.base64EncodedString()
+        switch capabilities.inlineImages {
+        case .iTerm2:
+            return "\u{001B}]1337;File=inline=1;preserveAspectRatio=1:\(encoded)\u{0007}"
+        case .kitty:
+            let chunkSize = 4096
+            var chunks: [String] = []
+            var offset = encoded.startIndex
+            var first = true
+            while offset < encoded.endIndex {
+                let end = encoded.index(offset, offsetBy: min(chunkSize, encoded.distance(from: offset, to: encoded.endIndex)))
+                let more = end < encoded.endIndex ? 1 : 0
+                let control = first ? "a=T,f=100,m=\(more)" : "m=\(more)"
+                chunks.append("\u{001B}_G\(control);\(encoded[offset..<end])\u{001B}\\")
+                first = false
+                offset = end
+            }
+            return chunks.joined()
+        case .none:
+            return nil
+        }
+    }
+
+    private static func runOpen(_ arguments: [String]) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { throw TUIArtifactError.commandFailed("open failed") }
+    }
+}

--- a/Sources/AFMTerminalUI/ArtifactActions.swift
+++ b/Sources/AFMTerminalUI/ArtifactActions.swift
@@ -268,9 +268,19 @@ public enum TUIArtifactActions {
     }
 
     public static func preflightRegularFile(at url: URL, maximumBytes: Int) throws {
+        guard maximumBytes >= 0 else {
+            throw TUIArtifactError.unsafeReadableFile(url.path)
+        }
+        let descriptor = open(
+            url.path,
+            O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC
+        )
+        guard descriptor >= 0 else {
+            throw TUIArtifactError.unsafeReadableFile(url.path)
+        }
+        defer { close(descriptor) }
         var info = stat()
-        guard maximumBytes >= 0,
-              lstat(url.path, &info) == 0,
+        guard fstat(descriptor, &info) == 0,
               (info.st_mode & S_IFMT) == S_IFREG,
               info.st_size >= 0,
               info.st_size <= maximumBytes else {
@@ -306,5 +316,49 @@ public enum TUIArtifactActions {
             data.append(contentsOf: buffer.prefix(count))
         }
         return data
+    }
+}
+
+public enum TUIMediaAttachmentKind: Equatable, Sendable {
+    case image
+    case video
+}
+
+public enum TUIMediaAttachmentPolicy {
+    private static let imageExtensions: Set<String> = [
+        "png", "jpg", "jpeg", "gif", "webp", "heic", "tif", "tiff", "bmp"
+    ]
+    private static let videoExtensions: Set<String> = [
+        "mp4", "mov", "avi", "mkv", "webm", "m4v"
+    ]
+
+    public static func kind(for url: URL) -> TUIMediaAttachmentKind? {
+        let pathExtension = url.pathExtension.lowercased()
+        if imageExtensions.contains(pathExtension) { return .image }
+        if videoExtensions.contains(pathExtension) { return .video }
+        return nil
+    }
+
+    public static func validate(_ url: URL) throws {
+        guard let kind = kind(for: url) else {
+            throw TUIArtifactError.invalidPath(
+                "Unsupported media type for \(url.path). Use an image or video file."
+            )
+        }
+        try TUIArtifactActions.preflightRegularFile(
+            at: url,
+            maximumBytes: kind == .image ? 20_000_000 : Int.max
+        )
+    }
+
+    public static func resolveAndValidate(
+        _ paths: [String],
+        cwd: URL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    ) throws -> [URL] {
+        try paths.map { path in
+            let url = try TUIArtifactActions.resolvedURL(path, cwd: cwd)
+            try validate(url)
+            return url
+        }
     }
 }

--- a/Sources/AFMTerminalUI/ArtifactActions.swift
+++ b/Sources/AFMTerminalUI/ArtifactActions.swift
@@ -3,6 +3,8 @@ import Foundation
 
 public enum TUIArtifactError: Error, LocalizedError, Equatable {
     case exists(String), invalidPath(String), unsupportedBlock(String), commandFailed(String)
+    case unsafeReadableFile(String)
+    case incompatibleSession(savedBackend: String, savedModel: String, currentBackend: String, currentModel: String)
 
     public var errorDescription: String? {
         switch self {
@@ -10,6 +12,9 @@ public enum TUIArtifactError: Error, LocalizedError, Equatable {
         case .invalidPath(let path): return "Invalid output path: \(path)"
         case .unsupportedBlock(let language): return "Only HTML and JavaScript blocks can be opened in a browser (got \(language.isEmpty ? "untyped code" : language))."
         case .commandFailed(let reason): return reason
+        case .unsafeReadableFile(let path): return "Refusing to read a non-regular, linked, unreadable, or oversized local artifact: \(path)"
+        case .incompatibleSession(let savedBackend, let savedModel, let currentBackend, let currentModel):
+            return "Saved session uses \(savedBackend) · \(savedModel), but this TUI uses \(currentBackend) · \(currentModel)."
         }
     }
 }
@@ -86,12 +91,22 @@ public enum TUIArtifactActions {
             <iframe sandbox="allow-scripts" srcdoc="\(escaped)" style="position:fixed;inset:0;width:100%;height:100%;border:0"></iframe>
             """
         } else {
+            let document = """
+            <!doctype html><meta charset="utf-8">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:">
+            <style>body{font:16px -apple-system;padding:2rem;color:#eee;background:#111}pre{white-space:pre-wrap}</style>
+            <div id="app"></div><script>\(block.content)</script>
+            """
+            let escaped = document
+                .replacingOccurrences(of: "&", with: "&amp;")
+                .replacingOccurrences(of: "\"", with: "&quot;")
+                .replacingOccurrences(of: "<", with: "&lt;")
+                .replacingOccurrences(of: ">", with: "&gt;")
             html = """
             <!doctype html><meta charset="utf-8">
             <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:">
             <title>AFM TUI JavaScript Preview</title>
-            <style>body{font:16px -apple-system;padding:2rem;color:#eee;background:#111}pre{white-space:pre-wrap}</style>
-            <div id="app"></div><script>\(block.content)</script>
+            <iframe sandbox="allow-scripts" srcdoc="\(escaped)" style="position:fixed;inset:0;width:100%;height:100%;border:0"></iframe>
             """
         }
         try save(Data(html.utf8), to: url)
@@ -104,9 +119,9 @@ public enum TUIArtifactActions {
         return url
     }
 
-    public static func quickLook(_ rawPath: String) throws {
+    public static func quickLook(_ rawPath: String, maximumBytes: Int = 20_000_000) throws {
         let url = try resolvedURL(rawPath)
-        guard FileManager.default.fileExists(atPath: url.path) else { throw TUIArtifactError.invalidPath(url.path) }
+        try preflightRegularFile(at: url, maximumBytes: maximumBytes)
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/qlmanage")
         process.arguments = ["-p", url.path]
@@ -118,10 +133,8 @@ public enum TUIArtifactActions {
     public static func inlineImageSequence(path rawPath: String, capabilities: TerminalCapabilities) throws -> String? {
         guard capabilities.inlineImages != .none else { return nil }
         let url = try resolvedURL(rawPath)
-        let values = try url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
-        guard values.isRegularFile == true, (values.fileSize ?? 0) <= 20_000_000 else { return nil }
         if capabilities.inlineImages == .kitty, url.pathExtension.lowercased() != "png" { return nil }
-        let data = try Data(contentsOf: url)
+        let data = try readRegularFile(at: url, maximumBytes: 20_000_000)
         let encoded = data.base64EncodedString()
         switch capabilities.inlineImages {
         case .iTerm2:
@@ -143,6 +156,47 @@ public enum TUIArtifactActions {
         case .none:
             return nil
         }
+    }
+
+    public static func preflightRegularFile(at url: URL, maximumBytes: Int) throws {
+        var info = stat()
+        guard maximumBytes >= 0,
+              lstat(url.path, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              info.st_size >= 0,
+              info.st_size <= maximumBytes else {
+            throw TUIArtifactError.unsafeReadableFile(url.path)
+        }
+    }
+
+    public static func readRegularFile(at url: URL, maximumBytes: Int) throws -> Data {
+        try preflightRegularFile(at: url, maximumBytes: maximumBytes)
+        let descriptor = open(url.path, O_RDONLY | O_NOFOLLOW)
+        guard descriptor >= 0 else { throw TUIArtifactError.unsafeReadableFile(url.path) }
+        defer { close(descriptor) }
+
+        var info = stat()
+        guard fstat(descriptor, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              info.st_size >= 0,
+              info.st_size <= maximumBytes else {
+            throw TUIArtifactError.unsafeReadableFile(url.path)
+        }
+        var data = Data()
+        data.reserveCapacity(Int(info.st_size))
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let count = buffer.withUnsafeMutableBytes { bytes in
+                Darwin.read(descriptor, bytes.baseAddress, bytes.count)
+            }
+            guard count >= 0 else { throw TUIArtifactError.unsafeReadableFile(url.path) }
+            if count == 0 { break }
+            guard data.count <= maximumBytes - count else {
+                throw TUIArtifactError.unsafeReadableFile(url.path)
+            }
+            data.append(contentsOf: buffer.prefix(count))
+        }
+        return data
     }
 
     private static func runOpen(_ arguments: [String]) throws {

--- a/Sources/AFMTerminalUI/ArtifactActions.swift
+++ b/Sources/AFMTerminalUI/ArtifactActions.swift
@@ -77,23 +77,33 @@ public enum TUIArtifactActions {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
         let url = directory.appendingPathComponent("artifact.html")
+        let contentSecurityPolicy = "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; connect-src 'none'; media-src 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; base-uri 'none'"
+        let containerSecurityPolicy = contentSecurityPolicy.replacingOccurrences(
+            of: "frame-src 'none'",
+            with: "frame-src 'self'"
+        )
         let html: String
         if ["html", "htm"].contains(language) {
-            let escaped = block.content
+            let document = """
+            <!doctype html><meta charset="utf-8">
+            <meta http-equiv="Content-Security-Policy" content="\(contentSecurityPolicy)">
+            \(block.content)
+            """
+            let escaped = document
                 .replacingOccurrences(of: "&", with: "&amp;")
                 .replacingOccurrences(of: "\"", with: "&quot;")
                 .replacingOccurrences(of: "<", with: "&lt;")
                 .replacingOccurrences(of: ">", with: "&gt;")
             html = """
             <!doctype html><meta charset="utf-8">
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:">
+            <meta http-equiv="Content-Security-Policy" content="\(containerSecurityPolicy)">
             <title>AFM TUI HTML Preview</title>
             <iframe sandbox="allow-scripts" srcdoc="\(escaped)" style="position:fixed;inset:0;width:100%;height:100%;border:0"></iframe>
             """
         } else {
             let document = """
             <!doctype html><meta charset="utf-8">
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:">
+            <meta http-equiv="Content-Security-Policy" content="\(contentSecurityPolicy)">
             <style>body{font:16px -apple-system;padding:2rem;color:#eee;background:#111}pre{white-space:pre-wrap}</style>
             <div id="app"></div><script>\(block.content)</script>
             """
@@ -104,7 +114,7 @@ public enum TUIArtifactActions {
                 .replacingOccurrences(of: ">", with: "&gt;")
             html = """
             <!doctype html><meta charset="utf-8">
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:">
+            <meta http-equiv="Content-Security-Policy" content="\(containerSecurityPolicy)">
             <title>AFM TUI JavaScript Preview</title>
             <iframe sandbox="allow-scripts" srcdoc="\(escaped)" style="position:fixed;inset:0;width:100%;height:100%;border:0"></iframe>
             """
@@ -115,7 +125,15 @@ public enum TUIArtifactActions {
 
     public static func openInBrowser(_ block: TUICodeBlock) throws -> URL {
         let url = try prepareBrowserArtifact(block)
-        try runOpen([url.path])
+        guard let executableURL = Bundle.main.executableURL else {
+            throw TUIArtifactError.commandFailed("Unable to locate the afm executable for browser preview")
+        }
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = ["__tui-preview", url.path]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
         return url
     }
 
@@ -197,16 +215,5 @@ public enum TUIArtifactActions {
             data.append(contentsOf: buffer.prefix(count))
         }
         return data
-    }
-
-    private static func runOpen(_ arguments: [String]) throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        process.arguments = arguments
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        try process.run()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else { throw TUIArtifactError.commandFailed("open failed") }
     }
 }

--- a/Sources/AFMTerminalUI/BrowserPreview.swift
+++ b/Sources/AFMTerminalUI/BrowserPreview.swift
@@ -1,0 +1,84 @@
+import AppKit
+import Foundation
+import WebKit
+
+public struct TUIBrowserNavigationBoundary: Equatable, Sendable {
+    public let artifactURL: URL
+
+    public init(artifactURL: URL) {
+        self.artifactURL = artifactURL.standardizedFileURL
+    }
+
+    public func allows(_ candidate: URL?) -> Bool {
+        guard let candidate else { return false }
+        if candidate.scheme?.lowercased() == "about" {
+            return candidate.absoluteString == "about:blank" || candidate.absoluteString == "about:srcdoc"
+        }
+        return candidate.isFileURL && candidate.standardizedFileURL == artifactURL
+    }
+}
+
+@MainActor
+private final class TUIBrowserPreviewController: NSObject, NSWindowDelegate, WKNavigationDelegate {
+    private let boundary: TUIBrowserNavigationBoundary
+    private let window: NSWindow
+    private let webView: WKWebView
+
+    init(artifactURL: URL) {
+        boundary = TUIBrowserNavigationBoundary(artifactURL: artifactURL)
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        configuration.preferences.javaScriptCanOpenWindowsAutomatically = false
+        webView = WKWebView(frame: .zero, configuration: configuration)
+        window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 960, height: 720),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        super.init()
+        webView.navigationDelegate = self
+        window.delegate = self
+        window.title = "AFM TUI Preview"
+        window.contentView = webView
+        window.center()
+    }
+
+    func show(artifactURL: URL) {
+        let application = NSApplication.shared
+        application.setActivationPolicy(.regular)
+        window.makeKeyAndOrderFront(nil)
+        application.activate(ignoringOtherApps: true)
+        webView.loadFileURL(artifactURL, allowingReadAccessTo: artifactURL)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        NSApplication.shared.terminate(nil)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction
+    ) async -> WKNavigationActionPolicy {
+        boundary.allows(navigationAction.request.url) ? .allow : .cancel
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse
+    ) async -> WKNavigationResponsePolicy {
+        boundary.allows(navigationResponse.response.url) ? .allow : .cancel
+    }
+}
+
+public enum TUIBrowserPreview {
+    @MainActor
+    public static func run(artifactURL: URL) throws {
+        try TUIArtifactActions.preflightRegularFile(at: artifactURL, maximumBytes: 10_000_000)
+        let controller = TUIBrowserPreviewController(artifactURL: artifactURL)
+        controller.show(artifactURL: artifactURL)
+        withExtendedLifetime(controller) {
+            NSApplication.shared.run()
+        }
+    }
+}

--- a/Sources/AFMTerminalUI/MarkdownRenderer.swift
+++ b/Sources/AFMTerminalUI/MarkdownRenderer.swift
@@ -96,8 +96,16 @@ public struct TerminalMarkdownRenderer: Sendable {
         hyperlinks: Bool = false
     ) -> MarkdownRenderResult {
         let safeSource = Self.sanitized(markdown).replacingOccurrences(of: "\r\n", with: "\n")
-        let document = Document(parsing: safeSource)
-        var context = RenderContext(owner: self, width: max(24, width), hyperlinks: hyperlinks)
+        // Match llama.cpp's WebUI pipeline: protect math before CommonMark can
+        // consume TeX backslashes, while leaving code spans/fences byte-for-byte inert.
+        let prepared = TerminalMath.prepareMarkdown(safeSource)
+        let document = Document(parsing: prepared.source)
+        var context = RenderContext(
+            owner: self,
+            width: max(24, width),
+            hyperlinks: hyperlinks,
+            mathPlaceholders: prepared.expressions
+        )
         let text = context.renderBlock(document).trimmingCharacters(in: .newlines)
         return MarkdownRenderResult(
             text: text,
@@ -204,6 +212,7 @@ public struct TerminalMarkdownRenderer: Sendable {
         let owner: TerminalMarkdownRenderer
         let width: Int
         let hyperlinks: Bool
+        let mathPlaceholders: [TerminalMath.Segment]
         var codeBlocks: [TUICodeBlock] = []
 
         mutating func renderBlock(_ markup: Markup) -> String {
@@ -256,7 +265,7 @@ public struct TerminalMarkdownRenderer: Sendable {
         }
 
         private mutating func renderInline(_ markup: Markup) -> String {
-            if let text = markup as? Text { return TerminalMath.renderInlineText(text.string, style: mathStyle) }
+            if let text = markup as? Text { return renderMathText(text.string) }
             if let code = markup as? InlineCode { return owner.style(" \(code.code) ", owner.palette.code) }
             if markup is Strong { return owner.style(renderInlineChildren(markup), "1") }
             if markup is Emphasis { return owner.style(renderInlineChildren(markup), "3") }
@@ -287,13 +296,48 @@ public struct TerminalMarkdownRenderer: Sendable {
 
         private var mathStyle: (String) -> String { { owner.style($0, owner.palette.accent) } }
 
+        private mutating func renderMathText(_ source: String) -> String {
+            var output = ""
+            for segment in TerminalMath.segments(in: source, restoring: mathPlaceholders) {
+                switch segment {
+                case .text(let value):
+                    output += value
+                case .inline(let value):
+                    output += mathStyle(TerminalMath.renderExpression(value))
+                case .display(let value):
+                    if !output.hasSuffix("\n") { output += "\n" }
+                    output += renderMathBlock(value)
+                    output += "\n"
+                }
+            }
+            return output
+        }
+
         private mutating func renderMathBlock(_ source: String) -> String {
             let math = TerminalMath.renderExpression(source)
             let label = owner.style(" math ", owner.palette.accent)
-            let lines = math.split(separator: "\n", omittingEmptySubsequences: false).map {
+            let lines = math.split(separator: "\n", omittingEmptySubsequences: false)
+                .flatMap { Self.wrappedMathLine(String($0), width: max(12, width - 4)) }
+                .map {
                 owner.style("│", owner.palette.accent) + " " + owner.style(String($0), owner.palette.accent)
             }.joined(separator: "\n")
             return owner.style("┌─", owner.palette.accent) + label + "\n" + lines + "\n" + owner.style("└─", owner.palette.accent)
+        }
+
+        private static func wrappedMathLine(_ line: String, width: Int) -> [String] {
+            guard line.count > width else { return [line] }
+            var remaining = line[...]
+            var result: [String] = []
+            while remaining.count > width {
+                let limit = remaining.index(remaining.startIndex, offsetBy: width)
+                let prefix = remaining[..<limit]
+                let split = prefix.lastIndex(where: \.isWhitespace) ?? limit
+                let chunk = remaining[..<split].trimmingCharacters(in: .whitespaces)
+                if !chunk.isEmpty { result.append(chunk) }
+                remaining = remaining[split...].drop(while: \.isWhitespace)
+            }
+            if !remaining.isEmpty { result.append(String(remaining)) }
+            return result
         }
 
         private mutating func renderList(_ children: MarkupChildren, start: Int, ordered: Bool) -> String {
@@ -318,9 +362,10 @@ public struct TerminalMarkdownRenderer: Sendable {
         }
 
         private mutating func renderTable(_ table: Table) -> String {
-            let header = Array(table.head.cells.map { Self.normalizedCell($0) })
+            let placeholders = mathPlaceholders
+            let header = Array(table.head.cells.map { Self.normalizedCell($0, restoring: placeholders) })
             let body = Array(table.body.rows.map { row in
-                Array(row.cells.map { Self.normalizedCell($0) })
+                Array(row.cells.map { Self.normalizedCell($0, restoring: placeholders) })
             })
             let columnCount = max(header.count, body.map(\.count).max() ?? 0)
             guard columnCount > 0 else { return "" }
@@ -341,8 +386,11 @@ public struct TerminalMarkdownRenderer: Sendable {
             return rows.joined(separator: "\n")
         }
 
-        private static func normalizedCell(_ cell: Table.Cell) -> String {
-            TerminalMarkdownRenderer.latexFallback(TerminalMarkdownRenderer.plainText(cell))
+        private static func normalizedCell(_ cell: Table.Cell, restoring expressions: [TerminalMath.Segment]) -> String {
+            TerminalMath.renderInlineText(
+                TerminalMarkdownRenderer.plainText(cell),
+                restoring: expressions
+            )
                 .replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces)
         }
 
@@ -481,21 +529,71 @@ public struct TerminalMarkdownRenderer: Sendable {
 }
 
 private enum TerminalMath {
+    enum Segment: Equatable {
+        case text(String)
+        case inline(String)
+        case display(String)
+    }
+
+    struct PreparedMarkdown {
+        let source: String
+        let expressions: [Segment]
+    }
+
+    private static let placeholderPrefix = "AFMZMATHTOKEN"
+    private static let placeholderSuffix = "Z"
+
     private static let commandSymbols: [String: String] = [
-        "alpha": "α", "beta": "β", "gamma": "γ", "delta": "δ", "epsilon": "ε", "theta": "θ",
-        "lambda": "λ", "mu": "μ", "pi": "π", "rho": "ρ", "sigma": "σ", "phi": "φ", "psi": "ψ",
-        "omega": "ω", "Gamma": "Γ", "Delta": "Δ", "Theta": "Θ", "Lambda": "Λ", "Pi": "Π",
-        "Sigma": "Σ", "Phi": "Φ", "Psi": "Ψ", "Omega": "Ω", "infty": "∞", "sum": "∑",
-        "prod": "∏", "int": "∫", "oint": "∮", "partial": "∂", "nabla": "∇", "neq": "≠",
-        "le": "≤", "leq": "≤", "ge": "≥", "geq": "≥", "approx": "≈", "equiv": "≡",
-        "propto": "∝", "rightarrow": "→", "to": "→", "leftarrow": "←", "Rightarrow": "⇒",
-        "Leftarrow": "⇐", "leftrightarrow": "↔", "times": "×", "cdot": "·", "pm": "±", "mp": "∓",
-        "div": "÷", "forall": "∀", "exists": "∃", "in": "∈", "notin": "∉", "subset": "⊂",
-        "subseteq": "⊆", "supset": "⊃", "supseteq": "⊇", "cup": "∪", "cap": "∩", "land": "∧", "lor": "∨"
+        // Greek letters and common variants.
+        "alpha": "α", "beta": "β", "gamma": "γ", "delta": "δ", "epsilon": "ε", "varepsilon": "ε",
+        "zeta": "ζ", "eta": "η", "theta": "θ", "vartheta": "ϑ", "iota": "ι", "kappa": "κ",
+        "lambda": "λ", "mu": "μ", "nu": "ν", "xi": "ξ", "omicron": "ο", "pi": "π", "varpi": "ϖ",
+        "rho": "ρ", "varrho": "ϱ", "sigma": "σ", "varsigma": "ς", "tau": "τ", "upsilon": "υ",
+        "phi": "φ", "varphi": "ϕ", "chi": "χ", "psi": "ψ", "omega": "ω",
+        "Gamma": "Γ", "Delta": "Δ", "Theta": "Θ", "Lambda": "Λ", "Xi": "Ξ", "Pi": "Π",
+        "Sigma": "Σ", "Upsilon": "Υ", "Phi": "Φ", "Psi": "Ψ", "Omega": "Ω",
+
+        // Calculus, algebra, and named operators.
+        "infty": "∞", "sum": "∑", "prod": "∏", "coprod": "∐", "int": "∫", "iint": "∬",
+        "iiint": "∭", "oint": "∮", "partial": "∂", "nabla": "∇", "ell": "ℓ", "hbar": "ℏ",
+        "lim": "lim", "limsup": "lim sup", "liminf": "lim inf", "sup": "sup", "inf": "inf",
+        "max": "max", "min": "min", "argmax": "arg max", "argmin": "arg min", "det": "det",
+        "dim": "dim", "ker": "ker", "gcd": "gcd", "log": "log", "ln": "ln", "exp": "exp",
+        "sin": "sin", "cos": "cos", "tan": "tan", "cot": "cot", "sec": "sec", "csc": "csc",
+        "arcsin": "arcsin", "arccos": "arccos", "arctan": "arctan", "sinh": "sinh", "cosh": "cosh",
+        "tanh": "tanh", "Re": "ℜ", "Im": "ℑ", "prime": "′", "degree": "°",
+
+        // Relations, logic, sets, and arrows.
+        "neq": "≠", "ne": "≠", "le": "≤", "leq": "≤", "ge": "≥", "geq": "≥", "ll": "≪",
+        "gg": "≫", "approx": "≈", "sim": "∼", "simeq": "≃", "cong": "≅", "equiv": "≡",
+        "propto": "∝", "parallel": "∥", "perp": "⊥", "mid": "∣", "nmid": "∤",
+        "rightarrow": "→", "longrightarrow": "⟶", "to": "→", "mapsto": "↦", "leftarrow": "←",
+        "longleftarrow": "⟵", "Rightarrow": "⇒", "implies": "⇒", "Leftarrow": "⇐", "impliedby": "⇐",
+        "leftrightarrow": "↔", "Leftrightarrow": "⇔", "iff": "⇔", "uparrow": "↑", "downarrow": "↓",
+        "times": "×", "cdot": "·", "circ": "∘", "bullet": "•", "pm": "±", "mp": "∓", "div": "÷",
+        "forall": "∀", "exists": "∃", "nexists": "∄", "therefore": "∴", "because": "∵", "neg": "¬",
+        "in": "∈", "notin": "∉", "ni": "∋", "subset": "⊂", "subseteq": "⊆", "supset": "⊃",
+        "supseteq": "⊇", "cup": "∪", "cap": "∩", "setminus": "∖", "emptyset": "∅", "varnothing": "∅",
+        "land": "∧", "wedge": "∧", "lor": "∨", "vee": "∨", "oplus": "⊕", "otimes": "⊗",
+
+        // Delimiters and typography.
+        "langle": "⟨", "rangle": "⟩", "lceil": "⌈", "rceil": "⌉", "lfloor": "⌊", "rfloor": "⌋",
+        "lVert": "‖", "rVert": "‖", "Vert": "‖", "vert": "|", "dots": "…", "ldots": "…",
+        "cdots": "⋯", "vdots": "⋮", "ddots": "⋱", "colon": ":",
+
+        // Frequent malformed shorthand emitted by small/local models.
+        "mathbbC": "ℂ", "mathbbH": "ℍ", "mathbbN": "ℕ", "mathbbP": "ℙ", "mathbbQ": "ℚ",
+        "mathbbR": "ℝ", "mathbbZ": "ℤ"
+    ]
+    private static let blackboardSymbols: [Character: Character] = [
+        "C": "ℂ", "H": "ℍ", "N": "ℕ", "P": "ℙ", "Q": "ℚ", "R": "ℝ", "Z": "ℤ"
     ]
     private static let superscripts: [Character: Character] = [
         "0": "⁰", "1": "¹", "2": "²", "3": "³", "4": "⁴", "5": "⁵", "6": "⁶", "7": "⁷",
-        "8": "⁸", "9": "⁹", "+": "⁺", "-": "⁻", "=": "⁼", "(": "⁽", ")": "⁾", "n": "ⁿ", "i": "ⁱ"
+        "8": "⁸", "9": "⁹", "+": "⁺", "-": "⁻", "=": "⁼", "(": "⁽", ")": "⁾", "a": "ᵃ",
+        "b": "ᵇ", "c": "ᶜ", "d": "ᵈ", "e": "ᵉ", "f": "ᶠ", "g": "ᵍ", "h": "ʰ", "i": "ⁱ",
+        "j": "ʲ", "k": "ᵏ", "l": "ˡ", "m": "ᵐ", "n": "ⁿ", "o": "ᵒ", "p": "ᵖ", "r": "ʳ",
+        "s": "ˢ", "t": "ᵗ", "u": "ᵘ", "v": "ᵛ", "w": "ʷ", "x": "ˣ", "y": "ʸ", "z": "ᶻ"
     ]
     private static let subscripts: [Character: Character] = [
         "0": "₀", "1": "₁", "2": "₂", "3": "₃", "4": "₄", "5": "₅", "6": "₆", "7": "₇",
@@ -504,67 +602,384 @@ private enum TerminalMath {
         "o": "ₒ", "p": "ₚ", "r": "ᵣ", "s": "ₛ", "t": "ₜ", "x": "ₓ"
     ]
 
-    static func renderInlineText(_ input: String, style: (String) -> String = { $0 }) -> String {
-        let characters = Array(input)
-        var result = ""
+    static func prepareMarkdown(_ input: String) -> PreparedMarkdown {
+        let normalized = normalizeDelimiters(in: input)
+        let characters = Array(normalized)
+        var expressions: [Segment] = []
+        var output = ""
+        var plain = ""
         var index = 0
+        var codeDelimiter: (character: Character, count: Int)?
+
+        func runLength(at start: Int, character: Character) -> Int {
+            var end = start
+            while end < characters.count, characters[end] == character { end += 1 }
+            return end - start
+        }
+
+        func flushPlain() {
+            guard !plain.isEmpty else { return }
+            for segment in segments(in: plain) {
+                switch segment {
+                case .text(let value):
+                    output += value
+                case .inline, .display:
+                    output += placeholder(for: expressions.count)
+                    expressions.append(segment)
+                }
+            }
+            plain = ""
+        }
+
         while index < characters.count {
-            if characters[index] == "\\", index + 1 < characters.count, characters[index + 1] == "$" {
-                result.append("$"); index += 2; continue
+            if let delimiter = codeDelimiter {
+                if characters[index] == delimiter.character {
+                    let count = runLength(at: index, character: delimiter.character)
+                    output += String(repeating: String(delimiter.character), count: count)
+                    index += count
+                    if count >= delimiter.count { codeDelimiter = nil }
+                } else {
+                    output.append(characters[index])
+                    index += 1
+                }
+                continue
             }
-            guard characters[index] == "$", index + 1 < characters.count,
-                  characters[index + 1] != "$", !characters[index + 1].isWhitespace else {
-                result.append(characters[index]); index += 1; continue
+
+            let character = characters[index]
+            if character == "`" || character == "~" {
+                let count = runLength(at: index, character: character)
+                if character == "`" || count >= 3 {
+                    flushPlain()
+                    codeDelimiter = (character, count)
+                    output += String(repeating: String(character), count: count)
+                    index += count
+                    continue
+                }
             }
-            var closing = index + 1
-            var found: Int?
-            while closing < characters.count {
-                if characters[closing] == "$", characters[closing - 1] != "\\" {
-                    let previousIsContent = !characters[closing - 1].isWhitespace
-                    let nextIsBoundary = closing + 1 == characters.count || characters[closing + 1].isWhitespace || ".,;:!?)]}".contains(characters[closing + 1])
-                    if previousIsContent && nextIsBoundary { found = closing }
+            plain.append(character)
+            index += 1
+        }
+        flushPlain()
+        return PreparedMarkdown(source: output, expressions: expressions)
+    }
+
+    private static func placeholder(for index: Int) -> String {
+        "\(placeholderPrefix)\(index)\(placeholderSuffix)"
+    }
+
+    /// Normalizes the same four delimiter families accepted by llama.cpp's WebUI.
+    /// CommonMark would otherwise consume `\(` and `\[` as ordinary escapes.
+    /// Backtick and tilde code spans/fences are copied byte-for-byte.
+    static func normalizeDelimiters(in input: String) -> String {
+        let characters = Array(input)
+        var output = ""
+        var index = 0
+        var codeDelimiter: (character: Character, count: Int)?
+
+        func runLength(at start: Int, character: Character) -> Int {
+            var end = start
+            while end < characters.count, characters[end] == character { end += 1 }
+            return end - start
+        }
+
+        func isEscaped(at position: Int) -> Bool {
+            guard position > 0 else { return false }
+            var cursor = position - 1
+            var slashes = 0
+            while cursor >= 0, characters[cursor] == "\\" {
+                slashes += 1
+                if cursor == 0 { break }
+                cursor -= 1
+            }
+            return slashes.isMultiple(of: 2) == false
+        }
+
+        while index < characters.count {
+            if let delimiter = codeDelimiter {
+                if characters[index] == delimiter.character {
+                    let count = runLength(at: index, character: delimiter.character)
+                    output += String(repeating: String(delimiter.character), count: count)
+                    index += count
+                    if count >= delimiter.count { codeDelimiter = nil }
+                } else {
+                    output.append(characters[index])
+                    index += 1
+                }
+                continue
+            }
+
+            if characters[index] == "`" {
+                let count = runLength(at: index, character: "`")
+                codeDelimiter = ("`", count)
+                output += String(repeating: "`", count: count)
+                index += count
+                continue
+            }
+
+            if characters[index] == "~" {
+                let count = runLength(at: index, character: "~")
+                if count >= 3 {
+                    codeDelimiter = ("~", count)
+                    output += String(repeating: "~", count: count)
+                    index += count
+                    continue
+                }
+            }
+
+            if characters[index] == "\\", !isEscaped(at: index), index + 1 < characters.count {
+                switch characters[index + 1] {
+                case "(":
+                    output.append("$"); index += 2; continue
+                case ")":
+                    output.append("$"); index += 2; continue
+                case "[":
+                    output += "$$"; index += 2; continue
+                case "]":
+                    output += "$$"; index += 2; continue
+                default:
                     break
                 }
-                closing += 1
             }
-            guard let end = found else { result.append("$"); index += 1; continue }
-            result += style(renderExpression(String(characters[(index + 1)..<end])))
+
+            output.append(characters[index])
+            index += 1
+        }
+        return output
+    }
+
+    static func segments(in input: String) -> [Segment] {
+        let characters = Array(input)
+        var result: [Segment] = []
+        var textBuffer = ""
+        var index = 0
+
+        func flushText() {
+            guard !textBuffer.isEmpty else { return }
+            if case .text(let previous)? = result.last {
+                result[result.count - 1] = .text(previous + textBuffer)
+            } else {
+                result.append(.text(textBuffer))
+            }
+            textBuffer = ""
+        }
+
+        func isEscaped(_ position: Int) -> Bool {
+            guard position > 0 else { return false }
+            var cursor = position - 1
+            var count = 0
+            while cursor >= 0, characters[cursor] == "\\" {
+                count += 1
+                if cursor == 0 { break }
+                cursor -= 1
+            }
+            return count.isMultiple(of: 2) == false
+        }
+
+        func closingDelimiter(_ delimiter: [Character], after start: Int) -> Int? {
+            guard !delimiter.isEmpty else { return nil }
+            var cursor = start
+            while cursor + delimiter.count <= characters.count {
+                if !isEscaped(cursor), Array(characters[cursor..<(cursor + delimiter.count)]) == delimiter {
+                    return cursor
+                }
+                cursor += 1
+            }
+            return nil
+        }
+
+        func isTokenCharacter(_ character: Character?) -> Bool {
+            guard let character else { return false }
+            return character.isLetter || character.isNumber || "_$".contains(character)
+        }
+
+        while index < characters.count {
+            if characters[index] == "\\", index + 1 < characters.count, characters[index + 1] == "$" {
+                textBuffer.append("$")
+                index += 2
+                continue
+            }
+
+            let pair = index + 1 < characters.count ? String(characters[index...index + 1]) : ""
+            if pair == "$$" {
+                if let end = closingDelimiter(["$", "$"], after: index + 2) {
+                    flushText()
+                    result.append(.display(String(characters[(index + 2)..<end])))
+                    index = end + 2
+                    continue
+                }
+                let remainder = String(characters.dropFirst(index + 2))
+                if plausiblyTruncatedMath(remainder) {
+                    flushText()
+                    result.append(.display(remainder))
+                    index = characters.count
+                    continue
+                }
+            }
+            if pair == "\\(" , let end = closingDelimiter(["\\", ")"], after: index + 2) {
+                flushText()
+                result.append(.inline(String(characters[(index + 2)..<end])))
+                index = end + 2
+                continue
+            }
+            if pair == "\\[", let end = closingDelimiter(["\\", "]"], after: index + 2) {
+                flushText()
+                result.append(.display(String(characters[(index + 2)..<end])))
+                index = end + 2
+                continue
+            }
+
+            if characters[index] == "$", !isEscaped(index), pair != "$$",
+               closingDelimiter(["$"], after: index + 1) == nil {
+                let beforeOpen = index > 0 ? characters[index - 1] : nil
+                let afterOpen = index + 1 < characters.count ? characters[index + 1] : nil
+                let remainder = String(characters.dropFirst(index + 1))
+                if !isTokenCharacter(beforeOpen), afterOpen?.isNumber != true,
+                   plausiblyTruncatedMath(remainder) {
+                    flushText()
+                    result.append(.inline(remainder))
+                    index = characters.count
+                    continue
+                }
+            }
+
+            guard characters[index] == "$", !isEscaped(index), pair != "$$",
+                  let end = closingDelimiter(["$"], after: index + 1),
+                  (end == 0 || characters[end - 1] != "$"),
+                  (end + 1 == characters.count || characters[end + 1] != "$") else {
+                textBuffer.append(characters[index])
+                index += 1
+                continue
+            }
+
+            let beforeOpen = index > 0 ? characters[index - 1] : nil
+            let afterOpen = index + 1 < characters.count ? characters[index + 1] : nil
+            let beforeClose = end > index + 1 ? characters[end - 1] : nil
+            let afterClose = end + 1 < characters.count ? characters[end + 1] : nil
+            let empty = end == index + 1
+            let looksLikeIdentifier = isTokenCharacter(beforeOpen)
+            let looksLikeMoney = afterOpen?.isNumber == true
+                && (isTokenCharacter(afterClose) || beforeClose?.isWhitespace == true)
+            if empty || looksLikeIdentifier || looksLikeMoney {
+                textBuffer.append("$")
+                index += 1
+                continue
+            }
+
+            flushText()
+            result.append(.inline(String(characters[(index + 1)..<end])))
             index = end + 1
         }
+        flushText()
         return result
     }
 
+    private static func plausiblyTruncatedMath(_ source: String) -> Bool {
+        let value = source.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return false }
+        return value.contains("\\") || value.contains("_") || value.contains("^") || value.contains("=")
+    }
+
+    static func segments(in input: String, restoring expressions: [Segment]) -> [Segment] {
+        guard !expressions.isEmpty, input.contains(placeholderPrefix) else { return segments(in: input) }
+        guard let regex = try? NSRegularExpression(
+            pattern: "\(placeholderPrefix)([0-9]+)\(placeholderSuffix)"
+        ) else { return segments(in: input) }
+        let range = NSRange(input.startIndex..<input.endIndex, in: input)
+        let matches = regex.matches(in: input, range: range)
+        guard !matches.isEmpty else { return segments(in: input) }
+
+        var restored: [Segment] = []
+        var cursor = input.startIndex
+        for match in matches {
+            guard let wholeRange = Range(match.range(at: 0), in: input),
+                  let indexRange = Range(match.range(at: 1), in: input),
+                  let expressionIndex = Int(input[indexRange]),
+                  expressions.indices.contains(expressionIndex) else { continue }
+            if cursor < wholeRange.lowerBound {
+                restored.append(contentsOf: segments(in: String(input[cursor..<wholeRange.lowerBound])))
+            }
+            restored.append(expressions[expressionIndex])
+            cursor = wholeRange.upperBound
+        }
+        if cursor < input.endIndex {
+            restored.append(contentsOf: segments(in: String(input[cursor...])))
+        }
+        return restored
+    }
+
+    static func renderInlineText(_ input: String, style: (String) -> String = { $0 }) -> String {
+        segments(in: input).map { segment in
+            switch segment {
+            case .text(let value): return value
+            case .inline(let value), .display(let value): return style(renderExpression(value))
+            }
+        }.joined()
+    }
+
+    static func renderInlineText(
+        _ input: String,
+        restoring expressions: [Segment],
+        style: (String) -> String = { $0 }
+    ) -> String {
+        segments(in: input, restoring: expressions).map { segment in
+            switch segment {
+            case .text(let value): return value
+            case .inline(let value), .display(let value): return style(renderExpression(value))
+            }
+        }.joined()
+    }
+
     static func renderExpression(_ source: String) -> String {
-        if let matrix = renderMatrix(source) { return matrix }
+        if let environment = renderEnvironment(source) { return environment }
+        return renderLinear(source)
+    }
+
+    private static func renderLinear(_ source: String) -> String {
         var parser = Parser(Array(source))
-        return parser.parse(until: nil).replacingOccurrences(of: "  ", with: " ")
+        return parser.parse(until: nil)
+            .replacingOccurrences(of: #"[ \t]{2,}"#, with: " ", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private static func renderMatrix(_ source: String) -> String? {
-        guard let regex = try? NSRegularExpression(pattern: #"\\begin\{(bmatrix|pmatrix|matrix|cases)\}([\s\S]*?)\\end\{\1\}"#) else { return nil }
+    private static func renderEnvironment(_ source: String) -> String? {
+        let pattern = #"\\begin\{(bmatrix|pmatrix|matrix|cases|aligned|alignedat|align\*?|gathered|split|array)\}([\s\S]*?)\\end\{\1\}"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
         let range = NSRange(source.startIndex..<source.endIndex, in: source)
         guard let match = regex.firstMatch(in: source, range: range),
               let environmentRange = Range(match.range(at: 1), in: source),
-              let bodyRange = Range(match.range(at: 2), in: source) else { return nil }
+              let bodyRange = Range(match.range(at: 2), in: source),
+              let wholeRange = Range(match.range(at: 0), in: source) else { return nil }
         let environment = String(source[environmentRange])
-        let cells = String(source[bodyRange]).components(separatedBy: "\\\\").map { row in
-            row.split(separator: "&", omittingEmptySubsequences: false).map { renderExpression(String($0)) }
+        let body = String(source[bodyRange]).replacingOccurrences(
+            of: #"\\\\\s*\[[^\]]*\]"#,
+            with: "\\\\",
+            options: .regularExpression
+        )
+        let cells = body.components(separatedBy: "\\\\").compactMap { row -> [String]? in
+            let values = row.split(separator: "&", omittingEmptySubsequences: false)
+                .map { renderExpression(String($0)) }
+            return values.allSatisfy(\.isEmpty) ? nil : values
         }
         let columns = cells.map(\.count).max() ?? 0
         let widths = (0..<columns).map { column in cells.compactMap { $0.indices.contains(column) ? $0[column].count : nil }.max() ?? 0 }
-        return cells.enumerated().map { rowIndex, row in
+        let renderedBody = cells.enumerated().map { rowIndex, row in
             let body = widths.indices.map { column -> String in
                 let value = row.indices.contains(column) ? row[column] : ""
                 return value + String(repeating: " ", count: max(0, widths[column] - value.count))
-            }.joined(separator: "  ")
+            }.joined(separator: environment.hasPrefix("align") || ["gathered", "split"].contains(environment) ? " " : "  ")
+                .trimmingCharacters(in: .whitespaces)
             switch environment {
             case "bmatrix": return "[ \(body) ]"
             case "pmatrix": return "( \(body) )"
             case "cases": return (rowIndex == 0 ? "⎧ " : rowIndex == cells.count - 1 ? "⎩ " : "⎨ ") + body
-            default: return "│ \(body) │"
+            case "matrix", "array": return "│ \(body) │"
+            default: return body
             }
         }.joined(separator: "\n")
+
+        let prefix = renderLinear(String(source[..<wholeRange.lowerBound]))
+        let suffix = renderLinear(String(source[wholeRange.upperBound...]))
+        return [prefix, renderedBody, suffix].filter { !$0.isEmpty }.joined(separator: "\n")
     }
 
     private struct Parser {
@@ -602,23 +1017,72 @@ private enum TerminalMath {
             if characters[index] == "\\" { index += 1; return "\n" }
             let start = index
             while index < characters.count && characters[index].isLetter { index += 1 }
-            if start == index { let value = characters[index]; index += 1; return String(value) }
+            if start == index {
+                let value = characters[index]
+                index += 1
+                switch value {
+                case "|": return "‖"
+                case ",", ";", ":", " ": return " "
+                case "!", "/": return ""
+                default: return String(value)
+                }
+            }
             let name = String(characters[start..<index])
             if let symbol = TerminalMath.commandSymbols[name] { return symbol }
-            if name == "frac" { return "(\(parseArgument()))/(\(parseArgument()))" }
+            if ["frac", "dfrac", "tfrac"].contains(name) {
+                return "(\(parseArgument()))/(\(parseArgument()))"
+            }
             if name == "sqrt" {
+                var root = ""
                 if index < characters.count, characters[index] == "[" {
+                    index += 1
+                    let start = index
                     while index < characters.count && characters[index] != "]" { index += 1 }
+                    root = String(characters[start..<index])
                     if index < characters.count { index += 1 }
                 }
-                return "√(\(parseArgument()))"
+                let radical = root == "3" ? "∛" : root == "4" ? "∜" : root.isEmpty ? "√" : "^(1/\(root))"
+                return "\(radical)(\(parseArgument()))"
             }
-            if ["text", "textrm", "textbf", "mathrm", "mathbf", "operatorname", "overline", "underline"].contains(name) {
+            if name == "mathbb" {
+                let value = parseArgument()
+                return String(value.map { TerminalMath.blackboardSymbols[$0] ?? $0 })
+            }
+            if ["text", "textrm", "textnormal", "textbf", "textit", "mathrm", "mathbf", "mathit", "mathsf",
+                "mathtt", "mathcal", "mathscr", "mathfrak", "boldsymbol", "operatorname", "phantom"].contains(name) {
+                return parseArgument()
+            }
+            if ["vec", "overrightarrow"].contains(name) { return accented(parseArgument(), mark: "⃗") }
+            if ["bar", "overline"].contains(name) { return accented(parseArgument(), mark: "̅") }
+            if name == "underline" { return accented(parseArgument(), mark: "̲") }
+            if name == "hat" { return accented(parseArgument(), mark: "̂") }
+            if name == "tilde" { return accented(parseArgument(), mark: "̃") }
+            if name == "dot" { return accented(parseArgument(), mark: "̇") }
+            if name == "ddot" { return accented(parseArgument(), mark: "̈") }
+            if name == "boxed" { return "⟦\(parseArgument())⟧" }
+            if name == "abs" { return "|\(parseArgument())|" }
+            if name == "norm" { return "‖\(parseArgument())‖" }
+            if name == "binom" { return "C(\(parseArgument()), \(parseArgument()))" }
+            if ["overset", "stackrel"].contains(name) {
+                let upper = parseArgument()
+                return "\(parseArgument())^(\(upper))"
+            }
+            if name == "underset" {
+                let lower = parseArgument()
+                return "\(parseArgument())_(\(lower))"
+            }
+            if ["color", "textcolor"].contains(name) {
+                _ = parseArgument()
                 return parseArgument()
             }
             if ["left", "right"].contains(name) { return "" }
-            if [",", ";", "quad", "qquad"].contains(name) { return " " }
+            if ["quad", "qquad", "enspace", "thinspace"].contains(name) { return " " }
+            if ["limits", "nolimits", "displaystyle", "textstyle", "scriptstyle", "scriptscriptstyle"].contains(name) { return "" }
             return "\\\(name)"
+        }
+
+        private func accented(_ value: String, mark: Character) -> String {
+            value.map { "\($0)\(mark)" }.joined()
         }
 
         private mutating func parseArgument() -> String {

--- a/Sources/AFMTerminalUI/MarkdownRenderer.swift
+++ b/Sources/AFMTerminalUI/MarkdownRenderer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Markdown
 
 public struct TUICodeBlock: Equatable, Sendable {
     public let language: String
@@ -26,81 +27,114 @@ public struct MarkdownRenderResult: Equatable, Sendable {
     public let images: [TUIImageReference]
 }
 
-/// A deliberately small terminal renderer. It never evaluates Markdown/HTML or model output.
-/// Its output is ANSI text only when color is enabled, which keeps redirected transcripts clean.
+/// CommonMark/GFM renderer for interactive terminal output.
+///
+/// Parsing is delegated to swift-markdown's cmark-gfm syntax tree. Rendering stays
+/// local and inert: HTML, links, code, math, and model-provided control characters
+/// are displayed but never evaluated. Browser previews remain an explicit `/open` action.
 public struct TerminalMarkdownRenderer: Sendable {
     public enum Theme: String, CaseIterable, Sendable {
         case auto, dark, light, mono
     }
 
-    private let color: Bool
-    private let theme: Theme
+    private struct Palette: Sendable {
+        let heading1: String
+        let heading2: String
+        let heading3: String
+        let accent: String
+        let secondary: String
+        let code: String
+        let keyword: String
+        let type: String
+        let string: String
+        let number: String
+        let comment: String
+        let addition: String
+        let deletion: String
+        let warning: String
 
-    public init(color: Bool, theme: Theme = .auto) {
-        self.color = color && theme != .mono
-        self.theme = theme
+        static func resolve(_ theme: Theme) -> Palette {
+            switch theme {
+            case .light:
+                return Palette(
+                    heading1: "1;35", heading2: "1;34", heading3: "1;36",
+                    accent: "34", secondary: "2;30", code: "33", keyword: "35",
+                    type: "34", string: "32", number: "31", comment: "2;30",
+                    addition: "32", deletion: "31", warning: "33"
+                )
+            case .auto, .dark:
+                return Palette(
+                    heading1: "1;95", heading2: "1;94", heading3: "1;96",
+                    accent: "96", secondary: "2;37", code: "93", keyword: "95",
+                    type: "94", string: "92", number: "91", comment: "2;37",
+                    addition: "92", deletion: "91", warning: "93"
+                )
+            case .mono:
+                return Palette(
+                    heading1: "1", heading2: "1", heading3: "1",
+                    accent: "4", secondary: "2", code: "7", keyword: "1",
+                    type: "4", string: "0", number: "0", comment: "2",
+                    addition: "0", deletion: "0", warning: "1"
+                )
+            }
+        }
     }
 
-    public func render(_ markdown: String) -> MarkdownRenderResult {
-        let normalized = markdown.replacingOccurrences(of: "\r\n", with: "\n")
-        var rendered: [String] = []
-        var blocks: [TUICodeBlock] = []
-        var images: [TUIImageReference] = []
-        var language: String?
-        var code: [String] = []
+    private let ansi: Bool
+    private let palette: Palette
 
-        for rawLine in normalized.components(separatedBy: "\n") {
-            if rawLine.hasPrefix("```") {
-                if let activeLanguage = language {
-                    let content = code.joined(separator: "\n")
-                    let effectiveLanguage = activeLanguage.isEmpty ? Self.inferredLanguage(for: content) : activeLanguage
-                    blocks.append(TUICodeBlock(language: effectiveLanguage, content: content))
-                    rendered.append(renderCode(content, language: effectiveLanguage))
-                    language = nil
-                    code = []
-                } else {
-                    language = String(rawLine.dropFirst(3))
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                        .lowercased()
-                }
-                continue
-            }
-            if language != nil {
-                code.append(rawLine)
-                continue
-            }
+    public init(color: Bool, theme: Theme = .auto) {
+        self.ansi = color && theme != .mono
+        self.palette = Palette.resolve(theme)
+    }
 
-            images.append(contentsOf: Self.imageReferences(in: rawLine))
-            rendered.append(renderLine(rawLine))
-        }
-
-        // Be forgiving of a model that forgot the closing fence.
-        if let activeLanguage = language {
-            let content = code.joined(separator: "\n")
-            let effectiveLanguage = activeLanguage.isEmpty ? Self.inferredLanguage(for: content) : activeLanguage
-            blocks.append(TUICodeBlock(language: effectiveLanguage, content: content))
-            rendered.append(renderCode(content, language: effectiveLanguage))
-        }
-        return MarkdownRenderResult(text: rendered.joined(separator: "\n"), codeBlocks: blocks, images: images)
+    /// Renders Markdown at the current terminal width. OSC-8 links are opt-in and
+    /// should only be enabled after terminal capability detection.
+    public func render(
+        _ markdown: String,
+        width: Int = 100,
+        hyperlinks: Bool = false
+    ) -> MarkdownRenderResult {
+        let safeSource = Self.sanitized(markdown).replacingOccurrences(of: "\r\n", with: "\n")
+        let document = Document(parsing: safeSource)
+        var context = RenderContext(owner: self, width: max(24, width), hyperlinks: hyperlinks)
+        let text = context.renderBlock(document).trimmingCharacters(in: .newlines)
+        return MarkdownRenderResult(
+            text: text,
+            codeBlocks: context.codeBlocks,
+            images: Self.imageReferences(in: safeSource)
+        )
     }
 
     public static func imageReferences(in text: String) -> [TUIImageReference] {
-        let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
-        guard let markdownRegex = try? NSRegularExpression(pattern: #"!\[([^\]]*)\]\(([^)]+)\)"#) else { return [] }
-        var results = markdownRegex.matches(in: text, range: nsRange).compactMap { match -> TUIImageReference? in
-            guard let altRange = Range(match.range(at: 1), in: text),
-                  let pathRange = Range(match.range(at: 2), in: text) else { return nil }
-            let path = String(text[pathRange]).trimmingCharacters(in: .whitespacesAndNewlines)
-            guard path.hasPrefix("/") || path.hasPrefix("~") || path.hasPrefix("./") else { return nil }
-            return TUIImageReference(alt: String(text[altRange]), path: path)
+        let safeSource = sanitized(text)
+        let document = Document(parsing: safeSource)
+        var results: [TUIImageReference] = []
+
+        func visit(_ markup: Markup) {
+            if let image = markup as? Image, let source = image.source {
+                let path = source.trimmingCharacters(in: .whitespacesAndNewlines)
+                if isLocalPath(path) {
+                    let alt = plainText(image).trimmingCharacters(in: .whitespacesAndNewlines)
+                    let value = TUIImageReference(
+                        alt: alt.isEmpty ? URL(fileURLWithPath: path).lastPathComponent : alt,
+                        path: path
+                    )
+                    if !results.contains(where: { $0.path == value.path }) { results.append(value) }
+                }
+            }
+            for child in markup.children { visit(child) }
         }
+        visit(document)
+
+        let nsRange = NSRange(safeSource.startIndex..<safeSource.endIndex, in: safeSource)
         if let plainRegex = try? NSRegularExpression(
             pattern: #"(?:^|\s)((?:~|\.\.?/|/)[^\s<>\"']+\.(?:png|jpe?g|gif|webp|heic))\b"#,
             options: [.caseInsensitive]
         ) {
-            for match in plainRegex.matches(in: text, range: nsRange) {
-                guard let pathRange = Range(match.range(at: 1), in: text) else { continue }
-                let path = String(text[pathRange])
+            for match in plainRegex.matches(in: safeSource, range: nsRange) {
+                guard let pathRange = Range(match.range(at: 1), in: safeSource) else { continue }
+                let path = String(safeSource[pathRange])
                 if !results.contains(where: { $0.path == path }) {
                     results.append(TUIImageReference(alt: URL(fileURLWithPath: path).lastPathComponent, path: path))
                 }
@@ -109,92 +143,489 @@ public struct TerminalMarkdownRenderer: Sendable {
         return results
     }
 
+    /// Compatibility entry point used by tests and downstream callers. Unlike the
+    /// old fallback, it only consumes balanced math delimiters and preserves currency.
     public static func latexFallback(_ input: String) -> String {
-        var output = input
-        let replacements = [
-            #"\alpha"#: "α", #"\beta"#: "β", #"\gamma"#: "γ", #"\delta"#: "δ",
-            #"\theta"#: "θ", #"\lambda"#: "λ", #"\mu"#: "μ", #"\pi"#: "π",
-            #"\sigma"#: "σ", #"\phi"#: "φ", #"\omega"#: "ω", #"\Delta"#: "Δ",
-            #"\Sigma"#: "Σ", #"\Omega"#: "Ω", #"\infty"#: "∞", #"\sum"#: "∑",
-            #"\prod"#: "∏", #"\int"#: "∫", #"\sqrt"#: "√", #"\neq"#: "≠",
-            #"\leq"#: "≤", #"\geq"#: "≥", #"\rightarrow"#: "→", #"\leftarrow"#: "←",
-            #"\times"#: "×", #"\cdot"#: "·", #"\pm"#: "±"
-        ]
-        for (source, target) in replacements { output = output.replacingOccurrences(of: source, with: target) }
-        output = output.replacingOccurrences(of: #"\\frac\{([^{}]+)\}\{([^{}]+)\}"#, with: "($1)/($2)", options: .regularExpression)
-        output = output.replacingOccurrences(of: #"\\text\{([^{}]+)\}"#, with: "$1", options: .regularExpression)
-        output = output.replacingOccurrences(of: "$", with: "")
-        return output
+        TerminalMath.renderInlineText(input)
     }
 
     /// Labels common untyped fences so highlighting and artifact actions remain useful
     /// when a model omits the Markdown language hint.
     public static func inferredLanguage(for content: String) -> String {
         let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowercase = trimmed.lowercased()
         if trimmed.hasPrefix("diff --git ") || trimmed.contains("\n@@ ") { return "diff" }
-        if trimmed.hasPrefix("<!doctype html") || trimmed.hasPrefix("<html") { return "html" }
+        if lowercase.hasPrefix("<!doctype html") || lowercase.hasPrefix("<html") { return "html" }
         if (trimmed.hasPrefix("{") || trimmed.hasPrefix("[")),
            (try? JSONSerialization.jsonObject(with: Data(trimmed.utf8))) != nil { return "json" }
         if trimmed.hasPrefix("#!/") || trimmed.contains("\nset -e") { return "bash" }
         if trimmed.contains("func ") && (trimmed.contains("let ") || trimmed.contains("var ")) { return "swift" }
         if trimmed.contains("def ") && trimmed.contains(":") { return "python" }
         if trimmed.contains("const ") || trimmed.contains("function ") || trimmed.contains("=>") { return "javascript" }
+        if trimmed.contains("SELECT ") && trimmed.uppercased().contains(" FROM ") { return "sql" }
+        if trimmed.contains("apiVersion:") && trimmed.contains("kind:") { return "yaml" }
         return ""
     }
 
-    private func renderLine(_ raw: String) -> String {
-        let line = Self.latexFallback(raw)
-        if line.hasPrefix("### ") { return style(String(line.dropFirst(4)), "36") }
-        if line.hasPrefix("## ") { return style(String(line.dropFirst(3)), "1;36") }
-        if line.hasPrefix("# ") { return style(String(line.dropFirst(2)), "1;35") }
-        if line.hasPrefix("> ") { return style("│ " + String(line.dropFirst(2)), "2;36") }
-        if line.hasPrefix("@@") { return style(line, "36") }
-        if line.hasPrefix("+") && !line.hasPrefix("+++") { return style(line, "32") }
-        if line.hasPrefix("-") && !line.hasPrefix("---") { return style(line, "31") }
-        return inlineStyle(line)
+    private static func isLocalPath(_ value: String) -> Bool {
+        value.hasPrefix("/") || value.hasPrefix("~") || value.hasPrefix("./") || value.hasPrefix("../")
     }
 
-    private func renderCode(_ content: String, language: String) -> String {
-        let label = language.isEmpty ? "code" : language
-        let header = style("┌─ \(label)", "2;36")
-        let body = content.components(separatedBy: "\n").map { line in
-            "│ " + highlight(line, language: language)
-        }.joined(separator: "\n")
-        return "\(header)\n\(body)\n\(style("└─", "2;36"))"
-    }
-
-    private func highlight(_ line: String, language: String) -> String {
-        guard color else { return line }
-        let normalized = language.lowercased()
-        if ["diff", "patch"].contains(normalized) {
-            if line.hasPrefix("+") { return style(line, "32") }
-            if line.hasPrefix("-") { return style(line, "31") }
-            if line.hasPrefix("@@") { return style(line, "36") }
+    private static func sanitized(_ value: String) -> String {
+        var result = ""
+        result.reserveCapacity(value.count)
+        for scalar in value.unicodeScalars {
+            switch scalar.value {
+            case 0x09, 0x0A, 0x0D:
+                result.unicodeScalars.append(scalar)
+            case 0x00...0x08, 0x0B...0x0C, 0x0E...0x1F, 0x7F:
+                result.append("�")
+            default:
+                result.unicodeScalars.append(scalar)
+            }
         }
-        if ["swift", "js", "javascript", "ts", "typescript", "python", "py", "rust", "go", "c", "cpp", "java", "kotlin", "bash", "sh", "zsh"].contains(normalized) {
-            let keywordPattern = #"\b(func|let|var|struct|class|enum|actor|protocol|extension|import|return|if|else|for|while|switch|case|guard|try|await|async|throw|throws|public|private|internal|static|const|function|def|fn|use|package|interface|new|true|false|nil|null)\b"#
-            return replace(line, pattern: keywordPattern, code: "35")
-        }
-        if ["json", "yaml", "yml", "toml"].contains(normalized) {
-            return replace(line, pattern: #"("[^"\\]*(?:\\.[^"\\]*)*")\s*:"#, code: "36")
-        }
-        return line
-    }
-
-    private func inlineStyle(_ value: String) -> String {
-        guard color else { return value }
-        var result = replace(value, pattern: #"`([^`]+)`"#, code: "33")
-        result = replace(result, pattern: #"\*\*([^*]+)\*\*"#, code: "1")
         return result
     }
 
-    private func replace(_ input: String, pattern: String, code: String) -> String {
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return input }
-        let range = NSRange(input.startIndex..<input.endIndex, in: input)
-        return regex.stringByReplacingMatches(in: input, range: range, withTemplate: "\u{001B}[\(code)m$1\u{001B}[0m")
+    private static func plainText(_ markup: Markup) -> String {
+        if let text = markup as? Text { return text.string }
+        if let code = markup as? InlineCode { return code.code }
+        if let html = markup as? InlineHTML { return html.rawHTML }
+        if markup is SoftBreak { return " " }
+        if markup is LineBreak { return "\n" }
+        return markup.children.map(plainText).joined()
     }
 
     private func style(_ value: String, _ code: String) -> String {
-        color ? "\u{001B}[\(code)m\(value)\u{001B}[0m" : value
+        ansi ? "\u{001B}[\(code)m\(value)\u{001B}[0m" : value
+    }
+
+    private struct RenderContext {
+        let owner: TerminalMarkdownRenderer
+        let width: Int
+        let hyperlinks: Bool
+        var codeBlocks: [TUICodeBlock] = []
+
+        mutating func renderBlock(_ markup: Markup) -> String {
+            if markup is Document { return renderBlocks(markup.children) }
+            if let paragraph = markup as? Paragraph {
+                let raw = TerminalMarkdownRenderer.plainText(paragraph)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if raw.hasPrefix("$$"), raw.hasSuffix("$$"), raw.count >= 4 {
+                    let body = String(raw.dropFirst(2).dropLast(2))
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    return renderMathBlock(body)
+                }
+                return renderInlineChildren(paragraph)
+            }
+            if let heading = markup as? Heading {
+                let value = renderInlineChildren(heading)
+                switch heading.level {
+                case 1: return owner.style("▌ \(value)", owner.palette.heading1)
+                case 2: return owner.style("▸ \(value)", owner.palette.heading2)
+                default: return owner.style("• \(value)", owner.palette.heading3)
+                }
+            }
+            if let code = markup as? CodeBlock { return renderCodeBlock(code) }
+            if let quote = markup as? BlockQuote {
+                return renderBlocks(quote.children).split(separator: "\n", omittingEmptySubsequences: false)
+                    .map { owner.style("│", owner.palette.accent) + " " + $0 }.joined(separator: "\n")
+            }
+            if let list = markup as? OrderedList {
+                return renderList(list.children, start: Int(list.startIndex), ordered: true)
+            }
+            if let list = markup as? UnorderedList {
+                return renderList(list.children, start: 1, ordered: false)
+            }
+            if let table = markup as? Table { return renderTable(table) }
+            if markup is ThematicBreak {
+                return owner.style(String(repeating: "─", count: min(width, 72)), owner.palette.secondary)
+            }
+            if let html = markup as? HTMLBlock {
+                return renderPanel(html.rawHTML.trimmingCharacters(in: .newlines), label: "html")
+            }
+            return renderBlocks(markup.children)
+        }
+
+        private mutating func renderBlocks(_ children: MarkupChildren) -> String {
+            children.map { renderBlock($0) }.filter { !$0.isEmpty }.joined(separator: "\n\n")
+        }
+
+        private mutating func renderInlineChildren(_ markup: Markup) -> String {
+            markup.children.map { renderInline($0) }.joined()
+        }
+
+        private mutating func renderInline(_ markup: Markup) -> String {
+            if let text = markup as? Text { return TerminalMath.renderInlineText(text.string, style: mathStyle) }
+            if let code = markup as? InlineCode { return owner.style(" \(code.code) ", owner.palette.code) }
+            if markup is Strong { return owner.style(renderInlineChildren(markup), "1") }
+            if markup is Emphasis { return owner.style(renderInlineChildren(markup), "3") }
+            if markup is Strikethrough {
+                let value = renderInlineChildren(markup)
+                return owner.ansi ? owner.style(value, "9") : "~~\(value)~~"
+            }
+            if let link = markup as? Link {
+                let label = renderInlineChildren(link)
+                guard let destination = link.destination, !destination.isEmpty else { return label }
+                let safeDestination = destination.unicodeScalars.filter { $0.value >= 0x20 && $0.value != 0x7F }
+                    .map(String.init).joined()
+                let visible = label == safeDestination ? label : "\(label) \(owner.style("(\(safeDestination))", owner.palette.secondary))"
+                guard hyperlinks else { return visible }
+                return "\u{001B}]8;;\(safeDestination)\u{0007}\(visible)\u{001B}]8;;\u{0007}"
+            }
+            if let image = markup as? Image {
+                let alt = renderInlineChildren(image)
+                let source = image.source ?? ""
+                let label = alt.isEmpty ? "image" : alt
+                return owner.style("🖼 \(label)", owner.palette.accent) + (source.isEmpty ? "" : " (\(source))")
+            }
+            if let html = markup as? InlineHTML { return owner.style(html.rawHTML, owner.palette.warning) }
+            if markup is LineBreak { return "\n" }
+            if markup is SoftBreak { return " " }
+            return renderInlineChildren(markup)
+        }
+
+        private var mathStyle: (String) -> String { { owner.style($0, owner.palette.accent) } }
+
+        private mutating func renderMathBlock(_ source: String) -> String {
+            let math = TerminalMath.renderExpression(source)
+            let label = owner.style(" math ", owner.palette.accent)
+            let lines = math.split(separator: "\n", omittingEmptySubsequences: false).map {
+                owner.style("│", owner.palette.accent) + " " + owner.style(String($0), owner.palette.accent)
+            }.joined(separator: "\n")
+            return owner.style("┌─", owner.palette.accent) + label + "\n" + lines + "\n" + owner.style("└─", owner.palette.accent)
+        }
+
+        private mutating func renderList(_ children: MarkupChildren, start: Int, ordered: Bool) -> String {
+            var lines: [String] = []
+            for (offset, child) in children.enumerated() {
+                guard let item = child as? ListItem else { continue }
+                let checkbox: String
+                switch item.checkbox {
+                case .checked?: checkbox = owner.style("☑ ", owner.palette.addition)
+                case .unchecked?: checkbox = owner.style("☐ ", owner.palette.warning)
+                case nil: checkbox = ""
+                }
+                let marker = ordered ? "\(start + offset)." : "•"
+                let prefix = owner.style(marker, owner.palette.accent) + " " + checkbox
+                let continuation = String(repeating: " ", count: marker.count + 1)
+                let itemLines = renderBlocks(item.children).split(separator: "\n", omittingEmptySubsequences: false)
+                for (index, line) in itemLines.enumerated() {
+                    lines.append((index == 0 ? prefix : continuation) + String(line))
+                }
+            }
+            return lines.joined(separator: "\n")
+        }
+
+        private mutating func renderTable(_ table: Table) -> String {
+            let header = Array(table.head.cells.map { Self.normalizedCell($0) })
+            let body = Array(table.body.rows.map { row in
+                Array(row.cells.map { Self.normalizedCell($0) })
+            })
+            let columnCount = max(header.count, body.map(\.count).max() ?? 0)
+            guard columnCount > 0 else { return "" }
+            var widths = (0..<columnCount).map { column in
+                max(3, ([header] + body).compactMap { row in row.indices.contains(column) ? row[column].count : nil }.max() ?? 3)
+            }
+            let budget = max(columnCount * 3, width - (columnCount * 3 + 1))
+            while widths.reduce(0, +) > budget,
+                  let index = widths.indices.max(by: { widths[$0] < widths[$1] }), widths[index] > 3 {
+                widths[index] -= 1
+            }
+            let alignments = table.columnAlignments
+            var rows = [owner.style(tableRule("┌", "┬", "┐", widths), owner.palette.secondary)]
+            rows.append(tableRow(header, widths: widths, alignments: alignments, header: true))
+            rows.append(owner.style(tableRule("├", "┼", "┤", widths), owner.palette.secondary))
+            rows.append(contentsOf: body.map { tableRow($0, widths: widths, alignments: alignments, header: false) })
+            rows.append(owner.style(tableRule("└", "┴", "┘", widths), owner.palette.secondary))
+            return rows.joined(separator: "\n")
+        }
+
+        private static func normalizedCell(_ cell: Table.Cell) -> String {
+            TerminalMarkdownRenderer.latexFallback(TerminalMarkdownRenderer.plainText(cell))
+                .replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces)
+        }
+
+        private func tableRule(_ left: String, _ middle: String, _ right: String, _ widths: [Int]) -> String {
+            left + widths.map { String(repeating: "─", count: $0 + 2) }.joined(separator: middle) + right
+        }
+
+        private func tableRow(_ cells: [String], widths: [Int], alignments: [Table.ColumnAlignment?], header: Bool) -> String {
+            let values = widths.indices.map { column -> String in
+                let raw = cells.indices.contains(column) ? cells[column] : ""
+                let clipped = raw.count > widths[column] ? String(raw.prefix(max(1, widths[column] - 1))) + "…" : raw
+                let missing = max(0, widths[column] - clipped.count)
+                let aligned: String
+                switch alignments.indices.contains(column) ? alignments[column] : nil {
+                case .right?: aligned = String(repeating: " ", count: missing) + clipped
+                case .center?:
+                    let left = missing / 2
+                    aligned = String(repeating: " ", count: left) + clipped + String(repeating: " ", count: missing - left)
+                default: aligned = clipped + String(repeating: " ", count: missing)
+                }
+                return header ? owner.style(aligned, "1") : aligned
+            }
+            return owner.style("│", owner.palette.secondary) + " " + values.joined(
+                separator: " " + owner.style("│", owner.palette.secondary) + " "
+            ) + " " + owner.style("│", owner.palette.secondary)
+        }
+
+        private mutating func renderCodeBlock(_ block: CodeBlock) -> String {
+            let content = block.code.hasSuffix("\n") ? String(block.code.dropLast()) : block.code
+            let declared = block.language?.split(whereSeparator: \.isWhitespace).first.map(String.init)?.lowercased() ?? ""
+            let language = declared.isEmpty ? TerminalMarkdownRenderer.inferredLanguage(for: content) : declared
+            codeBlocks.append(TUICodeBlock(language: language, content: content))
+            return renderPanel(content, label: language.isEmpty ? "code" : language)
+        }
+
+        private func renderPanel(_ content: String, label: String) -> String {
+            let sourceLines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            let digits = max(1, String(sourceLines.count).count)
+            let header = owner.style("┌─", owner.palette.secondary) + owner.style(" \(label) ", owner.palette.accent)
+            let lines = sourceLines.enumerated().map { index, line in
+                let number = String(format: "%\(digits)d", index + 1)
+                return owner.style("│ \(number) │", owner.palette.secondary) + " " + highlight(line, language: label)
+            }
+            let footer = owner.style("└" + String(repeating: "─", count: min(max(8, label.count + 4), width - 1)), owner.palette.secondary)
+            return ([header] + lines + [footer]).joined(separator: "\n")
+        }
+
+        private func highlight(_ line: String, language: String) -> String {
+            guard owner.ansi else { return line }
+            let language = language.lowercased()
+            if ["diff", "patch"].contains(language) {
+                if line.hasPrefix("diff --git") || line.hasPrefix("---") || line.hasPrefix("+++") {
+                    return owner.style(line, "1;" + owner.palette.accent)
+                }
+                if line.hasPrefix("@@") { return owner.style(line, owner.palette.accent) }
+                if line.hasPrefix("+") { return owner.style(line, owner.palette.addition) }
+                if line.hasPrefix("-") { return owner.style(line, owner.palette.deletion) }
+                return owner.style(line, owner.palette.secondary)
+            }
+            if ["html", "xml", "svg"].contains(language) { return highlightMarkup(line) }
+
+            let keywords: Set<String> = [
+                "actor", "as", "async", "await", "break", "case", "catch", "class", "const", "continue",
+                "def", "defer", "do", "else", "enum", "export", "extension", "false", "final", "fn", "for",
+                "from", "func", "function", "guard", "if", "import", "in", "interface", "internal", "let", "mut",
+                "new", "nil", "null", "package", "private", "protocol", "public", "repeat", "return", "self",
+                "static", "struct", "switch", "throw", "throws", "true", "try", "typealias", "use", "var", "while", "yield"
+            ]
+            let hashComments = ["bash", "sh", "zsh", "python", "py", "ruby", "yaml", "yml", "toml"].contains(language)
+            let dashComments = ["sql", "lua", "haskell"].contains(language)
+            let characters = Array(line)
+            var output = ""
+            var index = 0
+            while index < characters.count {
+                if index + 1 < characters.count,
+                   (String(characters[index...index + 1]) == "//" || (dashComments && String(characters[index...index + 1]) == "--")) {
+                    output += owner.style(String(characters[index...]), owner.palette.comment); break
+                }
+                if hashComments && characters[index] == "#" {
+                    output += owner.style(String(characters[index...]), owner.palette.comment); break
+                }
+                if characters[index] == "\"" || characters[index] == "'" || characters[index] == "`" {
+                    let quote = characters[index]
+                    var end = index + 1
+                    var escaped = false
+                    while end < characters.count {
+                        let value = characters[end]
+                        if value == quote && !escaped { end += 1; break }
+                        escaped = value == "\\" && !escaped
+                        if value != "\\" { escaped = false }
+                        end += 1
+                    }
+                    output += owner.style(String(characters[index..<min(end, characters.count)]), owner.palette.string)
+                    index = end; continue
+                }
+                if characters[index].isNumber {
+                    var end = index + 1
+                    while end < characters.count && (characters[end].isNumber || ".xabcdefABCDEF_".contains(characters[end])) { end += 1 }
+                    output += owner.style(String(characters[index..<end]), owner.palette.number)
+                    index = end; continue
+                }
+                if characters[index].isLetter || characters[index] == "_" {
+                    var end = index + 1
+                    while end < characters.count && (characters[end].isLetter || characters[end].isNumber || characters[end] == "_") { end += 1 }
+                    let word = String(characters[index..<end])
+                    let next = characters.dropFirst(end).first { !$0.isWhitespace }
+                    if keywords.contains(word) { output += owner.style(word, owner.palette.keyword) }
+                    else if word.first?.isUppercase == true { output += owner.style(word, owner.palette.type) }
+                    else if next == "(" { output += owner.style(word, owner.palette.accent) }
+                    else { output += word }
+                    index = end; continue
+                }
+                output.append(characters[index]); index += 1
+            }
+            return output
+        }
+
+        private func highlightMarkup(_ line: String) -> String {
+            let characters = Array(line)
+            var output = ""
+            var index = 0
+            while index < characters.count {
+                if index + 3 < characters.count, String(characters[index...index + 3]) == "<!--" {
+                    output += owner.style(String(characters[index...]), owner.palette.comment); break
+                }
+                if characters[index] == "<", let end = characters[index...].firstIndex(of: ">") {
+                    output += owner.style(String(characters[index...end]), owner.palette.keyword)
+                    index = end + 1
+                } else {
+                    output.append(characters[index]); index += 1
+                }
+            }
+            return output
+        }
+    }
+}
+
+private enum TerminalMath {
+    private static let commandSymbols: [String: String] = [
+        "alpha": "α", "beta": "β", "gamma": "γ", "delta": "δ", "epsilon": "ε", "theta": "θ",
+        "lambda": "λ", "mu": "μ", "pi": "π", "rho": "ρ", "sigma": "σ", "phi": "φ", "psi": "ψ",
+        "omega": "ω", "Gamma": "Γ", "Delta": "Δ", "Theta": "Θ", "Lambda": "Λ", "Pi": "Π",
+        "Sigma": "Σ", "Phi": "Φ", "Psi": "Ψ", "Omega": "Ω", "infty": "∞", "sum": "∑",
+        "prod": "∏", "int": "∫", "oint": "∮", "partial": "∂", "nabla": "∇", "neq": "≠",
+        "le": "≤", "leq": "≤", "ge": "≥", "geq": "≥", "approx": "≈", "equiv": "≡",
+        "propto": "∝", "rightarrow": "→", "to": "→", "leftarrow": "←", "Rightarrow": "⇒",
+        "Leftarrow": "⇐", "leftrightarrow": "↔", "times": "×", "cdot": "·", "pm": "±", "mp": "∓",
+        "div": "÷", "forall": "∀", "exists": "∃", "in": "∈", "notin": "∉", "subset": "⊂",
+        "subseteq": "⊆", "supset": "⊃", "supseteq": "⊇", "cup": "∪", "cap": "∩", "land": "∧", "lor": "∨"
+    ]
+    private static let superscripts: [Character: Character] = [
+        "0": "⁰", "1": "¹", "2": "²", "3": "³", "4": "⁴", "5": "⁵", "6": "⁶", "7": "⁷",
+        "8": "⁸", "9": "⁹", "+": "⁺", "-": "⁻", "=": "⁼", "(": "⁽", ")": "⁾", "n": "ⁿ", "i": "ⁱ"
+    ]
+    private static let subscripts: [Character: Character] = [
+        "0": "₀", "1": "₁", "2": "₂", "3": "₃", "4": "₄", "5": "₅", "6": "₆", "7": "₇",
+        "8": "₈", "9": "₉", "+": "₊", "-": "₋", "=": "₌", "(": "₍", ")": "₎", "a": "ₐ",
+        "e": "ₑ", "h": "ₕ", "i": "ᵢ", "j": "ⱼ", "k": "ₖ", "l": "ₗ", "m": "ₘ", "n": "ₙ",
+        "o": "ₒ", "p": "ₚ", "r": "ᵣ", "s": "ₛ", "t": "ₜ", "x": "ₓ"
+    ]
+
+    static func renderInlineText(_ input: String, style: (String) -> String = { $0 }) -> String {
+        let characters = Array(input)
+        var result = ""
+        var index = 0
+        while index < characters.count {
+            if characters[index] == "\\", index + 1 < characters.count, characters[index + 1] == "$" {
+                result.append("$"); index += 2; continue
+            }
+            guard characters[index] == "$", index + 1 < characters.count,
+                  characters[index + 1] != "$", !characters[index + 1].isWhitespace else {
+                result.append(characters[index]); index += 1; continue
+            }
+            var closing = index + 1
+            var found: Int?
+            while closing < characters.count {
+                if characters[closing] == "$", characters[closing - 1] != "\\" {
+                    let previousIsContent = !characters[closing - 1].isWhitespace
+                    let nextIsBoundary = closing + 1 == characters.count || characters[closing + 1].isWhitespace || ".,;:!?)]}".contains(characters[closing + 1])
+                    if previousIsContent && nextIsBoundary { found = closing }
+                    break
+                }
+                closing += 1
+            }
+            guard let end = found else { result.append("$"); index += 1; continue }
+            result += style(renderExpression(String(characters[(index + 1)..<end])))
+            index = end + 1
+        }
+        return result
+    }
+
+    static func renderExpression(_ source: String) -> String {
+        if let matrix = renderMatrix(source) { return matrix }
+        var parser = Parser(Array(source))
+        return parser.parse(until: nil).replacingOccurrences(of: "  ", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func renderMatrix(_ source: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: #"\\begin\{(bmatrix|pmatrix|matrix|cases)\}([\s\S]*?)\\end\{\1\}"#) else { return nil }
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        guard let match = regex.firstMatch(in: source, range: range),
+              let environmentRange = Range(match.range(at: 1), in: source),
+              let bodyRange = Range(match.range(at: 2), in: source) else { return nil }
+        let environment = String(source[environmentRange])
+        let cells = String(source[bodyRange]).components(separatedBy: "\\\\").map { row in
+            row.split(separator: "&", omittingEmptySubsequences: false).map { renderExpression(String($0)) }
+        }
+        let columns = cells.map(\.count).max() ?? 0
+        let widths = (0..<columns).map { column in cells.compactMap { $0.indices.contains(column) ? $0[column].count : nil }.max() ?? 0 }
+        return cells.enumerated().map { rowIndex, row in
+            let body = widths.indices.map { column -> String in
+                let value = row.indices.contains(column) ? row[column] : ""
+                return value + String(repeating: " ", count: max(0, widths[column] - value.count))
+            }.joined(separator: "  ")
+            switch environment {
+            case "bmatrix": return "[ \(body) ]"
+            case "pmatrix": return "( \(body) )"
+            case "cases": return (rowIndex == 0 ? "⎧ " : rowIndex == cells.count - 1 ? "⎩ " : "⎨ ") + body
+            default: return "│ \(body) │"
+            }
+        }.joined(separator: "\n")
+    }
+
+    private struct Parser {
+        let characters: [Character]
+        var index = 0
+
+        init(_ characters: [Character]) { self.characters = characters }
+
+        mutating func parse(until terminator: Character?) -> String {
+            var output = ""
+            while index < characters.count {
+                let character = characters[index]
+                if let terminator, character == terminator { index += 1; break }
+                if character == "\\" { output += parseCommand(); continue }
+                if character == "^" || character == "_" {
+                    index += 1
+                    let argument = parseArgument()
+                    let map = character == "^" ? TerminalMath.superscripts : TerminalMath.subscripts
+                    output += argument.allSatisfy({ map[$0] != nil })
+                        ? String(argument.compactMap { map[$0] })
+                        : (character == "^" ? "^(\(argument))" : "_(\(argument))")
+                    continue
+                }
+                if character == "{" { index += 1; output += parse(until: "}"); continue }
+                if character == "}" && terminator == nil { index += 1; continue }
+                if character == "~" { output.append(" "); index += 1; continue }
+                output.append(character); index += 1
+            }
+            return output
+        }
+
+        private mutating func parseCommand() -> String {
+            index += 1
+            guard index < characters.count else { return "\\" }
+            if characters[index] == "\\" { index += 1; return "\n" }
+            let start = index
+            while index < characters.count && characters[index].isLetter { index += 1 }
+            if start == index { let value = characters[index]; index += 1; return String(value) }
+            let name = String(characters[start..<index])
+            if let symbol = TerminalMath.commandSymbols[name] { return symbol }
+            if name == "frac" { return "(\(parseArgument()))/(\(parseArgument()))" }
+            if name == "sqrt" {
+                if index < characters.count, characters[index] == "[" {
+                    while index < characters.count && characters[index] != "]" { index += 1 }
+                    if index < characters.count { index += 1 }
+                }
+                return "√(\(parseArgument()))"
+            }
+            if ["text", "textrm", "textbf", "mathrm", "mathbf", "operatorname", "overline", "underline"].contains(name) {
+                return parseArgument()
+            }
+            if ["left", "right"].contains(name) { return "" }
+            if [",", ";", "quad", "qquad"].contains(name) { return " " }
+            return "\\\(name)"
+        }
+
+        private mutating func parseArgument() -> String {
+            while index < characters.count && characters[index].isWhitespace { index += 1 }
+            guard index < characters.count else { return "" }
+            if characters[index] == "{" { index += 1; return parse(until: "}") }
+            let value = characters[index]; index += 1; return String(value)
+        }
     }
 }

--- a/Sources/AFMTerminalUI/MarkdownRenderer.swift
+++ b/Sources/AFMTerminalUI/MarkdownRenderer.swift
@@ -428,17 +428,79 @@ public struct TerminalMarkdownRenderer: Sendable {
 
         private func renderPanel(_ content: String, label: String) -> String {
             let sourceLines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            let highlightedLines = syntaxHighlightedLines(content, language: label) ??
+                sourceLines.map { highlightFallback($0, language: label) }
             let digits = max(1, String(sourceLines.count).count)
             let header = owner.style("┌─", owner.palette.secondary) + owner.style(" \(label) ", owner.palette.accent)
             let lines = sourceLines.enumerated().map { index, line in
                 let number = String(format: "%\(digits)d", index + 1)
-                return owner.style("│ \(number) │", owner.palette.secondary) + " " + highlight(line, language: label)
+                return owner.style("│ \(number) │", owner.palette.secondary) + " " + highlightedLines[index]
             }
             let footer = owner.style("└" + String(repeating: "─", count: min(max(8, label.count + 4), width - 1)), owner.palette.secondary)
             return ([header] + lines + [footer]).joined(separator: "\n")
         }
 
-        private func highlight(_ line: String, language: String) -> String {
+        private func syntaxHighlightedLines(_ content: String, language: String) -> [String]? {
+            guard owner.ansi,
+                  let tokens = TreeSitterSyntaxHighlighter.tokens(in: content, language: language) else {
+                return nil
+            }
+            let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            var location = 0
+            return lines.map { line in
+                let lineLength = (line as NSString).length
+                let lineRange = NSRange(location: location, length: lineLength)
+                let relevant = tokens.compactMap { token -> TUISyntaxToken? in
+                    let intersection = NSIntersectionRange(token.range, lineRange)
+                    guard intersection.length > 0 else { return nil }
+                    return TUISyntaxToken(
+                        range: NSRange(location: intersection.location - location, length: intersection.length),
+                        kind: token.kind
+                    )
+                }.sorted { $0.range.location < $1.range.location }
+                let lineNSString = line as NSString
+                var output = ""
+                var cursor = 0
+                for token in relevant where token.range.location >= cursor {
+                    if token.range.location > cursor {
+                        output += lineNSString.substring(with: NSRange(
+                            location: cursor,
+                            length: token.range.location - cursor
+                        ))
+                    }
+                    output += syntaxStyle(
+                        lineNSString.substring(with: token.range),
+                        kind: token.kind
+                    )
+                    cursor = NSMaxRange(token.range)
+                }
+                if cursor < lineLength {
+                    output += lineNSString.substring(from: cursor)
+                }
+                location += lineLength + 1
+                return output
+            }
+        }
+
+        private func syntaxStyle(_ value: String, kind: TUISyntaxKind) -> String {
+            switch kind {
+            case .comment: owner.style(value, owner.palette.comment)
+            case .string: owner.style(value, owner.palette.string)
+            case .number: owner.style(value, owner.palette.number)
+            case .keyword: owner.style(value, owner.palette.keyword)
+            case .type: owner.style(value, owner.palette.type)
+            case .function: owner.style(value, owner.palette.accent)
+            case .attribute: owner.style(value, owner.palette.code)
+            case .operator: owner.style(value, owner.palette.accent)
+            case .addition: owner.style(value, owner.palette.string)
+            case .deletion: owner.style(value, owner.palette.number)
+            case .metadata: owner.style(value, owner.palette.accent)
+            }
+        }
+
+        /// Unknown fence labels retain a safe lightweight lexer rather than losing
+        /// all readability. Registered languages never use this path in normal builds.
+        private func highlightFallback(_ line: String, language: String) -> String {
             guard owner.ansi else { return line }
             let language = language.lowercased()
             if ["diff", "patch"].contains(language) {

--- a/Sources/AFMTerminalUI/MarkdownRenderer.swift
+++ b/Sources/AFMTerminalUI/MarkdownRenderer.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+public struct TUICodeBlock: Equatable, Sendable {
+    public let language: String
+    public let content: String
+
+    public init(language: String, content: String) {
+        self.language = language
+        self.content = content
+    }
+}
+
+public struct TUIImageReference: Equatable, Sendable {
+    public let alt: String
+    public let path: String
+
+    public init(alt: String, path: String) {
+        self.alt = alt
+        self.path = path
+    }
+}
+
+public struct MarkdownRenderResult: Equatable, Sendable {
+    public let text: String
+    public let codeBlocks: [TUICodeBlock]
+    public let images: [TUIImageReference]
+}
+
+/// A deliberately small terminal renderer. It never evaluates Markdown/HTML or model output.
+/// Its output is ANSI text only when color is enabled, which keeps redirected transcripts clean.
+public struct TerminalMarkdownRenderer: Sendable {
+    public enum Theme: String, CaseIterable, Sendable {
+        case auto, dark, light, mono
+    }
+
+    private let color: Bool
+    private let theme: Theme
+
+    public init(color: Bool, theme: Theme = .auto) {
+        self.color = color && theme != .mono
+        self.theme = theme
+    }
+
+    public func render(_ markdown: String) -> MarkdownRenderResult {
+        let normalized = markdown.replacingOccurrences(of: "\r\n", with: "\n")
+        var rendered: [String] = []
+        var blocks: [TUICodeBlock] = []
+        var images: [TUIImageReference] = []
+        var language: String?
+        var code: [String] = []
+
+        for rawLine in normalized.components(separatedBy: "\n") {
+            if rawLine.hasPrefix("```") {
+                if let activeLanguage = language {
+                    let content = code.joined(separator: "\n")
+                    let effectiveLanguage = activeLanguage.isEmpty ? Self.inferredLanguage(for: content) : activeLanguage
+                    blocks.append(TUICodeBlock(language: effectiveLanguage, content: content))
+                    rendered.append(renderCode(content, language: effectiveLanguage))
+                    language = nil
+                    code = []
+                } else {
+                    language = String(rawLine.dropFirst(3))
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .lowercased()
+                }
+                continue
+            }
+            if language != nil {
+                code.append(rawLine)
+                continue
+            }
+
+            images.append(contentsOf: Self.imageReferences(in: rawLine))
+            rendered.append(renderLine(rawLine))
+        }
+
+        // Be forgiving of a model that forgot the closing fence.
+        if let activeLanguage = language {
+            let content = code.joined(separator: "\n")
+            let effectiveLanguage = activeLanguage.isEmpty ? Self.inferredLanguage(for: content) : activeLanguage
+            blocks.append(TUICodeBlock(language: effectiveLanguage, content: content))
+            rendered.append(renderCode(content, language: effectiveLanguage))
+        }
+        return MarkdownRenderResult(text: rendered.joined(separator: "\n"), codeBlocks: blocks, images: images)
+    }
+
+    public static func imageReferences(in text: String) -> [TUIImageReference] {
+        let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let markdownRegex = try? NSRegularExpression(pattern: #"!\[([^\]]*)\]\(([^)]+)\)"#) else { return [] }
+        var results = markdownRegex.matches(in: text, range: nsRange).compactMap { match -> TUIImageReference? in
+            guard let altRange = Range(match.range(at: 1), in: text),
+                  let pathRange = Range(match.range(at: 2), in: text) else { return nil }
+            let path = String(text[pathRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard path.hasPrefix("/") || path.hasPrefix("~") || path.hasPrefix("./") else { return nil }
+            return TUIImageReference(alt: String(text[altRange]), path: path)
+        }
+        if let plainRegex = try? NSRegularExpression(
+            pattern: #"(?:^|\s)((?:~|\.\.?/|/)[^\s<>\"']+\.(?:png|jpe?g|gif|webp|heic))\b"#,
+            options: [.caseInsensitive]
+        ) {
+            for match in plainRegex.matches(in: text, range: nsRange) {
+                guard let pathRange = Range(match.range(at: 1), in: text) else { continue }
+                let path = String(text[pathRange])
+                if !results.contains(where: { $0.path == path }) {
+                    results.append(TUIImageReference(alt: URL(fileURLWithPath: path).lastPathComponent, path: path))
+                }
+            }
+        }
+        return results
+    }
+
+    public static func latexFallback(_ input: String) -> String {
+        var output = input
+        let replacements = [
+            #"\alpha"#: "α", #"\beta"#: "β", #"\gamma"#: "γ", #"\delta"#: "δ",
+            #"\theta"#: "θ", #"\lambda"#: "λ", #"\mu"#: "μ", #"\pi"#: "π",
+            #"\sigma"#: "σ", #"\phi"#: "φ", #"\omega"#: "ω", #"\Delta"#: "Δ",
+            #"\Sigma"#: "Σ", #"\Omega"#: "Ω", #"\infty"#: "∞", #"\sum"#: "∑",
+            #"\prod"#: "∏", #"\int"#: "∫", #"\sqrt"#: "√", #"\neq"#: "≠",
+            #"\leq"#: "≤", #"\geq"#: "≥", #"\rightarrow"#: "→", #"\leftarrow"#: "←",
+            #"\times"#: "×", #"\cdot"#: "·", #"\pm"#: "±"
+        ]
+        for (source, target) in replacements { output = output.replacingOccurrences(of: source, with: target) }
+        output = output.replacingOccurrences(of: #"\\frac\{([^{}]+)\}\{([^{}]+)\}"#, with: "($1)/($2)", options: .regularExpression)
+        output = output.replacingOccurrences(of: #"\\text\{([^{}]+)\}"#, with: "$1", options: .regularExpression)
+        output = output.replacingOccurrences(of: "$", with: "")
+        return output
+    }
+
+    /// Labels common untyped fences so highlighting and artifact actions remain useful
+    /// when a model omits the Markdown language hint.
+    public static func inferredLanguage(for content: String) -> String {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("diff --git ") || trimmed.contains("\n@@ ") { return "diff" }
+        if trimmed.hasPrefix("<!doctype html") || trimmed.hasPrefix("<html") { return "html" }
+        if (trimmed.hasPrefix("{") || trimmed.hasPrefix("[")),
+           (try? JSONSerialization.jsonObject(with: Data(trimmed.utf8))) != nil { return "json" }
+        if trimmed.hasPrefix("#!/") || trimmed.contains("\nset -e") { return "bash" }
+        if trimmed.contains("func ") && (trimmed.contains("let ") || trimmed.contains("var ")) { return "swift" }
+        if trimmed.contains("def ") && trimmed.contains(":") { return "python" }
+        if trimmed.contains("const ") || trimmed.contains("function ") || trimmed.contains("=>") { return "javascript" }
+        return ""
+    }
+
+    private func renderLine(_ raw: String) -> String {
+        let line = Self.latexFallback(raw)
+        if line.hasPrefix("### ") { return style(String(line.dropFirst(4)), "36") }
+        if line.hasPrefix("## ") { return style(String(line.dropFirst(3)), "1;36") }
+        if line.hasPrefix("# ") { return style(String(line.dropFirst(2)), "1;35") }
+        if line.hasPrefix("> ") { return style("│ " + String(line.dropFirst(2)), "2;36") }
+        if line.hasPrefix("@@") { return style(line, "36") }
+        if line.hasPrefix("+") && !line.hasPrefix("+++") { return style(line, "32") }
+        if line.hasPrefix("-") && !line.hasPrefix("---") { return style(line, "31") }
+        return inlineStyle(line)
+    }
+
+    private func renderCode(_ content: String, language: String) -> String {
+        let label = language.isEmpty ? "code" : language
+        let header = style("┌─ \(label)", "2;36")
+        let body = content.components(separatedBy: "\n").map { line in
+            "│ " + highlight(line, language: language)
+        }.joined(separator: "\n")
+        return "\(header)\n\(body)\n\(style("└─", "2;36"))"
+    }
+
+    private func highlight(_ line: String, language: String) -> String {
+        guard color else { return line }
+        let normalized = language.lowercased()
+        if ["diff", "patch"].contains(normalized) {
+            if line.hasPrefix("+") { return style(line, "32") }
+            if line.hasPrefix("-") { return style(line, "31") }
+            if line.hasPrefix("@@") { return style(line, "36") }
+        }
+        if ["swift", "js", "javascript", "ts", "typescript", "python", "py", "rust", "go", "c", "cpp", "java", "kotlin", "bash", "sh", "zsh"].contains(normalized) {
+            let keywordPattern = #"\b(func|let|var|struct|class|enum|actor|protocol|extension|import|return|if|else|for|while|switch|case|guard|try|await|async|throw|throws|public|private|internal|static|const|function|def|fn|use|package|interface|new|true|false|nil|null)\b"#
+            return replace(line, pattern: keywordPattern, code: "35")
+        }
+        if ["json", "yaml", "yml", "toml"].contains(normalized) {
+            return replace(line, pattern: #"("[^"\\]*(?:\\.[^"\\]*)*")\s*:"#, code: "36")
+        }
+        return line
+    }
+
+    private func inlineStyle(_ value: String) -> String {
+        guard color else { return value }
+        var result = replace(value, pattern: #"`([^`]+)`"#, code: "33")
+        result = replace(result, pattern: #"\*\*([^*]+)\*\*"#, code: "1")
+        return result
+    }
+
+    private func replace(_ input: String, pattern: String, code: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return input }
+        let range = NSRange(input.startIndex..<input.endIndex, in: input)
+        return regex.stringByReplacingMatches(in: input, range: range, withTemplate: "\u{001B}[\(code)m$1\u{001B}[0m")
+    }
+
+    private func style(_ value: String, _ code: String) -> String {
+        color ? "\u{001B}[\(code)m\(value)\u{001B}[0m" : value
+    }
+}

--- a/Sources/AFMTerminalUI/SessionStore.swift
+++ b/Sources/AFMTerminalUI/SessionStore.swift
@@ -9,6 +9,9 @@ public struct TUISession: Codable, Sendable {
     public var createdAt: Date
     public var updatedAt: Date
     public var messages: [Message]
+    /// Reasoning is UI metadata rather than part of the OpenAI request message. Keys are
+    /// message indexes encoded as strings so older session files remain decodable.
+    public var reasoningByMessage: [String: String]
 
     public init(
         id: UUID = UUID(),
@@ -17,7 +20,8 @@ public struct TUISession: Codable, Sendable {
         model: String,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
-        messages: [Message] = []
+        messages: [Message] = [],
+        reasoningByMessage: [String: String] = [:]
     ) {
         self.id = id
         self.title = title
@@ -26,6 +30,27 @@ public struct TUISession: Codable, Sendable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.messages = messages
+        self.reasoningByMessage = reasoningByMessage
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, backend, model, createdAt, updatedAt, messages, reasoningByMessage
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        id = try values.decode(UUID.self, forKey: .id)
+        title = try values.decode(String.self, forKey: .title)
+        backend = try values.decode(String.self, forKey: .backend)
+        model = try values.decode(String.self, forKey: .model)
+        createdAt = try values.decode(Date.self, forKey: .createdAt)
+        updatedAt = try values.decode(Date.self, forKey: .updatedAt)
+        messages = try values.decode([Message].self, forKey: .messages)
+        reasoningByMessage = try values.decodeIfPresent([String: String].self, forKey: .reasoningByMessage) ?? [:]
+    }
+
+    public func reasoning(atMessageIndex index: Int) -> String? {
+        reasoningByMessage[String(index)]
     }
 }
 
@@ -85,8 +110,11 @@ public final class TUISessionStore: @unchecked Sendable {
     public func exportMarkdown(_ session: TUISession, to url: URL, overwrite: Bool = false) throws {
         var markdown = "# \(session.title)\n\n"
         markdown += "- Backend: \(session.backend)\n- Model: \(session.model)\n- Updated: \(ISO8601DateFormatter().string(from: session.updatedAt))\n\n"
-        for message in session.messages {
+        for (index, message) in session.messages.enumerated() {
             markdown += "## \(message.role.capitalized)\n\n\(message.textContent)\n\n"
+            if let reasoning = session.reasoning(atMessageIndex: index), !reasoning.isEmpty {
+                markdown += "<details><summary>Reasoning</summary>\n\n\(reasoning)\n\n</details>\n\n"
+            }
         }
         try TUIArtifactActions.save(Data(markdown.utf8), to: url, overwrite: overwrite)
     }
@@ -105,7 +133,8 @@ public final class TUISessionStore: @unchecked Sendable {
             guard let lowered, !lowered.isEmpty else {
                 return TUISessionSummary(id: session.id, title: session.title, updatedAt: session.updatedAt, matchingSnippet: nil)
             }
-            let matching = session.messages.map(\.textContent).first { $0.lowercased().contains(lowered) }
+            let matching = (session.messages.map(\.textContent) + Array(session.reasoningByMessage.values))
+                .first { $0.lowercased().contains(lowered) }
             guard session.title.lowercased().contains(lowered) || matching != nil else { return nil }
             return TUISessionSummary(id: session.id, title: session.title, updatedAt: session.updatedAt, matchingSnippet: matching)
         }.sorted { $0.updatedAt > $1.updatedAt }

--- a/Sources/AFMTerminalUI/SessionStore.swift
+++ b/Sources/AFMTerminalUI/SessionStore.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import AFMOpenAICompat
 
@@ -89,15 +90,33 @@ public struct TUISessionSummary: Equatable, Sendable {
     public let matchingSnippet: String?
 }
 
+public enum TUISessionStoreError: Error, LocalizedError, Equatable {
+    case sessionTooLarge(maximumBytes: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .sessionTooLarge(let maximumBytes):
+            return "Session exceeds the \(maximumBytes)-byte save/load limit."
+        }
+    }
+}
+
 public final class TUISessionStore: @unchecked Sendable {
-    private static let maximumSessionBytes = 10_000_000
+    public static let defaultMaximumSessionBytes = 32_000_000
     public let directory: URL
     private let fileManager: FileManager
+    private let maximumSessionBytes: Int
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
+    private let lock = NSLock()
 
-    public init(directory: URL? = nil, fileManager: FileManager = .default) {
+    public init(
+        directory: URL? = nil,
+        fileManager: FileManager = .default,
+        maximumSessionBytes: Int = TUISessionStore.defaultMaximumSessionBytes
+    ) {
         self.fileManager = fileManager
+        self.maximumSessionBytes = max(0, maximumSessionBytes)
         if let directory {
             self.directory = directory
         } else {
@@ -113,30 +132,98 @@ public final class TUISessionStore: @unchecked Sendable {
 
     @discardableResult
     public func save(_ session: TUISession) throws -> URL {
+        lock.lock()
+        defer { lock.unlock() }
         try ensureDirectory()
         let target = url(for: session.id)
-        let temporary = directory.appendingPathComponent(".\(session.id.uuidString).tmp")
+        let temporary = directory.appendingPathComponent(
+            ".\(session.id.uuidString).\(UUID().uuidString).tmp"
+        )
+        defer { try? fileManager.removeItem(at: temporary) }
         let data = try encoder.encode(session)
-        try data.write(to: temporary, options: .atomic)
-        if fileManager.fileExists(atPath: target.path) { try fileManager.removeItem(at: target) }
-        try fileManager.moveItem(at: temporary, to: target)
-        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: target.path)
+        guard data.count <= maximumSessionBytes else {
+            throw TUISessionStoreError.sessionTooLarge(maximumBytes: maximumSessionBytes)
+        }
+        try TUIArtifactActions.save(data, to: temporary)
+        try fileManager.setAttributes(
+            [.posixPermissions: 0o600, .modificationDate: session.updatedAt],
+            ofItemAtPath: temporary.path
+        )
+        guard Darwin.rename(temporary.path, target.path) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
         return target
     }
 
     public func load(id: UUID) throws -> TUISession {
-        try decoder.decode(
+        lock.lock()
+        defer { lock.unlock() }
+        return try decoder.decode(
             TUISession.self,
-            from: TUIArtifactActions.readRegularFile(at: url(for: id), maximumBytes: Self.maximumSessionBytes)
+            from: TUIArtifactActions.readRegularFile(at: url(for: id), maximumBytes: maximumSessionBytes)
         )
     }
 
     public func recent(limit: Int = 20) throws -> [TUISessionSummary] {
-        Array(try summaries(query: nil).prefix(max(0, limit)))
+        lock.lock()
+        defer { lock.unlock() }
+        let limit = max(0, limit)
+        guard limit > 0 else { return [] }
+
+        var candidates: [SessionFile] = []
+        try forEachSessionURL { url in
+            let values = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+            candidates.append(SessionFile(
+                url: url,
+                modificationDate: values?.contentModificationDate ?? .distantPast
+            ))
+            candidates.sort { $0.modificationDate > $1.modificationDate }
+            if candidates.count > limit { candidates.removeLast(candidates.count - limit) }
+        }
+
+        return candidates.compactMap { candidate in
+            guard let metadata = try? decoder.decode(
+                SessionMetadata.self,
+                from: TUIArtifactActions.readRegularFile(
+                    at: candidate.url,
+                    maximumBytes: maximumSessionBytes
+                )
+            ) else { return nil }
+            return TUISessionSummary(
+                id: metadata.id,
+                title: metadata.title,
+                updatedAt: metadata.updatedAt,
+                matchingSnippet: nil
+            )
+        }
     }
 
     public func search(_ query: String, limit: Int = 20) throws -> [TUISessionSummary] {
-        Array(try summaries(query: query).prefix(max(0, limit)))
+        lock.lock()
+        defer { lock.unlock() }
+        let limit = max(0, limit)
+        let lowered = query.lowercased()
+        guard limit > 0, !lowered.isEmpty else { return [] }
+
+        var result: [TUISessionSummary] = []
+        try forEachSessionURL { url in
+            guard let session = try? decoder.decode(
+                TUISession.self,
+                from: TUIArtifactActions.readRegularFile(at: url, maximumBytes: maximumSessionBytes)
+            ) else { return }
+            let matching = (session.messages.map(\.textContent) + Array(session.reasoningByMessage.values))
+                .first { $0.lowercased().contains(lowered) }
+            guard session.title.lowercased().contains(lowered) || matching != nil else { return }
+            result.append(TUISessionSummary(
+                id: session.id,
+                title: session.title,
+                updatedAt: session.updatedAt,
+                matchingSnippet: matching
+            ))
+            result.sort { $0.updatedAt > $1.updatedAt }
+            if result.count > limit { result.removeLast(result.count - limit) }
+        }
+        return result
     }
 
     public func exportMarkdown(_ session: TUISession, to url: URL, overwrite: Bool = false) throws {
@@ -151,28 +238,33 @@ public final class TUISessionStore: @unchecked Sendable {
         try TUIArtifactActions.save(Data(markdown.utf8), to: url, overwrite: overwrite)
     }
 
-    private func summaries(query: String?) throws -> [TUISessionSummary] {
-        guard fileManager.fileExists(atPath: directory.path) else { return [] }
-        let lowered = query?.lowercased()
-        let sessions: [TUISession] = try fileManager.contentsOfDirectory(
+    private struct SessionMetadata: Decodable {
+        let id: UUID
+        let title: String
+        let updatedAt: Date
+    }
+
+    private struct SessionFile {
+        let url: URL
+        let modificationDate: Date
+    }
+
+    private func forEachSessionURL(_ body: (URL) -> Void) throws {
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+        var enumerationError: Error?
+        guard let enumerator = fileManager.enumerator(
             at: directory,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        ).filter { $0.pathExtension == "json" }.compactMap { url in
-            try? decoder.decode(
-                TUISession.self,
-                from: TUIArtifactActions.readRegularFile(at: url, maximumBytes: Self.maximumSessionBytes)
-            )
-        }
-        return sessions.compactMap { session in
-            guard let lowered, !lowered.isEmpty else {
-                return TUISessionSummary(id: session.id, title: session.title, updatedAt: session.updatedAt, matchingSnippet: nil)
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants],
+            errorHandler: { _, error in
+                enumerationError = error
+                return false
             }
-            let matching = (session.messages.map(\.textContent) + Array(session.reasoningByMessage.values))
-                .first { $0.lowercased().contains(lowered) }
-            guard session.title.lowercased().contains(lowered) || matching != nil else { return nil }
-            return TUISessionSummary(id: session.id, title: session.title, updatedAt: session.updatedAt, matchingSnippet: matching)
-        }.sorted { $0.updatedAt > $1.updatedAt }
+        ) else { return }
+        for case let url as URL in enumerator where url.pathExtension == "json" {
+            body(url)
+        }
+        if let enumerationError { throw enumerationError }
     }
 
     private func ensureDirectory() throws {

--- a/Sources/AFMTerminalUI/SessionStore.swift
+++ b/Sources/AFMTerminalUI/SessionStore.swift
@@ -1,0 +1,120 @@
+import Foundation
+import AFMOpenAICompat
+
+public struct TUISession: Codable, Sendable {
+    public var id: UUID
+    public var title: String
+    public var backend: String
+    public var model: String
+    public var createdAt: Date
+    public var updatedAt: Date
+    public var messages: [Message]
+
+    public init(
+        id: UUID = UUID(),
+        title: String = "New chat",
+        backend: String,
+        model: String,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        messages: [Message] = []
+    ) {
+        self.id = id
+        self.title = title
+        self.backend = backend
+        self.model = model
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.messages = messages
+    }
+}
+
+public struct TUISessionSummary: Equatable, Sendable {
+    public let id: UUID
+    public let title: String
+    public let updatedAt: Date
+    public let matchingSnippet: String?
+}
+
+public final class TUISessionStore: @unchecked Sendable {
+    public let directory: URL
+    private let fileManager: FileManager
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init(directory: URL? = nil, fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        if let directory {
+            self.directory = directory
+        } else {
+            self.directory = fileManager.homeDirectoryForCurrentUser
+                .appendingPathComponent(".afm/sessions", isDirectory: true)
+        }
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    @discardableResult
+    public func save(_ session: TUISession) throws -> URL {
+        try ensureDirectory()
+        let target = url(for: session.id)
+        let temporary = directory.appendingPathComponent(".\(session.id.uuidString).tmp")
+        let data = try encoder.encode(session)
+        try data.write(to: temporary, options: .atomic)
+        if fileManager.fileExists(atPath: target.path) { try fileManager.removeItem(at: target) }
+        try fileManager.moveItem(at: temporary, to: target)
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: target.path)
+        return target
+    }
+
+    public func load(id: UUID) throws -> TUISession {
+        try decoder.decode(TUISession.self, from: Data(contentsOf: url(for: id)))
+    }
+
+    public func recent(limit: Int = 20) throws -> [TUISessionSummary] {
+        Array(try summaries(query: nil).prefix(max(0, limit)))
+    }
+
+    public func search(_ query: String, limit: Int = 20) throws -> [TUISessionSummary] {
+        Array(try summaries(query: query).prefix(max(0, limit)))
+    }
+
+    public func exportMarkdown(_ session: TUISession, to url: URL, overwrite: Bool = false) throws {
+        var markdown = "# \(session.title)\n\n"
+        markdown += "- Backend: \(session.backend)\n- Model: \(session.model)\n- Updated: \(ISO8601DateFormatter().string(from: session.updatedAt))\n\n"
+        for message in session.messages {
+            markdown += "## \(message.role.capitalized)\n\n\(message.textContent)\n\n"
+        }
+        try TUIArtifactActions.save(Data(markdown.utf8), to: url, overwrite: overwrite)
+    }
+
+    private func summaries(query: String?) throws -> [TUISessionSummary] {
+        guard fileManager.fileExists(atPath: directory.path) else { return [] }
+        let lowered = query?.lowercased()
+        let sessions: [TUISession] = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ).filter { $0.pathExtension == "json" }.compactMap { url in
+            try? decoder.decode(TUISession.self, from: Data(contentsOf: url))
+        }
+        return sessions.compactMap { session in
+            guard let lowered, !lowered.isEmpty else {
+                return TUISessionSummary(id: session.id, title: session.title, updatedAt: session.updatedAt, matchingSnippet: nil)
+            }
+            let matching = session.messages.map(\.textContent).first { $0.lowercased().contains(lowered) }
+            guard session.title.lowercased().contains(lowered) || matching != nil else { return nil }
+            return TUISessionSummary(id: session.id, title: session.title, updatedAt: session.updatedAt, matchingSnippet: matching)
+        }.sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    private func ensureDirectory() throws {
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+    }
+
+    private func url(for id: UUID) -> URL { directory.appendingPathComponent("\(id.uuidString).json") }
+}

--- a/Sources/AFMTerminalUI/SessionStore.swift
+++ b/Sources/AFMTerminalUI/SessionStore.swift
@@ -101,6 +101,12 @@ public enum TUISessionStoreError: Error, LocalizedError, Equatable {
     }
 }
 
+public enum TUISessionPersistenceResult: Equatable, Sendable {
+    case saved(URL)
+    case recovered(saveError: String, transcriptURL: URL)
+    case failed(saveError: String, recoveryError: String)
+}
+
 public final class TUISessionStore: @unchecked Sendable {
     public static let defaultMaximumSessionBytes = 32_000_000
     public let directory: URL
@@ -177,25 +183,27 @@ public final class TUISessionStore: @unchecked Sendable {
                 url: url,
                 modificationDate: values?.contentModificationDate ?? .distantPast
             ))
-            candidates.sort { $0.modificationDate > $1.modificationDate }
-            if candidates.count > limit { candidates.removeLast(candidates.count - limit) }
         }
+        candidates.sort { $0.modificationDate > $1.modificationDate }
 
-        return candidates.compactMap { candidate in
+        var summaries: [TUISessionSummary] = []
+        for candidate in candidates {
             guard let metadata = try? decoder.decode(
                 SessionMetadata.self,
                 from: TUIArtifactActions.readRegularFile(
                     at: candidate.url,
                     maximumBytes: maximumSessionBytes
                 )
-            ) else { return nil }
-            return TUISessionSummary(
+            ) else { continue }
+            summaries.append(TUISessionSummary(
                 id: metadata.id,
                 title: metadata.title,
                 updatedAt: metadata.updatedAt,
                 matchingSnippet: nil
-            )
+            ))
+            if summaries.count == limit { break }
         }
+        return summaries
     }
 
     public func search(_ query: String, limit: Int = 20) throws -> [TUISessionSummary] {
@@ -236,6 +244,28 @@ public final class TUISessionStore: @unchecked Sendable {
             }
         }
         try TUIArtifactActions.save(Data(markdown.utf8), to: url, overwrite: overwrite)
+    }
+
+    public func persistRecoveringTranscript(_ session: TUISession) -> TUISessionPersistenceResult {
+        do {
+            return .saved(try save(session))
+        } catch {
+            let saveError = error.localizedDescription
+            do {
+                let recoveryDirectory = directory.appendingPathComponent("recovery", isDirectory: true)
+                try fileManager.createDirectory(at: recoveryDirectory, withIntermediateDirectories: true)
+                try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: recoveryDirectory.path)
+                let transcriptURL = recoveryDirectory.appendingPathComponent("\(session.id.uuidString).md")
+                try exportMarkdown(session, to: transcriptURL, overwrite: true)
+                try? fileManager.setAttributes(
+                    [.posixPermissions: 0o600, .modificationDate: session.updatedAt],
+                    ofItemAtPath: transcriptURL.path
+                )
+                return .recovered(saveError: saveError, transcriptURL: transcriptURL)
+            } catch {
+                return .failed(saveError: saveError, recoveryError: error.localizedDescription)
+            }
+        }
     }
 
     private struct SessionMetadata: Decodable {

--- a/Sources/AFMTerminalUI/SessionStore.swift
+++ b/Sources/AFMTerminalUI/SessionStore.swift
@@ -92,26 +92,31 @@ public struct TUISessionSummary: Equatable, Sendable {
 
 public enum TUISessionStoreError: Error, LocalizedError, Equatable {
     case sessionTooLarge(maximumBytes: Int)
+    case recoveryTooLarge(maximumBytes: Int)
 
     public var errorDescription: String? {
         switch self {
         case .sessionTooLarge(let maximumBytes):
             return "Session exceeds the \(maximumBytes)-byte save/load limit."
+        case .recoveryTooLarge(let maximumBytes):
+            return "Session exceeds the \(maximumBytes)-byte recovery limit."
         }
     }
 }
 
 public enum TUISessionPersistenceResult: Equatable, Sendable {
     case saved(URL)
-    case recovered(saveError: String, transcriptURL: URL)
+    case recovered(saveError: String, recoveryURL: URL)
     case failed(saveError: String, recoveryError: String)
 }
 
 public final class TUISessionStore: @unchecked Sendable {
     public static let defaultMaximumSessionBytes = 32_000_000
+    public static let defaultMaximumRecoveryBytes = 128_000_000
     public let directory: URL
     private let fileManager: FileManager
     private let maximumSessionBytes: Int
+    private let maximumRecoveryBytes: Int
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
     private let lock = NSLock()
@@ -119,10 +124,12 @@ public final class TUISessionStore: @unchecked Sendable {
     public init(
         directory: URL? = nil,
         fileManager: FileManager = .default,
-        maximumSessionBytes: Int = TUISessionStore.defaultMaximumSessionBytes
+        maximumSessionBytes: Int = TUISessionStore.defaultMaximumSessionBytes,
+        maximumRecoveryBytes: Int = TUISessionStore.defaultMaximumRecoveryBytes
     ) {
         self.fileManager = fileManager
         self.maximumSessionBytes = max(0, maximumSessionBytes)
+        self.maximumRecoveryBytes = max(0, maximumRecoveryBytes)
         if let directory {
             self.directory = directory
         } else {
@@ -142,22 +149,12 @@ public final class TUISessionStore: @unchecked Sendable {
         defer { lock.unlock() }
         try ensureDirectory()
         let target = url(for: session.id)
-        let temporary = directory.appendingPathComponent(
-            ".\(session.id.uuidString).\(UUID().uuidString).tmp"
-        )
-        defer { try? fileManager.removeItem(at: temporary) }
         let data = try encoder.encode(session)
         guard data.count <= maximumSessionBytes else {
             throw TUISessionStoreError.sessionTooLarge(maximumBytes: maximumSessionBytes)
         }
-        try TUIArtifactActions.save(data, to: temporary)
-        try fileManager.setAttributes(
-            [.posixPermissions: 0o600, .modificationDate: session.updatedAt],
-            ofItemAtPath: temporary.path
-        )
-        guard Darwin.rename(temporary.path, target.path) == 0 else {
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
+        try TUIArtifactActions.save(data, to: target, overwrite: true)
+        try? fileManager.setAttributes([.modificationDate: session.updatedAt], ofItemAtPath: target.path)
         return target
     }
 
@@ -246,22 +243,40 @@ public final class TUISessionStore: @unchecked Sendable {
         try TUIArtifactActions.save(Data(markdown.utf8), to: url, overwrite: overwrite)
     }
 
-    public func persistRecoveringTranscript(_ session: TUISession) -> TUISessionPersistenceResult {
+    public func loadRecovery(id: UUID) throws -> TUISession {
+        lock.lock()
+        defer { lock.unlock() }
+        return try decoder.decode(
+            TUISession.self,
+            from: TUIArtifactActions.readRegularFile(
+                at: recoveryURL(for: id),
+                maximumBytes: maximumRecoveryBytes
+            )
+        )
+    }
+
+    public func persistRecoveringSession(_ session: TUISession) -> TUISessionPersistenceResult {
         do {
-            return .saved(try save(session))
+            let savedURL = try save(session)
+            try? fileManager.removeItem(at: recoveryURL(for: session.id))
+            return .saved(savedURL)
         } catch {
             let saveError = error.localizedDescription
             do {
-                let recoveryDirectory = directory.appendingPathComponent("recovery", isDirectory: true)
-                try fileManager.createDirectory(at: recoveryDirectory, withIntermediateDirectories: true)
-                try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: recoveryDirectory.path)
-                let transcriptURL = recoveryDirectory.appendingPathComponent("\(session.id.uuidString).md")
-                try exportMarkdown(session, to: transcriptURL, overwrite: true)
+                lock.lock()
+                defer { lock.unlock() }
+                try ensureRecoveryDirectory()
+                let data = try encoder.encode(session)
+                guard data.count <= maximumRecoveryBytes else {
+                    throw TUISessionStoreError.recoveryTooLarge(maximumBytes: maximumRecoveryBytes)
+                }
+                let recoveryURL = recoveryURL(for: session.id)
+                try TUIArtifactActions.save(data, to: recoveryURL, overwrite: true)
                 try? fileManager.setAttributes(
-                    [.posixPermissions: 0o600, .modificationDate: session.updatedAt],
-                    ofItemAtPath: transcriptURL.path
+                    [.modificationDate: session.updatedAt],
+                    ofItemAtPath: recoveryURL.path
                 )
-                return .recovered(saveError: saveError, transcriptURL: transcriptURL)
+                return .recovered(saveError: saveError, recoveryURL: recoveryURL)
             } catch {
                 return .failed(saveError: saveError, recoveryError: error.localizedDescription)
             }
@@ -302,5 +317,18 @@ public final class TUISessionStore: @unchecked Sendable {
         try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
     }
 
+    private func ensureRecoveryDirectory() throws {
+        try ensureDirectory()
+        let recoveryDirectory = directory.appendingPathComponent("recovery", isDirectory: true)
+        try fileManager.createDirectory(at: recoveryDirectory, withIntermediateDirectories: true)
+        try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: recoveryDirectory.path)
+    }
+
     private func url(for id: UUID) -> URL { directory.appendingPathComponent("\(id.uuidString).json") }
+
+    private func recoveryURL(for id: UUID) -> URL {
+        directory
+            .appendingPathComponent("recovery", isDirectory: true)
+            .appendingPathComponent("\(id.uuidString).json")
+    }
 }

--- a/Sources/AFMTerminalUI/SessionStore.swift
+++ b/Sources/AFMTerminalUI/SessionStore.swift
@@ -47,10 +47,38 @@ public struct TUISession: Codable, Sendable {
         updatedAt = try values.decode(Date.self, forKey: .updatedAt)
         messages = try values.decode([Message].self, forKey: .messages)
         reasoningByMessage = try values.decodeIfPresent([String: String].self, forKey: .reasoningByMessage) ?? [:]
+        pruneReasoningMetadata()
     }
 
     public func reasoning(atMessageIndex index: Int) -> String? {
         reasoningByMessage[String(index)]
+    }
+
+    public mutating func removeLastExchange() {
+        if messages.last?.role == "assistant" { messages.removeLast() }
+        if messages.last?.role == "user" { messages.removeLast() }
+        pruneReasoningMetadata()
+    }
+
+    public mutating func removeMessage(at index: Int) {
+        guard messages.indices.contains(index) else { return }
+        messages.remove(at: index)
+        var remapped: [String: String] = [:]
+        for (key, value) in reasoningByMessage {
+            guard let oldIndex = Int(key), oldIndex != index else { continue }
+            let newIndex = oldIndex > index ? oldIndex - 1 : oldIndex
+            if messages.indices.contains(newIndex), messages[newIndex].role == "assistant" {
+                remapped[String(newIndex)] = value
+            }
+        }
+        reasoningByMessage = remapped
+    }
+
+    public mutating func pruneReasoningMetadata() {
+        reasoningByMessage = reasoningByMessage.filter { key, _ in
+            guard let index = Int(key), messages.indices.contains(index) else { return false }
+            return messages[index].role == "assistant"
+        }
     }
 }
 
@@ -62,6 +90,7 @@ public struct TUISessionSummary: Equatable, Sendable {
 }
 
 public final class TUISessionStore: @unchecked Sendable {
+    private static let maximumSessionBytes = 10_000_000
     public let directory: URL
     private let fileManager: FileManager
     private let encoder: JSONEncoder
@@ -96,7 +125,10 @@ public final class TUISessionStore: @unchecked Sendable {
     }
 
     public func load(id: UUID) throws -> TUISession {
-        try decoder.decode(TUISession.self, from: Data(contentsOf: url(for: id)))
+        try decoder.decode(
+            TUISession.self,
+            from: TUIArtifactActions.readRegularFile(at: url(for: id), maximumBytes: Self.maximumSessionBytes)
+        )
     }
 
     public func recent(limit: Int = 20) throws -> [TUISessionSummary] {
@@ -127,7 +159,10 @@ public final class TUISessionStore: @unchecked Sendable {
             includingPropertiesForKeys: nil,
             options: [.skipsHiddenFiles]
         ).filter { $0.pathExtension == "json" }.compactMap { url in
-            try? decoder.decode(TUISession.self, from: Data(contentsOf: url))
+            try? decoder.decode(
+                TUISession.self,
+                from: TUIArtifactActions.readRegularFile(at: url, maximumBytes: Self.maximumSessionBytes)
+            )
         }
         return sessions.compactMap { session in
             guard let lowered, !lowered.isEmpty else {

--- a/Sources/AFMTerminalUI/SessionStore.swift
+++ b/Sources/AFMTerminalUI/SessionStore.swift
@@ -255,6 +255,13 @@ public final class TUISessionStore: @unchecked Sendable {
         )
     }
 
+    public func loadBestAvailable(id: UUID) throws -> TUISession {
+        if let recovery = try? loadRecovery(id: id) {
+            return recovery
+        }
+        return try load(id: id)
+    }
+
     public func persistRecoveringSession(_ session: TUISession) -> TUISessionPersistenceResult {
         do {
             let savedURL = try save(session)

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -13,6 +13,7 @@ public struct TerminalChatConfiguration: Sendable {
     public let theme: TerminalMarkdownRenderer.Theme
     public let showReasoning: Bool
     public let streaming: Bool
+    public let useAlternateScreen: Bool
     public let initialAttachments: [URL]
 
     public init(
@@ -24,6 +25,7 @@ public struct TerminalChatConfiguration: Sendable {
         theme: TerminalMarkdownRenderer.Theme = .auto,
         showReasoning: Bool = false,
         streaming: Bool = true,
+        useAlternateScreen: Bool = true,
         initialAttachments: [URL] = []
     ) {
         self.backend = backend
@@ -34,6 +36,7 @@ public struct TerminalChatConfiguration: Sendable {
         self.theme = theme
         self.showReasoning = showReasoning
         self.streaming = streaming
+        self.useAlternateScreen = useAlternateScreen
         self.initialAttachments = initialAttachments
     }
 }
@@ -169,6 +172,47 @@ enum TUIActivityIndicator {
         let frames = unicode ? unicodeFrames : asciiFrames
         return frames[abs(frame) % frames.count]
     }
+}
+
+struct TUIViewport: Equatable, Sendable {
+    let totalLineCount: Int
+    let pageSize: Int
+    private(set) var offset: Int
+
+    init(totalLineCount: Int, pageSize: Int, startAtBottom: Bool = true) {
+        self.totalLineCount = max(0, totalLineCount)
+        self.pageSize = max(1, pageSize)
+        offset = startAtBottom ? max(0, totalLineCount - self.pageSize) : 0
+    }
+
+    var visibleRange: Range<Int> {
+        offset..<min(totalLineCount, offset + pageSize)
+    }
+
+    mutating func lineUp() { offset = max(0, offset - 1) }
+    mutating func lineDown() { offset = min(maximumOffset, offset + 1) }
+    mutating func pageUp() { offset = max(0, offset - pageSize) }
+    mutating func pageDown() { offset = min(maximumOffset, offset + pageSize) }
+    mutating func halfPageUp() { offset = max(0, offset - max(1, pageSize / 2)) }
+    mutating func halfPageDown() { offset = min(maximumOffset, offset + max(1, pageSize / 2)) }
+    mutating func moveToTop() { offset = 0 }
+    mutating func moveToBottom() { offset = maximumOffset }
+
+    private var maximumOffset: Int { max(0, totalLineCount - pageSize) }
+}
+
+struct TUISessionCodeBlock: Equatable, Sendable {
+    let messageIndex: Int
+    let blockIndex: Int
+    let suggestedName: String?
+    let block: TUICodeBlock
+}
+
+private enum TUIBlockAction: String, CaseIterable {
+    case copy = "Copy to clipboard"
+    case save = "Save to file"
+    case preview = "Open HTML/JavaScript preview"
+    case back = "Back to blocks"
 }
 
 struct GenerationSnapshot: Sendable {
@@ -469,7 +513,6 @@ public final class AFMTerminalChat: @unchecked Sendable {
             try TUIMediaAttachmentPolicy.validate(attachment)
         }
         try terminal.enter()
-        terminal.enterAlternateScreen()
         let signalMonitor = TUISignalMonitor()
         defer {
             signalMonitor.stop()
@@ -711,7 +754,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
             elapsed: elapsed
         )
         terminal.write("\(style("↳ \(lastStatistics)", "2"))\n")
-        if !codeBlocks.isEmpty { terminal.write("\(style("\(codeBlocks.count) code block(s): /blocks, /copy, /save, /open", "2;36"))\n") }
+        if !codeBlocks.isEmpty { terminal.write("\(style("\(codeBlocks.count) new code block(s) · /blocks browses and saves the session", "2;36"))\n") }
         if !images.isEmpty { presentImages(images) }
         terminal.write("\n")
     }
@@ -914,13 +957,17 @@ public final class AFMTerminalChat: @unchecked Sendable {
         return style("… earlier streaming output omitted from redraw …", "2") + "\n" + renderedTail
     }
 
-    private func readInput(initial: String?, signalMonitor: TUISignalMonitor) -> String? {
+    private func readInput(
+        initial: String?,
+        signalMonitor: TUISignalMonitor,
+        promptLabel: String = "you"
+    ) -> String? {
         var characters = Array(initial ?? "")
         var cursor = characters.count
         var historyIndex = promptHistory.count
         var priorRows = 0
         while !signalMonitor.shouldTerminate {
-            priorRows = redrawInput(characters, cursor: cursor, priorRows: priorRows)
+            priorRows = redrawInput(characters, cursor: cursor, priorRows: priorRows, promptLabel: promptLabel)
             guard let key = terminal.readKey() else { continue }
             switch key {
             case .text(let value): characters.insert(contentsOf: value, at: cursor); cursor += value.count
@@ -934,6 +981,10 @@ public final class AFMTerminalChat: @unchecked Sendable {
             case .right where cursor < characters.count: cursor += 1
             case .home: cursor = 0
             case .end: cursor = characters.count
+            case .openTranscript:
+                eraseRows(priorRows)
+                browseTranscript(signalMonitor: signalMonitor)
+                priorRows = 0
             case .up where !promptHistory.isEmpty:
                 historyIndex = max(0, historyIndex - 1); characters = Array(promptHistory[historyIndex]); cursor = characters.count
             case .down where !promptHistory.isEmpty:
@@ -950,11 +1001,16 @@ public final class AFMTerminalChat: @unchecked Sendable {
         return nil
     }
 
-    private func redrawInput(_ characters: [Character], cursor: Int, priorRows: Int) -> Int {
+    private func redrawInput(
+        _ characters: [Character],
+        cursor: Int,
+        priorRows: Int,
+        promptLabel: String
+    ) -> Int {
         eraseRows(priorRows)
         let attachmentBadge = attachments.isEmpty ? "" : " [\(attachments.count) attachment(s)]"
         let content = String(characters).replacingOccurrences(of: "\n", with: "\n… ")
-        let display = style("you\(attachmentBadge)", "1;34") + " › " + content
+        let display = style("\(promptLabel)\(attachmentBadge)", "1;34") + " › " + content
         terminal.write(display)
         // Cursor positioning across wide Unicode is terminal-dependent. Keep navigation exact
         // in the buffer and show a visual cursor when editing away from the end.
@@ -1012,7 +1068,8 @@ public final class AFMTerminalChat: @unchecked Sendable {
             if reasoningDisplayMode == .expanded, !lastReasoning.isEmpty {
                 terminal.write("\(style("latest reasoning", "2;35")) ›\n\(renderMarkdown(lastReasoning).text)\n")
             }
-        case "/blocks": listBlocks()
+        case "/scroll": browseTranscript(signalMonitor: signalMonitor)
+        case "/blocks": try browseBlocks(signalMonitor: signalMonitor)
         case "/copy": try copyBlock(pieces)
         case "/save", "/save!": try saveBlock(pieces, overwrite: command == "/save!")
         case "/open": try openBlock(pieces)
@@ -1084,7 +1141,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
     private func drawWelcome() {
         let colorNote = capabilities.color ? "color" : "no-color"
         terminal.write("\(style("AFM Terminal Chat", "1;36"))  \(configuration.backendName) · \(configuration.modelName)\n")
-        terminal.write(style("Terminal: \(capabilities.terminalProgram) · \(colorNote) · Enter sends · Esc+Enter adds a line · Ctrl-C cancels", "2") + "\n")
+        terminal.write(style("Terminal: \(capabilities.terminalProgram) · \(colorNote) · Enter sends · Ctrl-T transcript · Ctrl-C cancels", "2") + "\n")
         terminal.write("Type \(style("/help", "36")) for commands. Model output is never executed automatically.\n\n")
     }
 
@@ -1097,7 +1154,9 @@ public final class AFMTerminalChat: @unchecked Sendable {
                                         control reasoning panels
         /status /history /search <text>   runtime and persisted-session search
         /resume <session-id>              resume a saved session
-        /blocks /copy <n>                 list/copy response code blocks
+        /scroll                            open the transcript overlay (same as Ctrl-T)
+        /blocks                            select blocks across the session
+        /copy <n>                          copy a session code block
         /save[!] <n> <path>               save block; ! explicitly permits overwrite
         /open <n>                         explicitly preview HTML/JS in the browser
         /attach <path>                    attach an image, video, or UTF-8 text file
@@ -1105,6 +1164,8 @@ public final class AFMTerminalChat: @unchecked Sendable {
         /export[!] <path>                 export this transcript as Markdown
         /theme <auto|dark|light|mono>     change terminal rendering
 
+        Ctrl-T opens/closes the transcript. Scroll with trackpad/mouse, arrows, or Page Up/Down.
+        In the transcript, Ctrl-U/Ctrl-D move half a page and Home/End jump top/bottom.
         Arrow keys edit/navigate prompt history. Esc+Enter inserts a newline.
         During generation Tab expands/collapses reasoning and Ctrl-C cancels only that response.
         Ctrl-C at an empty prompt exits.
@@ -1112,11 +1173,265 @@ public final class AFMTerminalChat: @unchecked Sendable {
         """)
     }
 
-    private func listBlocks() {
-        guard !codeBlocks.isEmpty else { terminal.write("No code blocks in the latest response.\n"); return }
-        for (index, block) in codeBlocks.enumerated() {
-            terminal.write("[\(index + 1)] \(block.language.isEmpty ? "code" : block.language) · \(block.content.split(separator: "\n", omittingEmptySubsequences: false).count) lines\n")
+    private func browseTranscript(signalMonitor: TUISignalMonitor) {
+        let lines = transcriptLines()
+        guard !lines.isEmpty else {
+            terminal.write("No transcript content yet.\n")
+            return
         }
+        let pageSize = max(4, terminal.height() - 4)
+        var viewport = TUIViewport(totalLineCount: lines.count, pageSize: pageSize)
+        if configuration.useAlternateScreen { terminal.enterAlternateScreen() }
+        defer {
+            if configuration.useAlternateScreen { terminal.leaveAlternateScreen() }
+        }
+        while !signalMonitor.shouldTerminate {
+            terminal.clearScreen()
+            terminal.write(style("Transcript", "1;36") + style(
+                "  lines \(viewport.visibleRange.lowerBound + 1)–\(viewport.visibleRange.upperBound) of \(lines.count)",
+                "2"
+            ) + "\n")
+            terminal.write(String(repeating: "─", count: max(1, min(terminal.width(), 120))) + "\n")
+            for index in viewport.visibleRange { terminal.write(lines[index] + "\n") }
+            terminal.write(style("↑/↓ or trackpad · PgUp/PgDn · Ctrl-U/Ctrl-D · Home/End · Ctrl-T close", "7") + "\n")
+
+            guard let key = terminal.readKey() else { continue }
+            switch key {
+            case .up, .text("k"): viewport.lineUp()
+            case .down, .text("j"): viewport.lineDown()
+            case .pageUp: viewport.pageUp()
+            case .pageDown, .text(" "): viewport.pageDown()
+            case .halfPageUp: viewport.halfPageUp()
+            case .eof: viewport.halfPageDown()
+            case .home: viewport.moveToTop()
+            case .end: viewport.moveToBottom()
+            case .openTranscript, .escape, .interrupt, .text("q"):
+                if !configuration.useAlternateScreen {
+                    terminal.clearScreen()
+                    drawWelcome()
+                }
+                return
+            default: break
+            }
+        }
+    }
+
+    private func transcriptLines() -> [String] {
+        var lines: [String] = []
+        for (index, message) in session.messages.enumerated() where message.role != "system" {
+            let role = message.role == "user" ? "you" : message.role
+            lines.append(style(role, message.role == "user" ? "1;34" : "1;32") + " ›")
+            lines.append(contentsOf: renderMarkdown(message.textContent).text.split(
+                separator: "\n",
+                omittingEmptySubsequences: false
+            ).map(String.init))
+            if let reasoning = session.reasoning(atMessageIndex: index), !reasoning.isEmpty {
+                lines.append(style("◇ reasoning available · /reasoning last", "2;35"))
+            }
+            lines.append("")
+        }
+        return lines
+    }
+
+    private func sessionCodeBlocks() -> [TUISessionCodeBlock] {
+        var values: [TUISessionCodeBlock] = []
+        for (messageIndex, message) in session.messages.enumerated() where message.role == "assistant" {
+            let suggestedNames = Self.artifactNames(in: message.textContent)
+            for (blockIndex, block) in renderMarkdown(message.textContent).codeBlocks.enumerated() {
+                values.append(TUISessionCodeBlock(
+                    messageIndex: messageIndex,
+                    blockIndex: blockIndex,
+                    suggestedName: suggestedNames.indices.contains(blockIndex) ? suggestedNames[blockIndex] : nil,
+                    block: block
+                ))
+            }
+        }
+        return values
+    }
+
+    static func artifactNames(in markdown: String) -> [String?] {
+        let pattern = #"\b([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\.(?:swift|m|mm|h|c|cc|cpp|cs|css|go|html?|java|js|jsx|json|kt|kts|md|php|py|rb|rs|sh|sql|toml|ts|tsx|ya?ml))\b"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return [] }
+        var names: [String?] = []
+        var recentName: String?
+        var fenceMarker: String?
+
+        for rawLine in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine)
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if let marker = fenceMarker {
+                if trimmed.hasPrefix(marker) { fenceMarker = nil }
+                continue
+            }
+            if trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~") {
+                fenceMarker = String(trimmed.prefix(3))
+                names.append(recentName)
+                recentName = nil
+                continue
+            }
+            let range = NSRange(line.startIndex..<line.endIndex, in: line)
+            if let match = regex.matches(in: line, range: range).last,
+               let nameRange = Range(match.range(at: 1), in: line) {
+                recentName = String(line[nameRange])
+            } else if !trimmed.isEmpty, !trimmed.hasPrefix("#"), !trimmed.hasPrefix(">") {
+                // Keep a filename through a short explanatory heading, but do not let an
+                // unrelated paragraph label a much later block.
+                recentName = nil
+            }
+        }
+        return names
+    }
+
+    private func browseBlocks(signalMonitor: TUISignalMonitor) throws {
+        let blocks = sessionCodeBlocks()
+        guard !blocks.isEmpty else {
+            terminal.write("No code blocks in this session.\n")
+            return
+        }
+        var selection = blocks.count - 1
+        var notice = ""
+        if configuration.useAlternateScreen { terminal.enterAlternateScreen() }
+        defer {
+            if configuration.useAlternateScreen { terminal.leaveAlternateScreen() }
+        }
+
+        while !signalMonitor.shouldTerminate {
+            let pageSize = max(1, terminal.height() - 6)
+            let pageStart = min(
+                max(0, selection - pageSize / 2),
+                max(0, blocks.count - pageSize)
+            )
+            let pageEnd = min(blocks.count, pageStart + pageSize)
+            terminal.clearScreen()
+            terminal.write(style("Code blocks", "1;36") + style("  \(blocks.count) in this session", "2") + "\n")
+            terminal.write(String(repeating: "─", count: max(1, min(terminal.width(), 120))) + "\n")
+            for index in pageStart..<pageEnd {
+                let reference = blocks[index]
+                let block = reference.block
+                let language = block.language.isEmpty ? "code" : block.language
+                let lineCount = block.content.split(separator: "\n", omittingEmptySubsequences: false).count
+                let firstLine = block.content.split(separator: "\n", omittingEmptySubsequences: false).first
+                    .map { String($0).trimmingCharacters(in: .whitespaces) } ?? ""
+                let preview = String(firstLine.prefix(max(12, terminal.width() - 38)))
+                let marker = index == selection ? "▶" : " "
+                let identity = reference.suggestedName.map { "\($0) · \(language)" } ?? language
+                let row = "\(marker) [\(index + 1)] \(identity) · \(lineCount) lines · \(preview)"
+                terminal.write(index == selection ? style(row, "7") + "\n" : row + "\n")
+            }
+            if !notice.isEmpty { terminal.write(style(notice, "2;36") + "\n") }
+            terminal.write(style("↑/↓ select · PgUp/PgDn · Home/End · Enter actions · Esc close", "7") + "\n")
+
+            guard let key = terminal.readKey() else { continue }
+            switch key {
+            case .up, .text("k"): selection = max(0, selection - 1)
+            case .down, .text("j"): selection = min(blocks.count - 1, selection + 1)
+            case .pageUp: selection = max(0, selection - pageSize)
+            case .pageDown: selection = min(blocks.count - 1, selection + pageSize)
+            case .home: selection = 0
+            case .end: selection = blocks.count - 1
+            case .enter:
+                notice = try performBlockAction(
+                    for: blocks[selection],
+                    number: selection + 1,
+                    signalMonitor: signalMonitor
+                ) ?? notice
+            case .escape, .interrupt, .eof:
+                if !configuration.useAlternateScreen {
+                    terminal.clearScreen()
+                    drawWelcome()
+                }
+                return
+            default: break
+            }
+        }
+    }
+
+    private func performBlockAction(
+        for reference: TUISessionCodeBlock,
+        number: Int,
+        signalMonitor: TUISignalMonitor
+    ) throws -> String? {
+        let language = reference.block.language.lowercased()
+        var actions: [TUIBlockAction] = [.copy, .save]
+        if ["html", "htm", "javascript", "js"].contains(language) { actions.append(.preview) }
+        actions.append(.back)
+        var selection = 0
+
+        while !signalMonitor.shouldTerminate {
+            terminal.clearScreen()
+            let name = reference.suggestedName ?? "block \(number)"
+            terminal.write(style(name, "1;36") + style("  \(language.isEmpty ? "code" : language)", "2") + "\n")
+            terminal.write(String(repeating: "─", count: max(1, min(terminal.width(), 120))) + "\n")
+            let previewLimit = max(3, terminal.height() - actions.count - 6)
+            for line in reference.block.content.split(separator: "\n", omittingEmptySubsequences: false).prefix(previewLimit) {
+                terminal.write(String(line) + "\n")
+            }
+            terminal.write("\n")
+            for (index, action) in actions.enumerated() {
+                let row = "\(index == selection ? "▶" : " ") \(action.rawValue)"
+                terminal.write(index == selection ? style(row, "7") + "\n" : row + "\n")
+            }
+            terminal.write(style("↑/↓ select · Enter confirm · Esc back", "7") + "\n")
+
+            guard let key = terminal.readKey() else { continue }
+            switch key {
+            case .up: selection = max(0, selection - 1)
+            case .down: selection = min(actions.count - 1, selection + 1)
+            case .home: selection = 0
+            case .end: selection = actions.count - 1
+            case .escape, .interrupt, .eof: return nil
+            case .enter:
+                switch actions[selection] {
+                case .copy:
+                    try TUIArtifactActions.copyToClipboard(reference.block.content)
+                    return "Copied block \(number) to the clipboard."
+                case .save:
+                    terminal.clearScreen()
+                    terminal.write("Save selected block. Edit the suggested path, then press Enter.\n")
+                    let suggestion = suggestedFilename(for: reference, number: number)
+                    guard let path = readInput(
+                        initial: suggestion,
+                        signalMonitor: signalMonitor,
+                        promptLabel: "save path"
+                    ), !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                        return "Save cancelled."
+                    }
+                    do {
+                        let url = try TUIArtifactActions.resolvedURL(path)
+                        try TUIArtifactActions.save(Data(reference.block.content.utf8), to: url)
+                        return "Saved \(url.path)"
+                    } catch {
+                        return error.localizedDescription
+                    }
+                case .preview:
+                    do {
+                        let url = try TUIArtifactActions.openInBrowser(reference.block)
+                        return "Opened block \(number): \(url.path)"
+                    } catch {
+                        return error.localizedDescription
+                    }
+                case .back:
+                    return nil
+                }
+            default: break
+            }
+        }
+        return nil
+    }
+
+    private func suggestedFilename(for reference: TUISessionCodeBlock, number: Int) -> String {
+        if let name = reference.suggestedName {
+            return URL(fileURLWithPath: name).lastPathComponent
+        }
+        let extensions: [String: String] = [
+            "bash": "sh", "c": "c", "cpp": "cpp", "csharp": "cs", "css": "css",
+            "diff": "patch", "go": "go", "html": "html", "java": "java",
+            "javascript": "js", "json": "json", "kotlin": "kt", "markdown": "md",
+            "php": "php", "python": "py", "ruby": "rb", "rust": "rs", "sql": "sql",
+            "swift": "swift", "toml": "toml", "tsx": "tsx", "typescript": "ts", "yaml": "yaml"
+        ]
+        let suffix = extensions[reference.block.language.lowercased()] ?? "txt"
+        return "block-\(number).\(suffix)"
     }
 
     private func copyBlock(_ pieces: [String]) throws {
@@ -1139,10 +1454,11 @@ public final class AFMTerminalChat: @unchecked Sendable {
     }
 
     private func selectedBlock(_ pieces: [String]) throws -> TUICodeBlock {
-        guard pieces.count >= 2, let number = Int(pieces[1]), codeBlocks.indices.contains(number - 1) else {
+        let blocks = sessionCodeBlocks()
+        guard pieces.count >= 2, let number = Int(pieces[1]), blocks.indices.contains(number - 1) else {
             throw TUIArtifactError.invalidPath("Choose a block number from /blocks")
         }
-        return codeBlocks[number - 1]
+        return blocks[number - 1].block
     }
 
     private func listImages() {

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -936,7 +936,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
 
     private func resumeSession(_ pieces: [String]) async throws {
         guard pieces.count == 2, let id = UUID(uuidString: pieces[1]) else { throw TUIArtifactError.invalidPath("usage: /resume <session-id>") }
-        var restored = try store.load(id: id)
+        var restored = try store.loadBestAvailable(id: id)
         try Self.validateRestoredSession(
             restored,
             backendName: configuration.backendName,

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -56,8 +56,12 @@ struct GenerationSnapshot: Sendable {
     let revision: UInt64
     let text: String
     let reasoning: String
+    let textTail: String
+    let reasoningTail: String
+    let textCharacterCount: Int
+    let reasoningCharacterCount: Int
     let tools: [AFMToolCall]
-    let toolStages: [AFMToolCallStage]
+    let toolDisplayLines: [String]
     let promptTokens: Int
     let completionTokens: Int
     let cachedTokens: Int
@@ -67,10 +71,16 @@ struct GenerationSnapshot: Sendable {
 }
 
 actor GenerationBuffer {
+    static let renderTailLimit = 12_000
     private var text = ""
     private var reasoning = ""
+    private var textTail = ""
+    private var reasoningTail = ""
+    private var textCharacterCount = 0
+    private var reasoningCharacterCount = 0
     private var tools: [AFMToolCall] = []
     private var toolStages: [AFMToolCallStage] = []
+    private var toolDisplayLines: [String] = []
     private var promptTokens = 0
     private var completionTokens = 0
     private var cachedTokens = 0
@@ -82,15 +92,31 @@ actor GenerationBuffer {
     func accept(_ event: AFMStreamEvent) {
         guard !completed else { return }
         switch event {
-        case .text(let value, let tokens): text += value; completionTokens = max(completionTokens, tokens)
-        case .reasoning(let value, _): reasoning += value
+        case .text(let value, let tokens):
+            let safe = TerminalOutputSanitizer.sanitize(value)
+            text += safe
+            textTail = Self.appendingToRenderTail(textTail, safe)
+            textCharacterCount += safe.count
+            completionTokens = max(completionTokens, tokens)
+        case .reasoning(let value, _):
+            let safe = TerminalOutputSanitizer.sanitize(value)
+            reasoning += safe
+            reasoningTail = Self.appendingToRenderTail(reasoningTail, safe)
+            reasoningCharacterCount += safe.count
         case .toolCall(let call, let stage):
-            if let index = tools.firstIndex(where: { $0.id == call.id }) {
-                tools[index] = call
+            let safeCall = AFMToolCall(
+                id: TerminalOutputSanitizer.sanitize(call.id),
+                name: TerminalOutputSanitizer.sanitize(call.name),
+                arguments: TerminalOutputSanitizer.sanitize(call.arguments)
+            )
+            if let index = tools.firstIndex(where: { $0.id == safeCall.id }) {
+                tools[index] = safeCall
                 toolStages[index] = stage
+                toolDisplayLines[index] = Self.toolDisplayLine(call: safeCall, stage: stage)
             } else {
-                tools.append(call)
+                tools.append(safeCall)
                 toolStages.append(stage)
+                toolDisplayLines.append(Self.toolDisplayLine(call: safeCall, stage: stage))
             }
         case .usage(let prompt, let completion, let cached):
             promptTokens = prompt; completionTokens = completion; cachedTokens = cached
@@ -102,14 +128,24 @@ actor GenerationBuffer {
 
     func accept(_ response: AFMResponse) {
         guard !completed else { return }
-        text = response.content
-        reasoning = response.reasoningContent ?? ""
+        text = TerminalOutputSanitizer.sanitize(response.content)
+        reasoning = TerminalOutputSanitizer.sanitize(response.reasoningContent ?? "")
+        textCharacterCount = text.count
+        reasoningCharacterCount = reasoning.count
+        textTail = String(text.suffix(Self.renderTailLimit))
+        reasoningTail = String(reasoning.suffix(Self.renderTailLimit))
         promptTokens = response.promptTokens
         completionTokens = response.completionTokens
         cachedTokens = response.cachedPromptTokens
         for call in response.toolCalls ?? [] {
-            tools.append(AFMToolCall(id: call.id, name: call.function.name, arguments: call.function.arguments))
+            let safeCall = AFMToolCall(
+                id: TerminalOutputSanitizer.sanitize(call.id),
+                name: TerminalOutputSanitizer.sanitize(call.function.name),
+                arguments: TerminalOutputSanitizer.sanitize(call.function.arguments)
+            )
+            tools.append(safeCall)
             toolStages.append(.completed)
+            toolDisplayLines.append(Self.toolDisplayLine(call: safeCall, stage: .completed))
         }
         completed = true
         revision &+= 1
@@ -117,7 +153,7 @@ actor GenerationBuffer {
 
     func fail(_ value: Error) {
         guard !completed else { return }
-        error = value.localizedDescription; completed = true; revision &+= 1
+        error = TerminalOutputSanitizer.sanitize(value.localizedDescription); completed = true; revision &+= 1
     }
     func cancel() {
         guard !completed else { return }
@@ -128,9 +164,23 @@ actor GenerationBuffer {
         completed = true; revision &+= 1
     }
     func snapshot() -> GenerationSnapshot {
+        makeSnapshot(includeFullContent: true)
+    }
+
+    func renderSnapshot() -> GenerationSnapshot {
+        makeSnapshot(includeFullContent: false)
+    }
+
+    private func makeSnapshot(includeFullContent: Bool) -> GenerationSnapshot {
         GenerationSnapshot(
             revision: revision,
-            text: text, reasoning: reasoning, tools: tools, toolStages: toolStages,
+            text: includeFullContent ? text : "",
+            reasoning: includeFullContent ? reasoning : "",
+            textTail: textTail, reasoningTail: reasoningTail,
+            textCharacterCount: textCharacterCount,
+            reasoningCharacterCount: reasoningCharacterCount,
+            tools: includeFullContent ? tools : [],
+            toolDisplayLines: toolDisplayLines,
             promptTokens: promptTokens, completionTokens: completionTokens,
             cachedTokens: cachedTokens, completed: completed,
             cancelled: cancelled, error: error
@@ -139,7 +189,32 @@ actor GenerationBuffer {
 
     func snapshot(ifChangedSince priorRevision: UInt64) -> GenerationSnapshot? {
         guard revision != priorRevision else { return nil }
-        return snapshot()
+        return renderSnapshot()
+    }
+
+    private static func appendingToRenderTail(_ tail: String, _ value: String) -> String {
+        var updated = tail
+        updated += value
+        guard updated.count > renderTailLimit else { return updated }
+        return String(updated.suffix(renderTailLimit))
+    }
+
+    private static func toolDisplayLine(call: AFMToolCall, stage: AFMToolCallStage) -> String {
+        let name = bounded(call.name, limit: 256)
+        let arguments = bounded(call.arguments, limit: 2_048)
+        let stageLabel: String
+        switch stage {
+        case .started: stageLabel = "started"
+        case .argumentsDelta: stageLabel = "arguments"
+        case .completed: stageLabel = "completed"
+        case .retracted: stageLabel = "retracted"
+        }
+        return "\(stageLabel): \(name)(\(arguments))"
+    }
+
+    private static func bounded(_ value: String, limit: Int) -> String {
+        let prefix = String(value.prefix(limit + 1))
+        return prefix.count > limit ? String(prefix.prefix(limit)) + "…" : prefix
     }
 }
 
@@ -156,7 +231,7 @@ final class TUISignalMonitor: @unchecked Sendable {
     private var stopped = false
     private var sources: [DispatchSourceSignal] = []
     private var previousHandlers: [(Int32, SignalHandler?)] = []
-    private let monitoredSignals = [SIGTERM, SIGHUP]
+    private let monitoredSignals = [SIGINT, SIGTERM, SIGHUP]
     private let queue = DispatchQueue(label: "ai.maclocal.afm.tui-signals")
 
     init() {
@@ -206,6 +281,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
     private var lastStatistics = "No generation yet"
     private var lastInput: String?
     private var lastReasoning = ""
+    private var lastInputWasRolledBack = false
 
     public init(
         configuration: TerminalChatConfiguration,
@@ -237,36 +313,85 @@ public final class AFMTerminalChat: @unchecked Sendable {
         let signalMonitor = TUISignalMonitor()
         defer {
             signalMonitor.stop()
-            Task { await engine.unload() }
             terminal.restore()
         }
 
-        drawWelcome()
-        terminal.write("Loading \(configuration.modelName)…\n")
-        let modelID = try await engine.load { [terminal] progress in
-            terminal.clearLine()
-            terminal.write(String(format: "Loading model %3.0f%%", progress * 100))
-        }
-        terminal.clearLine()
-        terminal.write("Ready: \(modelID)\n\n")
+        do {
+            drawWelcome()
+            terminal.write("Loading \(configuration.modelName)…\n")
+            if let modelID = try await loadModel(signalMonitor: signalMonitor) {
+                terminal.clearLine()
+                terminal.write("Ready: \(modelID)\n\n")
 
-        while !signalMonitor.shouldTerminate {
-            guard let input = readInput(initial: nil, signalMonitor: signalMonitor) else { break }
-            let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.isEmpty { continue }
-            if trimmed.hasPrefix("/") {
-                do {
-                    if try await handleCommand(trimmed, signalMonitor: signalMonitor) { break }
-                } catch {
-                    terminal.write("\(style("error", "1;31")): \(error.localizedDescription)\n")
+                while !signalMonitor.shouldTerminate {
+                    guard let input = readInput(initial: nil, signalMonitor: signalMonitor) else { break }
+                    let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if trimmed.isEmpty { continue }
+                    if trimmed.hasPrefix("/") {
+                        do {
+                            if try await handleCommand(trimmed, signalMonitor: signalMonitor) { break }
+                        } catch {
+                            terminal.write("\(style("error", "1;31")): \(error.localizedDescription)\n")
+                        }
+                        continue
+                    }
+                    try await send(input, signalMonitor: signalMonitor)
                 }
-                continue
             }
-            try await send(input, signalMonitor: signalMonitor)
+        } catch {
+            signalMonitor.stop()
+            terminal.restore()
+            await engine.unload()
+            throw error
         }
+        signalMonitor.stop()
+        terminal.restore()
+        await engine.unload()
+    }
+
+    private func loadModel(signalMonitor: TUISignalMonitor) async throws -> String? {
+        let state = GenerationTaskState()
+        let task = Task<String, Error> {
+            do {
+                let modelID = try await engine.load { [terminal] progress in
+                    terminal.clearLine()
+                    terminal.write(String(format: "Loading model %3.0f%%", progress * 100))
+                }
+                await state.markFinished()
+                return modelID
+            } catch {
+                await state.markFinished()
+                throw error
+            }
+        }
+        var interrupted = false
+        while !(await state.isFinished()) {
+            if signalMonitor.shouldTerminate {
+                interrupted = true
+                task.cancel()
+                break
+            }
+            if let key = terminal.readKey(timeoutMilliseconds: 40), key == .interrupt || key == .eof {
+                interrupted = true
+                task.cancel()
+                break
+            }
+        }
+        if interrupted {
+            signalMonitor.stop()
+            terminal.restore()
+            _ = try? await task.value
+            if !signalMonitor.shouldTerminate {
+                terminal.clearLine()
+                terminal.write("Loading cancelled.\n")
+            }
+            return nil
+        }
+        return try await task.value
     }
 
     private func send(_ input: String, signalMonitor: TUISignalMonitor) async throws {
+        lastInputWasRolledBack = false
         promptHistory.append(input)
         lastInput = input
         let userMessage = try makeUserMessage(input)
@@ -275,12 +400,12 @@ public final class AFMTerminalChat: @unchecked Sendable {
             session.title = String(input.replacingOccurrences(of: "\n", with: " ").prefix(72))
         }
         session.messages.append(userMessage)
+        let pendingUserIndex = session.messages.index(before: session.messages.endIndex)
         session.updatedAt = Date()
         terminal.write("\n\(style("you", "1;34")) › \(input)\n\n")
 
         let buffer = GenerationBuffer()
-        let taskState = GenerationTaskState()
-        let messages = session.messages
+        let messages = Self.requestMessages(for: configuration.backend, transcript: session.messages)
         let generation = configuration.generation
         let task = Task {
             do {
@@ -298,11 +423,10 @@ public final class AFMTerminalChat: @unchecked Sendable {
             } catch {
                 await buffer.fail(error)
             }
-            await taskState.markFinished()
         }
 
         var previousRows = 0
-        var lastSnapshot = await buffer.snapshot()
+        var lastSnapshot = await buffer.renderSnapshot()
         let start = Date()
         while !lastSnapshot.completed && !signalMonitor.shouldTerminate {
             if let key = terminal.readKey(timeoutMilliseconds: 40), key == .interrupt {
@@ -314,31 +438,39 @@ public final class AFMTerminalChat: @unchecked Sendable {
                 previousRows = redrawGeneration(lastSnapshot, previousRows: previousRows, final: false)
             }
         }
-        if signalMonitor.shouldTerminate { task.cancel() }
-        let clock = ContinuousClock()
-        let cancellationRequested = lastSnapshot.cancelled || signalMonitor.shouldTerminate
-        if cancellationRequested {
+        if signalMonitor.shouldTerminate {
+            signalMonitor.stop()
+            terminal.restore()
             task.cancel()
+            await buffer.cancel()
         }
-        let deadline = clock.now.advanced(by: cancellationRequested ? .milliseconds(500) : .seconds(1))
-        while !(await taskState.isFinished()), clock.now < deadline {
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        if !(await taskState.isFinished()) { task.cancel() }
+        await task.value
         lastSnapshot = await buffer.snapshot()
-        lastReasoning = lastSnapshot.reasoning
+        if signalMonitor.shouldTerminate {
+            session.removeMessage(at: pendingUserIndex)
+            lastInputWasRolledBack = true
+            try? await engine.resetConversation(with: session.messages)
+            return
+        }
         _ = redrawGeneration(lastSnapshot, previousRows: previousRows, final: true)
         terminal.write("\n")
 
         if let error = lastSnapshot.error {
+            session.removeMessage(at: pendingUserIndex)
+            lastInputWasRolledBack = true
+            try? await engine.resetConversation(with: session.messages)
             terminal.write("\(style("error", "1;31")): \(error)\n\n")
             return
         }
         if lastSnapshot.cancelled || (lastSnapshot.text.isEmpty && lastSnapshot.tools.isEmpty) {
+            session.removeMessage(at: pendingUserIndex)
+            lastInputWasRolledBack = true
+            try? await engine.resetConversation(with: session.messages)
             terminal.write("\(style("cancelled", "33")) — the partial response was not added.\n\n")
             return
         }
 
+        lastReasoning = lastSnapshot.reasoning
         let messageToolCalls = lastSnapshot.tools.map {
             MessageToolCall(
                 id: $0.id,
@@ -382,30 +514,44 @@ public final class AFMTerminalChat: @unchecked Sendable {
             terminal.write("\r")
         }
         var display = ""
-        if !snapshot.reasoning.isEmpty {
+        if snapshot.reasoningCharacterCount > 0 {
             if showReasoning {
-                display += style("reasoning", "2;35") + " ›\n" + renderGenerationMarkdown(snapshot.reasoning, final: final) + "\n\n"
+                display += style("reasoning", "2;35") + " ›\n" + renderGenerationMarkdown(
+                    full: snapshot.reasoning,
+                    tail: snapshot.reasoningTail,
+                    characterCount: snapshot.reasoningCharacterCount,
+                    final: final
+                ) + "\n\n"
             } else {
-                display += style("… reasoning hidden (\(snapshot.reasoning.count) chars; /reasoning show)", "2") + "\n"
+                display += style("… reasoning hidden (\(snapshot.reasoningCharacterCount) chars; /reasoning show)", "2") + "\n"
             }
         }
-        display += style("assistant", "1;32") + " › " + renderGenerationMarkdown(snapshot.text, final: final)
-        if snapshot.text.isEmpty && snapshot.reasoning.isEmpty { display += style("thinking…", "2") }
-        if !snapshot.tools.isEmpty {
-            let lines = zip(snapshot.tools, snapshot.toolStages).map { call, stage in
-                "\(stage): \(call.name)(\(call.arguments))"
-            }
-            display += "\n" + style(lines.joined(separator: "\n"), "36")
+        display += style("assistant", "1;32") + " › " + renderGenerationMarkdown(
+            full: snapshot.text,
+            tail: snapshot.textTail,
+            characterCount: snapshot.textCharacterCount,
+            final: final
+        )
+        if snapshot.textCharacterCount == 0 && snapshot.reasoningCharacterCount == 0 {
+            display += style("thinking…", "2")
+        }
+        if !snapshot.toolDisplayLines.isEmpty {
+            display += "\n" + style(snapshot.toolDisplayLines.joined(separator: "\n"), "36")
         }
         terminal.write(display)
         return displayRows(display, width: terminal.width())
     }
 
-    private func renderGenerationMarkdown(_ source: String, final: Bool) -> String {
-        let limit = 12_000
-        guard !final, source.count > limit else { return renderMarkdown(source).text }
-        let suffix = String(source.suffix(limit))
-        return style("… earlier streaming output omitted from redraw …", "2") + "\n" + renderMarkdown(suffix).text
+    private func renderGenerationMarkdown(
+        full: String,
+        tail: String,
+        characterCount: Int,
+        final: Bool
+    ) -> String {
+        if final { return renderMarkdown(full).text }
+        let renderedTail = renderMarkdown(tail).text
+        guard characterCount > GenerationBuffer.renderTailLimit else { return renderedTail }
+        return style("… earlier streaming output omitted from redraw …", "2") + "\n" + renderedTail
     }
 
     private func readInput(initial: String?, signalMonitor: TUISignalMonitor) -> String? {
@@ -473,12 +619,14 @@ public final class AFMTerminalChat: @unchecked Sendable {
         case "/quit", "/exit", "/q": return true
         case "/help", "/?": drawHelp()
         case "/new":
+            try await engine.resetConversation()
             session = TUISession(
                 backend: configuration.backendName,
                 model: configuration.modelName,
                 messages: Self.initialMessages(for: configuration)
             )
-            codeBlocks = []; images = []; terminal.clearScreen(); drawWelcome()
+            resetTransientSessionState()
+            terminal.clearScreen(); drawWelcome()
         case "/clear": terminal.clearScreen(); drawWelcome()
         case "/status": terminal.write("\(configuration.backendName) · \(configuration.modelName)\n\(lastStatistics)\n")
         case "/reasoning":
@@ -498,17 +646,17 @@ public final class AFMTerminalChat: @unchecked Sendable {
         case "/export", "/export!": try exportSession(pieces, overwrite: command == "/export!")
         case "/history": try listHistory()
         case "/search": try searchSessions(pieces)
-        case "/resume": try resumeSession(pieces)
+        case "/resume": try await resumeSession(pieces)
         case "/retry":
             guard let lastInput else { terminal.write("Nothing to retry.\n"); return false }
-            if session.messages.last?.role == "assistant" { session.messages.removeLast() }
-            if session.messages.last?.role == "user" { session.messages.removeLast() }
+            if !lastInputWasRolledBack { session.removeLastExchange() }
+            try await engine.resetConversation(with: session.messages)
             try await send(lastInput, signalMonitor: signalMonitor)
         case "/edit":
             guard let lastInput else { terminal.write("Nothing to edit.\n"); return false }
             if let revised = readInput(initial: lastInput, signalMonitor: signalMonitor), !revised.isEmpty {
-                if session.messages.last?.role == "assistant" { session.messages.removeLast() }
-                if session.messages.last?.role == "user" { session.messages.removeLast() }
+                if !lastInputWasRolledBack { session.removeLastExchange() }
+                try await engine.resetConversation(with: session.messages)
                 try await send(revised, signalMonitor: signalMonitor)
             }
         case "/theme":
@@ -528,12 +676,12 @@ public final class AFMTerminalChat: @unchecked Sendable {
         for url in attachments {
             let ext = url.pathExtension.lowercased()
             if ["png", "jpg", "jpeg", "gif", "webp", "heic"].contains(ext) {
-                let data = try Data(contentsOf: url)
+                let data = try TUIArtifactActions.readRegularFile(at: url, maximumBytes: 20_000_000)
                 let mime = ext == "jpg" || ext == "jpeg" ? "image/jpeg" : "image/\(ext)"
                 parts.append(ContentPart(type: "image_url", image_url: ImageURL(url: "data:\(mime);base64,\(data.base64EncodedString())", detail: "auto")))
             } else {
-                let data = try Data(contentsOf: url)
-                guard data.count <= 2_000_000, let text = String(data: data, encoding: .utf8) else {
+                let data = try TUIArtifactActions.readRegularFile(at: url, maximumBytes: 2_000_000)
+                guard let text = String(data: data, encoding: .utf8) else {
                     throw TUIArtifactError.invalidPath("Attachment must be an image or UTF-8 text file under 2 MB: \(url.path)")
                 }
                 parts.append(ContentPart(type: "text", text: "\n<attachment path=\"\(url.lastPathComponent)\">\n\(text)\n</attachment>"))
@@ -624,18 +772,15 @@ public final class AFMTerminalChat: @unchecked Sendable {
 
     private func presentImages(_ values: [TUIImageReference]) {
         for (index, image) in values.enumerated() {
-            if let sequence = try? TUIArtifactActions.inlineImageSequence(path: image.path, capabilities: capabilities) {
-                terminal.write("\n" + sequence + "\n")
-            } else {
-                terminal.write(style("Image \(index + 1): \(image.path) — use /image \(index + 1) for Quick Look", "2;36") + "\n")
-            }
+            terminal.write(style("Image \(index + 1): \(image.path) — use /image \(index + 1) to read and display", "2;36") + "\n")
         }
     }
 
     private func attach(_ pieces: [String]) throws {
         guard pieces.count >= 2 else { throw TUIArtifactError.invalidPath("usage: /attach <path>") }
         let url = try TUIArtifactActions.resolvedURL(pieces.dropFirst().joined(separator: " "))
-        guard FileManager.default.fileExists(atPath: url.path) else { throw TUIArtifactError.invalidPath(url.path) }
+        let isImage = ["png", "jpg", "jpeg", "gif", "webp", "heic"].contains(url.pathExtension.lowercased())
+        try TUIArtifactActions.preflightRegularFile(at: url, maximumBytes: isImage ? 20_000_000 : 2_000_000)
         attachments.append(url); terminal.write("Attached \(url.lastPathComponent). It will be sent with the next prompt.\n")
     }
 
@@ -657,19 +802,41 @@ public final class AFMTerminalChat: @unchecked Sendable {
         }
     }
 
-    private func resumeSession(_ pieces: [String]) throws {
+    private func resumeSession(_ pieces: [String]) async throws {
         guard pieces.count == 2, let id = UUID(uuidString: pieces[1]) else { throw TUIArtifactError.invalidPath("usage: /resume <session-id>") }
-        session = try store.load(id: id)
+        var restored = try store.load(id: id)
+        try Self.validateRestoredSession(
+            restored,
+            backendName: configuration.backendName,
+            modelName: configuration.modelName
+        )
+        restored.pruneReasoningMetadata()
+        try await engine.resetConversation(with: restored.messages)
+        session = restored
         promptHistory = session.messages.filter { $0.role == "user" }.map(\.textContent)
         lastInput = promptHistory.last
+        lastInputWasRolledBack = false
         let lastAssistantIndex = session.messages.indices.reversed().first { session.messages[$0].role == "assistant" }
         lastReasoning = lastAssistantIndex.flatMap { session.reasoning(atMessageIndex: $0) } ?? ""
         codeBlocks = []
         images = []
+        attachments = []
+        lastStatistics = "No generation yet"
         terminal.clearScreen(); drawWelcome()
         for message in session.messages where message.role != "system" {
             terminal.write("\(style(message.role, message.role == "user" ? "1;34" : "1;32")) › \(renderMarkdown(message.textContent).text)\n\n")
         }
+    }
+
+    private func resetTransientSessionState() {
+        promptHistory = []
+        codeBlocks = []
+        images = []
+        attachments = []
+        lastStatistics = "No generation yet"
+        lastInput = nil
+        lastReasoning = ""
+        lastInputWasRolledBack = false
     }
 
     private func splitCommand(_ input: String) -> [String] {
@@ -707,7 +874,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
 
     private func renderMarkdown(_ source: String) -> MarkdownRenderResult {
         renderer.render(
-            source,
+            TerminalOutputSanitizer.sanitize(source),
             width: max(24, terminal.width() - 4),
             hyperlinks: capabilities.hyperlinks
         )
@@ -718,6 +885,28 @@ public final class AFMTerminalChat: @unchecked Sendable {
             return [Message(role: "system", content: configuration.engine.instructions)]
         }
         return []
+    }
+
+    static func requestMessages(for backend: AFMBackend, transcript: [Message]) -> [Message] {
+        if case .foundationModels = backend {
+            return transcript.last.map { [$0] } ?? []
+        }
+        return transcript
+    }
+
+    static func validateRestoredSession(
+        _ restored: TUISession,
+        backendName: String,
+        modelName: String
+    ) throws {
+        guard restored.backend == backendName, restored.model == modelName else {
+            throw TUIArtifactError.incompatibleSession(
+                savedBackend: restored.backend,
+                savedModel: restored.model,
+                currentBackend: backendName,
+                currentModel: modelName
+            )
+        }
     }
 
     private func style(_ value: String, _ code: String) -> String {

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -701,11 +701,14 @@ public final class AFMTerminalChat: @unchecked Sendable {
         codeBlocks = rendered.codeBlocks
         images = rendered.images
         let elapsed = max(0.001, Date().timeIntervalSince(start))
-        let rate = Double(lastSnapshot.completionTokens) / elapsed
-        lastStatistics = String(
-            format: "%d prompt · %d cached · %d generated · %.2fs · %.1f tok/s",
-            lastSnapshot.promptTokens, lastSnapshot.cachedTokens,
-            lastSnapshot.completionTokens, elapsed, rate
+        lastStatistics = Self.turnStatistics(
+            backend: configuration.backend,
+            requestMessages: messages,
+            responseText: lastSnapshot.text,
+            promptTokens: lastSnapshot.promptTokens,
+            completionTokens: lastSnapshot.completionTokens,
+            cachedTokens: lastSnapshot.cachedTokens,
+            elapsed: elapsed
         )
         terminal.write("\(style("↳ \(lastStatistics)", "2"))\n")
         if !codeBlocks.isEmpty { terminal.write("\(style("\(codeBlocks.count) code block(s): /blocks, /copy, /save, /open", "2;36"))\n") }
@@ -721,6 +724,42 @@ public final class AFMTerminalChat: @unchecked Sendable {
             return .incomplete(snapshot.finishReason)
         }
         return .accepted
+    }
+
+    static func turnStatistics(
+        backend: AFMBackend,
+        requestMessages: [Message],
+        responseText: String,
+        promptTokens: Int,
+        completionTokens: Int,
+        cachedTokens: Int,
+        elapsed: TimeInterval
+    ) -> String {
+        let duration = max(0.001, elapsed)
+        if case .foundationModels = backend {
+            let estimatedInput = estimatedTokenCount(
+                requestMessages.map(\.textContent).joined(separator: " ")
+            )
+            let estimatedOutput = estimatedTokenCount(responseText)
+            let rate = Double(estimatedOutput) / duration
+            return String(
+                format: "~%d input · ~%d generated · %.2fs · ~%.1f tok/s · estimated",
+                estimatedInput, estimatedOutput, duration, rate
+            )
+        }
+        let rate = Double(completionTokens) / duration
+        return String(
+            format: "%d prompt · %d cached · %d generated · %.2fs · %.1f tok/s",
+            promptTokens, cachedTokens, completionTokens, duration, rate
+        )
+    }
+
+    static func estimatedTokenCount(_ text: String) -> Int {
+        guard !text.isEmpty else { return 0 }
+        let words = text.split(whereSeparator: \.isWhitespace).count
+        let characterEstimate = Double(text.count) / 4.0
+        let wordEstimate = Double(words) / 0.75
+        return max(1, Int(ceil(max(characterEstimate, wordEstimate))))
     }
 
     private func reportPersistenceResult(_ result: TUISessionPersistenceResult) {

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -155,6 +155,12 @@ enum TUIGenerationPhase: Equatable, Sendable {
     case completed
 }
 
+enum TUIGenerationDisposition: Equatable, Sendable {
+    case accepted
+    case cancelled
+    case incomplete(AFMFinishReason?)
+}
+
 enum TUIActivityIndicator {
     private static let unicodeFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
     private static let asciiFrames = ["|", "/", "-", "\\"]
@@ -180,6 +186,7 @@ struct GenerationSnapshot: Sendable {
     let cachedTokens: Int
     let phase: TUIGenerationPhase
     let reasoningDuration: TimeInterval?
+    let finishReason: AFMFinishReason?
     let completed: Bool
     let cancelled: Bool
     let error: String?
@@ -202,6 +209,7 @@ actor GenerationBuffer {
     private var currentPhase: TUIGenerationPhase = .preparing
     private var reasoningStartedAt: Date?
     private var reasoningFinishedAt: Date?
+    private var finishReason: AFMFinishReason?
     private var completed = false
     private var cancelled = false
     private var error: String?
@@ -244,8 +252,9 @@ actor GenerationBuffer {
             }
         case .usage(let prompt, let completion, let cached):
             promptTokens = prompt; completionTokens = completion; cachedTokens = cached
-        case .completed:
+        case .completed(let reason):
             finishReasoningIfNeeded()
+            finishReason = reason
             completed = true
         case .tokenLogprobs, .metadata, .custom: break
         }
@@ -267,6 +276,7 @@ actor GenerationBuffer {
         promptTokens = response.promptTokens
         completionTokens = response.completionTokens
         cachedTokens = response.cachedPromptTokens
+        finishReason = response.finishReason
         for call in response.toolCalls ?? [] {
             let safeCall = AFMToolCall(
                 id: TerminalOutputSanitizer.sanitize(call.id),
@@ -284,17 +294,19 @@ actor GenerationBuffer {
     func fail(_ value: Error) {
         guard !completed else { return }
         finishReasoningIfNeeded()
-        error = TerminalOutputSanitizer.sanitize(value.localizedDescription); completed = true; revision &+= 1
+        error = TerminalOutputSanitizer.sanitize(value.localizedDescription)
+        finishReason = .error
+        completed = true; revision &+= 1
     }
     func cancel() {
         guard !completed else { return }
         finishReasoningIfNeeded()
-        cancelled = true; completed = true; revision &+= 1
+        cancelled = true; finishReason = .cancelled; completed = true; revision &+= 1
     }
     func finish() {
         guard !completed else { return }
         finishReasoningIfNeeded()
-        completed = true; revision &+= 1
+        finishReason = .unknown; completed = true; revision &+= 1
     }
     func snapshot() -> GenerationSnapshot {
         makeSnapshot(includeFullContent: true)
@@ -320,7 +332,8 @@ actor GenerationBuffer {
             toolDisplayLines: toolDisplayLines,
             promptTokens: promptTokens, completionTokens: completionTokens,
             cachedTokens: cachedTokens, phase: phase,
-            reasoningDuration: reasoningDuration, completed: completed,
+            reasoningDuration: reasoningDuration, finishReason: finishReason,
+            completed: completed,
             cancelled: cancelled, error: error
         )
     }
@@ -595,6 +608,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
                 lastSnapshot = changed
                 forceRedraw = true
             }
+            if lastSnapshot.completed { break }
             let now = Date()
             if forceRedraw || now >= nextActivityRedraw {
                 if !forceRedraw { lastSnapshot = await buffer.renderSnapshot() }
@@ -639,15 +653,32 @@ public final class AFMTerminalChat: @unchecked Sendable {
             terminal.write("\(style("error", "1;31")): \(error)\n\n")
             return
         }
-        if lastSnapshot.cancelled || (lastSnapshot.text.isEmpty && lastSnapshot.tools.isEmpty) {
+        lastReasoning = lastSnapshot.reasoning
+        switch Self.generationDisposition(for: lastSnapshot) {
+        case .cancelled:
             session.removeMessage(at: pendingUserIndex)
             lastInputWasRolledBack = true
             try? await engine.resetConversation(with: session.messages)
             terminal.write("\(style("cancelled", "33")) — the partial response was not added.\n\n")
             return
+        case .incomplete(let reason):
+            session.removeMessage(at: pendingUserIndex)
+            lastInputWasRolledBack = true
+            try? await engine.resetConversation(with: session.messages)
+            let notice: String
+            if reason == .length {
+                notice = "token limit reached before the model produced an answer"
+            } else if reason == .contentFilter {
+                notice = "generation stopped by the content filter before producing an answer"
+            } else {
+                notice = "model stopped before producing an answer"
+            }
+            terminal.write("\(style("incomplete", "1;33")) — \(notice). The turn was not added; use /reasoning last, then /edit the prompt or restart with a higher --max-tokens value.\n\n")
+            return
+        case .accepted:
+            break
         }
 
-        lastReasoning = lastSnapshot.reasoning
         let messageToolCalls = lastSnapshot.tools.map {
             MessageToolCall(
                 id: $0.id,
@@ -680,6 +711,16 @@ public final class AFMTerminalChat: @unchecked Sendable {
         if !codeBlocks.isEmpty { terminal.write("\(style("\(codeBlocks.count) code block(s): /blocks, /copy, /save, /open", "2;36"))\n") }
         if !images.isEmpty { presentImages(images) }
         terminal.write("\n")
+    }
+
+    static func generationDisposition(for snapshot: GenerationSnapshot) -> TUIGenerationDisposition {
+        if snapshot.cancelled || snapshot.finishReason == .cancelled {
+            return .cancelled
+        }
+        if snapshot.text.isEmpty && snapshot.tools.isEmpty {
+            return .incomplete(snapshot.finishReason)
+        }
+        return .accepted
     }
 
     private func reportPersistenceResult(_ result: TUISessionPersistenceResult) {
@@ -741,12 +782,14 @@ public final class AFMTerminalChat: @unchecked Sendable {
         } else if !final && snapshot.phase == .usingTools {
             display += activityLine(label: "Using tools", frame: activityFrame, elapsed: elapsed) + "\n"
         }
-        display += style("assistant", "1;32") + " › " + renderGenerationMarkdown(
-            full: snapshot.text,
-            tail: snapshot.textTail,
-            characterCount: snapshot.textCharacterCount,
-            final: final
-        )
+        if !final || snapshot.textCharacterCount > 0 || !snapshot.toolDisplayLines.isEmpty {
+            display += style("assistant", "1;32") + " › " + renderGenerationMarkdown(
+                full: snapshot.text,
+                tail: snapshot.textTail,
+                characterCount: snapshot.textCharacterCount,
+                final: final
+            )
+        }
         if !snapshot.toolDisplayLines.isEmpty {
             display += "\n" + style(snapshot.toolDisplayLines.joined(separator: "\n"), "36")
         }
@@ -762,9 +805,17 @@ public final class AFMTerminalChat: @unchecked Sendable {
         let isActive = !final && snapshot.phase == .reasoning
         let duration = Self.formattedDuration(snapshot.reasoningDuration ?? 0)
         let size = Self.compactCount(snapshot.reasoningCharacterCount)
+        let completedStatus: String
+        if snapshot.finishReason == .length && snapshot.textCharacterCount == 0 {
+            completedStatus = "◇ Reasoning — token limit"
+        } else if snapshot.cancelled || snapshot.finishReason == .cancelled {
+            completedStatus = "◇ Reasoning — interrupted"
+        } else {
+            completedStatus = "◇ Reasoning ✓"
+        }
         let status = isActive
             ? "◆ Reasoning \(activitySymbol(activityFrame))"
-            : "◇ Reasoning ✓"
+            : completedStatus
         let hint = isActive
             ? (reasoningDisplayMode == .expanded ? "Tab collapse" : "Tab expand")
             : "/reasoning last"
@@ -772,7 +823,10 @@ public final class AFMTerminalChat: @unchecked Sendable {
 
         switch reasoningDisplayMode {
         case .hidden:
-            return style("\(isActive ? "◆" : "◇") Reasoning \(isActive ? activitySymbol(activityFrame) : "✓") (hidden)", "2;35")
+            let hiddenStatus = isActive
+                ? "◆ Reasoning \(activitySymbol(activityFrame))"
+                : completedStatus
+            return style("\(hiddenStatus) (hidden)", "2;35")
         case .collapsed:
             return style(summary, isActive ? "35" : "2;35")
         case .expanded:

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -562,7 +562,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
             session.reasoningByMessage[String(assistantIndex)] = lastSnapshot.reasoning
         }
         session.updatedAt = Date()
-        reportPersistenceResult(store.persistRecoveringTranscript(session))
+        reportPersistenceResult(store.persistRecoveringSession(session))
         let rendered = renderMarkdown(lastSnapshot.text)
         codeBlocks = rendered.codeBlocks
         images = rendered.images
@@ -588,11 +588,11 @@ public final class AFMTerminalChat: @unchecked Sendable {
         switch result {
         case .saved:
             return nil
-        case .recovered(let saveError, let transcriptURL):
+        case .recovered(let saveError, let recoveryURL):
             return """
             warning: Session save failed: \(saveError)
-            Recovery transcript: \(transcriptURL.path)
-            Inline image data is omitted from Markdown. This chat remains in memory; use /export <path> for another text copy before quitting.
+            Full recovery session: \(recoveryURL.path)
+            This bounded JSON recovery preserves multimodal content and tool calls. Use /export <path> for a separate text copy.
 
             """
         case .failed(let saveError, let recoveryError):

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -100,14 +100,25 @@ public enum TUIInvocationPolicy {
         tui: Bool,
         webUI: Bool,
         singlePrompt: Bool,
+        telegramOptions: Bool = false,
         inputIsTTY: Bool,
         outputIsTTY: Bool
     ) throws {
         guard tui else { return }
         if webUI { throw TUIInvocationError.conflict("--tui cannot be combined with --webui") }
         if singlePrompt { throw TUIInvocationError.conflict("--tui cannot be combined with --single-prompt") }
+        if telegramOptions { throw TUIInvocationError.conflict("--tui cannot be combined with Telegram server options") }
         if !inputIsTTY { throw TUIInvocationError.conflict("--tui requires interactive terminal input") }
         if !outputIsTTY { throw TUIInvocationError.conflict("--tui requires interactive terminal output") }
+    }
+
+    public static func hasTelegramOptions(
+        botToken: String?,
+        allowlist: String?,
+        replyFormat: String?,
+        requirePrefix: String?
+    ) -> Bool {
+        botToken != nil || allowlist != nil || replyFormat != nil || requirePrefix != nil
     }
 }
 
@@ -381,6 +392,9 @@ public final class AFMTerminalChat: @unchecked Sendable {
     public func run() async throws {
         guard capabilities.isInteractive else {
             throw TUIInvocationError.conflict("--tui requires an interactive terminal")
+        }
+        for attachment in configuration.initialAttachments {
+            try TUIMediaAttachmentPolicy.validate(attachment)
         }
         try terminal.enter()
         terminal.enterAlternateScreen()
@@ -771,16 +785,26 @@ public final class AFMTerminalChat: @unchecked Sendable {
     }
 
     private func makeUserTurn(_ input: String) throws -> TUIUserTurn {
+        try Self.makeUserTurn(input, attachments: attachments)
+    }
+
+    static func makeUserTurn(_ input: String, attachments: [URL]) throws -> TUIUserTurn {
         guard !attachments.isEmpty else {
             return TUIUserTurn(input: input, message: Message(role: "user", content: input))
         }
         var parts = [ContentPart(type: "text", text: input)]
         for url in attachments {
             let ext = url.pathExtension.lowercased()
-            if ["png", "jpg", "jpeg", "gif", "webp", "heic"].contains(ext) {
+            if TUIMediaAttachmentPolicy.kind(for: url) == .image {
                 let data = try TUIArtifactActions.readRegularFile(at: url, maximumBytes: 20_000_000)
                 let mime = ext == "jpg" || ext == "jpeg" ? "image/jpeg" : "image/\(ext)"
                 parts.append(ContentPart(type: "image_url", image_url: ImageURL(url: "data:\(mime);base64,\(data.base64EncodedString())", detail: "auto")))
+            } else if TUIMediaAttachmentPolicy.kind(for: url) == .video {
+                try TUIMediaAttachmentPolicy.validate(url)
+                parts.append(ContentPart(
+                    type: "image_url",
+                    image_url: ImageURL(url: url.absoluteString, detail: nil)
+                ))
             } else {
                 let data = try TUIArtifactActions.readRegularFile(at: url, maximumBytes: 2_000_000)
                 guard let text = String(data: data, encoding: .utf8) else {
@@ -813,7 +837,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
         /blocks /copy <n>                 list/copy response code blocks
         /save[!] <n> <path>               save block; ! explicitly permits overwrite
         /open <n>                         explicitly preview HTML/JS in the browser
-        /attach <path>                    attach an image or UTF-8 text file
+        /attach <path>                    attach an image, video, or UTF-8 text file
         /images /image <n>                list/display images (inline, or Quick Look fallback)
         /export[!] <path>                 export this transcript as Markdown
         /theme <auto|dark|light|mono>     change terminal rendering
@@ -884,8 +908,11 @@ public final class AFMTerminalChat: @unchecked Sendable {
     private func attach(_ pieces: [String]) throws {
         guard pieces.count >= 2 else { throw TUIArtifactError.invalidPath("usage: /attach <path>") }
         let url = try TUIArtifactActions.resolvedURL(pieces.dropFirst().joined(separator: " "))
-        let isImage = ["png", "jpg", "jpeg", "gif", "webp", "heic"].contains(url.pathExtension.lowercased())
-        try TUIArtifactActions.preflightRegularFile(at: url, maximumBytes: isImage ? 20_000_000 : 2_000_000)
+        if TUIMediaAttachmentPolicy.kind(for: url) != nil {
+            try TUIMediaAttachmentPolicy.validate(url)
+        } else {
+            try TUIArtifactActions.preflightRegularFile(at: url, maximumBytes: 2_000_000)
+        }
         attachments.append(url); terminal.write("Attached \(url.lastPathComponent). It will be sent with the next prompt.\n")
     }
 

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -297,7 +297,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
         ))
         session.updatedAt = Date()
         _ = try? store.save(session)
-        let rendered = renderer.render(lastSnapshot.text)
+        let rendered = renderMarkdown(lastSnapshot.text)
         codeBlocks = rendered.codeBlocks
         images = rendered.images
         let elapsed = max(0.001, Date().timeIntervalSince(start))
@@ -324,12 +324,12 @@ public final class AFMTerminalChat: @unchecked Sendable {
         var display = ""
         if !snapshot.reasoning.isEmpty {
             if showReasoning {
-                display += style("reasoning", "2;35") + " ›\n" + style(snapshot.reasoning, "2") + "\n\n"
+                display += style("reasoning", "2;35") + " ›\n" + renderMarkdown(snapshot.reasoning).text + "\n\n"
             } else {
                 display += style("… reasoning hidden (\(snapshot.reasoning.count) chars; /reasoning show)", "2") + "\n"
             }
         }
-        display += style("assistant", "1;32") + " › " + renderer.render(snapshot.text).text
+        display += style("assistant", "1;32") + " › " + renderMarkdown(snapshot.text).text
         if snapshot.text.isEmpty && snapshot.reasoning.isEmpty { display += style("thinking…", "2") }
         if !snapshot.tools.isEmpty {
             let lines = zip(snapshot.tools, snapshot.toolStages).map { call, stage in
@@ -419,7 +419,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
             showReasoning = value == "show" || value == "on" ? true : value == "hide" || value == "off" ? false : !showReasoning
             terminal.write("Reasoning is now \(showReasoning ? "visible" : "hidden").\n")
             if showReasoning, !lastReasoning.isEmpty {
-                terminal.write("\(style("latest reasoning", "2;35")) ›\n\(style(lastReasoning, "2"))\n")
+                terminal.write("\(style("latest reasoning", "2;35")) ›\n\(renderMarkdown(lastReasoning).text)\n")
             }
         case "/blocks": listBlocks()
         case "/copy": try copyBlock(pieces)
@@ -600,7 +600,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
         images = []
         terminal.clearScreen(); drawWelcome()
         for message in session.messages where message.role != "system" {
-            terminal.write("\(style(message.role, message.role == "user" ? "1;34" : "1;32")) › \(renderer.render(message.textContent).text)\n\n")
+            terminal.write("\(style(message.role, message.role == "user" ? "1;34" : "1;32")) › \(renderMarkdown(message.textContent).text)\n\n")
         }
     }
 
@@ -618,7 +618,16 @@ public final class AFMTerminalChat: @unchecked Sendable {
     }
 
     private func displayRows(_ input: String, width: Int) -> Int {
-        let plain = input.replacingOccurrences(of: #"\u001B\[[0-9;]*m"#, with: "", options: .regularExpression)
+        let withoutLinks = input.replacingOccurrences(
+            of: #"\u001B\][^\u0007]*(?:\u0007|\u001B\\)"#,
+            with: "",
+            options: .regularExpression
+        )
+        let plain = withoutLinks.replacingOccurrences(
+            of: #"\u001B\[[0-?]*[ -/]*[@-~]"#,
+            with: "",
+            options: .regularExpression
+        )
         let columns = max(1, width)
         return max(1, plain.split(separator: "\n", omittingEmptySubsequences: false).reduce(0) {
             let cells = String($1).unicodeScalars.reduce(0) { total, scalar in
@@ -626,6 +635,14 @@ public final class AFMTerminalChat: @unchecked Sendable {
             }
             return $0 + max(1, (cells + columns - 1) / columns)
         })
+    }
+
+    private func renderMarkdown(_ source: String) -> MarkdownRenderResult {
+        renderer.render(
+            source,
+            width: max(24, terminal.width() - 4),
+            hyperlinks: capabilities.hyperlinks
+        )
     }
 
     private static func initialMessages(for configuration: TerminalChatConfiguration) -> [Message] {

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -137,6 +137,34 @@ public struct TUILogprobConfiguration: Equatable, Sendable {
     }
 }
 
+public enum TUIReasoningDisplayMode: String, Equatable, Sendable {
+    case collapsed
+    case expanded
+    case hidden
+
+    mutating func togglePanel() {
+        self = self == .expanded ? .collapsed : .expanded
+    }
+}
+
+enum TUIGenerationPhase: Equatable, Sendable {
+    case preparing
+    case reasoning
+    case answering
+    case usingTools
+    case completed
+}
+
+enum TUIActivityIndicator {
+    private static let unicodeFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+    private static let asciiFrames = ["|", "/", "-", "\\"]
+
+    static func symbol(frame: Int, unicode: Bool) -> String {
+        let frames = unicode ? unicodeFrames : asciiFrames
+        return frames[abs(frame) % frames.count]
+    }
+}
+
 struct GenerationSnapshot: Sendable {
     let revision: UInt64
     let text: String
@@ -150,6 +178,8 @@ struct GenerationSnapshot: Sendable {
     let promptTokens: Int
     let completionTokens: Int
     let cachedTokens: Int
+    let phase: TUIGenerationPhase
+    let reasoningDuration: TimeInterval?
     let completed: Bool
     let cancelled: Bool
     let error: String?
@@ -169,6 +199,9 @@ actor GenerationBuffer {
     private var promptTokens = 0
     private var completionTokens = 0
     private var cachedTokens = 0
+    private var currentPhase: TUIGenerationPhase = .preparing
+    private var reasoningStartedAt: Date?
+    private var reasoningFinishedAt: Date?
     private var completed = false
     private var cancelled = false
     private var error: String?
@@ -178,17 +211,23 @@ actor GenerationBuffer {
         guard !completed else { return }
         switch event {
         case .text(let value, let tokens):
+            finishReasoningIfNeeded()
+            currentPhase = .answering
             let safe = TerminalOutputSanitizer.sanitize(value)
             text += safe
             textTail = Self.appendingToRenderTail(textTail, safe)
             textCharacterCount += safe.count
             completionTokens = max(completionTokens, tokens)
         case .reasoning(let value, _):
+            if reasoningStartedAt == nil { reasoningStartedAt = Date() }
+            currentPhase = .reasoning
             let safe = TerminalOutputSanitizer.sanitize(value)
             reasoning += safe
             reasoningTail = Self.appendingToRenderTail(reasoningTail, safe)
             reasoningCharacterCount += safe.count
         case .toolCall(let call, let stage):
+            finishReasoningIfNeeded()
+            currentPhase = .usingTools
             let safeCall = AFMToolCall(
                 id: TerminalOutputSanitizer.sanitize(call.id),
                 name: TerminalOutputSanitizer.sanitize(call.name),
@@ -205,7 +244,9 @@ actor GenerationBuffer {
             }
         case .usage(let prompt, let completion, let cached):
             promptTokens = prompt; completionTokens = completion; cachedTokens = cached
-        case .completed: completed = true
+        case .completed:
+            finishReasoningIfNeeded()
+            completed = true
         case .tokenLogprobs, .metadata, .custom: break
         }
         revision &+= 1
@@ -215,6 +256,10 @@ actor GenerationBuffer {
         guard !completed else { return }
         text = TerminalOutputSanitizer.sanitize(response.content)
         reasoning = TerminalOutputSanitizer.sanitize(response.reasoningContent ?? "")
+        if !reasoning.isEmpty {
+            reasoningStartedAt = Date()
+            reasoningFinishedAt = reasoningStartedAt
+        }
         textCharacterCount = text.count
         reasoningCharacterCount = reasoning.count
         textTail = String(text.suffix(Self.renderTailLimit))
@@ -238,14 +283,17 @@ actor GenerationBuffer {
 
     func fail(_ value: Error) {
         guard !completed else { return }
+        finishReasoningIfNeeded()
         error = TerminalOutputSanitizer.sanitize(value.localizedDescription); completed = true; revision &+= 1
     }
     func cancel() {
         guard !completed else { return }
+        finishReasoningIfNeeded()
         cancelled = true; completed = true; revision &+= 1
     }
     func finish() {
         guard !completed else { return }
+        finishReasoningIfNeeded()
         completed = true; revision &+= 1
     }
     func snapshot() -> GenerationSnapshot {
@@ -257,7 +305,11 @@ actor GenerationBuffer {
     }
 
     private func makeSnapshot(includeFullContent: Bool) -> GenerationSnapshot {
-        GenerationSnapshot(
+        let phase: TUIGenerationPhase = completed ? .completed : currentPhase
+        let reasoningDuration = reasoningStartedAt.map {
+            (reasoningFinishedAt ?? Date()).timeIntervalSince($0)
+        }
+        return GenerationSnapshot(
             revision: revision,
             text: includeFullContent ? text : "",
             reasoning: includeFullContent ? reasoning : "",
@@ -267,9 +319,16 @@ actor GenerationBuffer {
             tools: includeFullContent ? tools : [],
             toolDisplayLines: toolDisplayLines,
             promptTokens: promptTokens, completionTokens: completionTokens,
-            cachedTokens: cachedTokens, completed: completed,
+            cachedTokens: cachedTokens, phase: phase,
+            reasoningDuration: reasoningDuration, completed: completed,
             cancelled: cancelled, error: error
         )
+    }
+
+    private func finishReasoningIfNeeded() {
+        if reasoningStartedAt != nil, reasoningFinishedAt == nil {
+            reasoningFinishedAt = Date()
+        }
     }
 
     func snapshot(ifChangedSince priorRevision: UInt64) -> GenerationSnapshot? {
@@ -358,7 +417,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
     private let engine: AFMEngine
     private var session: TUISession
     private var renderer: TerminalMarkdownRenderer
-    private var showReasoning: Bool
+    private var reasoningDisplayMode: TUIReasoningDisplayMode
     private var promptHistory: [String] = []
     private var codeBlocks: [TUICodeBlock] = []
     private var images: [TUIImageReference] = []
@@ -385,7 +444,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
             messages: Self.initialMessages(for: configuration)
         )
         self.renderer = TerminalMarkdownRenderer(color: capabilities.color, theme: configuration.theme)
-        self.showReasoning = configuration.showReasoning
+        self.reasoningDisplayMode = configuration.showReasoning ? .expanded : .collapsed
         self.attachments = configuration.initialAttachments
     }
 
@@ -516,14 +575,38 @@ public final class AFMTerminalChat: @unchecked Sendable {
         var previousRows = 0
         var lastSnapshot = await buffer.renderSnapshot()
         let start = Date()
+        var activityFrame = 0
+        var nextActivityRedraw = Date.distantPast
         while !lastSnapshot.completed && !signalMonitor.shouldTerminate {
-            if let key = terminal.readKey(timeoutMilliseconds: 40), key == .interrupt {
-                task.cancel()
-                await buffer.cancel()
+            var forceRedraw = false
+            if let key = terminal.readKey(timeoutMilliseconds: 40) {
+                switch key {
+                case .interrupt:
+                    task.cancel()
+                    await buffer.cancel()
+                case .tab:
+                    reasoningDisplayMode.togglePanel()
+                    forceRedraw = true
+                default:
+                    break
+                }
             }
             if let changed = await buffer.snapshot(ifChangedSince: lastSnapshot.revision) {
                 lastSnapshot = changed
-                previousRows = redrawGeneration(lastSnapshot, previousRows: previousRows, final: false)
+                forceRedraw = true
+            }
+            let now = Date()
+            if forceRedraw || now >= nextActivityRedraw {
+                if !forceRedraw { lastSnapshot = await buffer.renderSnapshot() }
+                previousRows = redrawGeneration(
+                    lastSnapshot,
+                    previousRows: previousRows,
+                    final: false,
+                    activityFrame: activityFrame,
+                    elapsed: now.timeIntervalSince(start)
+                )
+                activityFrame &+= 1
+                nextActivityRedraw = now.addingTimeInterval(0.12)
             }
         }
         if signalMonitor.shouldTerminate {
@@ -540,7 +623,13 @@ public final class AFMTerminalChat: @unchecked Sendable {
             try? await engine.resetConversation(with: session.messages)
             return
         }
-        _ = redrawGeneration(lastSnapshot, previousRows: previousRows, final: true)
+        _ = redrawGeneration(
+            lastSnapshot,
+            previousRows: previousRows,
+            final: true,
+            activityFrame: activityFrame,
+            elapsed: Date().timeIntervalSince(start)
+        )
         terminal.write("\n")
 
         if let error = lastSnapshot.error {
@@ -619,7 +708,13 @@ public final class AFMTerminalChat: @unchecked Sendable {
         }
     }
 
-    private func redrawGeneration(_ snapshot: GenerationSnapshot, previousRows: Int, final: Bool) -> Int {
+    private func redrawGeneration(
+        _ snapshot: GenerationSnapshot,
+        previousRows: Int,
+        final: Bool,
+        activityFrame: Int,
+        elapsed: TimeInterval
+    ) -> Int {
         if previousRows > 0 {
             for index in 0..<previousRows {
                 terminal.clearLine()
@@ -629,16 +724,22 @@ public final class AFMTerminalChat: @unchecked Sendable {
         }
         var display = ""
         if snapshot.reasoningCharacterCount > 0 {
-            if showReasoning {
-                display += style("reasoning", "2;35") + " ›\n" + renderGenerationMarkdown(
-                    full: snapshot.reasoning,
-                    tail: snapshot.reasoningTail,
-                    characterCount: snapshot.reasoningCharacterCount,
-                    final: final
-                ) + "\n\n"
-            } else {
-                display += style("… reasoning hidden (\(snapshot.reasoningCharacterCount) chars; /reasoning show)", "2") + "\n"
-            }
+            display += reasoningPanel(
+                snapshot,
+                final: final,
+                activityFrame: activityFrame
+            ) + "\n"
+        } else if !final && snapshot.phase == .preparing {
+            display += activityLine(
+                label: "Preparing context",
+                frame: activityFrame,
+                elapsed: elapsed
+            ) + "\n"
+        }
+        if !final && snapshot.phase == .answering {
+            display += activityLine(label: "Writing answer", frame: activityFrame, elapsed: elapsed) + "\n"
+        } else if !final && snapshot.phase == .usingTools {
+            display += activityLine(label: "Using tools", frame: activityFrame, elapsed: elapsed) + "\n"
         }
         display += style("assistant", "1;32") + " › " + renderGenerationMarkdown(
             full: snapshot.text,
@@ -646,14 +747,66 @@ public final class AFMTerminalChat: @unchecked Sendable {
             characterCount: snapshot.textCharacterCount,
             final: final
         )
-        if snapshot.textCharacterCount == 0 && snapshot.reasoningCharacterCount == 0 {
-            display += style("thinking…", "2")
-        }
         if !snapshot.toolDisplayLines.isEmpty {
             display += "\n" + style(snapshot.toolDisplayLines.joined(separator: "\n"), "36")
         }
         terminal.write(display)
         return displayRows(display, width: terminal.width())
+    }
+
+    private func reasoningPanel(
+        _ snapshot: GenerationSnapshot,
+        final: Bool,
+        activityFrame: Int
+    ) -> String {
+        let isActive = !final && snapshot.phase == .reasoning
+        let duration = Self.formattedDuration(snapshot.reasoningDuration ?? 0)
+        let size = Self.compactCount(snapshot.reasoningCharacterCount)
+        let status = isActive
+            ? "◆ Reasoning \(activitySymbol(activityFrame))"
+            : "◇ Reasoning ✓"
+        let hint = isActive
+            ? (reasoningDisplayMode == .expanded ? "Tab collapse" : "Tab expand")
+            : "/reasoning last"
+        let summary = "\(status)  \(duration) · \(size) chars  [\(hint)]"
+
+        switch reasoningDisplayMode {
+        case .hidden:
+            return style("\(isActive ? "◆" : "◇") Reasoning \(isActive ? activitySymbol(activityFrame) : "✓") (hidden)", "2;35")
+        case .collapsed:
+            return style(summary, isActive ? "35" : "2;35")
+        case .expanded:
+            let rendered = renderGenerationMarkdown(
+                full: snapshot.reasoning,
+                tail: snapshot.reasoningTail,
+                characterCount: snapshot.reasoningCharacterCount,
+                final: final
+            )
+            let body = rendered.split(separator: "\n", omittingEmptySubsequences: false)
+                .map { style("│", "2;35") + " " + String($0) }
+                .joined(separator: "\n")
+            return style("╭─ \(summary)", isActive ? "35" : "2;35")
+                + "\n" + body + "\n" + style("╰─", "2;35")
+        }
+    }
+
+    private func activityLine(label: String, frame: Int, elapsed: TimeInterval) -> String {
+        style("◆ \(label)  \(activitySymbol(frame))  \(Self.formattedDuration(elapsed))  [Ctrl-C cancel]", "2;36")
+    }
+
+    private func activitySymbol(_ frame: Int) -> String {
+        TUIActivityIndicator.symbol(
+            frame: frame,
+            unicode: capabilities.terminalProgram != "dumb"
+        )
+    }
+
+    private static func formattedDuration(_ value: TimeInterval) -> String {
+        String(format: "%.1fs", max(0, value))
+    }
+
+    private static func compactCount(_ value: Int) -> String {
+        value >= 1_000 ? String(format: "%.1fk", Double(value) / 1_000) : "\(value)"
     }
 
     private func renderGenerationMarkdown(
@@ -745,9 +898,25 @@ public final class AFMTerminalChat: @unchecked Sendable {
         case "/status": terminal.write("\(configuration.backendName) · \(configuration.modelName)\n\(lastStatistics)\n")
         case "/reasoning":
             let value = pieces.dropFirst().first?.lowercased()
-            showReasoning = value == "show" || value == "on" ? true : value == "hide" || value == "off" ? false : !showReasoning
-            terminal.write("Reasoning is now \(showReasoning ? "visible" : "hidden").\n")
-            if showReasoning, !lastReasoning.isEmpty {
+            if value == "last" {
+                if lastReasoning.isEmpty {
+                    terminal.write("No reasoning is available for the latest response.\n")
+                } else {
+                    terminal.write("\(style("latest reasoning", "2;35")) ›\n\(renderMarkdown(lastReasoning).text)\n")
+                }
+                return false
+            }
+            switch value {
+            case "show", "on", "expanded", "expand": reasoningDisplayMode = .expanded
+            case "collapsed", "collapse": reasoningDisplayMode = .collapsed
+            case "hide", "hidden", "off": reasoningDisplayMode = .hidden
+            case nil: reasoningDisplayMode.togglePanel()
+            default:
+                terminal.write("Usage: /reasoning [collapsed|expanded|off|last]\n")
+                return false
+            }
+            terminal.write("Reasoning display: \(reasoningDisplayMode.rawValue).\n")
+            if reasoningDisplayMode == .expanded, !lastReasoning.isEmpty {
                 terminal.write("\(style("latest reasoning", "2;35")) ›\n\(renderMarkdown(lastReasoning).text)\n")
             }
         case "/blocks": listBlocks()
@@ -831,7 +1000,8 @@ public final class AFMTerminalChat: @unchecked Sendable {
 
         /new /clear /quit                 session controls
         /retry /edit                      regenerate or edit the previous prompt
-        /reasoning [show|hide]            toggle reasoning panels
+        /reasoning [collapsed|expanded|off|last]
+                                        control reasoning panels
         /status /history /search <text>   runtime and persisted-session search
         /resume <session-id>              resume a saved session
         /blocks /copy <n>                 list/copy response code blocks
@@ -843,7 +1013,8 @@ public final class AFMTerminalChat: @unchecked Sendable {
         /theme <auto|dark|light|mono>     change terminal rendering
 
         Arrow keys edit/navigate prompt history. Esc+Enter inserts a newline.
-        During generation Ctrl-C cancels only that response; Ctrl-C at an empty prompt exits.
+        During generation Tab expands/collapses reasoning and Ctrl-C cancels only that response.
+        Ctrl-C at an empty prompt exits.
 
         """)
     }

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -39,17 +39,34 @@ public struct TerminalChatConfiguration: Sendable {
 }
 
 public enum TUIInvocationPolicy {
-    public static func validate(tui: Bool, webUI: Bool, singlePrompt: Bool, pipedInput: Bool) throws {
+    public static func validate(
+        tui: Bool,
+        webUI: Bool,
+        singlePrompt: Bool,
+        inputIsTTY: Bool,
+        outputIsTTY: Bool
+    ) throws {
         guard tui else { return }
         if webUI { throw TUIInvocationError.conflict("--tui cannot be combined with --webui") }
         if singlePrompt { throw TUIInvocationError.conflict("--tui cannot be combined with --single-prompt") }
-        if pipedInput { throw TUIInvocationError.conflict("--tui requires an interactive terminal and cannot read piped input") }
+        if !inputIsTTY { throw TUIInvocationError.conflict("--tui requires interactive terminal input") }
+        if !outputIsTTY { throw TUIInvocationError.conflict("--tui requires interactive terminal output") }
     }
 }
 
 public enum TUIInvocationError: Error, LocalizedError, Equatable {
     case conflict(String)
     public var errorDescription: String? { if case .conflict(let value) = self { return value }; return nil }
+}
+
+public struct TUILogprobConfiguration: Equatable, Sendable {
+    public let enabled: Bool
+    public let maximum: Int?
+
+    public init(maximum: Int?) {
+        self.enabled = maximum != nil
+        self.maximum = maximum
+    }
 }
 
 struct GenerationSnapshot: Sendable {

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -38,6 +38,63 @@ public struct TerminalChatConfiguration: Sendable {
     }
 }
 
+struct TUIUserTurn: Sendable {
+    let input: String
+    let message: Message
+
+    init(input: String, message: Message) {
+        self.input = input
+        self.message = message
+    }
+
+    init?(message: Message) {
+        guard message.role == "user", let content = message.content else { return nil }
+        self.message = message
+        switch content {
+        case .text(let text):
+            input = text
+        case .parts(let parts):
+            input = parts.first { $0.type == "text" }?.text ?? ""
+        }
+    }
+
+    func replacingInput(with revisedInput: String) -> TUIUserTurn {
+        let revisedContent: MessageContent?
+        switch message.content {
+        case .some(.text):
+            revisedContent = .text(revisedInput)
+        case .some(.parts(let parts)):
+            var replacedPrimaryText = false
+            var revisedParts = parts.map { part in
+                guard !replacedPrimaryText, part.type == "text" else { return part }
+                replacedPrimaryText = true
+                return ContentPart(
+                    type: part.type,
+                    text: revisedInput,
+                    image_url: part.image_url,
+                    input_audio: part.input_audio
+                )
+            }
+            if !replacedPrimaryText {
+                revisedParts.insert(ContentPart(type: "text", text: revisedInput), at: 0)
+            }
+            revisedContent = .parts(revisedParts)
+        case .none:
+            revisedContent = .text(revisedInput)
+        }
+        return TUIUserTurn(
+            input: revisedInput,
+            message: Message(
+                role: message.role,
+                content: revisedContent,
+                toolCalls: message.toolCalls,
+                toolCallId: message.toolCallId,
+                name: message.name
+            )
+        )
+    }
+}
+
 public enum TUIInvocationPolicy {
     public static func validate(
         tui: Bool,
@@ -296,7 +353,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
     private var images: [TUIImageReference] = []
     private var attachments: [URL] = []
     private var lastStatistics = "No generation yet"
-    private var lastInput: String?
+    private var lastUserTurn: TUIUserTurn?
     private var lastReasoning = ""
     private var lastInputWasRolledBack = false
 
@@ -352,7 +409,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
                         }
                         continue
                     }
-                    try await send(input, signalMonitor: signalMonitor)
+                    try await send(try makeUserTurn(input), signalMonitor: signalMonitor)
                 }
             }
         } catch {
@@ -407,16 +464,16 @@ public final class AFMTerminalChat: @unchecked Sendable {
         return try await task.value
     }
 
-    private func send(_ input: String, signalMonitor: TUISignalMonitor) async throws {
+    private func send(_ userTurn: TUIUserTurn, signalMonitor: TUISignalMonitor) async throws {
+        let input = userTurn.input
         lastInputWasRolledBack = false
         promptHistory.append(input)
-        lastInput = input
-        let userMessage = try makeUserMessage(input)
+        lastUserTurn = userTurn
         attachments.removeAll()
         if !session.messages.contains(where: { $0.role == "user" }) {
             session.title = String(input.replacingOccurrences(of: "\n", with: " ").prefix(72))
         }
-        session.messages.append(userMessage)
+        session.messages.append(userTurn.message)
         let pendingUserIndex = session.messages.index(before: session.messages.endIndex)
         session.updatedAt = Date()
         terminal.write("\n\(style("you", "1;34")) › \(input)\n\n")
@@ -505,7 +562,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
             session.reasoningByMessage[String(assistantIndex)] = lastSnapshot.reasoning
         }
         session.updatedAt = Date()
-        _ = try? store.save(session)
+        reportPersistenceResult(store.persistRecoveringTranscript(session))
         let rendered = renderMarkdown(lastSnapshot.text)
         codeBlocks = rendered.codeBlocks
         images = rendered.images
@@ -520,6 +577,32 @@ public final class AFMTerminalChat: @unchecked Sendable {
         if !codeBlocks.isEmpty { terminal.write("\(style("\(codeBlocks.count) code block(s): /blocks, /copy, /save, /open", "2;36"))\n") }
         if !images.isEmpty { presentImages(images) }
         terminal.write("\n")
+    }
+
+    private func reportPersistenceResult(_ result: TUISessionPersistenceResult) {
+        guard let notice = Self.persistenceNotice(for: result) else { return }
+        terminal.write(TerminalOutputSanitizer.sanitize(notice))
+    }
+
+    static func persistenceNotice(for result: TUISessionPersistenceResult) -> String? {
+        switch result {
+        case .saved:
+            return nil
+        case .recovered(let saveError, let transcriptURL):
+            return """
+            warning: Session save failed: \(saveError)
+            Recovery transcript: \(transcriptURL.path)
+            Inline image data is omitted from Markdown. This chat remains in memory; use /export <path> for another text copy before quitting.
+
+            """
+        case .failed(let saveError, let recoveryError):
+            return """
+            error: Session save failed: \(saveError)
+            Automatic recovery export also failed: \(recoveryError)
+            This chat remains in memory. Use /export <path> before quitting.
+
+            """
+        }
     }
 
     private func redrawGeneration(_ snapshot: GenerationSnapshot, previousRows: Int, final: Bool) -> Int {
@@ -665,16 +748,16 @@ public final class AFMTerminalChat: @unchecked Sendable {
         case "/search": try searchSessions(pieces)
         case "/resume": try await resumeSession(pieces)
         case "/retry":
-            guard let lastInput else { terminal.write("Nothing to retry.\n"); return false }
+            guard let lastUserTurn else { terminal.write("Nothing to retry.\n"); return false }
             if !lastInputWasRolledBack { session.removeLastExchange() }
             try await engine.resetConversation(with: session.messages)
-            try await send(lastInput, signalMonitor: signalMonitor)
+            try await send(lastUserTurn, signalMonitor: signalMonitor)
         case "/edit":
-            guard let lastInput else { terminal.write("Nothing to edit.\n"); return false }
-            if let revised = readInput(initial: lastInput, signalMonitor: signalMonitor), !revised.isEmpty {
+            guard let lastUserTurn else { terminal.write("Nothing to edit.\n"); return false }
+            if let revised = readInput(initial: lastUserTurn.input, signalMonitor: signalMonitor), !revised.isEmpty {
                 if !lastInputWasRolledBack { session.removeLastExchange() }
                 try await engine.resetConversation(with: session.messages)
-                try await send(revised, signalMonitor: signalMonitor)
+                try await send(lastUserTurn.replacingInput(with: revised), signalMonitor: signalMonitor)
             }
         case "/theme":
             guard let value = pieces.dropFirst().first, let theme = TerminalMarkdownRenderer.Theme(rawValue: value) else {
@@ -687,8 +770,10 @@ public final class AFMTerminalChat: @unchecked Sendable {
         return false
     }
 
-    private func makeUserMessage(_ input: String) throws -> Message {
-        guard !attachments.isEmpty else { return Message(role: "user", content: input) }
+    private func makeUserTurn(_ input: String) throws -> TUIUserTurn {
+        guard !attachments.isEmpty else {
+            return TUIUserTurn(input: input, message: Message(role: "user", content: input))
+        }
         var parts = [ContentPart(type: "text", text: input)]
         for url in attachments {
             let ext = url.pathExtension.lowercased()
@@ -704,7 +789,10 @@ public final class AFMTerminalChat: @unchecked Sendable {
                 parts.append(ContentPart(type: "text", text: "\n<attachment path=\"\(url.lastPathComponent)\">\n\(text)\n</attachment>"))
             }
         }
-        return Message(role: "user", content: .parts(parts))
+        return TUIUserTurn(
+            input: input,
+            message: Message(role: "user", content: .parts(parts))
+        )
     }
 
     private func drawWelcome() {
@@ -830,8 +918,9 @@ public final class AFMTerminalChat: @unchecked Sendable {
         restored.pruneReasoningMetadata()
         try await engine.resetConversation(with: restored.messages)
         session = restored
-        promptHistory = session.messages.filter { $0.role == "user" }.map(\.textContent)
-        lastInput = promptHistory.last
+        let restoredUserTurns = session.messages.compactMap(TUIUserTurn.init(message:))
+        promptHistory = restoredUserTurns.map(\.input)
+        lastUserTurn = restoredUserTurns.last
         lastInputWasRolledBack = false
         let lastAssistantIndex = session.messages.indices.reversed().first { session.messages[$0].role == "assistant" }
         lastReasoning = lastAssistantIndex.flatMap { session.reasoning(atMessageIndex: $0) } ?? ""
@@ -851,7 +940,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
         images = []
         attachments = []
         lastStatistics = "No generation yet"
-        lastInput = nil
+        lastUserTurn = nil
         lastReasoning = ""
         lastInputWasRolledBack = false
     }

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -1,0 +1,641 @@
+import Darwin
+import Dispatch
+import Foundation
+import AFMKit
+import AFMOpenAICompat
+
+public struct TerminalChatConfiguration: Sendable {
+    public let backend: AFMBackend
+    public let backendName: String
+    public let modelName: String
+    public let engine: EngineConfig
+    public let generation: GenerationConfig
+    public let theme: TerminalMarkdownRenderer.Theme
+    public let showReasoning: Bool
+    public let streaming: Bool
+    public let initialAttachments: [URL]
+
+    public init(
+        backend: AFMBackend,
+        backendName: String,
+        modelName: String,
+        engine: EngineConfig = .init(),
+        generation: GenerationConfig = .init(),
+        theme: TerminalMarkdownRenderer.Theme = .auto,
+        showReasoning: Bool = false,
+        streaming: Bool = true,
+        initialAttachments: [URL] = []
+    ) {
+        self.backend = backend
+        self.backendName = backendName
+        self.modelName = modelName
+        self.engine = engine
+        self.generation = generation
+        self.theme = theme
+        self.showReasoning = showReasoning
+        self.streaming = streaming
+        self.initialAttachments = initialAttachments
+    }
+}
+
+public enum TUIInvocationPolicy {
+    public static func validate(tui: Bool, webUI: Bool, singlePrompt: Bool, pipedInput: Bool) throws {
+        guard tui else { return }
+        if webUI { throw TUIInvocationError.conflict("--tui cannot be combined with --webui") }
+        if singlePrompt { throw TUIInvocationError.conflict("--tui cannot be combined with --single-prompt") }
+        if pipedInput { throw TUIInvocationError.conflict("--tui requires an interactive terminal and cannot read piped input") }
+    }
+}
+
+public enum TUIInvocationError: Error, LocalizedError, Equatable {
+    case conflict(String)
+    public var errorDescription: String? { if case .conflict(let value) = self { return value }; return nil }
+}
+
+private struct GenerationSnapshot: Sendable {
+    let text: String
+    let reasoning: String
+    let tools: [AFMToolCall]
+    let toolStages: [AFMToolCallStage]
+    let promptTokens: Int
+    let completionTokens: Int
+    let cachedTokens: Int
+    let completed: Bool
+    let cancelled: Bool
+    let error: String?
+}
+
+private actor GenerationBuffer {
+    private var text = ""
+    private var reasoning = ""
+    private var tools: [AFMToolCall] = []
+    private var toolStages: [AFMToolCallStage] = []
+    private var promptTokens = 0
+    private var completionTokens = 0
+    private var cachedTokens = 0
+    private var completed = false
+    private var cancelled = false
+    private var error: String?
+
+    func accept(_ event: AFMStreamEvent) {
+        switch event {
+        case .text(let value, let tokens): text += value; completionTokens = max(completionTokens, tokens)
+        case .reasoning(let value, _): reasoning += value
+        case .toolCall(let call, let stage):
+            if let index = tools.firstIndex(where: { $0.id == call.id }) {
+                tools[index] = call
+                toolStages[index] = stage
+            } else {
+                tools.append(call)
+                toolStages.append(stage)
+            }
+        case .usage(let prompt, let completion, let cached):
+            promptTokens = prompt; completionTokens = completion; cachedTokens = cached
+        case .completed: completed = true
+        case .tokenLogprobs, .metadata, .custom: break
+        }
+    }
+
+    func accept(_ response: AFMResponse) {
+        text = response.content
+        reasoning = response.reasoningContent ?? ""
+        promptTokens = response.promptTokens
+        completionTokens = response.completionTokens
+        cachedTokens = response.cachedPromptTokens
+        for call in response.toolCalls ?? [] {
+            tools.append(AFMToolCall(id: call.id, name: call.function.name, arguments: call.function.arguments))
+            toolStages.append(.completed)
+        }
+        completed = true
+    }
+
+    func fail(_ value: Error) { error = value.localizedDescription; completed = true }
+    func cancel() { cancelled = true; completed = true }
+    func finish() { completed = true }
+    func snapshot() -> GenerationSnapshot {
+        GenerationSnapshot(
+            text: text, reasoning: reasoning, tools: tools, toolStages: toolStages,
+            promptTokens: promptTokens, completionTokens: completionTokens,
+            cachedTokens: cachedTokens, completed: completed,
+            cancelled: cancelled, error: error
+        )
+    }
+}
+
+private final class TUISignalMonitor: @unchecked Sendable {
+    private let lock = NSLock()
+    private var terminated = false
+    private var sources: [DispatchSourceSignal] = []
+    private let monitoredSignals = [SIGTERM, SIGHUP]
+
+    init(onTermination: @escaping @Sendable () -> Void) {
+        for signalNumber in monitoredSignals {
+            signal(signalNumber, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global(qos: .userInteractive))
+            source.setEventHandler { [weak self] in
+                self?.lock.lock(); self?.terminated = true; self?.lock.unlock()
+                onTermination()
+            }
+            source.resume()
+            sources.append(source)
+        }
+    }
+
+    var shouldTerminate: Bool { lock.lock(); defer { lock.unlock() }; return terminated }
+    deinit {
+        for source in sources { source.cancel() }
+        for signalNumber in monitoredSignals { signal(signalNumber, SIG_DFL) }
+    }
+}
+
+public final class AFMTerminalChat: @unchecked Sendable {
+    private let configuration: TerminalChatConfiguration
+    private let terminal: TerminalIO
+    private let capabilities: TerminalCapabilities
+    private let store: TUISessionStore
+    private let engine: AFMEngine
+    private var session: TUISession
+    private var renderer: TerminalMarkdownRenderer
+    private var showReasoning: Bool
+    private var promptHistory: [String] = []
+    private var codeBlocks: [TUICodeBlock] = []
+    private var images: [TUIImageReference] = []
+    private var attachments: [URL] = []
+    private var lastStatistics = "No generation yet"
+    private var lastInput: String?
+    private var lastReasoning = ""
+
+    public init(
+        configuration: TerminalChatConfiguration,
+        terminal: TerminalIO = TerminalIO(),
+        capabilities: TerminalCapabilities = .detect(),
+        sessionStore: TUISessionStore = TUISessionStore()
+    ) {
+        self.configuration = configuration
+        self.terminal = terminal
+        self.capabilities = capabilities
+        self.store = sessionStore
+        self.engine = AFMEngine(backend: configuration.backend, config: configuration.engine)
+        self.session = TUISession(
+            backend: configuration.backendName,
+            model: configuration.modelName,
+            messages: Self.initialMessages(for: configuration)
+        )
+        self.renderer = TerminalMarkdownRenderer(color: capabilities.color, theme: configuration.theme)
+        self.showReasoning = configuration.showReasoning
+        self.attachments = configuration.initialAttachments
+    }
+
+    public func run() async throws {
+        guard capabilities.isInteractive else {
+            throw TUIInvocationError.conflict("--tui requires an interactive terminal")
+        }
+        try terminal.enter()
+        terminal.enterAlternateScreen()
+        let signalMonitor = TUISignalMonitor { [terminal] in terminal.restore() }
+        defer {
+            Task { await engine.unload() }
+            terminal.restore()
+        }
+
+        drawWelcome()
+        terminal.write("Loading \(configuration.modelName)…\n")
+        let modelID = try await engine.load { [terminal] progress in
+            terminal.clearLine()
+            terminal.write(String(format: "Loading model %3.0f%%", progress * 100))
+        }
+        terminal.clearLine()
+        terminal.write("Ready: \(modelID)\n\n")
+
+        while !signalMonitor.shouldTerminate {
+            guard let input = readInput(initial: nil, signalMonitor: signalMonitor) else { break }
+            let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+            if trimmed.hasPrefix("/") {
+                do {
+                    if try await handleCommand(trimmed, signalMonitor: signalMonitor) { break }
+                } catch {
+                    terminal.write("\(style("error", "1;31")): \(error.localizedDescription)\n")
+                }
+                continue
+            }
+            try await send(input, signalMonitor: signalMonitor)
+        }
+    }
+
+    private func send(_ input: String, signalMonitor: TUISignalMonitor) async throws {
+        promptHistory.append(input)
+        lastInput = input
+        let userMessage = try makeUserMessage(input)
+        attachments.removeAll()
+        if !session.messages.contains(where: { $0.role == "user" }) {
+            session.title = String(input.replacingOccurrences(of: "\n", with: " ").prefix(72))
+        }
+        session.messages.append(userMessage)
+        session.updatedAt = Date()
+        terminal.write("\n\(style("you", "1;34")) › \(input)\n\n")
+
+        let buffer = GenerationBuffer()
+        let messages = session.messages
+        let generation = configuration.generation
+        let task = Task {
+            do {
+                if configuration.streaming {
+                    for try await event in engine.streamEvents(to: messages, generation) {
+                        try Task.checkCancellation()
+                        await buffer.accept(event)
+                    }
+                    await buffer.finish()
+                } else {
+                    await buffer.accept(try await engine.respond(to: messages, generation))
+                }
+            } catch is CancellationError {
+                await buffer.cancel()
+            } catch {
+                await buffer.fail(error)
+            }
+        }
+
+        var previousRows = 0
+        var lastSnapshot = await buffer.snapshot()
+        let start = Date()
+        while !lastSnapshot.completed && !signalMonitor.shouldTerminate {
+            if let key = terminal.readKey(timeoutMilliseconds: 40), key == .interrupt {
+                task.cancel()
+                await buffer.cancel()
+            }
+            lastSnapshot = await buffer.snapshot()
+            previousRows = redrawGeneration(lastSnapshot, previousRows: previousRows)
+        }
+        if signalMonitor.shouldTerminate { task.cancel() }
+        await task.value
+        lastSnapshot = await buffer.snapshot()
+        lastReasoning = lastSnapshot.reasoning
+        _ = redrawGeneration(lastSnapshot, previousRows: previousRows)
+        terminal.write("\n")
+
+        if let error = lastSnapshot.error {
+            terminal.write("\(style("error", "1;31")): \(error)\n\n")
+            return
+        }
+        if lastSnapshot.cancelled || (lastSnapshot.text.isEmpty && lastSnapshot.tools.isEmpty) {
+            terminal.write("\(style("cancelled", "33")) — the partial response was not added.\n\n")
+            return
+        }
+
+        let messageToolCalls = lastSnapshot.tools.map {
+            MessageToolCall(
+                id: $0.id,
+                type: "function",
+                function: MessageToolCallFunction(name: $0.name, arguments: $0.arguments)
+            )
+        }
+        session.messages.append(Message(
+            role: "assistant",
+            content: lastSnapshot.text.isEmpty ? nil : .text(lastSnapshot.text),
+            toolCalls: messageToolCalls.isEmpty ? nil : messageToolCalls
+        ))
+        session.updatedAt = Date()
+        _ = try? store.save(session)
+        let rendered = renderer.render(lastSnapshot.text)
+        codeBlocks = rendered.codeBlocks
+        images = rendered.images
+        let elapsed = max(0.001, Date().timeIntervalSince(start))
+        let rate = Double(lastSnapshot.completionTokens) / elapsed
+        lastStatistics = String(
+            format: "%d prompt · %d cached · %d generated · %.2fs · %.1f tok/s",
+            lastSnapshot.promptTokens, lastSnapshot.cachedTokens,
+            lastSnapshot.completionTokens, elapsed, rate
+        )
+        terminal.write("\(style("↳ \(lastStatistics)", "2"))\n")
+        if !codeBlocks.isEmpty { terminal.write("\(style("\(codeBlocks.count) code block(s): /blocks, /copy, /save, /open", "2;36"))\n") }
+        if !images.isEmpty { presentImages(images) }
+        terminal.write("\n")
+    }
+
+    private func redrawGeneration(_ snapshot: GenerationSnapshot, previousRows: Int) -> Int {
+        if previousRows > 0 {
+            for index in 0..<previousRows {
+                terminal.clearLine()
+                if index < previousRows - 1 { terminal.write("\u{001B}[1A") }
+            }
+            terminal.write("\r")
+        }
+        var display = ""
+        if !snapshot.reasoning.isEmpty {
+            if showReasoning {
+                display += style("reasoning", "2;35") + " ›\n" + style(snapshot.reasoning, "2") + "\n\n"
+            } else {
+                display += style("… reasoning hidden (\(snapshot.reasoning.count) chars; /reasoning show)", "2") + "\n"
+            }
+        }
+        display += style("assistant", "1;32") + " › " + renderer.render(snapshot.text).text
+        if snapshot.text.isEmpty && snapshot.reasoning.isEmpty { display += style("thinking…", "2") }
+        if !snapshot.tools.isEmpty {
+            let lines = zip(snapshot.tools, snapshot.toolStages).map { call, stage in
+                "\(stage): \(call.name)(\(call.arguments))"
+            }
+            display += "\n" + style(lines.joined(separator: "\n"), "36")
+        }
+        terminal.write(display)
+        return displayRows(display, width: terminal.width())
+    }
+
+    private func readInput(initial: String?, signalMonitor: TUISignalMonitor) -> String? {
+        var characters = Array(initial ?? "")
+        var cursor = characters.count
+        var historyIndex = promptHistory.count
+        var priorRows = 0
+        while !signalMonitor.shouldTerminate {
+            priorRows = redrawInput(characters, cursor: cursor, priorRows: priorRows)
+            guard let key = terminal.readKey() else { continue }
+            switch key {
+            case .text(let value): characters.insert(contentsOf: value, at: cursor); cursor += value.count
+            case .enter:
+                eraseRows(priorRows)
+                return String(characters)
+            case .newline: characters.insert("\n", at: cursor); cursor += 1
+            case .backspace where cursor > 0: cursor -= 1; characters.remove(at: cursor)
+            case .delete where cursor < characters.count: characters.remove(at: cursor)
+            case .left where cursor > 0: cursor -= 1
+            case .right where cursor < characters.count: cursor += 1
+            case .home: cursor = 0
+            case .end: cursor = characters.count
+            case .up where !promptHistory.isEmpty:
+                historyIndex = max(0, historyIndex - 1); characters = Array(promptHistory[historyIndex]); cursor = characters.count
+            case .down where !promptHistory.isEmpty:
+                historyIndex = min(promptHistory.count, historyIndex + 1)
+                characters = historyIndex == promptHistory.count ? [] : Array(promptHistory[historyIndex]); cursor = characters.count
+            case .clear: terminal.clearScreen(); drawWelcome(); priorRows = 0
+            case .interrupt:
+                if characters.isEmpty { eraseRows(priorRows); return nil }
+                characters.removeAll(); cursor = 0
+            case .eof: eraseRows(priorRows); return nil
+            default: break
+            }
+        }
+        return nil
+    }
+
+    private func redrawInput(_ characters: [Character], cursor: Int, priorRows: Int) -> Int {
+        eraseRows(priorRows)
+        let attachmentBadge = attachments.isEmpty ? "" : " [\(attachments.count) attachment(s)]"
+        let content = String(characters).replacingOccurrences(of: "\n", with: "\n… ")
+        let display = style("you\(attachmentBadge)", "1;34") + " › " + content
+        terminal.write(display)
+        // Cursor positioning across wide Unicode is terminal-dependent. Keep navigation exact
+        // in the buffer and show a visual cursor when editing away from the end.
+        if cursor < characters.count { terminal.write(style("  [cursor \(cursor)/\(characters.count)]", "2")) }
+        return displayRows(display, width: terminal.width())
+    }
+
+    private func eraseRows(_ count: Int) {
+        guard count > 0 else { return }
+        for index in 0..<count {
+            terminal.clearLine()
+            if index < count - 1 { terminal.write("\u{001B}[1A") }
+        }
+        terminal.write("\r")
+    }
+
+    /// Returns true when the UI should exit.
+    private func handleCommand(_ raw: String, signalMonitor: TUISignalMonitor) async throws -> Bool {
+        let pieces = splitCommand(raw)
+        let command = pieces.first?.lowercased() ?? ""
+        switch command {
+        case "/quit", "/exit", "/q": return true
+        case "/help", "/?": drawHelp()
+        case "/new":
+            session = TUISession(
+                backend: configuration.backendName,
+                model: configuration.modelName,
+                messages: Self.initialMessages(for: configuration)
+            )
+            codeBlocks = []; images = []; terminal.clearScreen(); drawWelcome()
+        case "/clear": terminal.clearScreen(); drawWelcome()
+        case "/status": terminal.write("\(configuration.backendName) · \(configuration.modelName)\n\(lastStatistics)\n")
+        case "/reasoning":
+            let value = pieces.dropFirst().first?.lowercased()
+            showReasoning = value == "show" || value == "on" ? true : value == "hide" || value == "off" ? false : !showReasoning
+            terminal.write("Reasoning is now \(showReasoning ? "visible" : "hidden").\n")
+            if showReasoning, !lastReasoning.isEmpty {
+                terminal.write("\(style("latest reasoning", "2;35")) ›\n\(style(lastReasoning, "2"))\n")
+            }
+        case "/blocks": listBlocks()
+        case "/copy": try copyBlock(pieces)
+        case "/save", "/save!": try saveBlock(pieces, overwrite: command == "/save!")
+        case "/open": try openBlock(pieces)
+        case "/images": listImages()
+        case "/image": try showImage(pieces)
+        case "/attach": try attach(pieces)
+        case "/export", "/export!": try exportSession(pieces, overwrite: command == "/export!")
+        case "/history": try listHistory()
+        case "/search": try searchSessions(pieces)
+        case "/resume": try resumeSession(pieces)
+        case "/retry":
+            guard let lastInput else { terminal.write("Nothing to retry.\n"); return false }
+            if session.messages.last?.role == "assistant" { session.messages.removeLast() }
+            if session.messages.last?.role == "user" { session.messages.removeLast() }
+            try await send(lastInput, signalMonitor: signalMonitor)
+        case "/edit":
+            guard let lastInput else { terminal.write("Nothing to edit.\n"); return false }
+            if let revised = readInput(initial: lastInput, signalMonitor: signalMonitor), !revised.isEmpty {
+                if session.messages.last?.role == "assistant" { session.messages.removeLast() }
+                if session.messages.last?.role == "user" { session.messages.removeLast() }
+                try await send(revised, signalMonitor: signalMonitor)
+            }
+        case "/theme":
+            guard let value = pieces.dropFirst().first, let theme = TerminalMarkdownRenderer.Theme(rawValue: value) else {
+                terminal.write("Themes: \(TerminalMarkdownRenderer.Theme.allCases.map(\.rawValue).joined(separator: ", "))\n"); return false
+            }
+            renderer = TerminalMarkdownRenderer(color: capabilities.color, theme: theme)
+            terminal.write("Theme changed to \(theme.rawValue).\n")
+        default: terminal.write("Unknown command. Use /help.\n")
+        }
+        return false
+    }
+
+    private func makeUserMessage(_ input: String) throws -> Message {
+        guard !attachments.isEmpty else { return Message(role: "user", content: input) }
+        var parts = [ContentPart(type: "text", text: input)]
+        for url in attachments {
+            let ext = url.pathExtension.lowercased()
+            if ["png", "jpg", "jpeg", "gif", "webp", "heic"].contains(ext) {
+                let data = try Data(contentsOf: url)
+                let mime = ext == "jpg" || ext == "jpeg" ? "image/jpeg" : "image/\(ext)"
+                parts.append(ContentPart(type: "image_url", image_url: ImageURL(url: "data:\(mime);base64,\(data.base64EncodedString())", detail: "auto")))
+            } else {
+                let data = try Data(contentsOf: url)
+                guard data.count <= 2_000_000, let text = String(data: data, encoding: .utf8) else {
+                    throw TUIArtifactError.invalidPath("Attachment must be an image or UTF-8 text file under 2 MB: \(url.path)")
+                }
+                parts.append(ContentPart(type: "text", text: "\n<attachment path=\"\(url.lastPathComponent)\">\n\(text)\n</attachment>"))
+            }
+        }
+        return Message(role: "user", content: .parts(parts))
+    }
+
+    private func drawWelcome() {
+        let colorNote = capabilities.color ? "color" : "no-color"
+        terminal.write("\(style("AFM Terminal Chat", "1;36"))  \(configuration.backendName) · \(configuration.modelName)\n")
+        terminal.write(style("Terminal: \(capabilities.terminalProgram) · \(colorNote) · Enter sends · Esc+Enter adds a line · Ctrl-C cancels", "2") + "\n")
+        terminal.write("Type \(style("/help", "36")) for commands. Model output is never executed automatically.\n\n")
+    }
+
+    private func drawHelp() {
+        terminal.write("""
+
+        /new /clear /quit                 session controls
+        /retry /edit                      regenerate or edit the previous prompt
+        /reasoning [show|hide]            toggle reasoning panels
+        /status /history /search <text>   runtime and persisted-session search
+        /resume <session-id>              resume a saved session
+        /blocks /copy <n>                 list/copy response code blocks
+        /save[!] <n> <path>               save block; ! explicitly permits overwrite
+        /open <n>                         explicitly preview HTML/JS in the browser
+        /attach <path>                    attach an image or UTF-8 text file
+        /images /image <n>                list/display images (inline, or Quick Look fallback)
+        /export[!] <path>                 export this transcript as Markdown
+        /theme <auto|dark|light|mono>     change terminal rendering
+
+        Arrow keys edit/navigate prompt history. Esc+Enter inserts a newline.
+        During generation Ctrl-C cancels only that response; Ctrl-C at an empty prompt exits.
+
+        """)
+    }
+
+    private func listBlocks() {
+        guard !codeBlocks.isEmpty else { terminal.write("No code blocks in the latest response.\n"); return }
+        for (index, block) in codeBlocks.enumerated() {
+            terminal.write("[\(index + 1)] \(block.language.isEmpty ? "code" : block.language) · \(block.content.split(separator: "\n", omittingEmptySubsequences: false).count) lines\n")
+        }
+    }
+
+    private func copyBlock(_ pieces: [String]) throws {
+        let block = try selectedBlock(pieces)
+        try TUIArtifactActions.copyToClipboard(block.content)
+        terminal.write("Copied code block to the clipboard.\n")
+    }
+
+    private func saveBlock(_ pieces: [String], overwrite: Bool) throws {
+        guard pieces.count >= 3 else { throw TUIArtifactError.invalidPath("usage: /save[!] <block> <path>") }
+        let block = try selectedBlock(pieces)
+        let url = try TUIArtifactActions.resolvedURL(pieces.dropFirst(2).joined(separator: " "))
+        try TUIArtifactActions.save(Data(block.content.utf8), to: url, overwrite: overwrite)
+        terminal.write("Saved \(url.path)\n")
+    }
+
+    private func openBlock(_ pieces: [String]) throws {
+        let url = try TUIArtifactActions.openInBrowser(try selectedBlock(pieces))
+        terminal.write("Opened explicit browser preview: \(url.path)\n")
+    }
+
+    private func selectedBlock(_ pieces: [String]) throws -> TUICodeBlock {
+        guard pieces.count >= 2, let number = Int(pieces[1]), codeBlocks.indices.contains(number - 1) else {
+            throw TUIArtifactError.invalidPath("Choose a block number from /blocks")
+        }
+        return codeBlocks[number - 1]
+    }
+
+    private func listImages() {
+        guard !images.isEmpty else { terminal.write("No local image paths in the latest response.\n"); return }
+        for (index, image) in images.enumerated() { terminal.write("[\(index + 1)] \(image.alt): \(image.path)\n") }
+    }
+
+    private func showImage(_ pieces: [String]) throws {
+        guard pieces.count >= 2, let number = Int(pieces[1]), images.indices.contains(number - 1) else {
+            throw TUIArtifactError.invalidPath("Choose an image number from /images")
+        }
+        let image = images[number - 1]
+        if let sequence = try TUIArtifactActions.inlineImageSequence(path: image.path, capabilities: capabilities) {
+            terminal.write(sequence + "\n")
+        } else {
+            try TUIArtifactActions.quickLook(image.path)
+            terminal.write("Opened image with Quick Look (inline images are unavailable in \(capabilities.terminalProgram)).\n")
+        }
+    }
+
+    private func presentImages(_ values: [TUIImageReference]) {
+        for (index, image) in values.enumerated() {
+            if let sequence = try? TUIArtifactActions.inlineImageSequence(path: image.path, capabilities: capabilities) {
+                terminal.write("\n" + sequence + "\n")
+            } else {
+                terminal.write(style("Image \(index + 1): \(image.path) — use /image \(index + 1) for Quick Look", "2;36") + "\n")
+            }
+        }
+    }
+
+    private func attach(_ pieces: [String]) throws {
+        guard pieces.count >= 2 else { throw TUIArtifactError.invalidPath("usage: /attach <path>") }
+        let url = try TUIArtifactActions.resolvedURL(pieces.dropFirst().joined(separator: " "))
+        guard FileManager.default.fileExists(atPath: url.path) else { throw TUIArtifactError.invalidPath(url.path) }
+        attachments.append(url); terminal.write("Attached \(url.lastPathComponent). It will be sent with the next prompt.\n")
+    }
+
+    private func exportSession(_ pieces: [String], overwrite: Bool) throws {
+        guard pieces.count >= 2 else { throw TUIArtifactError.invalidPath("usage: /export[!] <path>") }
+        let url = try TUIArtifactActions.resolvedURL(pieces.dropFirst().joined(separator: " "))
+        try store.exportMarkdown(session, to: url, overwrite: overwrite)
+        terminal.write("Exported \(url.path)\n")
+    }
+
+    private func listHistory() throws {
+        for value in try store.recent() { terminal.write("\(value.id.uuidString)  \(value.title)\n") }
+    }
+
+    private func searchSessions(_ pieces: [String]) throws {
+        guard pieces.count >= 2 else { terminal.write("usage: /search <text>\n"); return }
+        for value in try store.search(pieces.dropFirst().joined(separator: " ")) {
+            terminal.write("\(value.id.uuidString)  \(value.title)\n")
+        }
+    }
+
+    private func resumeSession(_ pieces: [String]) throws {
+        guard pieces.count == 2, let id = UUID(uuidString: pieces[1]) else { throw TUIArtifactError.invalidPath("usage: /resume <session-id>") }
+        session = try store.load(id: id)
+        promptHistory = session.messages.filter { $0.role == "user" }.map(\.textContent)
+        lastInput = promptHistory.last
+        lastReasoning = ""
+        codeBlocks = []
+        images = []
+        terminal.clearScreen(); drawWelcome()
+        for message in session.messages where message.role != "system" {
+            terminal.write("\(style(message.role, message.role == "user" ? "1;34" : "1;32")) › \(renderer.render(message.textContent).text)\n\n")
+        }
+    }
+
+    private func splitCommand(_ input: String) -> [String] {
+        var result: [String] = [], current = "", quote: Character?
+        for character in input {
+            if character == "\"" || character == "'" {
+                if quote == character { quote = nil } else if quote == nil { quote = character } else { current.append(character) }
+            } else if character.isWhitespace && quote == nil {
+                if !current.isEmpty { result.append(current); current = "" }
+            } else { current.append(character) }
+        }
+        if !current.isEmpty { result.append(current) }
+        return result
+    }
+
+    private func displayRows(_ input: String, width: Int) -> Int {
+        let plain = input.replacingOccurrences(of: #"\u001B\[[0-9;]*m"#, with: "", options: .regularExpression)
+        let columns = max(1, width)
+        return max(1, plain.split(separator: "\n", omittingEmptySubsequences: false).reduce(0) {
+            let cells = String($1).unicodeScalars.reduce(0) { total, scalar in
+                total + max(0, Int(wcwidth(wchar_t(scalar.value))))
+            }
+            return $0 + max(1, (cells + columns - 1) / columns)
+        })
+    }
+
+    private static func initialMessages(for configuration: TerminalChatConfiguration) -> [Message] {
+        if case .mlx = configuration.backend {
+            return [Message(role: "system", content: configuration.engine.instructions)]
+        }
+        return []
+    }
+
+    private func style(_ value: String, _ code: String) -> String {
+        capabilities.color ? "\u{001B}[\(code)m\(value)\u{001B}[0m" : value
+    }
+}

--- a/Sources/AFMTerminalUI/TerminalChatUI.swift
+++ b/Sources/AFMTerminalUI/TerminalChatUI.swift
@@ -52,7 +52,8 @@ public enum TUIInvocationError: Error, LocalizedError, Equatable {
     public var errorDescription: String? { if case .conflict(let value) = self { return value }; return nil }
 }
 
-private struct GenerationSnapshot: Sendable {
+struct GenerationSnapshot: Sendable {
+    let revision: UInt64
     let text: String
     let reasoning: String
     let tools: [AFMToolCall]
@@ -65,7 +66,7 @@ private struct GenerationSnapshot: Sendable {
     let error: String?
 }
 
-private actor GenerationBuffer {
+actor GenerationBuffer {
     private var text = ""
     private var reasoning = ""
     private var tools: [AFMToolCall] = []
@@ -76,8 +77,10 @@ private actor GenerationBuffer {
     private var completed = false
     private var cancelled = false
     private var error: String?
+    private var revision: UInt64 = 0
 
     func accept(_ event: AFMStreamEvent) {
+        guard !completed else { return }
         switch event {
         case .text(let value, let tokens): text += value; completionTokens = max(completionTokens, tokens)
         case .reasoning(let value, _): reasoning += value
@@ -94,9 +97,11 @@ private actor GenerationBuffer {
         case .completed: completed = true
         case .tokenLogprobs, .metadata, .custom: break
         }
+        revision &+= 1
     }
 
     func accept(_ response: AFMResponse) {
+        guard !completed else { return }
         text = response.content
         reasoning = response.reasoningContent ?? ""
         promptTokens = response.promptTokens
@@ -107,34 +112,59 @@ private actor GenerationBuffer {
             toolStages.append(.completed)
         }
         completed = true
+        revision &+= 1
     }
 
-    func fail(_ value: Error) { error = value.localizedDescription; completed = true }
-    func cancel() { cancelled = true; completed = true }
-    func finish() { completed = true }
+    func fail(_ value: Error) {
+        guard !completed else { return }
+        error = value.localizedDescription; completed = true; revision &+= 1
+    }
+    func cancel() {
+        guard !completed else { return }
+        cancelled = true; completed = true; revision &+= 1
+    }
+    func finish() {
+        guard !completed else { return }
+        completed = true; revision &+= 1
+    }
     func snapshot() -> GenerationSnapshot {
         GenerationSnapshot(
+            revision: revision,
             text: text, reasoning: reasoning, tools: tools, toolStages: toolStages,
             promptTokens: promptTokens, completionTokens: completionTokens,
             cachedTokens: cachedTokens, completed: completed,
             cancelled: cancelled, error: error
         )
     }
+
+    func snapshot(ifChangedSince priorRevision: UInt64) -> GenerationSnapshot? {
+        guard revision != priorRevision else { return nil }
+        return snapshot()
+    }
 }
 
-private final class TUISignalMonitor: @unchecked Sendable {
+private actor GenerationTaskState {
+    private var finished = false
+    func markFinished() { finished = true }
+    func isFinished() -> Bool { finished }
+}
+
+final class TUISignalMonitor: @unchecked Sendable {
+    private typealias SignalHandler = @convention(c) (Int32) -> Void
     private let lock = NSLock()
     private var terminated = false
+    private var stopped = false
     private var sources: [DispatchSourceSignal] = []
+    private var previousHandlers: [(Int32, SignalHandler?)] = []
     private let monitoredSignals = [SIGTERM, SIGHUP]
+    private let queue = DispatchQueue(label: "ai.maclocal.afm.tui-signals")
 
-    init(onTermination: @escaping @Sendable () -> Void) {
+    init() {
         for signalNumber in monitoredSignals {
-            signal(signalNumber, SIG_IGN)
-            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global(qos: .userInteractive))
+            previousHandlers.append((signalNumber, signal(signalNumber, SIG_IGN)))
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: queue)
             source.setEventHandler { [weak self] in
                 self?.lock.lock(); self?.terminated = true; self?.lock.unlock()
-                onTermination()
             }
             source.resume()
             sources.append(source)
@@ -142,10 +172,22 @@ private final class TUISignalMonitor: @unchecked Sendable {
     }
 
     var shouldTerminate: Bool { lock.lock(); defer { lock.unlock() }; return terminated }
-    deinit {
+    func stop() {
+        lock.lock()
+        guard !stopped else { lock.unlock(); return }
+        stopped = true
+        let sources = sources
+        self.sources.removeAll()
+        let handlers = previousHandlers
+        previousHandlers.removeAll()
+        lock.unlock()
+
         for source in sources { source.cancel() }
-        for signalNumber in monitoredSignals { signal(signalNumber, SIG_DFL) }
+        queue.sync {}
+        for (signalNumber, handler) in handlers { signal(signalNumber, handler) }
     }
+
+    deinit { stop() }
 }
 
 public final class AFMTerminalChat: @unchecked Sendable {
@@ -192,8 +234,9 @@ public final class AFMTerminalChat: @unchecked Sendable {
         }
         try terminal.enter()
         terminal.enterAlternateScreen()
-        let signalMonitor = TUISignalMonitor { [terminal] in terminal.restore() }
+        let signalMonitor = TUISignalMonitor()
         defer {
+            signalMonitor.stop()
             Task { await engine.unload() }
             terminal.restore()
         }
@@ -236,6 +279,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
         terminal.write("\n\(style("you", "1;34")) › \(input)\n\n")
 
         let buffer = GenerationBuffer()
+        let taskState = GenerationTaskState()
         let messages = session.messages
         let generation = configuration.generation
         let task = Task {
@@ -254,6 +298,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
             } catch {
                 await buffer.fail(error)
             }
+            await taskState.markFinished()
         }
 
         var previousRows = 0
@@ -264,14 +309,25 @@ public final class AFMTerminalChat: @unchecked Sendable {
                 task.cancel()
                 await buffer.cancel()
             }
-            lastSnapshot = await buffer.snapshot()
-            previousRows = redrawGeneration(lastSnapshot, previousRows: previousRows)
+            if let changed = await buffer.snapshot(ifChangedSince: lastSnapshot.revision) {
+                lastSnapshot = changed
+                previousRows = redrawGeneration(lastSnapshot, previousRows: previousRows, final: false)
+            }
         }
         if signalMonitor.shouldTerminate { task.cancel() }
-        await task.value
+        let clock = ContinuousClock()
+        let cancellationRequested = lastSnapshot.cancelled || signalMonitor.shouldTerminate
+        if cancellationRequested {
+            task.cancel()
+        }
+        let deadline = clock.now.advanced(by: cancellationRequested ? .milliseconds(500) : .seconds(1))
+        while !(await taskState.isFinished()), clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        if !(await taskState.isFinished()) { task.cancel() }
         lastSnapshot = await buffer.snapshot()
         lastReasoning = lastSnapshot.reasoning
-        _ = redrawGeneration(lastSnapshot, previousRows: previousRows)
+        _ = redrawGeneration(lastSnapshot, previousRows: previousRows, final: true)
         terminal.write("\n")
 
         if let error = lastSnapshot.error {
@@ -290,11 +346,15 @@ public final class AFMTerminalChat: @unchecked Sendable {
                 function: MessageToolCallFunction(name: $0.name, arguments: $0.arguments)
             )
         }
+        let assistantIndex = session.messages.count
         session.messages.append(Message(
             role: "assistant",
             content: lastSnapshot.text.isEmpty ? nil : .text(lastSnapshot.text),
             toolCalls: messageToolCalls.isEmpty ? nil : messageToolCalls
         ))
+        if !lastSnapshot.reasoning.isEmpty {
+            session.reasoningByMessage[String(assistantIndex)] = lastSnapshot.reasoning
+        }
         session.updatedAt = Date()
         _ = try? store.save(session)
         let rendered = renderMarkdown(lastSnapshot.text)
@@ -313,7 +373,7 @@ public final class AFMTerminalChat: @unchecked Sendable {
         terminal.write("\n")
     }
 
-    private func redrawGeneration(_ snapshot: GenerationSnapshot, previousRows: Int) -> Int {
+    private func redrawGeneration(_ snapshot: GenerationSnapshot, previousRows: Int, final: Bool) -> Int {
         if previousRows > 0 {
             for index in 0..<previousRows {
                 terminal.clearLine()
@@ -324,12 +384,12 @@ public final class AFMTerminalChat: @unchecked Sendable {
         var display = ""
         if !snapshot.reasoning.isEmpty {
             if showReasoning {
-                display += style("reasoning", "2;35") + " ›\n" + renderMarkdown(snapshot.reasoning).text + "\n\n"
+                display += style("reasoning", "2;35") + " ›\n" + renderGenerationMarkdown(snapshot.reasoning, final: final) + "\n\n"
             } else {
                 display += style("… reasoning hidden (\(snapshot.reasoning.count) chars; /reasoning show)", "2") + "\n"
             }
         }
-        display += style("assistant", "1;32") + " › " + renderMarkdown(snapshot.text).text
+        display += style("assistant", "1;32") + " › " + renderGenerationMarkdown(snapshot.text, final: final)
         if snapshot.text.isEmpty && snapshot.reasoning.isEmpty { display += style("thinking…", "2") }
         if !snapshot.tools.isEmpty {
             let lines = zip(snapshot.tools, snapshot.toolStages).map { call, stage in
@@ -339,6 +399,13 @@ public final class AFMTerminalChat: @unchecked Sendable {
         }
         terminal.write(display)
         return displayRows(display, width: terminal.width())
+    }
+
+    private func renderGenerationMarkdown(_ source: String, final: Bool) -> String {
+        let limit = 12_000
+        guard !final, source.count > limit else { return renderMarkdown(source).text }
+        let suffix = String(source.suffix(limit))
+        return style("… earlier streaming output omitted from redraw …", "2") + "\n" + renderMarkdown(suffix).text
     }
 
     private func readInput(initial: String?, signalMonitor: TUISignalMonitor) -> String? {
@@ -595,7 +662,8 @@ public final class AFMTerminalChat: @unchecked Sendable {
         session = try store.load(id: id)
         promptHistory = session.messages.filter { $0.role == "user" }.map(\.textContent)
         lastInput = promptHistory.last
-        lastReasoning = ""
+        let lastAssistantIndex = session.messages.indices.reversed().first { session.messages[$0].role == "assistant" }
+        lastReasoning = lastAssistantIndex.flatMap { session.reasoning(atMessageIndex: $0) } ?? ""
         codeBlocks = []
         images = []
         terminal.clearScreen(); drawWelcome()

--- a/Sources/AFMTerminalUI/TerminalSupport.swift
+++ b/Sources/AFMTerminalUI/TerminalSupport.swift
@@ -48,7 +48,8 @@ public struct TerminalCapabilities: Equatable, Sendable {
 
 public enum TerminalKey: Equatable, Sendable {
     case text(String), enter, newline, tab, backspace, delete, left, right, up, down
-    case home, end, escape, interrupt, eof, clear, unknown
+    case home, end, pageUp, pageDown, escape, interrupt, eof, clear
+    case openTranscript, halfPageUp, unknown
 }
 
 public enum TerminalOutputSanitizer {
@@ -215,6 +216,9 @@ public final class TerminalIO: @unchecked Sendable {
     private let inputFD: Int32
     private let outputFD: Int32
     private var original = termios()
+    private let stateLock = NSLock()
+    private var alternateScreenActive = false
+    private var alternateScrollActive = false
     private lazy var mode = TerminalModeController(
         enter: { [weak self] in
             guard let self else { throw POSIXError(.ENOTTY) }
@@ -231,11 +235,51 @@ public final class TerminalIO: @unchecked Sendable {
     public func enter() throws { try mode.enter() }
 
     public func restore() {
+        stateLock.lock()
+        let leaveAlternateScreen = alternateScreenActive
+        let disableAlternateScroll = alternateScrollActive
+        alternateScreenActive = false
+        alternateScrollActive = false
+        stateLock.unlock()
         mode.restore()
-        write("\u{001B}[?25h\u{001B}[0m\u{001B}[?1049l")
+        if disableAlternateScroll { write("\u{001B}[?1007l") }
+        write("\u{001B}[?25h\u{001B}[0m")
+        if leaveAlternateScreen { write("\u{001B}[?1049l") }
     }
 
-    public func enterAlternateScreen() { write("\u{001B}[?1049h\u{001B}[2J\u{001B}[H") }
+    public func enterAlternateScreen() {
+        stateLock.lock()
+        alternateScreenActive = true
+        alternateScrollActive = true
+        stateLock.unlock()
+        write("\u{001B}[?1049h\u{001B}[?1007h\u{001B}[2J\u{001B}[H")
+    }
+
+    public func leaveAlternateScreen() {
+        stateLock.lock()
+        let wasActive = alternateScreenActive
+        alternateScreenActive = false
+        alternateScrollActive = false
+        stateLock.unlock()
+        if wasActive { write("\u{001B}[?1007l\u{001B}[?1049l") }
+    }
+
+    /// Makes a mouse wheel or two-finger trackpad gesture emit arrow keys while
+    /// the transcript overlay is active in the alternate screen.
+    public func enableAlternateScroll() {
+        stateLock.lock()
+        alternateScrollActive = true
+        stateLock.unlock()
+        write("\u{001B}[?1007h")
+    }
+
+    public func disableAlternateScroll() {
+        stateLock.lock()
+        let wasActive = alternateScrollActive
+        alternateScrollActive = false
+        stateLock.unlock()
+        if wasActive { write("\u{001B}[?1007l") }
+    }
     public func clearScreen() { write("\u{001B}[2J\u{001B}[H") }
     public func clearLine() { write("\r\u{001B}[2K") }
     public func hideCursor() { write("\u{001B}[?25l") }
@@ -259,6 +303,11 @@ public final class TerminalIO: @unchecked Sendable {
         return ioctl(outputFD, TIOCGWINSZ, &size) == 0 && size.ws_col > 0 ? Int(size.ws_col) : 80
     }
 
+    public func height() -> Int {
+        var size = winsize()
+        return ioctl(outputFD, TIOCGWINSZ, &size) == 0 && size.ws_row > 0 ? Int(size.ws_row) : 24
+    }
+
     public func readKey(timeoutMilliseconds: Int32 = 100) -> TerminalKey? {
         var readSet = fd_set()
         FD_ZERO(&readSet)
@@ -276,6 +325,8 @@ public final class TerminalIO: @unchecked Sendable {
         case 10: return .newline
         case 12: return .clear
         case 13: return .enter
+        case 20: return .openTranscript
+        case 21: return .halfPageUp
         case 27: return readEscapeSequence()
         default:
             if byte < 32 { return .unknown }
@@ -298,6 +349,10 @@ public final class TerminalIO: @unchecked Sendable {
         case 51:
             _ = readByte(20)
             return .delete
+        case 53:
+            return readByte(20) == 126 ? .pageUp : .unknown
+        case 54:
+            return readByte(20) == 126 ? .pageDown : .unknown
         default: return .unknown
         }
     }

--- a/Sources/AFMTerminalUI/TerminalSupport.swift
+++ b/Sources/AFMTerminalUI/TerminalSupport.swift
@@ -12,19 +12,34 @@ public struct TerminalCapabilities: Equatable, Sendable {
 
     public static func detect(
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        isTTY: Bool = isatty(STDIN_FILENO) != 0
+        inputFD: Int32 = STDIN_FILENO,
+        outputFD: Int32 = STDOUT_FILENO
     ) -> Self {
+        detect(
+            environment: environment,
+            inputIsTTY: isatty(inputFD) != 0,
+            outputIsTTY: isatty(outputFD) != 0
+        )
+    }
+
+    public static func detect(
+        environment: [String: String],
+        inputIsTTY: Bool,
+        outputIsTTY: Bool
+    ) -> Self {
+        let isInteractive = inputIsTTY && outputIsTTY
         let program = environment["TERM_PROGRAM"] ?? environment["TERM"] ?? "terminal"
         let term = environment["TERM"] ?? ""
-        let color = isTTY && environment["NO_COLOR"] == nil && term != "dumb"
+        let color = isInteractive && environment["NO_COLOR"] == nil && term != "dumb"
         let imageProtocol: InlineImageProtocol
-        if program == "iTerm.app" { imageProtocol = .iTerm2 }
+        if !isInteractive { imageProtocol = .none }
+        else if program == "iTerm.app" { imageProtocol = .iTerm2 }
         else if term.contains("kitty") || environment["KITTY_WINDOW_ID"] != nil { imageProtocol = .kitty }
         else { imageProtocol = .none }
         return Self(
-            isInteractive: isTTY,
+            isInteractive: isInteractive,
             color: color,
-            hyperlinks: isTTY && term != "dumb",
+            hyperlinks: isInteractive && term != "dumb",
             inlineImages: imageProtocol,
             terminalProgram: program
         )

--- a/Sources/AFMTerminalUI/TerminalSupport.swift
+++ b/Sources/AFMTerminalUI/TerminalSupport.swift
@@ -1,0 +1,212 @@
+import Darwin
+import Foundation
+
+public struct TerminalCapabilities: Equatable, Sendable {
+    public enum InlineImageProtocol: Equatable, Sendable { case iTerm2, kitty, none }
+
+    public let isInteractive: Bool
+    public let color: Bool
+    public let hyperlinks: Bool
+    public let inlineImages: InlineImageProtocol
+    public let terminalProgram: String
+
+    public static func detect(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        isTTY: Bool = isatty(STDIN_FILENO) != 0
+    ) -> Self {
+        let program = environment["TERM_PROGRAM"] ?? environment["TERM"] ?? "terminal"
+        let term = environment["TERM"] ?? ""
+        let color = isTTY && environment["NO_COLOR"] == nil && term != "dumb"
+        let imageProtocol: InlineImageProtocol
+        if program == "iTerm.app" { imageProtocol = .iTerm2 }
+        else if term.contains("kitty") || environment["KITTY_WINDOW_ID"] != nil { imageProtocol = .kitty }
+        else { imageProtocol = .none }
+        return Self(
+            isInteractive: isTTY,
+            color: color,
+            hyperlinks: isTTY && term != "dumb",
+            inlineImages: imageProtocol,
+            terminalProgram: program
+        )
+    }
+}
+
+public enum TerminalKey: Equatable, Sendable {
+    case text(String), enter, newline, backspace, delete, left, right, up, down
+    case home, end, escape, interrupt, eof, clear, unknown
+}
+
+/// Owns terminal mode transitions. Restoration is idempotent and occurs on every exit path.
+public final class TerminalModeController: @unchecked Sendable {
+    private let enterAction: () throws -> Void
+    private let restoreAction: () -> Void
+    private let lock = NSLock()
+    private var active = false
+
+    public init(enter: @escaping () throws -> Void, restore: @escaping () -> Void) {
+        enterAction = enter
+        restoreAction = restore
+    }
+
+    public func enter() throws {
+        lock.lock(); defer { lock.unlock() }
+        guard !active else { return }
+        try enterAction()
+        active = true
+    }
+
+    public func restore() {
+        lock.lock()
+        let shouldRestore = active
+        active = false
+        lock.unlock()
+        if shouldRestore { restoreAction() }
+    }
+
+    deinit { restore() }
+}
+
+public final class TerminalIO: @unchecked Sendable {
+    private let inputFD: Int32
+    private let outputFD: Int32
+    private var original = termios()
+    private lazy var mode = TerminalModeController(
+        enter: { [weak self] in
+            guard let self else { throw POSIXError(.ENOTTY) }
+            try self.enterRawMode()
+        },
+        restore: { [weak self] in self?.restoreTermios() }
+    )
+
+    public init(inputFD: Int32 = STDIN_FILENO, outputFD: Int32 = STDOUT_FILENO) {
+        self.inputFD = inputFD
+        self.outputFD = outputFD
+    }
+
+    public func enter() throws { try mode.enter() }
+
+    public func restore() {
+        mode.restore()
+        write("\u{001B}[?25h\u{001B}[0m\u{001B}[?1049l")
+    }
+
+    public func enterAlternateScreen() { write("\u{001B}[?1049h\u{001B}[2J\u{001B}[H") }
+    public func clearScreen() { write("\u{001B}[2J\u{001B}[H") }
+    public func clearLine() { write("\r\u{001B}[2K") }
+    public func hideCursor() { write("\u{001B}[?25l") }
+    public func showCursor() { write("\u{001B}[?25h") }
+
+    public func write(_ string: String) {
+        let data = Data(string.utf8)
+        data.withUnsafeBytes { bytes in
+            guard let base = bytes.baseAddress else { return }
+            var offset = 0
+            while offset < bytes.count {
+                let count = Darwin.write(outputFD, base.advanced(by: offset), bytes.count - offset)
+                if count <= 0 { break }
+                offset += count
+            }
+        }
+    }
+
+    public func width() -> Int {
+        var size = winsize()
+        return ioctl(outputFD, TIOCGWINSZ, &size) == 0 && size.ws_col > 0 ? Int(size.ws_col) : 80
+    }
+
+    public func readKey(timeoutMilliseconds: Int32 = 100) -> TerminalKey? {
+        var readSet = fd_set()
+        FD_ZERO(&readSet)
+        FD_SET(inputFD, &readSet)
+        var timeout = timeval(tv_sec: 0, tv_usec: timeoutMilliseconds * 1_000)
+        let ready = select(inputFD + 1, &readSet, nil, nil, &timeout)
+        guard ready > 0 else { return nil }
+        var byte: UInt8 = 0
+        guard Darwin.read(inputFD, &byte, 1) == 1 else { return .eof }
+        switch byte {
+        case 3: return .interrupt
+        case 4: return .eof
+        case 8, 127: return .backspace
+        case 10: return .newline
+        case 12: return .clear
+        case 13: return .enter
+        case 27: return readEscapeSequence()
+        default:
+            if byte < 32 { return .unknown }
+            return readUTF8(first: byte)
+        }
+    }
+
+    private func readEscapeSequence() -> TerminalKey {
+        guard let next = readByte(20) else { return .escape }
+        if next == 13 || next == 10 { return .newline } // Option/Escape + Enter
+        guard next == 91 else { return .escape }
+        guard let third = readByte(20) else { return .escape }
+        switch third {
+        case 65: return .up
+        case 66: return .down
+        case 67: return .right
+        case 68: return .left
+        case 72: return .home
+        case 70: return .end
+        case 51:
+            _ = readByte(20)
+            return .delete
+        default: return .unknown
+        }
+    }
+
+    private func readByte(_ timeoutMS: Int32) -> UInt8? {
+        var readSet = fd_set(); FD_ZERO(&readSet); FD_SET(inputFD, &readSet)
+        var timeout = timeval(tv_sec: 0, tv_usec: timeoutMS * 1_000)
+        guard select(inputFD + 1, &readSet, nil, nil, &timeout) > 0 else { return nil }
+        var byte: UInt8 = 0
+        return Darwin.read(inputFD, &byte, 1) == 1 ? byte : nil
+    }
+
+    private func readUTF8(first: UInt8) -> TerminalKey {
+        let length: Int
+        if first < 0x80 { length = 1 }
+        else if first & 0xE0 == 0xC0 { length = 2 }
+        else if first & 0xF0 == 0xE0 { length = 3 }
+        else if first & 0xF8 == 0xF0 { length = 4 }
+        else { return .unknown }
+        var bytes = [first]
+        while bytes.count < length {
+            guard let byte = readByte(20) else { return .unknown }
+            bytes.append(byte)
+        }
+        return String(bytes: bytes, encoding: .utf8).map(TerminalKey.text) ?? .unknown
+    }
+
+    private func enterRawMode() throws {
+        guard tcgetattr(inputFD, &original) == 0 else {
+            throw POSIXError(.ENOTTY)
+        }
+        var raw = original
+        raw.c_lflag &= ~tcflag_t(ECHO | ICANON | IEXTEN | ISIG)
+        raw.c_iflag &= ~tcflag_t(IXON | ICRNL | BRKINT | INPCK | ISTRIP)
+        raw.c_cflag |= tcflag_t(CS8)
+        withUnsafeMutablePointer(to: &raw.c_cc) { pointer in
+            pointer.withMemoryRebound(to: cc_t.self, capacity: Int(NCCS)) { control in
+                control[Int(VMIN)] = 0
+                control[Int(VTIME)] = 1
+            }
+        }
+        guard tcsetattr(inputFD, TCSAFLUSH, &raw) == 0 else { throw POSIXError(.EIO) }
+    }
+
+    private func restoreTermios() { _ = tcsetattr(inputFD, TCSAFLUSH, &original) }
+}
+
+private func FD_ZERO(_ set: inout fd_set) { set = fd_set() }
+
+private func FD_SET(_ fd: Int32, _ set: inout fd_set) {
+    let intOffset = Int(fd) / 32
+    let bitOffset = Int(fd) % 32
+    withUnsafeMutablePointer(to: &set.fds_bits) { pointer in
+        pointer.withMemoryRebound(to: Int32.self, capacity: 32) { bits in
+            bits[intOffset] |= 1 << bitOffset
+        }
+    }
+}

--- a/Sources/AFMTerminalUI/TerminalSupport.swift
+++ b/Sources/AFMTerminalUI/TerminalSupport.swift
@@ -70,6 +70,117 @@ public enum TerminalOutputSanitizer {
     }
 }
 
+/// Keeps process-level backend diagnostics away from the interactive terminal.
+///
+/// MLX and some of its dependencies write directly to stdout/stderr instead of
+/// going through AFM's structured response stream. Those writes invalidate the
+/// TUI's cursor accounting during a redraw. This scope preserves a duplicate of
+/// the original terminal for `TerminalIO`, redirects the process streams to a
+/// private log, and restores both streams on every exit path.
+public final class TerminalOutputIsolation: @unchecked Sendable {
+    public static var defaultLogURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".afm/logs/tui.log", isDirectory: false)
+    }
+
+    public let terminalOutputFD: Int32
+    public let logURL: URL
+
+    private let outputFD: Int32
+    private let errorFD: Int32
+    private var originalErrorFD: Int32
+    private var logFD: Int32
+    private let lock = NSLock()
+    private var active = true
+
+    public init(
+        logURL: URL = TerminalOutputIsolation.defaultLogURL,
+        outputFD: Int32 = STDOUT_FILENO,
+        errorFD: Int32 = STDERR_FILENO
+    ) throws {
+        self.logURL = logURL
+        self.outputFD = outputFD
+        self.errorFD = errorFD
+
+        let directory = logURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: directory.path
+        )
+
+        Self.flushIfStandard(outputFD, errorFD)
+
+        let savedOutput = dup(outputFD)
+        guard savedOutput >= 0 else { throw Self.posixError() }
+        terminalOutputFD = savedOutput
+
+        let savedError = dup(errorFD)
+        guard savedError >= 0 else {
+            close(savedOutput)
+            throw Self.posixError()
+        }
+        originalErrorFD = savedError
+
+        let openedLog = open(
+            logURL.path,
+            O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC,
+            S_IRUSR | S_IWUSR
+        )
+        guard openedLog >= 0 else {
+            close(savedOutput)
+            close(savedError)
+            throw Self.posixError()
+        }
+        logFD = openedLog
+        _ = fchmod(openedLog, S_IRUSR | S_IWUSR)
+
+        guard dup2(openedLog, outputFD) >= 0 else {
+            close(savedOutput)
+            close(savedError)
+            close(openedLog)
+            throw Self.posixError()
+        }
+        guard dup2(openedLog, errorFD) >= 0 else {
+            _ = dup2(savedOutput, outputFD)
+            close(savedOutput)
+            close(savedError)
+            close(openedLog)
+            throw Self.posixError()
+        }
+    }
+
+    public func restore() {
+        lock.lock()
+        guard active else { lock.unlock(); return }
+        active = false
+        let savedOutput = terminalOutputFD
+        let savedError = originalErrorFD
+        let sink = logFD
+        originalErrorFD = -1
+        logFD = -1
+        lock.unlock()
+
+        Self.flushIfStandard(outputFD, errorFD)
+        _ = dup2(savedOutput, outputFD)
+        _ = dup2(savedError, errorFD)
+        close(savedOutput)
+        close(savedError)
+        close(sink)
+    }
+
+    deinit { restore() }
+
+    private static func flushIfStandard(_ outputFD: Int32, _ errorFD: Int32) {
+        if outputFD == STDOUT_FILENO { fflush(stdout) }
+        if errorFD == STDERR_FILENO { fflush(stderr) }
+    }
+
+    private static func posixError() -> POSIXError {
+        POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+}
+
 /// Owns terminal mode transitions. Restoration is idempotent and occurs on every exit path.
 public final class TerminalModeController: @unchecked Sendable {
     private let enterAction: () throws -> Void

--- a/Sources/AFMTerminalUI/TerminalSupport.swift
+++ b/Sources/AFMTerminalUI/TerminalSupport.swift
@@ -36,6 +36,25 @@ public enum TerminalKey: Equatable, Sendable {
     case home, end, escape, interrupt, eof, clear, unknown
 }
 
+public enum TerminalOutputSanitizer {
+    public static func sanitize(_ value: String) -> String {
+        var result = String.UnicodeScalarView()
+        for scalar in value.unicodeScalars {
+            switch scalar.value {
+            case 0x0A:
+                result.append(scalar)
+            case 0x09:
+                result.append(contentsOf: "    ".unicodeScalars)
+            case 0x00...0x1F, 0x7F...0x9F, 0x202A...0x202E, 0x2066...0x2069:
+                result.append("�")
+            default:
+                result.append(scalar)
+            }
+        }
+        return String(result)
+    }
+}
+
 /// Owns terminal mode transitions. Restoration is idempotent and occurs on every exit path.
 public final class TerminalModeController: @unchecked Sendable {
     private let enterAction: () throws -> Void

--- a/Sources/AFMTerminalUI/TerminalSupport.swift
+++ b/Sources/AFMTerminalUI/TerminalSupport.swift
@@ -47,7 +47,7 @@ public struct TerminalCapabilities: Equatable, Sendable {
 }
 
 public enum TerminalKey: Equatable, Sendable {
-    case text(String), enter, newline, backspace, delete, left, right, up, down
+    case text(String), enter, newline, tab, backspace, delete, left, right, up, down
     case home, end, escape, interrupt, eof, clear, unknown
 }
 
@@ -271,6 +271,7 @@ public final class TerminalIO: @unchecked Sendable {
         switch byte {
         case 3: return .interrupt
         case 4: return .eof
+        case 9: return .tab
         case 8, 127: return .backspace
         case 10: return .newline
         case 12: return .clear

--- a/Sources/AFMTerminalUI/TreeSitterSyntaxHighlighter.swift
+++ b/Sources/AFMTerminalUI/TreeSitterSyntaxHighlighter.swift
@@ -1,0 +1,299 @@
+import Foundation
+import SwiftTreeSitter
+import TreeSitterBash
+import TreeSitterC
+import TreeSitterCPP
+import TreeSitterCSharp
+import TreeSitterCSS
+import TreeSitterDiff
+import TreeSitterGo
+import TreeSitterHTML
+import TreeSitterJava
+import TreeSitterJavaScript
+import TreeSitterJSON
+import TreeSitterKotlin
+import TreeSitterMarkdown
+import TreeSitterPHP
+import TreeSitterPython
+import TreeSitterRuby
+import TreeSitterRust
+import TreeSitterSql
+import TreeSitterSwift
+import TreeSitterTOML
+import TreeSitterTSX
+import TreeSitterTypeScript
+import TreeSitterYAML
+
+enum TUISyntaxKind: Int, CaseIterable, Sendable {
+    case comment
+    case string
+    case number
+    case keyword
+    case type
+    case function
+    case attribute
+    case `operator`
+    case addition
+    case deletion
+    case metadata
+}
+
+struct TUISyntaxToken: Equatable, Sendable {
+    let range: NSRange
+    let kind: TUISyntaxKind
+}
+
+/// Source-compiled Tree-sitter registry used by the terminal renderer.
+///
+/// There are deliberately no optional imports or runtime grammar downloads here.
+/// Removing any parser dependency makes AFMTerminalUI fail to compile, and the
+/// build-integrity tests parse a sentinel with every registered grammar.
+enum TreeSitterSyntaxHighlighter {
+    static let maximumSourceBytes = 1_000_000
+
+    static let supportedLanguages = [
+        "bash", "c", "cpp", "csharp", "css", "diff", "go", "html", "java",
+        "javascript", "json", "kotlin", "markdown", "php", "python", "ruby",
+        "rust", "sql", "swift", "toml", "tsx", "typescript", "yaml"
+    ]
+
+    private static let aliases: [String: String] = [
+        "shell": "bash", "sh": "bash", "zsh": "bash", "console": "bash",
+        "h": "c",
+        "c++": "cpp", "cc": "cpp", "cxx": "cpp", "hpp": "cpp",
+        "c#": "csharp", "cs": "csharp", "dotnet": "csharp",
+        "patch": "diff",
+        "golang": "go",
+        "htm": "html", "xml": "html", "svg": "html",
+        "js": "javascript", "jsx": "javascript", "mjs": "javascript", "cjs": "javascript",
+        "kt": "kotlin", "kts": "kotlin",
+        "md": "markdown", "mdown": "markdown",
+        "py": "python", "python3": "python",
+        "rb": "ruby",
+        "rs": "rust",
+        "postgres": "sql", "postgresql": "sql", "mysql": "sql", "sqlite": "sql",
+        "ts": "typescript",
+        "yml": "yaml"
+    ]
+
+    static func canonicalLanguage(_ rawValue: String) -> String? {
+        let value = rawValue.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        if supportedLanguages.contains(value) { return value }
+        return aliases[value]
+    }
+
+    static func tokens(in source: String, language rawLanguage: String) -> [TUISyntaxToken]? {
+        guard source.utf8.count <= maximumSourceBytes,
+              let languageName = canonicalLanguage(rawLanguage),
+              let language = language(named: languageName) else {
+            return nil
+        }
+
+        // The PHP grammar models a complete document. Fenced snippets normally
+        // omit `<?php`; add it only for parsing, then translate ranges back to
+        // the user's untouched source.
+        let parsePrefix = languageName == "php" && !source.contains("<?") ? "<?php " : ""
+        let parsedSource = parsePrefix + source
+        let prefixLength = (parsePrefix as NSString).length
+        let parser = Parser()
+        do {
+            try parser.setLanguage(language)
+        } catch {
+            return nil
+        }
+        guard let root = parser.parse(parsedSource)?.rootNode else { return nil }
+
+        let sourceNSString = parsedSource as NSString
+        var candidates: [TUISyntaxToken] = []
+
+        func add(_ node: Node, kind: TUISyntaxKind) {
+            let parsedRange = node.range
+            guard parsedRange.location >= prefixLength, parsedRange.length > 0,
+                  NSMaxRange(parsedRange) <= sourceNSString.length else { return }
+            candidates.append(TUISyntaxToken(
+                range: NSRange(location: parsedRange.location - prefixLength, length: parsedRange.length),
+                kind: kind
+            ))
+        }
+
+        func visit(_ node: Node) {
+            let nodeType = node.nodeType ?? ""
+            if let kind = wholeNodeKind(nodeType) {
+                add(node, kind: kind)
+                return
+            }
+
+            if node.childCount == 0 {
+                let value = sourceNSString.substring(with: node.range)
+                if let kind = leafKind(node: node, type: nodeType, value: value) {
+                    add(node, kind: kind)
+                }
+                return
+            }
+
+            for index in 0..<node.childCount {
+                if let child = node.child(at: index) { visit(child) }
+            }
+        }
+
+        visit(root)
+        return nonOverlappingTokens(candidates)
+    }
+
+    /// Exercises every compiled parser and verifies its ABI against the linked runtime.
+    /// Release/build tests call this so a missing or incompatible grammar is a hard failure.
+    static func validateCompiledGrammars() -> [String] {
+        supportedLanguages.compactMap { name in
+            guard let language = language(named: name) else { return name }
+            guard language.ABIVersion >= Language.minimumCompatibleVersion,
+                  language.ABIVersion <= Language.version else { return name }
+            let parser = Parser()
+            do {
+                try parser.setLanguage(language)
+            } catch {
+                return name
+            }
+            return parser.parse(sentinel(for: name))?.rootNode == nil ? name : nil
+        }
+    }
+
+    private static func language(named name: String) -> Language? {
+        switch name {
+        case "bash": Language(tree_sitter_bash())
+        case "c": Language(tree_sitter_c())
+        case "cpp": Language(tree_sitter_cpp())
+        case "csharp": Language(tree_sitter_c_sharp())
+        case "css": Language(tree_sitter_css())
+        case "diff": Language(tree_sitter_diff())
+        case "go": Language(tree_sitter_go())
+        case "html": Language(tree_sitter_html())
+        case "java": Language(tree_sitter_java())
+        case "javascript": Language(tree_sitter_javascript())
+        case "json": Language(tree_sitter_json())
+        case "kotlin": Language(tree_sitter_kotlin())
+        case "markdown": Language(tree_sitter_markdown())
+        case "php": Language(tree_sitter_php())
+        case "python": Language(tree_sitter_python())
+        case "ruby": Language(tree_sitter_ruby())
+        case "rust": Language(tree_sitter_rust())
+        case "sql": Language(tree_sitter_sql())
+        case "swift": Language(tree_sitter_swift())
+        case "toml": Language(tree_sitter_toml())
+        case "tsx": Language(tree_sitter_tsx())
+        case "typescript": Language(tree_sitter_typescript())
+        case "yaml": Language(tree_sitter_yaml())
+        default: nil
+        }
+    }
+
+    private static func wholeNodeKind(_ type: String) -> TUISyntaxKind? {
+        let value = type.lowercased()
+        if value == "addition" { return .addition }
+        if value == "deletion" { return .deletion }
+        if value == "hunk" || value == "location" || value == "old_file" || value == "new_file" ||
+            value == "file_change" || value == "commit" || value == "index" {
+            return .metadata
+        }
+        if value.contains("comment") { return .comment }
+        if value.contains("string") || value.contains("heredoc") || value.contains("regex_pattern") ||
+            value == "regex" || value == "character_literal" || value == "char_literal" {
+            return .string
+        }
+        if value == "integer" || value == "float" || value == "number" ||
+            value.contains("integer_literal") || value.contains("float_literal") ||
+            value.contains("number_literal") || value.contains("numeric_literal") ||
+            value == "integer_value" || value == "float_value" ||
+            value == "integer_scalar" || value == "float_scalar" {
+            return .number
+        }
+        if value == "boolean_scalar" || value == "null_scalar" { return .keyword }
+        if value == "string_scalar" || value == "plain_scalar" || value == "double_quote_scalar" ||
+            value == "single_quote_scalar" || value == "block_scalar" {
+            return .string
+        }
+        if value == "type_identifier" || value == "primitive_type" || value == "predefined_type" ||
+            value == "builtin_type" || value == "scoped_type_identifier" {
+            return .type
+        }
+        if value == "tag_name" { return .keyword }
+        if value == "attribute_name" || value == "property_name" || value == "property_identifier" {
+            return .attribute
+        }
+        if value.contains("attribute") || value.contains("annotation") || value == "decorator" {
+            return .attribute
+        }
+        if value.contains("heading") { return .type }
+        if value == "code_span" || value == "fenced_code_block" || value == "inline_link" { return .string }
+        if value == "emphasis" || value == "strong_emphasis" || value == "link_destination" { return .attribute }
+        return nil
+    }
+
+    private static func leafKind(node: Node, type: String, value: String) -> TUISyntaxKind? {
+        let lowercaseType = type.lowercased()
+        if ["true", "false", "null", "nil", "none", "self", "super", "this"].contains(value.lowercased()) {
+            return .keyword
+        }
+        if !node.isNamed, value.unicodeScalars.contains(where: CharacterSet.letters.contains) {
+            return .keyword
+        }
+        if lowercaseType.contains("keyword") { return .keyword }
+        if lowercaseType.contains("operator") || operatorTokens.contains(value) { return .operator }
+        if lowercaseType.contains("function") || lowercaseType.contains("method") || isCallableIdentifier(node) {
+            return .function
+        }
+        if lowercaseType == "type_identifier" || lowercaseType.contains("primitive_type") {
+            return .type
+        }
+        return nil
+    }
+
+    private static func isCallableIdentifier(_ node: Node) -> Bool {
+        guard node.nodeType?.lowercased().contains("identifier") == true,
+              let parentType = node.parent?.nodeType?.lowercased() else { return false }
+        return parentType.contains("call") || parentType.contains("invocation") ||
+            parentType.contains("function_declarator") || parentType.contains("method_declaration")
+    }
+
+    private static let operatorTokens: Set<String> = [
+        "=", "==", "===", "!=", "!==", "<", ">", "<=", ">=", "+", "-", "*", "/", "%",
+        "&&", "||", "!", "??", "?.", "=>", "->", "::", "..", "...", "|>", "&", "|", "^", "~"
+    ]
+
+    private static func nonOverlappingTokens(_ values: [TUISyntaxToken]) -> [TUISyntaxToken] {
+        let sorted = values.sorted {
+            if $0.range.location != $1.range.location { return $0.range.location < $1.range.location }
+            if $0.range.length != $1.range.length { return $0.range.length > $1.range.length }
+            return $0.kind.rawValue < $1.kind.rawValue
+        }
+        var result: [TUISyntaxToken] = []
+        for token in sorted {
+            guard result.last.map({ NSMaxRange($0.range) <= token.range.location }) ?? true else { continue }
+            result.append(token)
+        }
+        return result
+    }
+
+    private static func sentinel(for language: String) -> String {
+        switch language {
+        case "bash": "echo test"
+        case "c", "cpp": "int main(void) { return 0; }"
+        case "csharp", "java", "kotlin": "class Test {}"
+        case "css": ".test { color: red; }"
+        case "diff": "--- a/a\n+++ b/a\n-old\n+new"
+        case "go": "package main\nfunc main() {}"
+        case "html": "<main>test</main>"
+        case "javascript", "typescript", "tsx": "const test = 1;"
+        case "json": "{\"test\": true}"
+        case "markdown": "# Test"
+        case "php": "<?php echo 'test';"
+        case "python": "def test():\n    return True"
+        case "ruby": "def test\nend"
+        case "rust": "fn main() {}"
+        case "sql": "SELECT 1;"
+        case "swift": "func test() {}"
+        case "toml": "test = true"
+        case "yaml": "test: true"
+        default: "test"
+        }
+    }
+}

--- a/Sources/AFMTreeSitterScanners/LICENSES.md
+++ b/Sources/AFMTreeSitterScanners/LICENSES.md
@@ -1,0 +1,25 @@
+# Licenses
+
+The scanner sources in this directory are redistributed under the MIT license.
+
+CSS copyright (c) 2018 Max Brunsfeld. JavaScript copyright (c) 2014 Max
+Brunsfeld. Python copyright (c) 2016 Max Brunsfeld. YAML copyright (c) 2024
+tree-sitter-grammars contributors and copyright (c) 2019-2021 Ika.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Sources/AFMTreeSitterScanners/README.md
+++ b/Sources/AFMTreeSitterScanners/README.md
@@ -1,0 +1,20 @@
+# Pinned Tree-sitter external scanners
+
+SwiftPM evaluates dependency manifests with the root package as the current
+working directory. Four official grammar manifests use a relative
+`FileManager.fileExists` check before adding `src/scanner.c`; as transitive
+dependencies, that check omits the scanner and leaves unresolved symbols at
+the final executable link.
+
+This target compiles exact copies of only those scanner sources. The generated
+parsers remain supplied by their pinned upstream Swift packages. Their source
+revisions match `Package.swift`:
+
+- CSS: `tree-sitter/tree-sitter-css@dda5cfc5722c429eaba1c910ca32c2c0c5bb1a3f`
+- JavaScript: `tree-sitter/tree-sitter-javascript@58404d8cf191d69f2674a8fd507bd5776f46cb11`
+- Python: `tree-sitter/tree-sitter-python@26855eabccb19c6abf499fbc5b8dc7cc9ab8bc64`
+- YAML: `tree-sitter-grammars/tree-sitter-yaml@a1c4812a73ec5e089de8e441fdea3a921e8d5079`
+
+`schema.core.c` is a generated include required by the pinned YAML scanner.
+Do not update these files without updating the corresponding package revision,
+running the grammar ABI tests, and linking the release `afm` executable.

--- a/Sources/AFMTreeSitterScanners/css_scanner.c
+++ b/Sources/AFMTreeSitterScanners/css_scanner.c
@@ -1,0 +1,100 @@
+#include "tree_sitter/parser.h"
+
+#include <wctype.h>
+
+enum TokenType {
+    DESCENDANT_OP,
+    PSEUDO_CLASS_SELECTOR_COLON,
+    ERROR_RECOVERY,
+};
+
+static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
+
+static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
+
+void *tree_sitter_css_external_scanner_create() { return NULL; }
+
+void tree_sitter_css_external_scanner_destroy(void *payload) {}
+
+unsigned tree_sitter_css_external_scanner_serialize(void *payload, char *buffer) { return 0; }
+
+void tree_sitter_css_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {}
+
+bool tree_sitter_css_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+    if (valid_symbols[ERROR_RECOVERY]) {
+        return false;
+    }
+
+    if (iswspace(lexer->lookahead) && valid_symbols[DESCENDANT_OP]) {
+        lexer->result_symbol = DESCENDANT_OP;
+
+        skip(lexer);
+        while (iswspace(lexer->lookahead)) {
+            skip(lexer);
+        }
+        lexer->mark_end(lexer);
+
+        if (lexer->lookahead == '#' || lexer->lookahead == '.' || lexer->lookahead == '[' || lexer->lookahead == '-' ||
+            lexer->lookahead == '*' || iswalnum(lexer->lookahead)) {
+            return true;
+        }
+
+        if (lexer->lookahead == ':') {
+            advance(lexer);
+            if (iswspace(lexer->lookahead)) {
+                return false;
+            }
+            for (;;) {
+                if (lexer->lookahead == ';' || lexer->lookahead == '}' || lexer->eof(lexer)) {
+                    return false;
+                }
+                if (lexer->lookahead == '{') {
+                    return true;
+                }
+                advance(lexer);
+            }
+        }
+    }
+
+    if (valid_symbols[PSEUDO_CLASS_SELECTOR_COLON]) {
+        while (iswspace(lexer->lookahead)) {
+            skip(lexer);
+        }
+        if (lexer->lookahead == ':') {
+            advance(lexer);
+            if (lexer->lookahead == ':') {
+                return false;
+            }
+            lexer->mark_end(lexer);
+            lexer->result_symbol = PSEUDO_CLASS_SELECTOR_COLON;
+
+            // We need a `{` to be a pseudo class selector, a `;` indicates a property.
+            // This does not apply if we're in a comment, however.
+            bool in_comment = false;
+            while (lexer->lookahead != ';' && lexer->lookahead != '}' && !lexer->eof(lexer)) {
+                advance(lexer);
+                if (lexer->lookahead == '{' && !in_comment) {
+                    return true;
+                }
+                if (lexer->lookahead == '/' && !in_comment) {
+                    advance(lexer);
+                    if (lexer->lookahead == '*') {
+                        in_comment = true;
+                    }
+                } else if (lexer->lookahead == '*' && in_comment) {
+                    advance(lexer);
+                    if (lexer->lookahead == '/') {
+                        in_comment = false;
+                    }
+                }
+            }
+
+            // If we're at eof, and we happened to *not* find an opening brace to indicate we have a pseudo class
+            // selector, we should *still* return one at EOF. This will improve error recovery, and the malformed code
+            // can be parsed as an erroneous pseudo-class selector, rather than an erroneous property.
+            return lexer->eof(lexer);
+        }
+    }
+
+    return false;
+}

--- a/Sources/AFMTreeSitterScanners/javascript_scanner.c
+++ b/Sources/AFMTreeSitterScanners/javascript_scanner.c
@@ -1,0 +1,364 @@
+#include "tree_sitter/parser.h"
+
+#include <stdio.h>
+#include <wctype.h>
+
+enum TokenType {
+    AUTOMATIC_SEMICOLON,
+    TEMPLATE_CHARS,
+    TERNARY_QMARK,
+    HTML_COMMENT,
+    LOGICAL_OR,
+    ESCAPE_SEQUENCE,
+    REGEX_PATTERN,
+    JSX_TEXT,
+};
+
+void *tree_sitter_javascript_external_scanner_create() { return NULL; }
+
+void tree_sitter_javascript_external_scanner_destroy(void *p) {}
+
+unsigned tree_sitter_javascript_external_scanner_serialize(void *payload, char *buffer) { return 0; }
+
+void tree_sitter_javascript_external_scanner_deserialize(void *p, const char *b, unsigned n) {}
+
+static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
+
+static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
+
+static bool scan_template_chars(TSLexer *lexer) {
+    lexer->result_symbol = TEMPLATE_CHARS;
+    for (bool has_content = false;; has_content = true) {
+        lexer->mark_end(lexer);
+        switch (lexer->lookahead) {
+            case '`':
+                return has_content;
+            case '\0':
+                return false;
+            case '$':
+                advance(lexer);
+                if (lexer->lookahead == '{') {
+                    return has_content;
+                }
+                break;
+            case '\\':
+                return has_content;
+            default:
+                advance(lexer);
+        }
+    }
+}
+
+typedef enum {
+    REJECT,     // Semicolon is illegal, ie a syntax error occurred
+    NO_NEWLINE, // Unclear if semicolon will be legal, continue
+    ACCEPT,     // Semicolon is legal, assuming a comment was encountered
+} WhitespaceResult;
+
+/**
+ * @param consume If false, only consume enough to check if comment indicates semicolon-legality
+ */
+static WhitespaceResult scan_whitespace_and_comments(TSLexer *lexer, bool *scanned_comment, bool consume) {
+    bool saw_block_newline = false;
+
+    for (;;) {
+        while (iswspace(lexer->lookahead)) {
+            skip(lexer);
+        }
+
+        if (lexer->lookahead == '/') {
+            skip(lexer);
+
+            if (lexer->lookahead == '/') {
+                skip(lexer);
+                while (lexer->lookahead != 0 && lexer->lookahead != '\n' && lexer->lookahead != 0x2028 &&
+                       lexer->lookahead != 0x2029) {
+                    skip(lexer);
+                }
+                *scanned_comment = true;
+            } else if (lexer->lookahead == '*') {
+                skip(lexer);
+                while (lexer->lookahead != 0) {
+                    if (lexer->lookahead == '*') {
+                        skip(lexer);
+                        if (lexer->lookahead == '/') {
+                            skip(lexer);
+                            *scanned_comment = true;
+
+                            if (lexer->lookahead != '/' && !consume) {
+                                return saw_block_newline ? ACCEPT : NO_NEWLINE;
+                            }
+
+                            break;
+                        }
+                    } else if (lexer->lookahead == '\n' || lexer->lookahead == 0x2028 || lexer->lookahead == 0x2029) {
+                        saw_block_newline = true;
+                        skip(lexer);
+                    } else {
+                        skip(lexer);
+                    }
+                }
+            } else {
+                return REJECT;
+            }
+        } else {
+            return ACCEPT;
+        }
+    }
+}
+
+static bool scan_automatic_semicolon(TSLexer *lexer, bool comment_condition, bool *scanned_comment) {
+    lexer->result_symbol = AUTOMATIC_SEMICOLON;
+    lexer->mark_end(lexer);
+
+    for (;;) {
+        if (lexer->lookahead == 0) {
+            return true;
+        }
+
+        if (lexer->lookahead == '/') {
+            WhitespaceResult result = scan_whitespace_and_comments(lexer, scanned_comment, false);
+            if (result == REJECT) {
+                return false;
+            }
+
+            if (result == ACCEPT && comment_condition && lexer->lookahead != ',' && lexer->lookahead != '=') {
+                return true;
+            }
+        }
+
+        if (lexer->lookahead == '}') {
+            return true;
+        }
+
+        if (lexer->is_at_included_range_start(lexer)) {
+            return true;
+        }
+
+        if (lexer->lookahead == '\n' || lexer->lookahead == 0x2028 || lexer->lookahead == 0x2029) {
+            break;
+        }
+
+        if (!iswspace(lexer->lookahead)) {
+            return false;
+        }
+
+        skip(lexer);
+    }
+
+    skip(lexer);
+
+    if (scan_whitespace_and_comments(lexer, scanned_comment, true) == REJECT) {
+        return false;
+    }
+
+    switch (lexer->lookahead) {
+        case '`':
+        case ',':
+        case ':':
+        case ';':
+        case '*':
+        case '%':
+        case '>':
+        case '<':
+        case '=':
+        case '[':
+        case '(':
+        case '?':
+        case '^':
+        case '|':
+        case '&':
+        case '/':
+            return false;
+
+        // Insert a semicolon before decimals literals but not otherwise.
+        case '.':
+            skip(lexer);
+            return iswdigit(lexer->lookahead);
+
+        // Insert a semicolon before `--` and `++`, but not before binary `+` or `-`.
+        case '+':
+            skip(lexer);
+            return lexer->lookahead == '+';
+        case '-':
+            skip(lexer);
+            return lexer->lookahead == '-';
+
+        // Don't insert a semicolon before `!=`, but do insert one before a unary `!`.
+        case '!':
+            skip(lexer);
+            return lexer->lookahead != '=';
+
+        // Don't insert a semicolon before `in` or `instanceof`, but do insert one
+        // before an identifier.
+        case 'i':
+            skip(lexer);
+
+            if (lexer->lookahead != 'n') {
+                return true;
+            }
+            skip(lexer);
+
+            if (!iswalpha(lexer->lookahead)) {
+                return false;
+            }
+
+            for (unsigned i = 0; i < 8; i++) {
+                if (lexer->lookahead != "stanceof"[i]) {
+                    return true;
+                }
+                skip(lexer);
+            }
+
+            if (!iswalpha(lexer->lookahead)) {
+                return false;
+            }
+            break;
+
+        default:
+            break;
+    }
+
+    return true;
+}
+
+static bool scan_ternary_qmark(TSLexer *lexer) {
+    for (;;) {
+        if (!iswspace(lexer->lookahead)) {
+            break;
+        }
+        skip(lexer);
+    }
+
+    if (lexer->lookahead == '?') {
+        advance(lexer);
+
+        if (lexer->lookahead == '?') {
+            return false;
+        }
+
+        lexer->mark_end(lexer);
+        lexer->result_symbol = TERNARY_QMARK;
+
+        if (lexer->lookahead == '.') {
+            advance(lexer);
+            if (iswdigit(lexer->lookahead)) {
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+static bool scan_html_comment(TSLexer *lexer) {
+    while (iswspace(lexer->lookahead) || lexer->lookahead == 0x2028 || lexer->lookahead == 0x2029) {
+        skip(lexer);
+    }
+
+    const char *comment_start = "<!--";
+    const char *comment_end = "-->";
+
+    if (lexer->lookahead == '<') {
+        for (unsigned i = 0; i < 4; i++) {
+            if (lexer->lookahead != comment_start[i]) {
+                return false;
+            }
+            advance(lexer);
+        }
+    } else if (lexer->lookahead == '-') {
+        for (unsigned i = 0; i < 3; i++) {
+            if (lexer->lookahead != comment_end[i]) {
+                return false;
+            }
+            advance(lexer);
+        }
+    } else {
+        return false;
+    }
+
+    while (lexer->lookahead != 0 && lexer->lookahead != '\n' && lexer->lookahead != 0x2028 &&
+           lexer->lookahead != 0x2029) {
+        advance(lexer);
+    }
+
+    lexer->result_symbol = HTML_COMMENT;
+    lexer->mark_end(lexer);
+
+    return true;
+}
+
+static bool scan_jsx_text(TSLexer *lexer) {
+    // saw_text will be true if we see any non-whitespace content, or any whitespace content that is not a newline and
+    // does not immediately follow a newline.
+    bool saw_text = false;
+    // at_newline will be true if we are currently at a newline, or if we are at whitespace that is not a newline but
+    // immediately follows a newline.
+    bool at_newline = false;
+
+    while (lexer->lookahead != 0 && lexer->lookahead != '<' && lexer->lookahead != '>' && lexer->lookahead != '{' &&
+           lexer->lookahead != '}' && lexer->lookahead != '&') {
+        bool is_wspace = iswspace(lexer->lookahead);
+        if (lexer->lookahead == '\n') {
+            at_newline = true;
+        } else {
+            // If at_newline is already true, and we see some whitespace, then it must stay true.
+            // Otherwise, it should be false.
+            //
+            // See the table below to determine the logic for computing `saw_text`.
+            //
+            // |------------------------------------|
+            // | at_newline | is_wspace | saw_text  |
+            // |------------|-----------|-----------|
+            // | false (0)  | false (0) | true  (1) |
+            // | false (0)  | true  (1) | true  (1) |
+            // | true  (1)  | false (0) | true  (1) |
+            // | true  (1)  | true  (1) | false (0) |
+            // |------------------------------------|
+
+            at_newline &= is_wspace;
+            if (!at_newline) {
+                saw_text = true;
+            }
+        }
+
+        advance(lexer);
+    }
+
+    lexer->result_symbol = JSX_TEXT;
+    return saw_text;
+}
+
+bool tree_sitter_javascript_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+    if (valid_symbols[TEMPLATE_CHARS]) {
+        if (valid_symbols[AUTOMATIC_SEMICOLON]) {
+            return false;
+        }
+        return scan_template_chars(lexer);
+    }
+
+    if (valid_symbols[JSX_TEXT] && scan_jsx_text(lexer)) {
+        return true;
+    }
+
+    if (valid_symbols[AUTOMATIC_SEMICOLON]) {
+        bool scanned_comment = false;
+        bool ret = scan_automatic_semicolon(lexer, !valid_symbols[LOGICAL_OR], &scanned_comment);
+        if (!ret && !scanned_comment && valid_symbols[TERNARY_QMARK] && lexer->lookahead == '?') {
+            return scan_ternary_qmark(lexer);
+        }
+        return ret;
+    }
+
+    if (valid_symbols[TERNARY_QMARK]) {
+        return scan_ternary_qmark(lexer);
+    }
+
+    if (valid_symbols[HTML_COMMENT] && !valid_symbols[LOGICAL_OR] && !valid_symbols[ESCAPE_SEQUENCE] &&
+        !valid_symbols[REGEX_PATTERN]) {
+        return scan_html_comment(lexer);
+    }
+
+    return false;
+}

--- a/Sources/AFMTreeSitterScanners/python_scanner.c
+++ b/Sources/AFMTreeSitterScanners/python_scanner.c
@@ -1,0 +1,437 @@
+#include "tree_sitter/array.h"
+#include "tree_sitter/parser.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+enum TokenType {
+    NEWLINE,
+    INDENT,
+    DEDENT,
+    STRING_START,
+    STRING_CONTENT,
+    ESCAPE_INTERPOLATION,
+    STRING_END,
+    COMMENT,
+    CLOSE_PAREN,
+    CLOSE_BRACKET,
+    CLOSE_BRACE,
+    EXCEPT,
+};
+
+typedef enum {
+    SingleQuote = 1 << 0,
+    DoubleQuote = 1 << 1,
+    BackQuote = 1 << 2,
+    Raw = 1 << 3,
+    Format = 1 << 4,
+    Triple = 1 << 5,
+    Bytes = 1 << 6,
+} Flags;
+
+typedef struct {
+    char flags;
+} Delimiter;
+
+static inline Delimiter new_delimiter() { return (Delimiter){0}; }
+
+static inline bool is_format(Delimiter *delimiter) { return delimiter->flags & Format; }
+
+static inline bool is_raw(Delimiter *delimiter) { return delimiter->flags & Raw; }
+
+static inline bool is_triple(Delimiter *delimiter) { return delimiter->flags & Triple; }
+
+static inline bool is_bytes(Delimiter *delimiter) { return delimiter->flags & Bytes; }
+
+static inline int32_t end_character(Delimiter *delimiter) {
+    if (delimiter->flags & SingleQuote) {
+        return '\'';
+    }
+    if (delimiter->flags & DoubleQuote) {
+        return '"';
+    }
+    if (delimiter->flags & BackQuote) {
+        return '`';
+    }
+    return 0;
+}
+
+static inline void set_format(Delimiter *delimiter) { delimiter->flags |= Format; }
+
+static inline void set_raw(Delimiter *delimiter) { delimiter->flags |= Raw; }
+
+static inline void set_triple(Delimiter *delimiter) { delimiter->flags |= Triple; }
+
+static inline void set_bytes(Delimiter *delimiter) { delimiter->flags |= Bytes; }
+
+static inline void set_end_character(Delimiter *delimiter, int32_t character) {
+    switch (character) {
+        case '\'':
+            delimiter->flags |= SingleQuote;
+            break;
+        case '"':
+            delimiter->flags |= DoubleQuote;
+            break;
+        case '`':
+            delimiter->flags |= BackQuote;
+            break;
+        default:
+            assert(false);
+    }
+}
+
+typedef struct {
+    Array(uint16_t) indents;
+    Array(Delimiter) delimiters;
+    bool inside_interpolated_string;
+} Scanner;
+
+static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
+
+static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
+
+bool tree_sitter_python_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+    Scanner *scanner = (Scanner *)payload;
+
+    bool error_recovery_mode = valid_symbols[STRING_CONTENT] && valid_symbols[INDENT];
+    bool within_brackets = valid_symbols[CLOSE_BRACE] || valid_symbols[CLOSE_PAREN] || valid_symbols[CLOSE_BRACKET];
+
+    bool advanced_once = false;
+    if (valid_symbols[ESCAPE_INTERPOLATION] && scanner->delimiters.size > 0 &&
+        (lexer->lookahead == '{' || lexer->lookahead == '}') && !error_recovery_mode) {
+        Delimiter *delimiter = array_back(&scanner->delimiters);
+        if (is_format(delimiter)) {
+            lexer->mark_end(lexer);
+            bool is_left_brace = lexer->lookahead == '{';
+            advance(lexer);
+            advanced_once = true;
+            if ((lexer->lookahead == '{' && is_left_brace) || (lexer->lookahead == '}' && !is_left_brace)) {
+                advance(lexer);
+                lexer->mark_end(lexer);
+                lexer->result_symbol = ESCAPE_INTERPOLATION;
+                return true;
+            }
+            return false;
+        }
+    }
+
+    if (valid_symbols[STRING_CONTENT] && scanner->delimiters.size > 0 && !error_recovery_mode) {
+        Delimiter *delimiter = array_back(&scanner->delimiters);
+        int32_t end_char = end_character(delimiter);
+        bool has_content = advanced_once;
+        while (lexer->lookahead) {
+            if ((advanced_once || lexer->lookahead == '{' || lexer->lookahead == '}') && is_format(delimiter)) {
+                lexer->mark_end(lexer);
+                lexer->result_symbol = STRING_CONTENT;
+                return has_content;
+            }
+            if (lexer->lookahead == '\\') {
+                if (is_raw(delimiter)) {
+                    // Step over the backslash.
+                    advance(lexer);
+                    // Step over any escaped quotes.
+                    if (lexer->lookahead == end_character(delimiter) || lexer->lookahead == '\\') {
+                        advance(lexer);
+                    }
+                    // Step over newlines
+                    if (lexer->lookahead == '\r') {
+                        advance(lexer);
+                        if (lexer->lookahead == '\n') {
+                            advance(lexer);
+                        }
+                    } else if (lexer->lookahead == '\n') {
+                        advance(lexer);
+                    }
+                    continue;
+                }
+                if (is_bytes(delimiter)) {
+                    lexer->mark_end(lexer);
+                    advance(lexer);
+                    if (lexer->lookahead == 'N' || lexer->lookahead == 'u' || lexer->lookahead == 'U') {
+                        // In bytes string, \N{...}, \uXXXX and \UXXXXXXXX are
+                        // not escape sequences
+                        // https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
+                        advance(lexer);
+                    } else {
+                        lexer->result_symbol = STRING_CONTENT;
+                        return has_content;
+                    }
+                } else {
+                    lexer->mark_end(lexer);
+                    lexer->result_symbol = STRING_CONTENT;
+                    return has_content;
+                }
+            } else if (lexer->lookahead == end_char) {
+                if (is_triple(delimiter)) {
+                    lexer->mark_end(lexer);
+                    advance(lexer);
+                    if (lexer->lookahead == end_char) {
+                        advance(lexer);
+                        if (lexer->lookahead == end_char) {
+                            if (has_content) {
+                                lexer->result_symbol = STRING_CONTENT;
+                            } else {
+                                advance(lexer);
+                                lexer->mark_end(lexer);
+                                array_pop(&scanner->delimiters);
+                                lexer->result_symbol = STRING_END;
+                                scanner->inside_interpolated_string = false;
+                            }
+                            return true;
+                        }
+                        lexer->mark_end(lexer);
+                        lexer->result_symbol = STRING_CONTENT;
+                        return true;
+                    }
+                    lexer->mark_end(lexer);
+                    lexer->result_symbol = STRING_CONTENT;
+                    return true;
+                }
+                if (has_content) {
+                    lexer->result_symbol = STRING_CONTENT;
+                } else {
+                    advance(lexer);
+                    array_pop(&scanner->delimiters);
+                    lexer->result_symbol = STRING_END;
+                    scanner->inside_interpolated_string = false;
+                }
+                lexer->mark_end(lexer);
+                return true;
+
+            } else if (lexer->lookahead == '\n' && has_content && !is_triple(delimiter)) {
+                return false;
+            }
+            advance(lexer);
+            has_content = true;
+        }
+    }
+
+    lexer->mark_end(lexer);
+
+    bool found_end_of_line = false;
+    uint16_t indent_length = 0;
+    int32_t first_comment_indent_length = -1;
+    for (;;) {
+        if (lexer->lookahead == '\n') {
+            found_end_of_line = true;
+            indent_length = 0;
+            skip(lexer);
+        } else if (lexer->lookahead == ' ') {
+            indent_length++;
+            skip(lexer);
+        } else if (lexer->lookahead == '\r' || lexer->lookahead == '\f') {
+            indent_length = 0;
+            skip(lexer);
+        } else if (lexer->lookahead == '\t') {
+            indent_length += 8;
+            skip(lexer);
+        } else if (lexer->lookahead == '#' && (valid_symbols[INDENT] || valid_symbols[DEDENT] ||
+                                               valid_symbols[NEWLINE] || valid_symbols[EXCEPT])) {
+            // If we haven't found an EOL yet,
+            // then this is a comment after an expression:
+            //   foo = bar # comment
+            // Just return, since we don't want to generate an indent/dedent
+            // token.
+            if (!found_end_of_line) {
+                return false;
+            }
+            if (first_comment_indent_length == -1) {
+                first_comment_indent_length = (int32_t)indent_length;
+            }
+            while (lexer->lookahead && lexer->lookahead != '\n') {
+                skip(lexer);
+            }
+            skip(lexer);
+            indent_length = 0;
+        } else if (lexer->lookahead == '\\') {
+            skip(lexer);
+            if (lexer->lookahead == '\r') {
+                skip(lexer);
+            }
+            if (lexer->lookahead == '\n' || lexer->eof(lexer)) {
+                skip(lexer);
+            } else {
+                return false;
+            }
+        } else if (lexer->eof(lexer)) {
+            indent_length = 0;
+            found_end_of_line = true;
+            break;
+        } else {
+            break;
+        }
+    }
+
+    if (found_end_of_line) {
+        if (scanner->indents.size > 0) {
+            uint16_t current_indent_length = *array_back(&scanner->indents);
+
+            if (valid_symbols[INDENT] && indent_length > current_indent_length) {
+                array_push(&scanner->indents, indent_length);
+                lexer->result_symbol = INDENT;
+                return true;
+            }
+
+            bool next_tok_is_string_start =
+                lexer->lookahead == '\"' || lexer->lookahead == '\'' || lexer->lookahead == '`';
+
+            if ((valid_symbols[DEDENT] ||
+                 (!valid_symbols[NEWLINE] && !(valid_symbols[STRING_START] && next_tok_is_string_start) &&
+                  !within_brackets)) &&
+                indent_length < current_indent_length && !scanner->inside_interpolated_string &&
+
+                // Wait to create a dedent token until we've consumed any
+                // comments
+                // whose indentation matches the current block.
+                first_comment_indent_length < (int32_t)current_indent_length) {
+                array_pop(&scanner->indents);
+                lexer->result_symbol = DEDENT;
+                return true;
+            }
+        }
+
+        if (valid_symbols[NEWLINE] && !error_recovery_mode) {
+            lexer->result_symbol = NEWLINE;
+            return true;
+        }
+    }
+
+    if (first_comment_indent_length == -1 && valid_symbols[STRING_START]) {
+        Delimiter delimiter = new_delimiter();
+
+        bool has_flags = false;
+        while (lexer->lookahead) {
+            if (lexer->lookahead == 'f' || lexer->lookahead == 'F' || lexer->lookahead == 't' ||
+                lexer->lookahead == 'T') {
+                set_format(&delimiter);
+            } else if (lexer->lookahead == 'r' || lexer->lookahead == 'R') {
+                set_raw(&delimiter);
+            } else if (lexer->lookahead == 'b' || lexer->lookahead == 'B') {
+                set_bytes(&delimiter);
+            } else if (lexer->lookahead != 'u' && lexer->lookahead != 'U') {
+                break;
+            }
+            has_flags = true;
+            advance(lexer);
+        }
+
+        if (lexer->lookahead == '`') {
+            set_end_character(&delimiter, '`');
+            advance(lexer);
+            lexer->mark_end(lexer);
+        } else if (lexer->lookahead == '\'') {
+            set_end_character(&delimiter, '\'');
+            advance(lexer);
+            lexer->mark_end(lexer);
+            if (lexer->lookahead == '\'') {
+                advance(lexer);
+                if (lexer->lookahead == '\'') {
+                    advance(lexer);
+                    lexer->mark_end(lexer);
+                    set_triple(&delimiter);
+                }
+            }
+        } else if (lexer->lookahead == '"') {
+            set_end_character(&delimiter, '"');
+            advance(lexer);
+            lexer->mark_end(lexer);
+            if (lexer->lookahead == '"') {
+                advance(lexer);
+                if (lexer->lookahead == '"') {
+                    advance(lexer);
+                    lexer->mark_end(lexer);
+                    set_triple(&delimiter);
+                }
+            }
+        }
+
+        if (end_character(&delimiter)) {
+            array_push(&scanner->delimiters, delimiter);
+            lexer->result_symbol = STRING_START;
+            scanner->inside_interpolated_string = is_format(&delimiter);
+            return true;
+        }
+        if (has_flags) {
+            return false;
+        }
+    }
+
+    return false;
+}
+
+unsigned tree_sitter_python_external_scanner_serialize(void *payload, char *buffer) {
+    Scanner *scanner = (Scanner *)payload;
+
+    size_t size = 0;
+
+    buffer[size++] = (char)scanner->inside_interpolated_string;
+
+    size_t delimiter_count = scanner->delimiters.size;
+    if (delimiter_count > UINT8_MAX) {
+        delimiter_count = UINT8_MAX;
+    }
+    buffer[size++] = (char)delimiter_count;
+
+    if (delimiter_count > 0) {
+        memcpy(&buffer[size], scanner->delimiters.contents, delimiter_count);
+    }
+    size += delimiter_count;
+
+    uint32_t iter = 1;
+    for (; iter < scanner->indents.size && size < TREE_SITTER_SERIALIZATION_BUFFER_SIZE; ++iter) {
+        uint16_t indent_value = *array_get(&scanner->indents, iter);
+        buffer[size++] = (char)(indent_value & 0xFF);
+        buffer[size++] = (char)((indent_value >> 8) & 0xFF);
+    }
+
+    return size;
+}
+
+void tree_sitter_python_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
+    Scanner *scanner = (Scanner *)payload;
+
+    array_delete(&scanner->delimiters);
+    array_delete(&scanner->indents);
+    array_push(&scanner->indents, 0);
+
+    if (length > 0) {
+        size_t size = 0;
+
+        scanner->inside_interpolated_string = (bool)buffer[size++];
+
+        size_t delimiter_count = (uint8_t)buffer[size++];
+        if (delimiter_count > 0) {
+            array_reserve(&scanner->delimiters, delimiter_count);
+            scanner->delimiters.size = delimiter_count;
+            memcpy(scanner->delimiters.contents, &buffer[size], delimiter_count);
+            size += delimiter_count;
+        }
+
+        for (; size + 1 < length; size += 2) {
+            uint16_t indent_value = (unsigned char)buffer[size] | ((unsigned char)buffer[size + 1] << 8);
+            array_push(&scanner->indents, indent_value);
+        }
+    }
+}
+
+void *tree_sitter_python_external_scanner_create() {
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+    _Static_assert(sizeof(Delimiter) == sizeof(char), "");
+#else
+    assert(sizeof(Delimiter) == sizeof(char));
+#endif
+    Scanner *scanner = calloc(1, sizeof(Scanner));
+    array_init(&scanner->indents);
+    array_init(&scanner->delimiters);
+    tree_sitter_python_external_scanner_deserialize(scanner, NULL, 0);
+    return scanner;
+}
+
+void tree_sitter_python_external_scanner_destroy(void *payload) {
+    Scanner *scanner = (Scanner *)payload;
+    array_delete(&scanner->indents);
+    array_delete(&scanner->delimiters);
+    free(scanner);
+}

--- a/Sources/AFMTreeSitterScanners/schema.core.c
+++ b/Sources/AFMTreeSitterScanners/schema.core.c
@@ -1,0 +1,204 @@
+#include <stdint.h>
+
+#include <stdlib.h>
+
+#define SCH_STT_FRZ -1
+
+#define HAS_TIMESTAMP 0
+
+typedef enum {
+  RS_STR,
+  RS_INT,
+  RS_NULL,
+  RS_BOOL,
+  RS_FLOAT,
+} ResultSchema;
+
+static int8_t adv_sch_stt(int8_t sch_stt, int32_t cur_chr, ResultSchema *rlt_sch) {
+  switch (sch_stt) {
+    case SCH_STT_FRZ:
+      break;
+    case 0:
+        if (cur_chr == '.') {*rlt_sch = RS_STR; return 6;}
+        if (cur_chr == '0') {*rlt_sch = RS_INT; return 37;}
+        if (cur_chr == 'F') {*rlt_sch = RS_STR; return 2;}
+        if (cur_chr == 'N') {*rlt_sch = RS_STR; return 16;}
+        if (cur_chr == 'T') {*rlt_sch = RS_STR; return 13;}
+        if (cur_chr == 'f') {*rlt_sch = RS_STR; return 17;}
+        if (cur_chr == 'n') {*rlt_sch = RS_STR; return 29;}
+        if (cur_chr == 't') {*rlt_sch = RS_STR; return 26;}
+        if (cur_chr == '~') {*rlt_sch = RS_NULL; return 35;}
+        if (cur_chr == '+') {*rlt_sch = RS_STR; return 1;}
+        if (cur_chr == '-') {*rlt_sch = RS_STR; return 1;}
+        if (('1' <= cur_chr && cur_chr <= '9')) {*rlt_sch = RS_INT; return 38;}
+      break;
+    case 1:
+      if (cur_chr == '.') {*rlt_sch = RS_STR; return 7;}
+      if (('0' <= cur_chr && cur_chr <= '9')) {*rlt_sch = RS_INT; return 38;}
+      break;
+    case 2:
+      if (cur_chr == 'A') {*rlt_sch = RS_STR; return 9;}
+      if (cur_chr == 'a') {*rlt_sch = RS_STR; return 22;}
+      break;
+    case 3:
+      if (cur_chr == 'A') {*rlt_sch = RS_STR; return 12;}
+      if (cur_chr == 'a') {*rlt_sch = RS_STR; return 12;}
+      break;
+    case 4:
+      if (cur_chr == 'E') {*rlt_sch = RS_BOOL; return 36;}
+      break;
+    case 5:
+      if (cur_chr == 'F') {*rlt_sch = RS_FLOAT; return 41;}
+      break;
+    case 6:
+      if (cur_chr == 'I') {*rlt_sch = RS_STR; return 11;}
+      if (cur_chr == 'N') {*rlt_sch = RS_STR; return 3;}
+      if (cur_chr == 'i') {*rlt_sch = RS_STR; return 24;}
+      if (cur_chr == 'n') {*rlt_sch = RS_STR; return 18;}
+      if (('0' <= cur_chr && cur_chr <= '9')) {*rlt_sch = RS_FLOAT; return 42;}
+      break;
+    case 7:
+      if (cur_chr == 'I') {*rlt_sch = RS_STR; return 11;}
+      if (cur_chr == 'i') {*rlt_sch = RS_STR; return 24;}
+      if (('0' <= cur_chr && cur_chr <= '9')) {*rlt_sch = RS_FLOAT; return 42;}
+      break;
+    case 8:
+      if (cur_chr == 'L') {*rlt_sch = RS_NULL; return 35;}
+      break;
+    case 9:
+      if (cur_chr == 'L') {*rlt_sch = RS_STR; return 14;}
+      break;
+    case 10:
+      if (cur_chr == 'L') {*rlt_sch = RS_STR; return 8;}
+      break;
+    case 11:
+      if (cur_chr == 'N') {*rlt_sch = RS_STR; return 5;}
+      if (cur_chr == 'n') {*rlt_sch = RS_STR; return 20;}
+      break;
+    case 12:
+      if (cur_chr == 'N') {*rlt_sch = RS_FLOAT; return 41;}
+      break;
+    case 13:
+      if (cur_chr == 'R') {*rlt_sch = RS_STR; return 15;}
+      if (cur_chr == 'r') {*rlt_sch = RS_STR; return 28;}
+      break;
+    case 14:
+      if (cur_chr == 'S') {*rlt_sch = RS_STR; return 4;}
+      break;
+    case 15:
+      if (cur_chr == 'U') {*rlt_sch = RS_STR; return 4;}
+      break;
+    case 16:
+      if (cur_chr == 'U') {*rlt_sch = RS_STR; return 10;}
+      if (cur_chr == 'u') {*rlt_sch = RS_STR; return 23;}
+      break;
+    case 17:
+      if (cur_chr == 'a') {*rlt_sch = RS_STR; return 22;}
+      break;
+    case 18:
+      if (cur_chr == 'a') {*rlt_sch = RS_STR; return 25;}
+      break;
+    case 19:
+      if (cur_chr == 'e') {*rlt_sch = RS_BOOL; return 36;}
+      break;
+    case 20:
+      if (cur_chr == 'f') {*rlt_sch = RS_FLOAT; return 41;}
+      break;
+    case 21:
+      if (cur_chr == 'l') {*rlt_sch = RS_NULL; return 35;}
+      break;
+    case 22:
+      if (cur_chr == 'l') {*rlt_sch = RS_STR; return 27;}
+      break;
+    case 23:
+      if (cur_chr == 'l') {*rlt_sch = RS_STR; return 21;}
+      break;
+    case 24:
+      if (cur_chr == 'n') {*rlt_sch = RS_STR; return 20;}
+      break;
+    case 25:
+      if (cur_chr == 'n') {*rlt_sch = RS_FLOAT; return 41;}
+      break;
+    case 26:
+      if (cur_chr == 'r') {*rlt_sch = RS_STR; return 28;}
+      break;
+    case 27:
+      if (cur_chr == 's') {*rlt_sch = RS_STR; return 19;}
+      break;
+    case 28:
+      if (cur_chr == 'u') {*rlt_sch = RS_STR; return 19;}
+      break;
+    case 29:
+      if (cur_chr == 'u') {*rlt_sch = RS_STR; return 23;}
+      break;
+    case 30:
+      if (cur_chr == '+' ||
+          cur_chr == '-') {*rlt_sch = RS_STR; return 32;}
+      if (('0' <= cur_chr && cur_chr <= '9')) {*rlt_sch = RS_FLOAT; return 43;}
+      break;
+    case 31:
+      if (('0' <= cur_chr && cur_chr <= '7')) {*rlt_sch = RS_INT; return 39;}
+      break;
+    case 32:
+      if (('0' <= cur_chr && cur_chr <= '9')) {*rlt_sch = RS_FLOAT; return 43;}
+      break;
+    case 33:
+      if (('0' <= cur_chr && cur_chr <= '9') ||
+          ('A' <= cur_chr && cur_chr <= 'F') ||
+          ('a' <= cur_chr && cur_chr <= 'f')) {*rlt_sch = RS_INT; return 40;}
+      break;
+    case 34:
+      abort();
+      break;
+    case 35:
+      *rlt_sch = RS_NULL;
+      break;
+    case 36:
+      *rlt_sch = RS_BOOL;
+      break;
+    case 37:
+      *rlt_sch = RS_INT;
+      if (cur_chr == '.') {*rlt_sch = RS_FLOAT; return 42;}
+      if (cur_chr == 'o') {*rlt_sch = RS_STR; return 31;}
+      if (cur_chr == 'x') {*rlt_sch = RS_STR; return 33;}
+      if (cur_chr == 'E' ||
+          cur_chr == 'e') {*rlt_sch = RS_STR; return 30;}
+      if (('0' <= cur_chr && cur_chr <= '9')) {*rlt_sch = RS_INT; return 38;}
+      break;
+    case 38:
+      *rlt_sch = RS_INT;
+      if (cur_chr == '.') {*rlt_sch = RS_FLOAT; return 42;}
+      if (cur_chr == 'E' ||
+          cur_chr == 'e') {*rlt_sch = RS_STR; return 30;}
+      if (('0' <= cur_chr && cur_chr <= '9')) {*rlt_sch = RS_INT; return 38;}
+      break;
+    case 39:
+      *rlt_sch = RS_INT;
+      if (('0' <= cur_chr && cur_chr <= '7')) {*rlt_sch = RS_INT; return 39;}
+      break;
+    case 40:
+      *rlt_sch = RS_INT;
+      if (('0' <= cur_chr && cur_chr <= '9') ||
+          ('A' <= cur_chr && cur_chr <= 'F') ||
+          ('a' <= cur_chr && cur_chr <= 'f')) {*rlt_sch = RS_INT; return 40;}
+      break;
+    case 41:
+      *rlt_sch = RS_FLOAT;
+      break;
+    case 42:
+      *rlt_sch = RS_FLOAT;
+      if (cur_chr == 'E' ||
+          cur_chr == 'e') {*rlt_sch = RS_STR; return 30;}
+      if (('0' <= cur_chr && cur_chr <= '9')) {*rlt_sch = RS_FLOAT; return 42;}
+      break;
+    case 43:
+      *rlt_sch = RS_FLOAT;
+      if (('0' <= cur_chr && cur_chr <= '9')) {*rlt_sch = RS_FLOAT; return 43;}
+      break;
+    default:
+      *rlt_sch = RS_STR;
+      return SCH_STT_FRZ;
+  }
+  if (cur_chr != '\r' && cur_chr != '\n' && cur_chr != ' ' && cur_chr != 0) *rlt_sch = RS_STR;
+  return SCH_STT_FRZ;
+}

--- a/Sources/AFMTreeSitterScanners/tree_sitter/alloc.h
+++ b/Sources/AFMTreeSitterScanners/tree_sitter/alloc.h
@@ -1,0 +1,54 @@
+#ifndef TREE_SITTER_ALLOC_H_
+#define TREE_SITTER_ALLOC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Allow clients to override allocation functions
+#ifdef TREE_SITTER_REUSE_ALLOCATOR
+
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
+
+#ifndef ts_malloc
+#define ts_malloc  ts_current_malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  ts_current_calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc ts_current_realloc
+#endif
+#ifndef ts_free
+#define ts_free    ts_current_free
+#endif
+
+#else
+
+#ifndef ts_malloc
+#define ts_malloc  malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc realloc
+#endif
+#ifndef ts_free
+#define ts_free    free
+#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_ALLOC_H_

--- a/Sources/AFMTreeSitterScanners/tree_sitter/array.h
+++ b/Sources/AFMTreeSitterScanners/tree_sitter/array.h
@@ -1,0 +1,291 @@
+#ifndef TREE_SITTER_ARRAY_H_
+#define TREE_SITTER_ARRAY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "./alloc.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
+#define Array(T)       \
+  struct {             \
+    T *contents;       \
+    uint32_t size;     \
+    uint32_t capacity; \
+  }
+
+/// Initialize an array.
+#define array_init(self) \
+  ((self)->size = 0, (self)->capacity = 0, (self)->contents = NULL)
+
+/// Create an empty array.
+#define array_new() \
+  { NULL, 0, 0 }
+
+/// Get a pointer to the element at a given `index` in the array.
+#define array_get(self, _index) \
+  (assert((uint32_t)(_index) < (self)->size), &(self)->contents[_index])
+
+/// Get a pointer to the first element in the array.
+#define array_front(self) array_get(self, 0)
+
+/// Get a pointer to the last element in the array.
+#define array_back(self) array_get(self, (self)->size - 1)
+
+/// Clear the array, setting its size to zero. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_clear(self) ((self)->size = 0)
+
+/// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
+/// less than the array's current capacity, this function has no effect.
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
+
+/// Free any memory allocated for this array. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_delete(self) _array__delete((Array *)(self))
+
+/// Push a new `element` onto the end of the array.
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
+
+/// Increase the array's size by `count` elements.
+/// New elements are zero-initialized.
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
+
+/// Append all elements from one array to the end of another.
+#define array_push_all(self, other)                                       \
+  array_extend((self), (other)->size, (other)->contents)
+
+/// Append `count` elements to the end of the array, reading their values from the
+/// `contents` pointer.
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
+  )
+
+/// Remove `old_count` elements from the array starting at the given `index`. At
+/// the same index, insert `new_count` new elements, reading their values from the
+/// `new_contents` pointer.
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
+  )
+
+/// Insert one `element` into the array at the given `index`.
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
+
+/// Remove one element from the array at the given `index`.
+#define array_erase(self, _index) \
+  _array__erase((Array *)(self), array_elem_size(self), _index)
+
+/// Pop the last element off the array, returning the element by value.
+#define array_pop(self) ((self)->contents[--(self)->size])
+
+/// Assign the contents of one array to another, reallocating if necessary.
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
+
+/// Swap one array with another
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
+
+/// Get the size of the array contents
+#define array_elem_size(self) (sizeof *(self)->contents)
+
+/// Search a sorted array for a given `needle` value, using the given `compare`
+/// callback to determine the order.
+///
+/// If an existing element is found to be equal to `needle`, then the `index`
+/// out-parameter is set to the existing value's index, and the `exists`
+/// out-parameter is set to true. Otherwise, `index` is set to an index where
+/// `needle` should be inserted in order to preserve the sorting, and `exists`
+/// is set to false.
+#define array_search_sorted_with(self, compare, needle, _index, _exists) \
+  _array__search_sorted(self, 0, compare, , needle, _index, _exists)
+
+/// Search a sorted array for a given `needle` value, using integer comparisons
+/// of a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_with`.
+#define array_search_sorted_by(self, field, needle, _index, _exists) \
+  _array__search_sorted(self, 0, _compare_int, field, needle, _index, _exists)
+
+/// Insert a given `value` into a sorted array, using the given `compare`
+/// callback to determine the order.
+#define array_insert_sorted_with(self, compare, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_with(self, compare, &(value), &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+/// Insert a given `value` into a sorted array, using integer comparisons of
+/// a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_by`.
+#define array_insert_sorted_by(self, field, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_by(self, field, (value) field, &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+// Private
+
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
+
+/// This is not what you're looking for, see `array_erase`.
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
+  memmove(contents + index * element_size, contents + (index + 1) * element_size,
+          (self->size - index - 1) * element_size);
+  self->size--;
+}
+
+/// This is not what you're looking for, see `array_reserve`.
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
+    } else {
+      self->contents = ts_malloc(new_capacity * element_size);
+    }
+    self->capacity = new_capacity;
+  }
+}
+
+/// This is not what you're looking for, see `array_assign`.
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
+}
+
+/// This is not what you're looking for, see `array_swap`.
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
+}
+
+/// This is not what you're looking for, see `array_push` or `array_grow_by`.
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
+    if (new_capacity < 8) new_capacity = 8;
+    if (new_capacity < new_size) new_capacity = new_size;
+    _array__reserve(self, element_size, new_capacity);
+  }
+}
+
+/// This is not what you're looking for, see `array_splice`.
+static inline void _array__splice(Array *self, size_t element_size,
+                                 uint32_t index, uint32_t old_count,
+                                 uint32_t new_count, const void *elements) {
+  uint32_t new_size = self->size + new_count - old_count;
+  uint32_t old_end = index + old_count;
+  uint32_t new_end = index + new_count;
+  assert(old_end <= self->size);
+
+  _array__reserve(self, element_size, new_size);
+
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
+    memmove(
+      contents + new_end * element_size,
+      contents + old_end * element_size,
+      (self->size - old_end) * element_size
+    );
+  }
+  if (new_count > 0) {
+    if (elements) {
+      memcpy(
+        (contents + index * element_size),
+        elements,
+        new_count * element_size
+      );
+    } else {
+      memset(
+        (contents + index * element_size),
+        0,
+        new_count * element_size
+      );
+    }
+  }
+  self->size += new_count - old_count;
+}
+
+/// A binary search routine, based on Rust's `std::slice::binary_search_by`.
+/// This is not what you're looking for, see `array_search_sorted_with` or `array_search_sorted_by`.
+#define _array__search_sorted(self, start, compare, suffix, needle, _index, _exists) \
+  do { \
+    *(_index) = start; \
+    *(_exists) = false; \
+    uint32_t size = (self)->size - *(_index); \
+    if (size == 0) break; \
+    int comparison; \
+    while (size > 1) { \
+      uint32_t half_size = size / 2; \
+      uint32_t mid_index = *(_index) + half_size; \
+      comparison = compare(&((self)->contents[mid_index] suffix), (needle)); \
+      if (comparison <= 0) *(_index) = mid_index; \
+      size -= half_size; \
+    } \
+    comparison = compare(&((self)->contents[*(_index)] suffix), (needle)); \
+    if (comparison == 0) *(_exists) = true; \
+    else if (comparison < 0) *(_index) += 1; \
+  } while (0)
+
+/// Helper macro for the `_sorted_by` routines below. This takes the left (existing)
+/// parameter by reference in order to work with the generic sorting function above.
+#define _compare_int(a, b) ((int)*(a) - (int)(b))
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_ARRAY_H_

--- a/Sources/AFMTreeSitterScanners/tree_sitter/parser.h
+++ b/Sources/AFMTreeSitterScanners/tree_sitter/parser.h
@@ -1,0 +1,286 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+// Used to index the field and supertype maps.
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
+struct TSLanguage {
+  uint32_t abi_version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexerMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+  const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
+};
+
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    const TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  const TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
+/*
+ *  Lexer Macros
+ */
+
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  UNUSED                        \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value)          \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value),         \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_

--- a/Sources/AFMTreeSitterScanners/yaml_scanner.c
+++ b/Sources/AFMTreeSitterScanners/yaml_scanner.c
@@ -1,0 +1,1417 @@
+#include "tree_sitter/array.h"
+#include "tree_sitter/parser.h"
+
+#define _str(x) #x
+#define _file(x) _str(schema.x.c)
+
+#ifndef YAML_SCHEMA
+#define YAML_SCHEMA core
+#endif
+
+#include _file(YAML_SCHEMA)
+
+// clang-format off
+
+typedef enum {
+    END_OF_FILE,
+
+    S_DIR_YML_BGN,  R_DIR_YML_VER,
+    S_DIR_TAG_BGN,  R_DIR_TAG_HDL,  R_DIR_TAG_PFX,
+    S_DIR_RSV_BGN,  R_DIR_RSV_PRM,
+    S_DRS_END,
+    S_DOC_END,
+    R_BLK_SEQ_BGN,  BR_BLK_SEQ_BGN, B_BLK_SEQ_BGN,
+    R_BLK_KEY_BGN,  BR_BLK_KEY_BGN, B_BLK_KEY_BGN,
+    R_BLK_VAL_BGN,  BR_BLK_VAL_BGN, B_BLK_VAL_BGN,
+    R_BLK_IMP_BGN,
+    R_BLK_LIT_BGN,  BR_BLK_LIT_BGN,
+    R_BLK_FLD_BGN,  BR_BLK_FLD_BGN,
+    BR_BLK_STR_CTN,
+    R_FLW_SEQ_BGN,  BR_FLW_SEQ_BGN, B_FLW_SEQ_BGN,
+    R_FLW_SEQ_END,  BR_FLW_SEQ_END, B_FLW_SEQ_END,
+    R_FLW_MAP_BGN,  BR_FLW_MAP_BGN, B_FLW_MAP_BGN,
+    R_FLW_MAP_END,  BR_FLW_MAP_END, B_FLW_MAP_END,
+    R_FLW_SEP_BGN,  BR_FLW_SEP_BGN,
+    R_FLW_KEY_BGN,  BR_FLW_KEY_BGN,
+    R_FLW_JSV_BGN,  BR_FLW_JSV_BGN,
+    R_FLW_NJV_BGN,  BR_FLW_NJV_BGN,
+    R_DQT_STR_BGN,  BR_DQT_STR_BGN, B_DQT_STR_BGN,
+    R_DQT_STR_CTN,  BR_DQT_STR_CTN,
+    R_DQT_ESC_NWL,  BR_DQT_ESC_NWL,
+    R_DQT_ESC_SEQ,  BR_DQT_ESC_SEQ,
+    R_DQT_STR_END,  BR_DQT_STR_END,
+    R_SQT_STR_BGN,  BR_SQT_STR_BGN, B_SQT_STR_BGN,
+    R_SQT_STR_CTN,  BR_SQT_STR_CTN,
+    R_SQT_ESC_SQT,  BR_SQT_ESC_SQT,
+    R_SQT_STR_END,  BR_SQT_STR_END,
+
+    R_SGL_PLN_NUL_BLK, BR_SGL_PLN_NUL_BLK, B_SGL_PLN_NUL_BLK, R_SGL_PLN_NUL_FLW, BR_SGL_PLN_NUL_FLW,
+    R_SGL_PLN_BOL_BLK, BR_SGL_PLN_BOL_BLK, B_SGL_PLN_BOL_BLK, R_SGL_PLN_BOL_FLW, BR_SGL_PLN_BOL_FLW,
+    R_SGL_PLN_INT_BLK, BR_SGL_PLN_INT_BLK, B_SGL_PLN_INT_BLK, R_SGL_PLN_INT_FLW, BR_SGL_PLN_INT_FLW,
+    R_SGL_PLN_FLT_BLK, BR_SGL_PLN_FLT_BLK, B_SGL_PLN_FLT_BLK, R_SGL_PLN_FLT_FLW, BR_SGL_PLN_FLT_FLW,
+    R_SGL_PLN_TMS_BLK, BR_SGL_PLN_TMS_BLK, B_SGL_PLN_TMS_BLK, R_SGL_PLN_TMS_FLW, BR_SGL_PLN_TMS_FLW,
+    R_SGL_PLN_STR_BLK, BR_SGL_PLN_STR_BLK, B_SGL_PLN_STR_BLK, R_SGL_PLN_STR_FLW, BR_SGL_PLN_STR_FLW,
+
+    R_MTL_PLN_STR_BLK,  BR_MTL_PLN_STR_BLK,
+    R_MTL_PLN_STR_FLW,  BR_MTL_PLN_STR_FLW,
+
+    R_TAG,     BR_TAG,     B_TAG,
+    R_ACR_BGN, BR_ACR_BGN, B_ACR_BGN, R_ACR_CTN,
+    R_ALS_BGN, BR_ALS_BGN, B_ALS_BGN, R_ALS_CTN,
+
+    BL,
+    COMMENT,
+
+    ERR_REC,
+} TokenType;
+
+// clang-format on
+
+typedef enum {
+    SCN_FAIL = -1,
+    SCN_STOP,
+    SCN_SUCC,
+} ScanStatus;
+
+#define IND_ROT 'r'
+#define IND_MAP 'm'
+#define IND_SEQ 'q'
+#define IND_STR 's'
+
+#define RET_SYM(RESULT_SYMBOL)                                                                                         \
+    {                                                                                                                  \
+        flush(scanner);                                                                                                \
+        lexer->result_symbol = RESULT_SYMBOL;                                                                          \
+        return true;                                                                                                   \
+    }
+
+#define POP_IND()                                                                                                      \
+    {                                                                                                                  \
+        /* incorrect status caused by error recovering */                                                              \
+        if (scanner->ind_typ_stk.size == 1) {                                                                          \
+            return false;                                                                                              \
+        }                                                                                                              \
+        pop_ind(scanner);                                                                                              \
+    }
+
+#define PUSH_IND(TYP, LEN) push_ind(scanner, TYP, LEN)
+
+#define PUSH_BGN_IND(TYP)                                                                                              \
+    {                                                                                                                  \
+        if (has_tab_ind)                                                                                               \
+            return false;                                                                                              \
+        push_ind(scanner, TYP, bgn_col);                                                                               \
+    }
+
+#define MAY_PUSH_IMP_IND(TYP)                                                                                          \
+    {                                                                                                                  \
+        if (cur_ind != scanner->blk_imp_col) {                                                                         \
+            if (scanner->blk_imp_tab)                                                                                  \
+                return false;                                                                                          \
+            push_ind(scanner, IND_MAP, scanner->blk_imp_col);                                                          \
+        }                                                                                                              \
+    }
+
+#define MAY_PUSH_SPC_SEQ_IND()                                                                                         \
+    {                                                                                                                  \
+        if (cur_ind_typ == IND_MAP) {                                                                                  \
+            push_ind(scanner, IND_SEQ, bgn_col);                                                                       \
+        }                                                                                                              \
+    }
+
+#define MAY_UPD_IMP_COL()                                                                                              \
+    {                                                                                                                  \
+        if (scanner->blk_imp_row != bgn_row) {                                                                         \
+            scanner->blk_imp_row = bgn_row;                                                                            \
+            scanner->blk_imp_col = bgn_col;                                                                            \
+            scanner->blk_imp_tab = has_tab_ind;                                                                        \
+        }                                                                                                              \
+    }
+
+#if HAS_TIMESTAMP
+#define SGL_PLN_SYM(POS, CTX)                                                                                          \
+    (scanner->rlt_sch == RS_NULL        ? POS##_SGL_PLN_NUL_##CTX                                                      \
+     : scanner->rlt_sch == RS_BOOL      ? POS##_SGL_PLN_BOL_##CTX                                                      \
+     : scanner->rlt_sch == RS_INT       ? POS##_SGL_PLN_INT_##CTX                                                      \
+     : scanner->rlt_sch == RS_FLOAT     ? POS##_SGL_PLN_FLT_##CTX                                                      \
+     : scanner->rlt_sch == RS_TIMESTAMP ? POS##_SGL_PLN_TMS_##CTX                                                      \
+                                        : POS##_SGL_PLN_STR_##CTX)
+#else
+#define SGL_PLN_SYM(POS, CTX)                                                                                          \
+    (scanner->rlt_sch == RS_NULL        ? POS##_SGL_PLN_NUL_##CTX                                                      \
+     : scanner->rlt_sch == RS_BOOL      ? POS##_SGL_PLN_BOL_##CTX                                                      \
+     : scanner->rlt_sch == RS_INT       ? POS##_SGL_PLN_INT_##CTX                                                      \
+     : scanner->rlt_sch == RS_FLOAT     ? POS##_SGL_PLN_FLT_##CTX                                                      \
+                                        : POS##_SGL_PLN_STR_##CTX)
+#endif
+
+typedef struct {
+    int16_t row;
+    int16_t col;
+    int16_t blk_imp_row;
+    int16_t blk_imp_col;
+    int16_t blk_imp_tab;
+    Array(int16_t) ind_typ_stk;
+    Array(int16_t) ind_len_stk;
+
+    // temp
+    int16_t end_row;
+    int16_t end_col;
+    int16_t cur_row;
+    int16_t cur_col;
+    int32_t cur_chr;
+    int8_t sch_stt;
+    ResultSchema rlt_sch;
+} Scanner;
+
+static unsigned serialize(Scanner *scanner, char *buffer) {
+    size_t size = 0;
+    *(int16_t *)&buffer[size] = scanner->row;
+    size += sizeof(int16_t);
+    *(int16_t *)&buffer[size] = scanner->col;
+    size += sizeof(int16_t);
+    *(int16_t *)&buffer[size] = scanner->blk_imp_row;
+    size += sizeof(int16_t);
+    *(int16_t *)&buffer[size] = scanner->blk_imp_col;
+    size += sizeof(int16_t);
+    *(int16_t *)&buffer[size] = scanner->blk_imp_tab;
+    size += sizeof(int16_t);
+    int16_t *typ_itr = scanner->ind_typ_stk.contents + 1;
+    int16_t *typ_end = scanner->ind_typ_stk.contents + scanner->ind_typ_stk.size;
+    int16_t *len_itr = scanner->ind_len_stk.contents + 1;
+    for (; typ_itr != typ_end && size < TREE_SITTER_SERIALIZATION_BUFFER_SIZE; ++typ_itr, ++len_itr) {
+        *(int16_t *)&buffer[size] = *typ_itr;
+        size += sizeof(int16_t);
+        *(int16_t *)&buffer[size] = *len_itr;
+        size += sizeof(int16_t);
+    }
+    return size;
+}
+
+static void deserialize(Scanner *scanner, const char *buffer, unsigned length) {
+    scanner->row = 0;
+    scanner->col = 0;
+    scanner->blk_imp_row = -1;
+    scanner->blk_imp_col = -1;
+    scanner->blk_imp_tab = 0;
+    array_delete(&scanner->ind_typ_stk);
+    array_push(&scanner->ind_typ_stk, IND_ROT);
+    array_delete(&scanner->ind_len_stk);
+    array_push(&scanner->ind_len_stk, -1);
+    if (length > 0) {
+        size_t size = 0;
+        scanner->row = *(int16_t *)&buffer[size];
+        size += sizeof(int16_t);
+        scanner->col = *(int16_t *)&buffer[size];
+        size += sizeof(int16_t);
+        scanner->blk_imp_row = *(int16_t *)&buffer[size];
+        size += sizeof(int16_t);
+        scanner->blk_imp_col = *(int16_t *)&buffer[size];
+        size += sizeof(int16_t);
+        scanner->blk_imp_tab = *(int16_t *)&buffer[size];
+        size += sizeof(int16_t);
+        while (size < length) {
+            array_push(&scanner->ind_typ_stk, *(int16_t *)&buffer[size]);
+            size += sizeof(int16_t);
+            array_push(&scanner->ind_len_stk, *(int16_t *)&buffer[size]);
+            size += sizeof(int16_t);
+        }
+        assert(size == length);
+    }
+}
+
+static inline void adv(Scanner *scanner, TSLexer *lexer) {
+    scanner->cur_col++;
+    scanner->cur_chr = lexer->lookahead;
+    lexer->advance(lexer, false);
+}
+
+static inline void adv_nwl(Scanner *scanner, TSLexer *lexer) {
+    scanner->cur_row++;
+    scanner->cur_col = 0;
+    scanner->cur_chr = lexer->lookahead;
+    lexer->advance(lexer, false);
+}
+
+static inline void skp(Scanner *scanner, TSLexer *lexer) {
+    scanner->cur_col++;
+    scanner->cur_chr = lexer->lookahead;
+    lexer->advance(lexer, true);
+}
+
+static inline void skp_nwl(Scanner *scanner, TSLexer *lexer) {
+    scanner->cur_row++;
+    scanner->cur_col = 0;
+    scanner->cur_chr = lexer->lookahead;
+    lexer->advance(lexer, true);
+}
+
+static inline void mrk_end(Scanner *scanner, TSLexer *lexer) {
+    scanner->end_row = scanner->cur_row;
+    scanner->end_col = scanner->cur_col;
+    lexer->mark_end(lexer);
+}
+
+static inline void init(Scanner *scanner) {
+    scanner->cur_row = scanner->row;
+    scanner->cur_col = scanner->col;
+    scanner->cur_chr = 0;
+    scanner->sch_stt = 0;
+    scanner->rlt_sch = RS_STR;
+}
+
+static inline void flush(Scanner *scanner) {
+    scanner->row = scanner->end_row;
+    scanner->col = scanner->end_col;
+}
+
+static inline void pop_ind(Scanner *scanner) {
+    array_pop(&scanner->ind_len_stk);
+    array_pop(&scanner->ind_typ_stk);
+}
+
+static inline void push_ind(Scanner *scanner, int16_t typ, int16_t len) {
+    array_push(&scanner->ind_len_stk, len);
+    array_push(&scanner->ind_typ_stk, typ);
+}
+
+static inline bool is_wsp(int32_t c) { return c == ' ' || c == '\t'; }
+
+static inline bool is_nwl(int32_t c) { return c == '\r' || c == '\n'; }
+
+static inline bool is_wht(int32_t c) { return is_wsp(c) || is_nwl(c) || c == 0; }
+
+static inline bool is_ns_dec_digit(int32_t c) { return c >= '0' && c <= '9'; }
+
+static inline bool is_ns_hex_digit(int32_t c) {
+    return is_ns_dec_digit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+static inline bool is_ns_word_char(int32_t c) {
+    return c == '-' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+static inline bool is_nb_json(int32_t c) { return c == 0x09 || (c >= 0x20 && c <= 0x10ffff); }
+
+static inline bool is_nb_double_char(int32_t c) { return is_nb_json(c) && c != '\\' && c != '"'; }
+
+static inline bool is_nb_single_char(int32_t c) { return is_nb_json(c) && c != '\''; }
+
+static inline bool is_ns_char(int32_t c) {
+    return (c >= 0x21 && c <= 0x7e) || c == 0x85 || (c >= 0xa0 && c <= 0xd7ff) || (c >= 0xe000 && c <= 0xfefe) ||
+           (c >= 0xff00 && c <= 0xfffd) || (c >= 0x10000 && c <= 0x10ffff);
+}
+
+static inline bool is_c_indicator(int32_t c) {
+    return c == '-' || c == '?' || c == ':' || c == ',' || c == '[' || c == ']' || c == '{' || c == '}' || c == '#' ||
+           c == '&' || c == '*' || c == '!' || c == '|' || c == '>' || c == '\'' || c == '"' || c == '%' || c == '@' ||
+           c == '`';
+}
+
+static inline bool is_c_flow_indicator(int32_t c) { return c == ',' || c == '[' || c == ']' || c == '{' || c == '}'; }
+
+static inline bool is_plain_safe_in_block(int32_t c) { return is_ns_char(c); }
+
+static inline bool is_plain_safe_in_flow(int32_t c) { return is_ns_char(c) && !is_c_flow_indicator(c); }
+
+static inline bool is_ns_uri_char(int32_t c) {
+    return is_ns_word_char(c) || c == '#' || c == ';' || c == '/' || c == '?' || c == ':' || c == '@' || c == '&' ||
+           c == '=' || c == '+' || c == '$' || c == ',' || c == '_' || c == '.' || c == '!' || c == '~' || c == '*' ||
+           c == '\'' || c == '(' || c == ')' || c == '[' || c == ']';
+}
+
+static inline bool is_ns_tag_char(int32_t c) {
+    return is_ns_word_char(c) || c == '#' || c == ';' || c == '/' || c == '?' || c == ':' || c == '@' || c == '&' ||
+           c == '=' || c == '+' || c == '$' || c == '_' || c == '.' || c == '~' || c == '*' || c == '\'' || c == '(' ||
+           c == ')';
+}
+
+static inline bool is_ns_anchor_char(int32_t c) { return is_ns_char(c) && !is_c_flow_indicator(c); }
+
+static ScanStatus scn_uri_esc(Scanner *scanner, TSLexer *lexer) {
+    if (lexer->lookahead != '%') {
+        return SCN_STOP;
+    }
+    mrk_end(scanner, lexer);
+    adv(scanner, lexer);
+    if (!is_ns_hex_digit(lexer->lookahead)) {
+        return SCN_FAIL;
+    }
+    adv(scanner, lexer);
+    if (!is_ns_hex_digit(lexer->lookahead)) {
+        return SCN_FAIL;
+    }
+    adv(scanner, lexer);
+    return SCN_SUCC;
+}
+
+static ScanStatus scn_ns_uri_char(Scanner *scanner, TSLexer *lexer) {
+    if (is_ns_uri_char(lexer->lookahead)) {
+        adv(scanner, lexer);
+        return SCN_SUCC;
+    }
+    return scn_uri_esc(scanner, lexer);
+}
+
+static ScanStatus scn_ns_tag_char(Scanner *scanner, TSLexer *lexer) {
+    if (is_ns_tag_char(lexer->lookahead)) {
+        adv(scanner, lexer);
+        return SCN_SUCC;
+    }
+    return scn_uri_esc(scanner, lexer);
+}
+
+static bool scn_dir_bgn(Scanner *scanner, TSLexer *lexer) {
+    adv(scanner, lexer);
+    if (lexer->lookahead == 'Y') {
+        adv(scanner, lexer);
+        if (lexer->lookahead == 'A') {
+            adv(scanner, lexer);
+            if (lexer->lookahead == 'M') {
+                adv(scanner, lexer);
+                if (lexer->lookahead == 'L') {
+                    adv(scanner, lexer);
+                    if (is_wht(lexer->lookahead)) {
+                        mrk_end(scanner, lexer);
+                        RET_SYM(S_DIR_YML_BGN);
+                    }
+                }
+            }
+        }
+    } else if (lexer->lookahead == 'T') {
+        adv(scanner, lexer);
+        if (lexer->lookahead == 'A') {
+            adv(scanner, lexer);
+            if (lexer->lookahead == 'G') {
+                adv(scanner, lexer);
+                if (is_wht(lexer->lookahead)) {
+                    mrk_end(scanner, lexer);
+                    RET_SYM(S_DIR_TAG_BGN);
+                }
+            }
+        }
+    }
+    for (;;) {
+        if (!is_ns_char(lexer->lookahead)) {
+            break;
+        }
+        adv(scanner, lexer);
+    }
+    if (scanner->cur_col > 1 && is_wht(lexer->lookahead)) {
+        mrk_end(scanner, lexer);
+        RET_SYM(S_DIR_RSV_BGN);
+    }
+    return false;
+}
+
+static bool scn_dir_yml_ver(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    uint16_t n1 = 0;
+    uint16_t n2 = 0;
+    while (is_ns_dec_digit(lexer->lookahead)) {
+        adv(scanner, lexer);
+        n1++;
+    }
+    if (lexer->lookahead != '.') {
+        return false;
+    }
+    adv(scanner, lexer);
+    while (is_ns_dec_digit(lexer->lookahead)) {
+        adv(scanner, lexer);
+        n2++;
+    }
+    if (n1 == 0 || n2 == 0) {
+        return false;
+    }
+    mrk_end(scanner, lexer);
+    RET_SYM(result_symbol);
+}
+
+static bool scn_tag_hdl_tal(Scanner *scanner, TSLexer *lexer) {
+    if (lexer->lookahead == '!') {
+        adv(scanner, lexer);
+        return true;
+    }
+    uint16_t n = 0;
+    while (is_ns_word_char(lexer->lookahead)) {
+        adv(scanner, lexer);
+        n++;
+    }
+    if (n == 0) {
+        return true;
+    }
+    if (lexer->lookahead == '!') {
+        adv(scanner, lexer);
+        return true;
+    }
+    return false;
+}
+
+static bool scn_dir_tag_hdl(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    if (lexer->lookahead == '!') {
+        adv(scanner, lexer);
+        if (scn_tag_hdl_tal(scanner, lexer)) {
+            mrk_end(scanner, lexer);
+            RET_SYM(result_symbol);
+        }
+    }
+    return false;
+}
+
+static bool scn_dir_tag_pfx(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    if (lexer->lookahead == '!') {
+        adv(scanner, lexer);
+    } else if (scn_ns_tag_char(scanner, lexer) == SCN_SUCC) {
+        ;
+    } else {
+        return false;
+    }
+    for (;;) {
+        switch (scn_ns_uri_char(scanner, lexer)) {
+            case SCN_STOP:
+                mrk_end(scanner, lexer);
+            case SCN_FAIL:
+                RET_SYM(result_symbol);
+            default:
+                break;
+        }
+    }
+}
+
+static bool scn_dir_rsv_prm(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    if (!is_ns_char(lexer->lookahead)) {
+        return false;
+    }
+    adv(scanner, lexer);
+    while (is_ns_char(lexer->lookahead)) {
+        adv(scanner, lexer);
+    }
+    mrk_end(scanner, lexer);
+    RET_SYM(result_symbol);
+}
+
+static bool scn_tag(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    if (lexer->lookahead != '!') {
+        return false;
+    }
+    adv(scanner, lexer);
+    if (is_wht(lexer->lookahead)) {
+        mrk_end(scanner, lexer);
+        RET_SYM(result_symbol);
+    }
+    if (lexer->lookahead == '<') {
+        adv(scanner, lexer);
+        if (scn_ns_uri_char(scanner, lexer) != SCN_SUCC) {
+            return false;
+        }
+        for (;;) {
+            switch (scn_ns_uri_char(scanner, lexer)) {
+                case SCN_STOP:
+                    if (lexer->lookahead == '>') {
+                        adv(scanner, lexer);
+                        mrk_end(scanner, lexer);
+                        RET_SYM(result_symbol);
+                    }
+                case SCN_FAIL:
+                    return false;
+                default:
+                    break;
+            }
+        }
+    } else {
+        if (scn_tag_hdl_tal(scanner, lexer) && scn_ns_tag_char(scanner, lexer) != SCN_SUCC) {
+            return false;
+        }
+        for (;;) {
+            switch (scn_ns_tag_char(scanner, lexer)) {
+                case SCN_STOP:
+                    mrk_end(scanner, lexer);
+                case SCN_FAIL:
+                    RET_SYM(result_symbol);
+                default:
+                    break;
+            }
+        }
+    }
+    return false;
+}
+
+static bool scn_acr_bgn(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    if (lexer->lookahead != '&') {
+        return false;
+    }
+    adv(scanner, lexer);
+    if (!is_ns_anchor_char(lexer->lookahead)) {
+        return false;
+    }
+    mrk_end(scanner, lexer);
+    RET_SYM(result_symbol);
+}
+
+static bool scn_acr_ctn(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    while (is_ns_anchor_char(lexer->lookahead)) {
+        adv(scanner, lexer);
+    }
+    mrk_end(scanner, lexer);
+    RET_SYM(result_symbol);
+}
+
+static bool scn_als_bgn(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    if (lexer->lookahead != '*') {
+        return false;
+    }
+    adv(scanner, lexer);
+    if (!is_ns_anchor_char(lexer->lookahead)) {
+        return false;
+    }
+    mrk_end(scanner, lexer);
+    RET_SYM(result_symbol);
+}
+
+static bool scn_als_ctn(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    while (is_ns_anchor_char(lexer->lookahead)) {
+        adv(scanner, lexer);
+    }
+    mrk_end(scanner, lexer);
+    RET_SYM(result_symbol);
+}
+
+static bool scn_dqt_esc_seq(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    uint16_t i;
+    switch (lexer->lookahead) {
+        case '0':
+        case 'a':
+        case 'b':
+        case 't':
+        case '\t':
+        case 'n':
+        case 'v':
+        case 'r':
+        case 'e':
+        case 'f':
+        case ' ':
+        case '"':
+        case '/':
+        case '\\':
+        case 'N':
+        case '_':
+        case 'L':
+        case 'P':
+            adv(scanner, lexer);
+            break;
+        case 'U':
+            adv(scanner, lexer);
+            for (i = 0; i < 8; i++) {
+                if (is_ns_hex_digit(lexer->lookahead)) {
+                    adv(scanner, lexer);
+                } else {
+                    return false;
+                }
+            }
+            break;
+        case 'u':
+            adv(scanner, lexer);
+            for (i = 0; i < 4; i++) {
+                if (is_ns_hex_digit(lexer->lookahead)) {
+                    adv(scanner, lexer);
+                } else {
+                    return false;
+                }
+            }
+            break;
+        case 'x':
+            adv(scanner, lexer);
+            for (i = 0; i < 2; i++) {
+                if (is_ns_hex_digit(lexer->lookahead)) {
+                    adv(scanner, lexer);
+                } else {
+                    return false;
+                }
+            }
+            break;
+        default:
+            return false;
+    }
+    mrk_end(scanner, lexer);
+    RET_SYM(result_symbol);
+}
+
+static bool scn_drs_doc_end(Scanner *scanner, TSLexer *lexer) {
+    if (lexer->lookahead != '-' && lexer->lookahead != '.') {
+        return false;
+    }
+    int32_t delimeter = lexer->lookahead;
+    adv(scanner, lexer);
+    if (lexer->lookahead == delimeter) {
+        adv(scanner, lexer);
+        if (lexer->lookahead == delimeter) {
+            adv(scanner, lexer);
+            if (is_wht(lexer->lookahead)) {
+                return true;
+            }
+        }
+    }
+    mrk_end(scanner, lexer);
+    return false;
+}
+
+static bool scn_dqt_str_cnt(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    if (!is_nb_double_char(lexer->lookahead)) {
+        return false;
+    }
+    if (scanner->cur_col == 0 && scn_drs_doc_end(scanner, lexer)) {
+        mrk_end(scanner, lexer);
+        RET_SYM(scanner->cur_chr == '-' ? S_DRS_END : S_DOC_END);
+    } else {
+        adv(scanner, lexer);
+    }
+    while (is_nb_double_char(lexer->lookahead)) {
+        adv(scanner, lexer);
+    }
+    mrk_end(scanner, lexer);
+    RET_SYM(result_symbol);
+}
+
+static bool scn_sqt_str_cnt(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    if (!is_nb_single_char(lexer->lookahead)) {
+        return false;
+    }
+    if (scanner->cur_col == 0 && scn_drs_doc_end(scanner, lexer)) {
+        mrk_end(scanner, lexer);
+        RET_SYM(scanner->cur_chr == '-' ? S_DRS_END : S_DOC_END);
+    } else {
+        adv(scanner, lexer);
+    }
+    while (is_nb_single_char(lexer->lookahead)) {
+        adv(scanner, lexer);
+    }
+    mrk_end(scanner, lexer);
+    RET_SYM(result_symbol);
+}
+
+static bool scn_blk_str_bgn(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    if (lexer->lookahead != '|' && lexer->lookahead != '>') {
+        return false;
+    }
+    adv(scanner, lexer);
+    int16_t cur_ind = *array_back(&scanner->ind_len_stk);
+    int16_t ind = -1;
+    if (lexer->lookahead >= '1' && lexer->lookahead <= '9') {
+        ind = lexer->lookahead - '1';
+        adv(scanner, lexer);
+        if (lexer->lookahead == '+' || lexer->lookahead == '-') {
+            adv(scanner, lexer);
+        }
+    } else if (lexer->lookahead == '+' || lexer->lookahead == '-') {
+        adv(scanner, lexer);
+        if (lexer->lookahead >= '1' && lexer->lookahead <= '9') {
+            ind = lexer->lookahead - '1';
+            adv(scanner, lexer);
+        }
+    }
+    if (!is_wht(lexer->lookahead)) {
+        return false;
+    }
+    mrk_end(scanner, lexer);
+    if (ind != -1) {
+        ind += cur_ind;
+    } else {
+        ind = cur_ind;
+        while (is_wsp(lexer->lookahead)) {
+            adv(scanner, lexer);
+        }
+        if (lexer->lookahead == '#') {
+            adv(scanner, lexer);
+            while (!is_nwl(lexer->lookahead) && lexer->lookahead != 0) {
+                adv(scanner, lexer);
+            }
+        }
+        if (is_nwl(lexer->lookahead)) {
+            adv_nwl(scanner, lexer);
+        }
+        while (lexer->lookahead != 0) {
+            if (lexer->lookahead == ' ') {
+                adv(scanner, lexer);
+            } else if (is_nwl(lexer->lookahead)) {
+                if (scanner->cur_col - 1 < ind) {
+                    break;
+                }
+                ind = scanner->cur_col - 1;
+                adv_nwl(scanner, lexer);
+            } else {
+                if (scanner->cur_col - 1 > ind) {
+                    ind = scanner->cur_col - 1;
+                }
+                break;
+            }
+        }
+    }
+    PUSH_IND(IND_STR, ind);
+    RET_SYM(result_symbol);
+}
+
+static bool scn_blk_str_cnt(Scanner *scanner, TSLexer *lexer, TSSymbol result_symbol) {
+    if (!is_ns_char(lexer->lookahead)) {
+        return false;
+    }
+    if (scanner->cur_col == 0 && scn_drs_doc_end(scanner, lexer)) {
+        POP_IND();
+        RET_SYM(BL);
+    } else {
+        adv(scanner, lexer);
+    }
+    mrk_end(scanner, lexer);
+    for (;;) {
+        if (is_ns_char(lexer->lookahead)) {
+            adv(scanner, lexer);
+            while (is_ns_char(lexer->lookahead)) {
+                adv(scanner, lexer);
+            }
+            mrk_end(scanner, lexer);
+        }
+        if (is_wsp(lexer->lookahead)) {
+            adv(scanner, lexer);
+            while (is_wsp(lexer->lookahead)) {
+                adv(scanner, lexer);
+            }
+        } else {
+            break;
+        }
+    }
+    RET_SYM(result_symbol);
+}
+
+static ScanStatus scn_pln_cnt(Scanner *scanner, TSLexer *lexer, bool (*is_plain_safe)(int32_t)) {
+    bool is_cur_wsp = is_wsp(scanner->cur_chr);
+    bool is_cur_saf = is_plain_safe(scanner->cur_chr);
+    bool is_lka_wsp = is_wsp(lexer->lookahead);
+    bool is_lka_saf = is_plain_safe(lexer->lookahead);
+    if (is_lka_saf || is_lka_wsp) {
+        for (;;) {
+            if (is_lka_saf && lexer->lookahead != '#' && lexer->lookahead != ':') {
+                adv(scanner, lexer);
+                mrk_end(scanner, lexer);
+                scanner->sch_stt = adv_sch_stt(scanner->sch_stt, scanner->cur_chr, &scanner->rlt_sch);
+            } else if (is_cur_saf && lexer->lookahead == '#') {
+                adv(scanner, lexer);
+                mrk_end(scanner, lexer);
+                scanner->sch_stt = adv_sch_stt(scanner->sch_stt, scanner->cur_chr, &scanner->rlt_sch);
+            } else if (is_lka_wsp) {
+                adv(scanner, lexer);
+                scanner->sch_stt = adv_sch_stt(scanner->sch_stt, scanner->cur_chr, &scanner->rlt_sch);
+            } else if (lexer->lookahead == ':') {
+                adv(scanner, lexer); // check later
+            } else {
+                break;
+            }
+
+            is_cur_wsp = is_lka_wsp;
+            is_cur_saf = is_lka_saf;
+            is_lka_wsp = is_wsp(lexer->lookahead);
+            is_lka_saf = is_plain_safe(lexer->lookahead);
+
+            if (scanner->cur_chr == ':') {
+                if (is_lka_saf) {
+                    mrk_end(scanner, lexer);
+                    scanner->sch_stt = adv_sch_stt(scanner->sch_stt, scanner->cur_chr, &scanner->rlt_sch);
+                } else {
+                    return SCN_FAIL;
+                }
+            }
+        }
+    } else {
+        return SCN_STOP;
+    }
+    return SCN_SUCC;
+}
+
+static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
+    init(scanner);
+    mrk_end(scanner, lexer);
+
+    bool allow_comment = !(valid_symbols[R_DQT_STR_CTN] || valid_symbols[BR_DQT_STR_CTN] ||
+                           valid_symbols[R_SQT_STR_CTN] || valid_symbols[BR_SQT_STR_CTN]);
+    int16_t *ind_ptr = scanner->ind_len_stk.contents + scanner->ind_len_stk.size - 1;
+    int16_t *ind_end = scanner->ind_len_stk.contents - 1;
+    int16_t cur_ind = *ind_ptr--;
+    int16_t prt_ind = ind_ptr == ind_end ? -1 : *ind_ptr;
+    int16_t cur_ind_typ = *array_back(&scanner->ind_typ_stk);
+
+    bool has_tab_ind = false;
+    int16_t leading_spaces = 0;
+
+    for (;;) {
+        if (lexer->lookahead == ' ') {
+            if (!has_tab_ind) {
+                leading_spaces++;
+            }
+            skp(scanner, lexer);
+        } else if (lexer->lookahead == '\t') {
+            has_tab_ind = true;
+            skp(scanner, lexer);
+        } else if (is_nwl(lexer->lookahead)) {
+            has_tab_ind = false;
+            leading_spaces = 0;
+            skp_nwl(scanner, lexer);
+        } else if (allow_comment && lexer->lookahead == '#') {
+            if (valid_symbols[BR_BLK_STR_CTN] && valid_symbols[BL] && scanner->cur_col <= cur_ind) {
+                POP_IND();
+                RET_SYM(BL);
+            }
+            if (valid_symbols[BR_BLK_STR_CTN]
+                    ? scanner->cur_row == scanner->row
+                    : scanner->cur_col == 0 || scanner->cur_row != scanner->row || scanner->cur_col > scanner->col) {
+                adv(scanner, lexer);
+                while (!is_nwl(lexer->lookahead) && lexer->lookahead != 0) {
+                    adv(scanner, lexer);
+                }
+                mrk_end(scanner, lexer);
+                RET_SYM(COMMENT);
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    if (lexer->lookahead == 0) {
+        if (valid_symbols[BL]) {
+            mrk_end(scanner, lexer);
+            POP_IND();
+            RET_SYM(BL)
+        }
+        if (valid_symbols[END_OF_FILE]) {
+            mrk_end(scanner, lexer);
+            RET_SYM(END_OF_FILE)
+        }
+        return false;
+    }
+
+    int16_t bgn_row = scanner->cur_row;
+    int16_t bgn_col = scanner->cur_col;
+    int32_t bgn_chr = lexer->lookahead;
+
+    if (valid_symbols[BL] && bgn_col <= cur_ind && !has_tab_ind) {
+        if (cur_ind == prt_ind && cur_ind_typ == IND_SEQ ? bgn_col < cur_ind || lexer->lookahead != '-'
+                                                         : bgn_col <= prt_ind || cur_ind_typ == IND_STR) {
+            POP_IND();
+            RET_SYM(BL);
+        }
+    }
+
+    bool has_nwl = scanner->cur_row > scanner->row;
+    bool is_r = !has_nwl;
+    bool is_br = has_nwl && leading_spaces > cur_ind;
+    bool is_b = has_nwl && leading_spaces == cur_ind && !has_tab_ind;
+    bool is_s = bgn_col == 0;
+
+    if (valid_symbols[R_DIR_YML_VER] && is_r) {
+        return scn_dir_yml_ver(scanner, lexer, R_DIR_YML_VER);
+    }
+    if (valid_symbols[R_DIR_TAG_HDL] && is_r) {
+        return scn_dir_tag_hdl(scanner, lexer, R_DIR_TAG_HDL);
+    }
+    if (valid_symbols[R_DIR_TAG_PFX] && is_r) {
+        return scn_dir_tag_pfx(scanner, lexer, R_DIR_TAG_PFX);
+    }
+    if (valid_symbols[R_DIR_RSV_PRM] && is_r) {
+        return scn_dir_rsv_prm(scanner, lexer, R_DIR_RSV_PRM);
+    }
+    if (valid_symbols[BR_BLK_STR_CTN] && is_br && scn_blk_str_cnt(scanner, lexer, BR_BLK_STR_CTN)) {
+        return true;
+    }
+
+    if ((valid_symbols[R_DQT_STR_CTN] && is_r && scn_dqt_str_cnt(scanner, lexer, R_DQT_STR_CTN)) ||
+        (valid_symbols[BR_DQT_STR_CTN] && (is_br || has_nwl) && scn_dqt_str_cnt(scanner, lexer, BR_DQT_STR_CTN))) {
+        return true;
+    }
+
+    if ((valid_symbols[R_SQT_STR_CTN] && is_r && scn_sqt_str_cnt(scanner, lexer, R_SQT_STR_CTN)) ||
+        (valid_symbols[BR_SQT_STR_CTN] && is_br && scn_sqt_str_cnt(scanner, lexer, BR_SQT_STR_CTN))) {
+        return true;
+    }
+
+    if (valid_symbols[R_ACR_CTN] && is_r) {
+        return scn_acr_ctn(scanner, lexer, R_ACR_CTN);
+    }
+    if (valid_symbols[R_ALS_CTN] && is_r) {
+        return scn_als_ctn(scanner, lexer, R_ALS_CTN);
+    }
+
+    if (lexer->lookahead == '%') {
+        if (valid_symbols[S_DIR_YML_BGN] && is_s) {
+            return scn_dir_bgn(scanner, lexer);
+        }
+    } else if (lexer->lookahead == '*') {
+        if (valid_symbols[R_ALS_BGN] && is_r) {
+            MAY_UPD_IMP_COL();
+            return scn_als_bgn(scanner, lexer, R_ALS_BGN);
+        }
+        if (valid_symbols[BR_ALS_BGN] && is_br) {
+            MAY_UPD_IMP_COL();
+            return scn_als_bgn(scanner, lexer, BR_ALS_BGN);
+        }
+        if (valid_symbols[B_ALS_BGN] && is_b) {
+            MAY_UPD_IMP_COL();
+            return scn_als_bgn(scanner, lexer, B_ALS_BGN);
+        }
+    } else if (lexer->lookahead == '&') {
+        if (valid_symbols[R_ACR_BGN] && is_r) {
+            MAY_UPD_IMP_COL();
+            return scn_acr_bgn(scanner, lexer, R_ACR_BGN);
+        }
+        if (valid_symbols[BR_ACR_BGN] && is_br) {
+            MAY_UPD_IMP_COL();
+            return scn_acr_bgn(scanner, lexer, BR_ACR_BGN);
+        }
+        if (valid_symbols[B_ACR_BGN] && is_b) {
+            MAY_UPD_IMP_COL();
+            return scn_acr_bgn(scanner, lexer, B_ACR_BGN);
+        }
+    } else if (lexer->lookahead == '!') {
+        if (valid_symbols[R_TAG] && is_r) {
+            MAY_UPD_IMP_COL();
+            return scn_tag(scanner, lexer, R_TAG);
+        }
+        if (valid_symbols[BR_TAG] && is_br) {
+            MAY_UPD_IMP_COL();
+            return scn_tag(scanner, lexer, BR_TAG);
+        }
+        if (valid_symbols[B_TAG] && is_b) {
+            MAY_UPD_IMP_COL();
+            return scn_tag(scanner, lexer, B_TAG);
+        }
+    } else if (lexer->lookahead == '[') {
+        if (valid_symbols[R_FLW_SEQ_BGN] && is_r) {
+            MAY_UPD_IMP_COL();
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(R_FLW_SEQ_BGN)
+        }
+        if (valid_symbols[BR_FLW_SEQ_BGN] && is_br) {
+            MAY_UPD_IMP_COL();
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(BR_FLW_SEQ_BGN)
+        }
+        if (valid_symbols[B_FLW_SEQ_BGN] && is_b) {
+            MAY_UPD_IMP_COL();
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(B_FLW_SEQ_BGN)
+        }
+    } else if (lexer->lookahead == ']') {
+        if (valid_symbols[R_FLW_SEQ_END] && is_r) {
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(R_FLW_SEQ_END)
+        }
+        if (valid_symbols[BR_FLW_SEQ_END] && is_br) {
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(BR_FLW_SEQ_END)
+        }
+        if (valid_symbols[B_FLW_SEQ_END] && is_b) {
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(BR_FLW_SEQ_END)
+        }
+    } else if (lexer->lookahead == '{') {
+        if (valid_symbols[R_FLW_MAP_BGN] && is_r) {
+            MAY_UPD_IMP_COL();
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(R_FLW_MAP_BGN)
+        }
+        if (valid_symbols[BR_FLW_MAP_BGN] && is_br) {
+            MAY_UPD_IMP_COL();
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(BR_FLW_MAP_BGN)
+        }
+        if (valid_symbols[B_FLW_MAP_BGN] && is_b) {
+            MAY_UPD_IMP_COL();
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(B_FLW_MAP_BGN)
+        }
+    } else if (lexer->lookahead == '}') {
+        if (valid_symbols[R_FLW_MAP_END] && is_r) {
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(R_FLW_MAP_END)
+        }
+        if (valid_symbols[BR_FLW_MAP_END] && is_br) {
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(BR_FLW_MAP_END)
+        }
+        if (valid_symbols[B_FLW_MAP_END] && is_b) {
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(BR_FLW_MAP_END)
+        }
+    } else if (lexer->lookahead == ',') {
+        if (valid_symbols[R_FLW_SEP_BGN] && is_r) {
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(R_FLW_SEP_BGN)
+        }
+        if (valid_symbols[BR_FLW_SEP_BGN] && is_br) {
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(BR_FLW_SEP_BGN)
+        }
+    } else if (lexer->lookahead == '"') {
+        if (valid_symbols[R_DQT_STR_BGN] && is_r) {
+            MAY_UPD_IMP_COL();
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(R_DQT_STR_BGN)
+        }
+        if (valid_symbols[BR_DQT_STR_BGN] && is_br) {
+            MAY_UPD_IMP_COL();
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(BR_DQT_STR_BGN)
+        }
+        if (valid_symbols[B_DQT_STR_BGN] && is_b) {
+            MAY_UPD_IMP_COL();
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(B_DQT_STR_BGN)
+        }
+        if (valid_symbols[R_DQT_STR_END] && is_r) {
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(R_DQT_STR_END)
+        }
+        if (valid_symbols[BR_DQT_STR_END] && is_br) {
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(BR_DQT_STR_END)
+        }
+    } else if (lexer->lookahead == '\'') {
+        if (valid_symbols[R_SQT_STR_BGN] && is_r) {
+            MAY_UPD_IMP_COL();
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(R_SQT_STR_BGN)
+        }
+        if (valid_symbols[BR_SQT_STR_BGN] && is_br) {
+            MAY_UPD_IMP_COL();
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(BR_SQT_STR_BGN)
+        }
+        if (valid_symbols[B_SQT_STR_BGN] && is_b) {
+            MAY_UPD_IMP_COL();
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(B_SQT_STR_BGN)
+        }
+        if (valid_symbols[R_SQT_STR_END] && is_r) {
+            adv(scanner, lexer);
+            if (lexer->lookahead == '\'') {
+                adv(scanner, lexer);
+                mrk_end(scanner, lexer);
+                RET_SYM(R_SQT_ESC_SQT)
+            } else {
+                mrk_end(scanner, lexer);
+                RET_SYM(R_SQT_STR_END)
+            }
+        }
+        if (valid_symbols[BR_SQT_STR_END] && is_br) {
+            adv(scanner, lexer);
+            if (lexer->lookahead == '\'') {
+                adv(scanner, lexer);
+                mrk_end(scanner, lexer);
+                RET_SYM(BR_SQT_ESC_SQT)
+            } else {
+                mrk_end(scanner, lexer);
+                RET_SYM(BR_SQT_STR_END)
+            }
+        }
+    } else if (lexer->lookahead == '?') {
+        bool is_r_blk_key_bgn = valid_symbols[R_BLK_KEY_BGN] && is_r;
+        bool is_br_blk_key_bgn = valid_symbols[BR_BLK_KEY_BGN] && is_br;
+        bool is_b_blk_key_bgn = valid_symbols[B_BLK_KEY_BGN] && is_b;
+        bool is_r_flw_key_bgn = valid_symbols[R_FLW_KEY_BGN] && is_r;
+        bool is_br_flw_key_bgn = valid_symbols[BR_FLW_KEY_BGN] && is_br;
+        if (is_r_blk_key_bgn || is_br_blk_key_bgn || is_b_blk_key_bgn || is_r_flw_key_bgn || is_br_flw_key_bgn) {
+            adv(scanner, lexer);
+            if (is_wht(lexer->lookahead)) {
+                mrk_end(scanner, lexer);
+                if (is_r_blk_key_bgn) {
+                    PUSH_BGN_IND(IND_MAP);
+                    RET_SYM(R_BLK_KEY_BGN);
+                }
+                if (is_br_blk_key_bgn) {
+                    PUSH_BGN_IND(IND_MAP);
+                    RET_SYM(BR_BLK_KEY_BGN);
+                }
+                if (is_b_blk_key_bgn)
+                    RET_SYM(B_BLK_KEY_BGN);
+                if (is_r_flw_key_bgn)
+                    RET_SYM(R_FLW_KEY_BGN);
+                if (is_br_flw_key_bgn)
+                    RET_SYM(BR_FLW_KEY_BGN);
+            }
+        }
+    } else if (lexer->lookahead == ':') {
+        if (valid_symbols[R_FLW_JSV_BGN] && is_r) {
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(R_FLW_JSV_BGN);
+        }
+        if (valid_symbols[BR_FLW_JSV_BGN] && is_br) {
+            adv(scanner, lexer);
+            mrk_end(scanner, lexer);
+            RET_SYM(BR_FLW_JSV_BGN);
+        }
+        bool is_r_blk_val_bgn = valid_symbols[R_BLK_VAL_BGN] && is_r;
+        bool is_br_blk_val_bgn = valid_symbols[BR_BLK_VAL_BGN] && is_br;
+        bool is_b_blk_val_bgn = valid_symbols[B_BLK_VAL_BGN] && is_b;
+        bool is_r_blk_imp_bgn = valid_symbols[R_BLK_IMP_BGN] && is_r;
+        bool is_r_flw_njv_bgn = valid_symbols[R_FLW_NJV_BGN] && is_r;
+        bool is_br_flw_njv_bgn = valid_symbols[BR_FLW_NJV_BGN] && is_br;
+        if (is_r_blk_val_bgn || is_br_blk_val_bgn || is_b_blk_val_bgn || is_r_blk_imp_bgn || is_r_flw_njv_bgn ||
+            is_br_flw_njv_bgn) {
+            adv(scanner, lexer);
+            bool is_lka_wht = is_wht(lexer->lookahead);
+            if (is_lka_wht) {
+                if (is_r_blk_val_bgn) {
+                    PUSH_BGN_IND(IND_MAP);
+                    mrk_end(scanner, lexer);
+                    RET_SYM(R_BLK_VAL_BGN);
+                }
+                if (is_br_blk_val_bgn) {
+                    PUSH_BGN_IND(IND_MAP);
+                    mrk_end(scanner, lexer);
+                    RET_SYM(BR_BLK_VAL_BGN);
+                }
+                if (is_b_blk_val_bgn) {
+                    mrk_end(scanner, lexer);
+                    RET_SYM(B_BLK_VAL_BGN);
+                }
+                if (is_r_blk_imp_bgn) {
+                    MAY_PUSH_IMP_IND();
+                    mrk_end(scanner, lexer);
+                    RET_SYM(R_BLK_IMP_BGN);
+                }
+            }
+            if (is_lka_wht || lexer->lookahead == ',' || lexer->lookahead == ']' || lexer->lookahead == '}') {
+                if (is_r_flw_njv_bgn) {
+                    mrk_end(scanner, lexer);
+                    RET_SYM(R_FLW_NJV_BGN);
+                }
+                if (is_br_flw_njv_bgn) {
+                    mrk_end(scanner, lexer);
+                    RET_SYM(BR_FLW_NJV_BGN);
+                }
+            }
+        }
+    } else if (lexer->lookahead == '-') {
+        bool is_r_blk_seq_bgn = valid_symbols[R_BLK_SEQ_BGN] && is_r;
+        bool is_br_blk_seq_bgn = valid_symbols[BR_BLK_SEQ_BGN] && is_br;
+        bool is_b_blk_seq_bgn = valid_symbols[B_BLK_SEQ_BGN] && is_b;
+        bool is_s_drs_end = is_s;
+        if (is_r_blk_seq_bgn || is_br_blk_seq_bgn || is_b_blk_seq_bgn || is_s_drs_end) {
+            adv(scanner, lexer);
+            if (is_wht(lexer->lookahead)) {
+                if (is_r_blk_seq_bgn) {
+                    PUSH_BGN_IND(IND_SEQ);
+                    mrk_end(scanner, lexer);
+                    RET_SYM(R_BLK_SEQ_BGN)
+                }
+                if (is_br_blk_seq_bgn) {
+                    PUSH_BGN_IND(IND_SEQ);
+                    mrk_end(scanner, lexer);
+                    RET_SYM(BR_BLK_SEQ_BGN)
+                }
+                if (is_b_blk_seq_bgn) {
+                    MAY_PUSH_SPC_SEQ_IND();
+                    mrk_end(scanner, lexer);
+                    RET_SYM(B_BLK_SEQ_BGN)
+                }
+            } else if (lexer->lookahead == '-' && is_s_drs_end) {
+                adv(scanner, lexer);
+                if (lexer->lookahead == '-') {
+                    adv(scanner, lexer);
+                    if (is_wht(lexer->lookahead)) {
+                        if (valid_symbols[BL]) {
+                            POP_IND();
+                            RET_SYM(BL);
+                        }
+                        mrk_end(scanner, lexer);
+                        RET_SYM(S_DRS_END);
+                    }
+                }
+            }
+        }
+    } else if (lexer->lookahead == '.') {
+        if (is_s) {
+            adv(scanner, lexer);
+            if (lexer->lookahead == '.') {
+                adv(scanner, lexer);
+                if (lexer->lookahead == '.') {
+                    adv(scanner, lexer);
+                    if (is_wht(lexer->lookahead)) {
+                        if (valid_symbols[BL]) {
+                            POP_IND();
+                            RET_SYM(BL);
+                        }
+                        mrk_end(scanner, lexer);
+                        RET_SYM(S_DOC_END);
+                    }
+                }
+            }
+        }
+    } else if (lexer->lookahead == '\\') {
+        bool is_r_dqt_esc_nwl = valid_symbols[R_DQT_ESC_NWL] && is_r;
+        bool is_br_dqt_esc_nwl = valid_symbols[BR_DQT_ESC_NWL] && is_br;
+        bool is_r_dqt_esc_seq = valid_symbols[R_DQT_ESC_SEQ] && is_r;
+        bool is_br_dqt_esc_seq = valid_symbols[BR_DQT_ESC_SEQ] && is_br;
+        if (is_r_dqt_esc_nwl || is_br_dqt_esc_nwl || is_r_dqt_esc_seq || is_br_dqt_esc_seq) {
+            adv(scanner, lexer);
+            if (is_nwl(lexer->lookahead)) {
+                if (is_r_dqt_esc_nwl) {
+                    mrk_end(scanner, lexer);
+                    RET_SYM(R_DQT_ESC_NWL)
+                }
+                if (is_br_dqt_esc_nwl) {
+                    mrk_end(scanner, lexer);
+                    RET_SYM(BR_DQT_ESC_NWL)
+                }
+            }
+            if (is_r_dqt_esc_seq) {
+                return scn_dqt_esc_seq(scanner, lexer, R_DQT_ESC_SEQ);
+            }
+            if (is_br_dqt_esc_seq) {
+                return scn_dqt_esc_seq(scanner, lexer, BR_DQT_ESC_SEQ);
+            }
+            return false;
+        }
+    } else if (lexer->lookahead == '|') {
+        if (valid_symbols[R_BLK_LIT_BGN] && is_r) {
+            return scn_blk_str_bgn(scanner, lexer, R_BLK_LIT_BGN);
+        }
+        if (valid_symbols[BR_BLK_LIT_BGN] && is_br) {
+            return scn_blk_str_bgn(scanner, lexer, BR_BLK_LIT_BGN);
+        }
+    } else if (lexer->lookahead == '>') {
+        if (valid_symbols[R_BLK_FLD_BGN] && is_r) {
+            return scn_blk_str_bgn(scanner, lexer, R_BLK_FLD_BGN);
+        }
+        if (valid_symbols[BR_BLK_FLD_BGN] && is_br) {
+            return scn_blk_str_bgn(scanner, lexer, BR_BLK_FLD_BGN);
+        }
+    }
+
+    bool maybe_sgl_pln_blk = (valid_symbols[R_SGL_PLN_STR_BLK] && is_r) ||
+                             (valid_symbols[BR_SGL_PLN_STR_BLK] && is_br) || (valid_symbols[B_SGL_PLN_STR_BLK] && is_b);
+    bool maybe_sgl_pln_flw = (valid_symbols[R_SGL_PLN_STR_FLW] && is_r) || (valid_symbols[BR_SGL_PLN_STR_FLW] && is_br);
+    bool maybe_mtl_pln_blk = (valid_symbols[R_MTL_PLN_STR_BLK] && is_r) || (valid_symbols[BR_MTL_PLN_STR_BLK] && is_br);
+    bool maybe_mtl_pln_flw = (valid_symbols[R_MTL_PLN_STR_FLW] && is_r) || (valid_symbols[BR_MTL_PLN_STR_FLW] && is_br);
+
+    if (maybe_sgl_pln_blk || maybe_sgl_pln_flw || maybe_mtl_pln_blk || maybe_mtl_pln_flw) {
+        bool is_in_blk = maybe_sgl_pln_blk || maybe_mtl_pln_blk;
+        bool (*is_plain_safe)(int32_t) = is_in_blk ? is_plain_safe_in_block : is_plain_safe_in_flow;
+        if (scanner->cur_col - bgn_col == 0) {
+            adv(scanner, lexer);
+        }
+        if (scanner->cur_col - bgn_col == 1) {
+            bool is_plain_first =
+                (is_ns_char(bgn_chr) && !is_c_indicator(bgn_chr)) ||
+                ((bgn_chr == '-' || bgn_chr == '?' || bgn_chr == ':') && is_plain_safe(lexer->lookahead));
+            if (!is_plain_first) {
+                return false;
+            }
+            scanner->sch_stt = adv_sch_stt(scanner->sch_stt, scanner->cur_chr, &scanner->rlt_sch);
+        } else {
+            // no need to check the following cases:
+            // ..X
+            // ...X
+            // --X
+            // ---X
+            // X: lookahead
+            scanner->sch_stt = SCH_STT_FRZ; // must be RS_STR
+        }
+
+        mrk_end(scanner, lexer);
+
+        for (;;) {
+            if (!is_nwl(lexer->lookahead)) {
+                if (scn_pln_cnt(scanner, lexer, is_plain_safe) != SCN_SUCC) {
+                    break;
+                }
+            }
+            if (lexer->lookahead == 0 || !is_nwl(lexer->lookahead)) {
+                break;
+            }
+            for (;;) {
+                if (is_nwl(lexer->lookahead)) {
+                    adv_nwl(scanner, lexer);
+                } else if (is_wsp(lexer->lookahead)) {
+                    adv(scanner, lexer);
+                } else {
+                    break;
+                }
+            }
+            if (lexer->lookahead == 0 || scanner->cur_col <= cur_ind) {
+                break;
+            }
+            if (scanner->cur_col == 0 && scn_drs_doc_end(scanner, lexer)) {
+                break;
+            }
+        }
+
+        if (scanner->end_row == bgn_row) {
+            if (maybe_sgl_pln_blk) {
+                MAY_UPD_IMP_COL();
+                RET_SYM(is_r ? SGL_PLN_SYM(R, BLK) : is_br ? SGL_PLN_SYM(BR, BLK) : SGL_PLN_SYM(B, BLK));
+            }
+            if (maybe_sgl_pln_flw)
+                RET_SYM(is_r ? SGL_PLN_SYM(R, FLW) : SGL_PLN_SYM(BR, FLW));
+        } else {
+            if (maybe_mtl_pln_blk) {
+                MAY_UPD_IMP_COL();
+                RET_SYM(is_r ? R_MTL_PLN_STR_BLK : BR_MTL_PLN_STR_BLK);
+            }
+            if (maybe_mtl_pln_flw)
+                RET_SYM(is_r ? R_MTL_PLN_STR_FLW : BR_MTL_PLN_STR_FLW);
+        }
+
+        return false;
+    }
+
+    return !valid_symbols[ERR_REC];
+}
+
+void *tree_sitter_yaml_external_scanner_create() {
+    Scanner *scanner = ts_calloc(1, sizeof(Scanner));
+    deserialize(scanner, NULL, 0);
+    return scanner;
+}
+
+void tree_sitter_yaml_external_scanner_destroy(void *payload) {
+    Scanner *scanner = (Scanner *)payload;
+    array_delete(&scanner->ind_len_stk);
+    array_delete(&scanner->ind_typ_stk);
+    ts_free(scanner);
+}
+
+unsigned tree_sitter_yaml_external_scanner_serialize(void *payload, char *buffer) {
+    Scanner *scanner = (Scanner *)payload;
+    return serialize(scanner, buffer);
+}
+
+void tree_sitter_yaml_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
+    Scanner *scanner = (Scanner *)payload;
+    deserialize(scanner, buffer, length);
+}
+
+bool tree_sitter_yaml_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+    Scanner *scanner = (Scanner *)payload;
+    return scan(scanner, lexer, valid_symbols);
+}

--- a/Tests/MacLocalAPITests/IssueRegressionTests.swift
+++ b/Tests/MacLocalAPITests/IssueRegressionTests.swift
@@ -12,7 +12,8 @@ struct IssueRegressionTests {
     func mlxDefaultMaxTokensFallback() {
         #expect(MLXChatCompletionsController.resolveEffectiveMaxTokens(requested: nil, serverDefault: nil) == MLXChatCompletionsController.defaultMaxCompletionTokens)
         #expect(MLXChatCompletionsController.resolveEffectiveMaxTokens(requested: 0, serverDefault: nil) == MLXChatCompletionsController.defaultMaxCompletionTokens)
-        #expect(MLXChatCompletionsController.defaultMaxCompletionTokens == 4096)
+        #expect(MLXChatCompletionsController.defaultMaxCompletionTokens == 8192)
+        #expect(MLXModelService.defaultMaximumResponseTokens == 8192)
         #expect(MLXChatCompletionsController.resolveEffectiveMaxTokens(requested: nil, serverDefault: 1024) == 1024)
         #expect(MLXChatCompletionsController.resolveEffectiveMaxTokens(requested: 2048, serverDefault: 1024) == 2048)
     }

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -9,6 +9,88 @@ import FoundationModels
 @testable import AFMTerminalUI
 
 final class TerminalMarkdownRendererTests: XCTestCase {
+    func testEveryPromisedTreeSitterGrammarIsCompiledAndABICompatible() {
+        XCTAssertEqual(TreeSitterSyntaxHighlighter.validateCompiledGrammars(), [])
+        XCTAssertEqual(TreeSitterSyntaxHighlighter.supportedLanguages.count, 23)
+    }
+
+    func testTreeSitterAliasesResolveWithoutRuntimeDiscovery() {
+        let aliases: [String: String] = [
+            "sh": "bash", "zsh": "bash", "c++": "cpp", "c#": "csharp",
+            "patch": "diff", "golang": "go", "xml": "html", "jsx": "javascript",
+            "kt": "kotlin", "md": "markdown", "py": "python", "rb": "ruby",
+            "postgresql": "sql", "ts": "typescript", "yml": "yaml"
+        ]
+        for (alias, canonical) in aliases {
+            XCTAssertEqual(TreeSitterSyntaxHighlighter.canonicalLanguage(alias), canonical)
+        }
+        XCTAssertNil(TreeSitterSyntaxHighlighter.canonicalLanguage("made-up-language"))
+    }
+
+    func testTreeSitterHighlightsMajorPopularFormats() {
+        let fixtures: [(String, String)] = [
+            ("bash", "if true; then echo \"ok\"; fi # note"),
+            ("c", "const char *message = \"ok\"; // note"),
+            ("cpp", "class User { public: int id = 42; };"),
+            ("csharp", "public sealed class User { string Name = \"Ada\"; }"),
+            ("css", ".app { color: #fff; margin: 12px; }"),
+            ("diff", "@@ -1 +1 @@\n-old\n+new"),
+            ("go", "package main\nfunc main() { println(\"ok\") }"),
+            ("html", "<main class=\"app\">Hello</main>"),
+            ("java", "public final class User { int id = 42; }"),
+            ("javascript", "const greet = (name) => `Hello ${name}`;"),
+            ("json", "{\"name\": \"Ada\", \"count\": 42, \"ok\": true}"),
+            ("kotlin", "data class User(val id: Int)\nfun main() = User(42)"),
+            ("markdown", "# Heading\n**bold** and `code`"),
+            ("php", "<?php function greet($name) { return \"Hello $name\"; }"),
+            ("python", "def greet(name):\n    return f\"Hello {name}\""),
+            ("ruby", "class User\n  def name = \"Ada\"\nend"),
+            ("rust", "pub struct User { id: usize }\nfn main() { let n = 42; }"),
+            ("sql", "SELECT id FROM users WHERE id = 42; -- note"),
+            ("swift", "public struct User { let id: Int = 42 }"),
+            ("toml", "name = \"afm\"\nenabled = true"),
+            ("tsx", "const App = () => <main>Hello</main>;"),
+            ("typescript", "interface User { id: number }\nconst id = 42;"),
+            ("yaml", "name: afm\nenabled: true\ncount: 42")
+        ]
+
+        for (language, source) in fixtures {
+            let tokens = TreeSitterSyntaxHighlighter.tokens(in: source, language: language)
+            XCTAssertNotNil(tokens, "Missing compiled parser for \(language)")
+            XCTAssertFalse(tokens?.isEmpty ?? true, "No semantic tokens for \(language)")
+
+            let rendered = TerminalMarkdownRenderer(color: true, theme: .dark)
+                .render("```\(language)\n\(source)\n```").text
+            XCTAssertTrue(rendered.contains("\u{001B}["), "No ANSI output for \(language)")
+            XCTAssertEqual(
+                TerminalMarkdownRenderer(color: false).render("```\(language)\n\(source)\n```").codeBlocks.first?.content,
+                source
+            )
+        }
+    }
+
+    func testTreeSitterHandlesMultilineSyntaxMalformedCodeAndUnicodeRanges() throws {
+        let python = "value = \"\"\"line one\nline two 🧪\"\"\"\nif value:\n    print(value"
+        let tokens = try XCTUnwrap(TreeSitterSyntaxHighlighter.tokens(in: python, language: "python"))
+        XCTAssertTrue(tokens.contains { $0.kind == .string && $0.range.length > "line one".utf16.count })
+        let sourceLength = (python as NSString).length
+        XCTAssertTrue(tokens.allSatisfy { NSMaxRange($0.range) <= sourceLength })
+
+        let c = "/* first\nsecond */\nint main( { return 42; }"
+        XCTAssertTrue(
+            TreeSitterSyntaxHighlighter.tokens(in: c, language: "c")?.contains { $0.kind == .comment } == true
+        )
+    }
+
+    func testUnknownFenceUsesFallbackAndOversizedKnownFenceFailsClosed() {
+        XCTAssertNil(TreeSitterSyntaxHighlighter.tokens(in: "let x = 1", language: "unknownlang"))
+        let oversized = String(repeating: "a", count: TreeSitterSyntaxHighlighter.maximumSourceBytes + 1)
+        XCTAssertNil(TreeSitterSyntaxHighlighter.tokens(in: oversized, language: "swift"))
+
+        let rendered = TerminalMarkdownRenderer(color: true).render("```unknownlang\nconst value = 42\n```").text
+        XCTAssertTrue(rendered.contains("\u{001B}[95mconst\u{001B}[0m"))
+    }
+
     func testParsesCodeDiffLatexAndLocalImagesWithoutColor() {
         let source = #"""
         # Result
@@ -197,7 +279,7 @@ final class TerminalMarkdownRendererTests: XCTestCase {
 
         XCTAssertNotEqual(dark, light)
         XCTAssertTrue(dark.contains("\u{001B}[95mlet"))
-        XCTAssertTrue(dark.contains("\u{001B}[94mWidget"))
+        XCTAssertTrue(dark.contains("\u{001B}[96mWidget"))
         XCTAssertTrue(dark.contains("\u{001B}[92m\"AFM\""))
         XCTAssertTrue(dark.contains("\u{001B}[91m42"))
         XCTAssertTrue(dark.contains("\u{001B}[2;37m// comment"))

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -345,6 +345,31 @@ final class TUISessionStoreTests: XCTestCase {
         XCTAssertEqual(try store.load(id: session.id).title, "original")
     }
 
+    func testOversizedPersistenceExportsRecoveryTranscriptAndRetainsLastSavedSession() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = TUISessionStore(directory: root, maximumSessionBytes: 1_024)
+        var session = TUISession(title: "saved version", backend: "MLX", model: "test/model")
+        try store.save(session)
+
+        session.title = "unsaved version"
+        session.messages = [
+            .init(role: "user", content: "latest turn " + String(repeating: "x", count: 2_000))
+        ]
+        let result = store.persistRecoveringTranscript(session)
+        guard case .recovered(let saveError, let transcriptURL) = result else {
+            return XCTFail("Expected an oversized save to produce a recovery transcript")
+        }
+
+        XCTAssertTrue(saveError.contains("save/load limit"))
+        XCTAssertEqual(try store.load(id: session.id).title, "saved version")
+        let recovery = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(recovery.contains("unsaved version"))
+        XCTAssertTrue(recovery.contains("latest turn"))
+        let permissions = try FileManager.default.attributesOfItem(atPath: transcriptURL.path)[.posixPermissions] as? NSNumber
+        XCTAssertEqual(permissions?.intValue, 0o600)
+    }
+
     func testRecentHistoryUsesBoundedMetadataDecoding() throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -369,6 +394,39 @@ final class TUISessionStoreTests: XCTestCase {
         XCTAssertEqual(recent.map(\.title), ["Metadata 3", "Metadata 2"])
         XCTAssertThrowsError(try store.load(id: ids[3]))
         XCTAssertTrue(try store.recent(limit: 0).isEmpty)
+    }
+
+    func testRecentHistoryBackfillsPastNewerCorruptAndOversizedFiles() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = TUISessionStore(directory: root, maximumSessionBytes: 1_024)
+        let validSessions = (1...3).map { index in
+            TUISession(
+                title: "Valid \(index)",
+                backend: "MLX",
+                model: "test/model",
+                createdAt: Date(timeIntervalSince1970: TimeInterval(index)),
+                updatedAt: Date(timeIntervalSince1970: TimeInterval(index))
+            )
+        }
+        for session in validSessions { try store.save(session) }
+
+        let corruptURL = root.appendingPathComponent("\(UUID().uuidString).json")
+        try Data("not json".utf8).write(to: corruptURL)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 5)],
+            ofItemAtPath: corruptURL.path
+        )
+        let oversizedURL = root.appendingPathComponent("\(UUID().uuidString).json")
+        try Data(repeating: 0x41, count: 2_000).write(to: oversizedURL)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 4)],
+            ofItemAtPath: oversizedURL.path
+        )
+
+        let recent = try store.recent(limit: 2)
+        XCTAssertEqual(recent.map(\.id), [validSessions[2].id, validSessions[1].id])
+        XCTAssertEqual(recent.map(\.title), ["Valid 3", "Valid 2"])
     }
 
     func testConcurrentStoresAtomicallyReplaceTheSameSession() async throws {
@@ -575,6 +633,52 @@ final class TUIConversationPolicyTests: XCTestCase {
         XCTAssertNoThrow(try AFMTerminalChat.validateRestoredSession(session, backendName: "MLX", modelName: "one"))
         XCTAssertThrowsError(try AFMTerminalChat.validateRestoredSession(session, backendName: "Foundation", modelName: "one"))
         XCTAssertThrowsError(try AFMTerminalChat.validateRestoredSession(session, backendName: "MLX", modelName: "two"))
+    }
+
+    func testRetryPreservesExactMultipartTurnAndEditPreservesAttachments() throws {
+        let original = Message(role: "user", content: .parts([
+            ContentPart(type: "text", text: "original prompt"),
+            ContentPart(
+                type: "image_url",
+                image_url: ImageURL(url: "data:image/png;base64,AQID", detail: "high")
+            ),
+            ContentPart(type: "text", text: "<attachment>reference text</attachment>"),
+            ContentPart(
+                type: "input_audio",
+                input_audio: InputAudio(data: "BAUG", format: "wav", language: "en-US")
+            )
+        ]))
+        let turn = try XCTUnwrap(TUIUserTurn(message: original))
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        XCTAssertEqual(turn.input, "original prompt")
+        XCTAssertEqual(try encoder.encode(turn.message), try encoder.encode(original))
+
+        let edited = turn.replacingInput(with: "revised prompt")
+        guard case .some(.parts(let originalParts)) = original.content,
+              case .some(.parts(let editedParts)) = edited.message.content else {
+            return XCTFail("Expected multipart user messages")
+        }
+        XCTAssertEqual(edited.input, "revised prompt")
+        XCTAssertEqual(editedParts.first?.text, "revised prompt")
+        XCTAssertEqual(
+            try encoder.encode(Array(editedParts.dropFirst())),
+            try encoder.encode(Array(originalParts.dropFirst()))
+        )
+    }
+
+    func testPersistenceFailureNoticeIncludesRecoveryAndManualExportPaths() throws {
+        let recoveryURL = URL(fileURLWithPath: "/safe/recovery/session.md")
+        let notice = try XCTUnwrap(AFMTerminalChat.persistenceNotice(for: .recovered(
+            saveError: "Session exceeds limit",
+            transcriptURL: recoveryURL
+        )))
+
+        XCTAssertTrue(notice.contains("Session save failed: Session exceeds limit"))
+        XCTAssertTrue(notice.contains(recoveryURL.path))
+        XCTAssertTrue(notice.contains("/export <path>"))
+        XCTAssertNil(AFMTerminalChat.persistenceNotice(for: .saved(recoveryURL)))
     }
 
     func testMLXMaximumLogprobsEnablesLogprobCollection() {

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -952,6 +952,38 @@ final class FoundationSessionOperationGateTests: XCTestCase {
 }
 
 final class TUIConversationPolicyTests: XCTestCase {
+    func testFoundationTurnStatisticsUseClearlyMarkedEstimates() {
+        let summary = AFMTerminalChat.turnStatistics(
+            backend: .foundationModels,
+            requestMessages: [Message(role: "user", content: "Say hello")],
+            responseText: "Hello there!",
+            promptTokens: 0,
+            completionTokens: 0,
+            cachedTokens: 0,
+            elapsed: 0.5
+        )
+
+        XCTAssertEqual(AFMTerminalChat.estimatedTokenCount("Hello there!"), 3)
+        XCTAssertTrue(summary.contains("~3 input"))
+        XCTAssertTrue(summary.contains("~3 generated"))
+        XCTAssertTrue(summary.contains("~6.0 tok/s"))
+        XCTAssertTrue(summary.hasSuffix("estimated"))
+    }
+
+    func testMLXTurnStatisticsRemainExact() {
+        let summary = AFMTerminalChat.turnStatistics(
+            backend: .mlx(modelID: "test/model"),
+            requestMessages: [],
+            responseText: "ignored",
+            promptTokens: 12,
+            completionTokens: 8,
+            cachedTokens: 4,
+            elapsed: 2
+        )
+
+        XCTAssertEqual(summary, "12 prompt · 4 cached · 8 generated · 2.00s · 4.0 tok/s")
+    }
+
     func testReasoningDisplayModesAndActivityFrames() {
         var mode = TUIReasoningDisplayMode.collapsed
         mode.togglePanel()

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -994,6 +994,30 @@ final class TUIConversationPolicyTests: XCTestCase {
         XCTAssertEqual(snapshot.reasoningDuration, finishedReasoningDuration)
     }
 
+    func testReasoningOnlyTokenLimitIsIncompleteRatherThanCancelled() async {
+        let buffer = GenerationBuffer()
+        await buffer.accept(.reasoning("unfinished reasoning", tokenCount: 8))
+        await buffer.accept(.completed(.length))
+
+        let snapshot = await buffer.snapshot()
+        XCTAssertEqual(snapshot.finishReason, .length)
+        XCTAssertFalse(snapshot.cancelled)
+        XCTAssertEqual(
+            AFMTerminalChat.generationDisposition(for: snapshot),
+            .incomplete(.length)
+        )
+    }
+
+    func testExplicitCancellationRemainsCancellation() async {
+        let buffer = GenerationBuffer()
+        await buffer.accept(.reasoning("partial", tokenCount: 2))
+        await buffer.cancel()
+
+        let snapshot = await buffer.snapshot()
+        XCTAssertEqual(snapshot.finishReason, .cancelled)
+        XCTAssertEqual(AFMTerminalChat.generationDisposition(for: snapshot), .cancelled)
+    }
+
     func testFoundationTurnsAreIncrementalWhileStatelessTurnsRetainHistory() {
         let transcript = [
             Message(role: "user", content: "first"),

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -100,6 +100,87 @@ final class TerminalMarkdownRendererTests: XCTestCase {
         XCTAssertTrue(text.contains("(4)/(5)"))
     }
 
+    func testRendersCalculusPromptNotationWithoutRawTeX() {
+        let source = #"""
+        #### 1.1 The $\epsilon-\delta$ Definition
+        Let $f: D \subseteq \mathbb{R} \to \mathbb{R}$ and suppose $\lim_{x \to c} f(x) = L$.
+
+        In $\epsilon$-$\delta$ terms, continuity means: $$ \forall \epsilon > 0, \exists \delta > 0 \text{ such that } |x-c| < \delta \implies |f(x)-f(c)| < \epsilon $$
+
+        The derivative is $$ f'(a) = \lim_{h \to 0} \frac{f(a+h)-f(a)}{h} $$ and
+        $$ S_n = \sum_{i=1}^{n} f(t_i) \Delta x_i. $$
+
+        For $f: \mathbb{R}^n \to \mathbb{R}$, $\|\mathbf{x}\| = \sqrt{x_1^2 + \dots + x_n^2}$ and
+        $\nabla f(\mathbf{a}) \cdot \mathbf{h}$ is the directional linearization.
+        """#
+        let text = TerminalMarkdownRenderer(color: false).render(source, width: 88).text
+
+        XCTAssertTrue(text.contains("ε-δ"))
+        XCTAssertTrue(text.contains("D ⊆ ℝ → ℝ"))
+        XCTAssertTrue(text.contains("lim_(x → c) f(x) = L"))
+        XCTAssertTrue(text.contains("∀ ε > 0, ∃ δ > 0 such that"))
+        XCTAssertTrue(text.contains("⇒"))
+        XCTAssertTrue(text.contains("(f(a+h)-f(a))/(h)"))
+        XCTAssertTrue(text.contains("∑ᵢ₌₁ⁿ"))
+        XCTAssertTrue(text.contains("ℝⁿ → ℝ"))
+        XCTAssertTrue(text.contains("‖x‖ = √(x₁² + … + xₙ²)"))
+        XCTAssertTrue(text.contains("∇ f(a) · h"))
+        for rawTeX in ["$$", "\\mathbb", "\\lim", "\\frac", "\\implies", "\\text", "\\mathbf", "\\dots"] {
+            XCTAssertFalse(text.contains(rawTeX), "left raw TeX in output: \(rawTeX)\n\(text)")
+        }
+    }
+
+    func testMatchesLlamaWebUIDelimitersWhileProtectingCodeAndCurrency() {
+        let source = #"""
+        Price $5 remains money; \(x^2 + 1\) is inline.
+
+        \[\int_0^1 x^2 \, dx = \frac{1}{3}\]
+
+        `literal \(not math\)`
+        ~~~text
+        literal \[still not math\]
+        ~~~
+        """#
+        let result = TerminalMarkdownRenderer(color: false).render(source)
+
+        XCTAssertTrue(result.text.contains("Price $5 remains money; x² + 1 is inline."))
+        XCTAssertTrue(result.text.contains("┌─ math"))
+        XCTAssertTrue(result.text.contains("∫₀¹ x² dx = (1)/(3)"))
+        XCTAssertTrue(result.text.contains(#"literal \(not math\)"#))
+        XCTAssertEqual(result.codeBlocks.last?.content, #"literal \[still not math\]"#)
+    }
+
+    func testRendersAlignedAndCasesEnvironments() {
+        let source = #"""
+        $$
+        \begin{aligned}
+        f'(x) &= 2x \\
+        f''(x) &= 2
+        \end{aligned}
+        $$
+
+        $$g(x)=\begin{cases}x^2 & x \ge 0 \\ -x & x < 0\end{cases}$$
+        """#
+        let text = TerminalMarkdownRenderer(color: false).render(source).text
+
+        XCTAssertTrue(text.contains("f'(x)  = 2x"))
+        XCTAssertTrue(text.contains("f''(x) = 2"))
+        XCTAssertTrue(text.contains("g(x)="))
+        XCTAssertTrue(text.contains("⎧ x²"))
+        XCTAssertTrue(text.contains("⎩ -x"))
+        XCTAssertFalse(text.contains("\\begin"))
+    }
+
+    func testRendersPlausibleTruncatedMathAtGenerationLimit() {
+        let source = #"In component form, $x_i = g_i(t_1, \dots"#
+        let text = TerminalMarkdownRenderer(color: false).render(source).text
+
+        XCTAssertEqual(text, "In component form, xᵢ = gᵢ(t₁, …")
+        XCTAssertFalse(text.contains("\\dots"))
+        XCTAssertEqual(TerminalMarkdownRenderer(color: false).render("Price is $5").text, "Price is $5")
+        XCTAssertEqual(TerminalMarkdownRenderer(color: false).render("Use $PATH/bin").text, "Use $PATH/bin")
+    }
+
     func testLanguageHighlightingDiffsAndThemesProduceDistinctANSI() {
         let source = #"""
         ```swift

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -1052,6 +1052,44 @@ final class TUIConversationPolicyTests: XCTestCase {
 }
 
 final class TerminalLifecycleAndInvocationTests: XCTestCase {
+    func testOutputIsolationKeepsBackendLogsOutOfTerminalAndRestoresDescriptors() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let logURL = root.appendingPathComponent("logs/tui.log")
+
+        var outputPipe: [Int32] = [0, 0]
+        var errorPipe: [Int32] = [0, 0]
+        XCTAssertEqual(pipe(&outputPipe), 0)
+        XCTAssertEqual(pipe(&errorPipe), 0)
+        defer {
+            close(outputPipe[0])
+            close(errorPipe[0])
+        }
+
+        let isolation = try TerminalOutputIsolation(
+            logURL: logURL,
+            outputFD: outputPipe[1],
+            errorFD: errorPipe[1]
+        )
+        XCTAssertEqual(writeString("backend-out\n", to: outputPipe[1]), 12)
+        XCTAssertEqual(writeString("backend-error\n", to: errorPipe[1]), 14)
+        XCTAssertEqual(writeString("chat\n", to: isolation.terminalOutputFD), 5)
+        isolation.restore()
+        isolation.restore()
+        XCTAssertEqual(writeString("after\n", to: outputPipe[1]), 6)
+        close(outputPipe[1])
+        close(errorPipe[1])
+
+        XCTAssertEqual(readString(from: outputPipe[0]), "chat\nafter\n")
+        XCTAssertEqual(readString(from: errorPipe[0]), "")
+        XCTAssertEqual(
+            try String(contentsOf: logURL, encoding: .utf8),
+            "backend-out\nbackend-error\n"
+        )
+        let permissions = try FileManager.default.attributesOfItem(atPath: logURL.path)[.posixPermissions] as? NSNumber
+        XCTAssertEqual(permissions?.intValue, 0o600)
+    }
+
     func testTerminalRestorationIsIdempotent() throws {
         var enters = 0
         var restores = 0
@@ -1175,5 +1213,22 @@ final class TerminalLifecycleAndInvocationTests: XCTestCase {
         XCTAssertEqual(terminal.readKey(), .enter)
         XCTAssertEqual(terminal.readKey(), .newline)
         XCTAssertEqual(terminal.readKey(), .left)
+    }
+
+    private func writeString(_ value: String, to descriptor: Int32) -> Int {
+        value.withCString { pointer in
+            Darwin.write(descriptor, pointer, strlen(pointer))
+        }
+    }
+
+    private func readString(from descriptor: Int32) -> String {
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 256)
+        while true {
+            let count = Darwin.read(descriptor, &buffer, buffer.count)
+            if count <= 0 { break }
+            data.append(buffer, count: count)
+        }
+        return String(decoding: data, as: UTF8.self)
     }
 }

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -1,5 +1,8 @@
 import Darwin
 import XCTest
+import AFMKit
+import AFMOpenAICompat
+@testable import AFMKitFoundationModels
 @testable import AFMTerminalUI
 
 final class TerminalMarkdownRendererTests: XCTestCase {
@@ -177,6 +180,8 @@ final class TUIArtifactActionsTests: XCTestCase {
         XCTAssertTrue(html.contains("Content-Security-Policy"))
         XCTAssertTrue(html.contains("default-src 'none'"))
         XCTAssertTrue(html.contains("querySelector"))
+        XCTAssertTrue(html.contains("sandbox=\"allow-scripts\""))
+        XCTAssertFalse(html.contains("<script>document.querySelector"))
     }
 
     func testHTMLBrowserArtifactIsSandboxed() throws {
@@ -196,6 +201,21 @@ final class TUIArtifactActionsTests: XCTestCase {
         XCTAssertThrowsError(
             try TUIArtifactActions.prepareBrowserArtifact(TUICodeBlock(language: "bash", content: "rm something"))
         )
+    }
+
+    func testBoundedRegularFileReadRejectsLinksDirectoriesAndOversizedFiles() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let regular = root.appendingPathComponent("regular.txt")
+        let link = root.appendingPathComponent("linked.txt")
+        try Data("1234".utf8).write(to: regular)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: regular)
+
+        XCTAssertEqual(try TUIArtifactActions.readRegularFile(at: regular, maximumBytes: 4), Data("1234".utf8))
+        XCTAssertThrowsError(try TUIArtifactActions.readRegularFile(at: regular, maximumBytes: 3))
+        XCTAssertThrowsError(try TUIArtifactActions.readRegularFile(at: link, maximumBytes: 100))
+        XCTAssertThrowsError(try TUIArtifactActions.readRegularFile(at: root, maximumBytes: 100))
     }
 }
 
@@ -251,6 +271,21 @@ final class TUISessionStoreTests: XCTestCase {
         try data.write(to: root.appendingPathComponent("\(session.id.uuidString).json"))
         XCTAssertTrue(try store.load(id: session.id).reasoningByMessage.isEmpty)
     }
+
+    func testReasoningMetadataIsPrunedAndRemappedWhenMessagesAreRemoved() {
+        var session = TUISession(backend: "MLX", model: "test/model", messages: [
+            .init(role: "user", content: "one"),
+            .init(role: "assistant", content: "first"),
+            .init(role: "user", content: "two"),
+            .init(role: "assistant", content: "second")
+        ], reasoningByMessage: ["1": "r1", "3": "r2", "99": "stale"])
+
+        session.removeMessage(at: 0)
+        XCTAssertEqual(session.reasoningByMessage, ["0": "r1", "2": "r2"])
+        session.removeLastExchange()
+        XCTAssertEqual(session.messages.count, 1)
+        XCTAssertEqual(session.reasoningByMessage, ["0": "r1"])
+    }
 }
 
 final class GenerationBufferTests: XCTestCase {
@@ -265,6 +300,76 @@ final class GenerationBufferTests: XCTestCase {
         let final = await buffer.snapshot()
         XCTAssertNil(unchanged)
         XCTAssertEqual(final.text, "one")
+    }
+
+    func testStreamingSnapshotUsesBoundedSanitizedRenderTails() async {
+        let buffer = GenerationBuffer()
+        let unsafePrefix = "safe\u{001B}]2;owned\u{0007}"
+        let longText = unsafePrefix + String(repeating: "x", count: GenerationBuffer.renderTailLimit + 500)
+        await buffer.accept(.text(longText, tokenCount: 1))
+        await buffer.accept(.reasoning("think\u{000D}again", tokenCount: 1))
+        await buffer.accept(.toolCall(
+            AFMToolCall(id: "id", name: "bad\u{001B}name", arguments: "{}\u{0007}"),
+            stage: .argumentsDelta("delta\u{001B}]2;owned")
+        ))
+        let renderSnapshot = await buffer.renderSnapshot()
+        let snapshot = await buffer.snapshot()
+
+        XCTAssertTrue(renderSnapshot.text.isEmpty)
+        XCTAssertTrue(renderSnapshot.reasoning.isEmpty)
+        XCTAssertTrue(renderSnapshot.tools.isEmpty)
+        XCTAssertEqual(snapshot.textTail.count, GenerationBuffer.renderTailLimit)
+        XCTAssertEqual(snapshot.textCharacterCount, snapshot.text.count)
+        XCTAssertFalse(snapshot.text.contains("\u{001B}"))
+        XCTAssertFalse(snapshot.reasoning.contains("\u{000D}"))
+        XCTAssertFalse(snapshot.toolDisplayLines.joined().contains("\u{0007}"))
+        XCTAssertFalse(snapshot.toolDisplayLines.joined().contains("owned"))
+    }
+}
+
+final class FoundationStopSequenceFilterTests: XCTestCase {
+    func testWithholdsSplitStopPrefixesAndDropsTheStopAndSuffix() {
+        var filter = FoundationStopSequenceFilter(stopSequences: ["<END>", "STOP"])
+        var output = ""
+        output += filter.consume("hello<")
+        output += filter.consume("EN")
+        output += filter.consume("D>ignored")
+        output += filter.finish()
+
+        XCTAssertEqual(output, "hello")
+        XCTAssertTrue(filter.stopped)
+    }
+
+    func testFlushesAnUnmatchedPrefixAtEndOfStream() {
+        var filter = FoundationStopSequenceFilter(stopSequences: ["<END>"])
+        XCTAssertEqual(filter.consume("hello<EN"), "hello")
+        XCTAssertEqual(filter.finish(), "<EN")
+    }
+}
+
+final class TUIConversationPolicyTests: XCTestCase {
+    func testFoundationTurnsAreIncrementalWhileStatelessTurnsRetainHistory() {
+        let transcript = [
+            Message(role: "user", content: "first"),
+            Message(role: "assistant", content: "answer"),
+            Message(role: "user", content: "second")
+        ]
+
+        XCTAssertEqual(
+            AFMTerminalChat.requestMessages(for: .foundationModels, transcript: transcript).map(\.textContent),
+            ["second"]
+        )
+        XCTAssertEqual(
+            AFMTerminalChat.requestMessages(for: .mlx(modelID: "test"), transcript: transcript).map(\.textContent),
+            ["first", "answer", "second"]
+        )
+    }
+
+    func testResumeRejectsBackendOrModelMismatch() {
+        let session = TUISession(backend: "MLX", model: "one", messages: [])
+        XCTAssertNoThrow(try AFMTerminalChat.validateRestoredSession(session, backendName: "MLX", modelName: "one"))
+        XCTAssertThrowsError(try AFMTerminalChat.validateRestoredSession(session, backendName: "Foundation", modelName: "one"))
+        XCTAssertThrowsError(try AFMTerminalChat.validateRestoredSession(session, backendName: "MLX", modelName: "two"))
     }
 }
 

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -457,8 +457,15 @@ final class TUISessionStoreTests: XCTestCase {
             try canonicalSessionData(store.loadRecovery(id: session.id)),
             try canonicalSessionData(session)
         )
+        XCTAssertEqual(
+            try canonicalSessionData(store.loadBestAvailable(id: session.id)),
+            try canonicalSessionData(session)
+        )
         let permissions = try FileManager.default.attributesOfItem(atPath: recoveryURL.path)[.posixPermissions] as? NSNumber
         XCTAssertEqual(permissions?.intValue, 0o600)
+
+        try Data("corrupt recovery".utf8).write(to: recoveryURL)
+        XCTAssertEqual(try store.loadBestAvailable(id: session.id).title, "saved version")
     }
 
     func testRepeatedRecoveryAtomicallyReplacesThePreviousVersion() throws {

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -952,6 +952,48 @@ final class FoundationSessionOperationGateTests: XCTestCase {
 }
 
 final class TUIConversationPolicyTests: XCTestCase {
+    func testReasoningDisplayModesAndActivityFrames() {
+        var mode = TUIReasoningDisplayMode.collapsed
+        mode.togglePanel()
+        XCTAssertEqual(mode, .expanded)
+        mode.togglePanel()
+        XCTAssertEqual(mode, .collapsed)
+        XCTAssertEqual(TUIActivityIndicator.symbol(frame: 0, unicode: true), "⠋")
+        XCTAssertEqual(TUIActivityIndicator.symbol(frame: 10, unicode: true), "⠋")
+        XCTAssertEqual(TUIActivityIndicator.symbol(frame: 0, unicode: false), "|")
+        XCTAssertEqual(TUIActivityIndicator.symbol(frame: 4, unicode: false), "|")
+    }
+
+    func testGenerationBufferTracksReasoningAndAnswerPhases() async {
+        let buffer = GenerationBuffer()
+        var snapshot = await buffer.renderSnapshot()
+        XCTAssertEqual(snapshot.phase, .preparing)
+        XCTAssertNil(snapshot.reasoningDuration)
+
+        await buffer.accept(.reasoning("checking", tokenCount: 1))
+        snapshot = await buffer.renderSnapshot()
+        XCTAssertEqual(snapshot.phase, .reasoning)
+        XCTAssertNotNil(snapshot.reasoningDuration)
+
+        await buffer.accept(.text("answer", tokenCount: 2))
+        let answering = await buffer.renderSnapshot()
+        XCTAssertEqual(answering.phase, .answering)
+        let finishedReasoningDuration = answering.reasoningDuration
+        await buffer.accept(.toolCall(
+            AFMToolCall(id: "call-1", name: "lookup", arguments: "{}"),
+            stage: .started
+        ))
+        let usingTools = await buffer.renderSnapshot()
+        XCTAssertEqual(usingTools.phase, .usingTools)
+        await buffer.accept(.text("done", tokenCount: 3))
+        let resumedAnswer = await buffer.renderSnapshot()
+        XCTAssertEqual(resumedAnswer.phase, .answering)
+        await buffer.finish()
+        snapshot = await buffer.snapshot()
+        XCTAssertEqual(snapshot.phase, .completed)
+        XCTAssertEqual(snapshot.reasoningDuration, finishedReasoningDuration)
+    }
+
     func testFoundationTurnsAreIncrementalWhileStatelessTurnsRetainHistory() {
         let transcript = [
             Message(role: "user", content: "first"),
@@ -1207,9 +1249,10 @@ final class TerminalLifecycleAndInvocationTests: XCTestCase {
         XCTAssertEqual(pipe(&descriptors), 0)
         defer { close(descriptors[0]); close(descriptors[1]) }
         let terminal = TerminalIO(inputFD: descriptors[0], outputFD: descriptors[1])
-        let bytes = Array("é".utf8) + [13, 10, 27, 91, 68]
+        let bytes = Array("é".utf8) + [9, 13, 10, 27, 91, 68]
         _ = bytes.withUnsafeBytes { write(descriptors[1], $0.baseAddress, bytes.count) }
         XCTAssertEqual(terminal.readKey(), .text("é"))
+        XCTAssertEqual(terminal.readKey(), .tab)
         XCTAssertEqual(terminal.readKey(), .enter)
         XCTAssertEqual(terminal.readKey(), .newline)
         XCTAssertEqual(terminal.readKey(), .left)

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -1,6 +1,6 @@
 import Darwin
 import XCTest
-import AFMKit
+@testable import AFMKit
 import AFMOpenAICompat
 #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
 import FoundationModels
@@ -572,6 +572,76 @@ private actor FoundationOperationProbe {
 
     func snapshot() -> (events: [String], maximumActive: Int) {
         (events, maximumActive)
+    }
+}
+
+private actor AFMEngineOrderingProbe {
+    private var events: [String] = []
+    private var streamTaskArrived = false
+    private var streamTaskWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func holdStreamTask() async {
+        streamTaskArrived = true
+        events.append("stream-task-arrived")
+        let waiters = streamTaskWaiters
+        streamTaskWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func waitForStreamTask() async {
+        guard !streamTaskArrived else { return }
+        await withCheckedContinuation { streamTaskWaiters.append($0) }
+    }
+
+    func releaseStreamTask() {
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+    }
+
+    func record(_ event: String) {
+        events.append(event)
+    }
+
+    func snapshot() -> [String] { events }
+}
+
+final class AFMEngineFoundationOrderingTests: XCTestCase {
+    func testStreamReservesOrderBeforeReturningAndResetCannotOvertakeIt() async throws {
+        let probe = AFMEngineOrderingProbe()
+        let engine = AFMEngine(foundationDriver: AFMEngineFoundationDriver(
+            beforeStreamTask: { await probe.holdStreamTask() },
+            resetConversation: { _ in await probe.record("reset") },
+            respond: { _, _ in "unused" },
+            stream: { _, _ in
+                await probe.record("stream")
+                return AsyncThrowingStream { continuation in
+                    continuation.yield("answer")
+                    continuation.finish()
+                }
+            }
+        ))
+
+        let stream = engine.streamEvents(to: [Message(role: "user", content: "question")])
+        let resetTask = Task { try await engine.resetConversation() }
+
+        await probe.waitForStreamTask()
+        for _ in 0..<20 { await Task.yield() }
+        let blockedEvents = await probe.snapshot()
+        XCTAssertEqual(blockedEvents, ["stream-task-arrived"])
+
+        await probe.releaseStreamTask()
+        var receivedText = ""
+        for try await event in stream {
+            if case .text(let text, _) = event { receivedText += text }
+        }
+        try await resetTask.value
+
+        XCTAssertEqual(receivedText, "answer")
+        let completedEvents = await probe.snapshot()
+        XCTAssertEqual(completedEvents, ["stream-task-arrived", "stream", "reset"])
     }
 }
 

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -1387,13 +1387,65 @@ final class TerminalLifecycleAndInvocationTests: XCTestCase {
         XCTAssertEqual(pipe(&descriptors), 0)
         defer { close(descriptors[0]); close(descriptors[1]) }
         let terminal = TerminalIO(inputFD: descriptors[0], outputFD: descriptors[1])
-        let bytes = Array("é".utf8) + [9, 13, 10, 27, 91, 68]
+        let bytes = Array("é".utf8) + [9, 13, 10, 20, 21, 27, 91, 68, 27, 91, 53, 126, 27, 91, 54, 126]
         _ = bytes.withUnsafeBytes { write(descriptors[1], $0.baseAddress, bytes.count) }
         XCTAssertEqual(terminal.readKey(), .text("é"))
         XCTAssertEqual(terminal.readKey(), .tab)
         XCTAssertEqual(terminal.readKey(), .enter)
         XCTAssertEqual(terminal.readKey(), .newline)
+        XCTAssertEqual(terminal.readKey(), .openTranscript)
+        XCTAssertEqual(terminal.readKey(), .halfPageUp)
         XCTAssertEqual(terminal.readKey(), .left)
+        XCTAssertEqual(terminal.readKey(), .pageUp)
+        XCTAssertEqual(terminal.readKey(), .pageDown)
+    }
+
+    func testTranscriptViewportClampsLineAndPageNavigation() {
+        var viewport = TUIViewport(totalLineCount: 100, pageSize: 20)
+        XCTAssertEqual(viewport.visibleRange, 80..<100)
+        viewport.pageUp()
+        XCTAssertEqual(viewport.visibleRange, 60..<80)
+        viewport.lineUp()
+        XCTAssertEqual(viewport.visibleRange, 59..<79)
+        viewport.halfPageUp()
+        XCTAssertEqual(viewport.visibleRange, 49..<69)
+        viewport.halfPageDown()
+        XCTAssertEqual(viewport.visibleRange, 59..<79)
+        viewport.moveToTop()
+        viewport.lineUp()
+        XCTAssertEqual(viewport.visibleRange, 0..<20)
+        viewport.moveToBottom()
+        viewport.pageDown()
+        XCTAssertEqual(viewport.visibleRange, 80..<100)
+    }
+
+    func testTranscriptViewportHandlesShortContent() {
+        var viewport = TUIViewport(totalLineCount: 3, pageSize: 20, startAtBottom: false)
+        XCTAssertEqual(viewport.visibleRange, 0..<3)
+        viewport.pageDown()
+        XCTAssertEqual(viewport.visibleRange, 0..<3)
+    }
+
+    func testArtifactNamesFollowGeneratedFileHeadings() {
+        let markdown = """
+        ### Sources/CoolApp/App.swift
+        ```swift
+        @main struct App {}
+        ```
+
+        **ContentView.swift**
+        ```swift
+        struct ContentView {}
+        ```
+
+        ```json
+        {"plain": true}
+        ```
+        """
+        XCTAssertEqual(
+            AFMTerminalChat.artifactNames(in: markdown),
+            ["Sources/CoolApp/App.swift", "ContentView.swift", nil]
+        )
     }
 
     private func writeString(_ value: String, to descriptor: Int32) -> Int {

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -921,6 +921,24 @@ final class TUIConversationPolicyTests: XCTestCase {
         )
     }
 
+    func testVideoAttachmentRemainsAFileURLMediaPart() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let video = root.appendingPathComponent("clip.mp4")
+        try Data("video fixture".utf8).write(to: video)
+
+        let turn = try AFMTerminalChat.makeUserTurn("describe", attachments: [video])
+        guard case .some(.parts(let parts)) = turn.message.content else {
+            return XCTFail("Expected multipart video request")
+        }
+
+        XCTAssertEqual(parts.count, 2)
+        XCTAssertEqual(parts[1].type, "image_url")
+        XCTAssertEqual(parts[1].image_url?.url, video.absoluteString)
+        XCTAssertNil(parts[1].image_url?.detail)
+    }
+
     func testPersistenceFailureNoticeIncludesRecoveryAndManualExportPaths() throws {
         let recoveryURL = URL(fileURLWithPath: "/safe/recovery/session.json")
         let notice = try XCTUnwrap(AFMTerminalChat.persistenceNotice(for: .recovered(
@@ -976,8 +994,58 @@ final class TerminalLifecycleAndInvocationTests: XCTestCase {
         XCTAssertNoThrow(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: false, inputIsTTY: true, outputIsTTY: true))
         XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: true, singlePrompt: false, inputIsTTY: true, outputIsTTY: true))
         XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: true, inputIsTTY: true, outputIsTTY: true))
+        XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: false, telegramOptions: true, inputIsTTY: true, outputIsTTY: true))
         XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: false, inputIsTTY: false, outputIsTTY: true))
         XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: false, inputIsTTY: true, outputIsTTY: false))
+    }
+
+    func testExplicitDefaultTelegramFormatStillCountsAsATUIConflict() {
+        XCTAssertTrue(TUIInvocationPolicy.hasTelegramOptions(
+            botToken: nil,
+            allowlist: nil,
+            replyFormat: "markdown",
+            requirePrefix: nil
+        ))
+        XCTAssertTrue(TUIInvocationPolicy.hasTelegramOptions(
+            botToken: nil,
+            allowlist: nil,
+            replyFormat: nil,
+            requirePrefix: "/afm"
+        ))
+        XCTAssertFalse(TUIInvocationPolicy.hasTelegramOptions(
+            botToken: nil,
+            allowlist: nil,
+            replyFormat: nil,
+            requirePrefix: nil
+        ))
+    }
+
+    func testMediaValidationAcceptsVideosAndRejectsMissingOrUnsupportedFiles() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let image = root.appendingPathComponent("image.png")
+        let video = root.appendingPathComponent("video.mp4")
+        let unsupported = root.appendingPathComponent("notes.txt")
+        try Data("image".utf8).write(to: image)
+        try Data("video".utf8).write(to: video)
+        try Data("text".utf8).write(to: unsupported)
+
+        let resolved = try TUIMediaAttachmentPolicy.resolveAndValidate(
+            ["image.png", "video.mp4"],
+            cwd: root
+        )
+        XCTAssertEqual(resolved, [image, video])
+        XCTAssertEqual(TUIMediaAttachmentPolicy.kind(for: image), .image)
+        XCTAssertEqual(TUIMediaAttachmentPolicy.kind(for: video), .video)
+        XCTAssertThrowsError(try TUIMediaAttachmentPolicy.resolveAndValidate(
+            ["missing.png"],
+            cwd: root
+        ))
+        XCTAssertThrowsError(try TUIMediaAttachmentPolicy.resolveAndValidate(
+            ["notes.txt"],
+            cwd: root
+        ))
     }
 
     func testTerminalCapabilitiesRequirePTYInputAndOutput() throws {

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -1,0 +1,180 @@
+import Darwin
+import XCTest
+@testable import AFMTerminalUI
+
+final class TerminalMarkdownRendererTests: XCTestCase {
+    func testParsesCodeDiffLatexAndLocalImagesWithoutColor() {
+        let source = #"""
+        # Result
+        $\frac{\alpha}{\beta} \leq \infty$
+        ```swift
+        let answer = 42
+        ```
+        ```diff
+        -old
+        +new
+        ```
+        ![plot](/tmp/chart.png)
+        """#
+        let result = TerminalMarkdownRenderer(color: false).render(source)
+
+        XCTAssertTrue(result.text.contains("(α)/(β) ≤ ∞"))
+        XCTAssertTrue(result.text.contains("┌─ swift"))
+        XCTAssertEqual(result.codeBlocks, [
+            TUICodeBlock(language: "swift", content: "let answer = 42"),
+            TUICodeBlock(language: "diff", content: "-old\n+new")
+        ])
+        XCTAssertEqual(result.images, [TUIImageReference(alt: "plot", path: "/tmp/chart.png")])
+        XCTAssertFalse(result.text.contains("\u{001B}"))
+    }
+
+    func testTreatsUnclosedFenceAsCodeInsteadOfDroppingContent() {
+        let result = TerminalMarkdownRenderer(color: false).render("```python\nprint('safe')")
+        XCTAssertEqual(result.codeBlocks.first?.content, "print('safe')")
+        XCTAssertTrue(result.text.contains("print('safe')"))
+    }
+
+    func testInfersLanguageForUntypedFences() {
+        let result = TerminalMarkdownRenderer(color: false).render("```\nconst answer = () => 42\n```")
+        XCTAssertEqual(result.codeBlocks.first?.language, "javascript")
+    }
+
+    func testRecognizesPlainLocalImagePath() {
+        XCTAssertEqual(
+            TerminalMarkdownRenderer.imageReferences(in: "Created /tmp/afm-output/chart.webp"),
+            [TUIImageReference(alt: "chart.webp", path: "/tmp/afm-output/chart.webp")]
+        )
+    }
+}
+
+final class TUIArtifactActionsTests: XCTestCase {
+    func testExclusiveSaveRefusesOverwriteAndExplicitOverwriteSucceeds() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let target = root.appendingPathComponent("nested/code.swift")
+
+        try TUIArtifactActions.save(Data("one".utf8), to: target)
+        XCTAssertThrowsError(try TUIArtifactActions.save(Data("two".utf8), to: target)) { error in
+            XCTAssertEqual(error as? TUIArtifactError, .exists(target.path))
+        }
+        try TUIArtifactActions.save(Data("two".utf8), to: target, overwrite: true)
+        XCTAssertEqual(try String(contentsOf: target, encoding: .utf8), "two")
+    }
+
+    func testExplicitOverwriteStillRefusesSymlinkTargets() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let victim = root.appendingPathComponent("victim")
+        let link = root.appendingPathComponent("output")
+        try Data("safe".utf8).write(to: victim)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: victim)
+
+        XCTAssertThrowsError(try TUIArtifactActions.save(Data("changed".utf8), to: link, overwrite: true))
+        XCTAssertEqual(try String(contentsOf: victim, encoding: .utf8), "safe")
+    }
+
+    func testJavaScriptBrowserArtifactHasLocalCSPAndDoesNotRunDuringPreparation() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let url = try TUIArtifactActions.prepareBrowserArtifact(
+            TUICodeBlock(language: "js", content: "document.querySelector('#app').textContent='ok'"),
+            temporaryRoot: root
+        )
+        let html = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(html.contains("Content-Security-Policy"))
+        XCTAssertTrue(html.contains("default-src 'none'"))
+        XCTAssertTrue(html.contains("querySelector"))
+    }
+
+    func testHTMLBrowserArtifactIsSandboxed() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = try TUIArtifactActions.prepareBrowserArtifact(
+            TUICodeBlock(language: "html", content: "<script>document.body.textContent='ok'</script>"),
+            temporaryRoot: root
+        )
+        let html = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(html.contains("sandbox=\"allow-scripts\""))
+        XCTAssertTrue(html.contains("default-src 'none'"))
+        XCTAssertFalse(html.contains("<script>document.body"))
+    }
+
+    func testBrowserPreparationRejectsExecutableLanguages() {
+        XCTAssertThrowsError(
+            try TUIArtifactActions.prepareBrowserArtifact(TUICodeBlock(language: "bash", content: "rm something"))
+        )
+    }
+}
+
+final class TUISessionStoreTests: XCTestCase {
+    func testPersistsSearchesAndExportsSession() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = TUISessionStore(directory: root)
+        var session = TUISession(title: "Swift help", backend: "MLX", model: "test/model")
+        session.messages = [
+            .init(role: "user", content: "Explain actors"),
+            .init(role: "assistant", content: "Actors isolate mutable state.")
+        ]
+
+        let saved = try store.save(session)
+        XCTAssertEqual(try store.load(id: session.id).messages.count, 2)
+        XCTAssertEqual(try store.search("mutable").first?.id, session.id)
+        let permissions = try FileManager.default.attributesOfItem(atPath: saved.path)[.posixPermissions] as? NSNumber
+        XCTAssertEqual(permissions?.intValue, 0o600)
+
+        let export = root.appendingPathComponent("transcript.md")
+        try store.exportMarkdown(session, to: export)
+        XCTAssertTrue(try String(contentsOf: export, encoding: .utf8).contains("## Assistant"))
+    }
+}
+
+final class TerminalLifecycleAndInvocationTests: XCTestCase {
+    func testTerminalRestorationIsIdempotent() throws {
+        var enters = 0
+        var restores = 0
+        let controller = TerminalModeController(
+            enter: { enters += 1 },
+            restore: { restores += 1 }
+        )
+        try controller.enter()
+        try controller.enter()
+        controller.restore()
+        controller.restore()
+        XCTAssertEqual(enters, 1)
+        XCTAssertEqual(restores, 1)
+    }
+
+    func testNoColorAndDumbTerminalFallback() {
+        let capabilities = TerminalCapabilities.detect(
+            environment: ["TERM": "dumb", "NO_COLOR": "1", "TERM_PROGRAM": "Apple_Terminal"],
+            isTTY: true
+        )
+        XCTAssertFalse(capabilities.color)
+        XCTAssertFalse(capabilities.hyperlinks)
+        XCTAssertEqual(capabilities.inlineImages, .none)
+    }
+
+    func testTUIArgumentConflictsAreRejected() {
+        XCTAssertNoThrow(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: false, pipedInput: false))
+        XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: true, singlePrompt: false, pipedInput: false))
+        XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: true, pipedInput: false))
+        XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: false, pipedInput: true))
+    }
+
+
+    func testTerminalKeyParsingHandlesMacReturnMultilineAndUnicode() throws {
+        var descriptors: [Int32] = [0, 0]
+        XCTAssertEqual(pipe(&descriptors), 0)
+        defer { close(descriptors[0]); close(descriptors[1]) }
+        let terminal = TerminalIO(inputFD: descriptors[0], outputFD: descriptors[1])
+        let bytes = Array("é".utf8) + [13, 10, 27, 91, 68]
+        _ = bytes.withUnsafeBytes { write(descriptors[1], $0.baseAddress, bytes.count) }
+        XCTAssertEqual(terminal.readKey(), .text("é"))
+        XCTAssertEqual(terminal.readKey(), .enter)
+        XCTAssertEqual(terminal.readKey(), .newline)
+        XCTAssertEqual(terminal.readKey(), .left)
+    }
+}

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -45,6 +45,97 @@ final class TerminalMarkdownRendererTests: XCTestCase {
             [TUIImageReference(alt: "chart.webp", path: "/tmp/afm-output/chart.webp")]
         )
     }
+
+    func testRendersCommonMarkAndGFMStructures() {
+        let source = #"""
+        # Heading
+
+        **bold**, *emphasis*, ~~removed~~, `inline`, and [AFM](https://example.com/afm).
+
+        > Quoted **answer**
+
+        - [x] parsed
+        - [ ] rendered
+          1. nested one
+          2. nested two
+
+        | Feature | State |
+        |:--------|------:|
+        | Tables  | ready |
+        """#
+        let text = TerminalMarkdownRenderer(color: false).render(source, width: 60).text
+
+        XCTAssertTrue(text.contains("▌ Heading"))
+        XCTAssertTrue(text.contains("bold, emphasis, ~~removed~~,  inline "))
+        XCTAssertTrue(text.contains("AFM (https://example.com/afm)"))
+        XCTAssertTrue(text.contains("│ Quoted answer"))
+        XCTAssertTrue(text.contains("☑ parsed"))
+        XCTAssertTrue(text.contains("☐ rendered"))
+        XCTAssertTrue(text.contains("1. nested one"))
+        XCTAssertTrue(text.contains("┌"))
+        XCTAssertTrue(text.contains("Feature"))
+        XCTAssertTrue(text.contains("ready"))
+    }
+
+    func testRendersInlineAndDisplayMathWithoutCorruptingCurrency() {
+        let source = #"""
+        It costs $5, while $x^2 + y_1 \leq \sqrt{9}$ is math.
+
+        $$
+        \begin{bmatrix} 1 & 2 \\ 3 & \frac{4}{5} \end{bmatrix}
+        $$
+        """#
+        let text = TerminalMarkdownRenderer(color: false).render(source).text
+
+        XCTAssertTrue(text.contains("costs $5"))
+        XCTAssertTrue(text.contains("x² + y₁ ≤ √(9)"))
+        XCTAssertTrue(text.contains("┌─ math"))
+        XCTAssertTrue(text.contains("[ 1  2"))
+        XCTAssertTrue(text.contains("(4)/(5)"))
+    }
+
+    func testLanguageHighlightingDiffsAndThemesProduceDistinctANSI() {
+        let source = #"""
+        ```swift
+        let value = Widget(name: "AFM", count: 42) // comment
+        ```
+        ```diff
+        @@ -1 +1 @@
+        -old
+        +new
+        ```
+        """#
+        let dark = TerminalMarkdownRenderer(color: true, theme: .dark).render(source).text
+        let light = TerminalMarkdownRenderer(color: true, theme: .light).render(source).text
+
+        XCTAssertNotEqual(dark, light)
+        XCTAssertTrue(dark.contains("\u{001B}[95mlet"))
+        XCTAssertTrue(dark.contains("\u{001B}[94mWidget"))
+        XCTAssertTrue(dark.contains("\u{001B}[92m\"AFM\""))
+        XCTAssertTrue(dark.contains("\u{001B}[91m42"))
+        XCTAssertTrue(dark.contains("\u{001B}[2;37m// comment"))
+        XCTAssertTrue(dark.contains("\u{001B}[92m+new"))
+        XCTAssertTrue(dark.contains("\u{001B}[91m-old"))
+    }
+
+    func testHyperlinksAreCapabilityGatedAndControlCharactersAreInert() {
+        let source = "[safe](https://example.com)\u{001B}]2;owned\u{0007}"
+        let plain = TerminalMarkdownRenderer(color: true).render(source, hyperlinks: false).text
+        let linked = TerminalMarkdownRenderer(color: true).render(source, hyperlinks: true).text
+
+        XCTAssertFalse(plain.contains("\u{001B}]8;;"))
+        XCTAssertTrue(linked.contains("\u{001B}]8;;https://example.com"))
+        XCTAssertFalse(plain.contains("\u{001B}]2;owned"))
+        XCTAssertTrue(plain.contains("�]2;owned�"))
+    }
+
+    func testOnlyLocalImagesBecomeArtifactActions() {
+        let source = "![local](./plot.png) ![remote](https://example.com/plot.png)"
+        XCTAssertEqual(
+            TerminalMarkdownRenderer(color: false).render(source).images,
+            [TUIImageReference(alt: "local", path: "./plot.png")]
+        )
+    }
 }
 
 final class TUIArtifactActionsTests: XCTestCase {

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -171,6 +171,63 @@ final class TUIArtifactActionsTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: victim, encoding: .utf8), "safe")
     }
 
+    func testOverwriteRestrictsExistingAndReplacementFilesToOwnerOnly() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let target = root.appendingPathComponent("output")
+        try Data("old".utf8).write(to: target)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: target.path)
+
+        try TUIArtifactActions.save(Data("new".utf8), to: target, overwrite: true)
+
+        let permissions = try FileManager.default.attributesOfItem(atPath: target.path)[.posixPermissions] as? NSNumber
+        XCTAssertEqual(permissions?.intValue, 0o600)
+        XCTAssertEqual(try String(contentsOf: target, encoding: .utf8), "new")
+    }
+
+    func testAtomicOverwriteDoesNotFollowTargetSwappedToSymlinkAfterValidation() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let target = root.appendingPathComponent("output")
+        let victim = root.appendingPathComponent("victim")
+        try Data("old".utf8).write(to: target)
+        try Data("safe".utf8).write(to: victim)
+
+        try TUIArtifactActions.save(
+            Data("replacement".utf8),
+            to: target,
+            overwrite: true,
+            beforeAtomicInstall: {
+                try FileManager.default.removeItem(at: target)
+                try FileManager.default.createSymbolicLink(at: target, withDestinationURL: victim)
+            }
+        )
+
+        XCTAssertEqual(try String(contentsOf: victim, encoding: .utf8), "safe")
+        XCTAssertEqual(try String(contentsOf: target, encoding: .utf8), "replacement")
+        var info = stat()
+        XCTAssertEqual(lstat(target.path, &info), 0)
+        XCTAssertEqual(info.st_mode & S_IFMT, S_IFREG)
+        XCTAssertEqual(info.st_mode & 0o777, 0o600)
+    }
+
+    func testOverwriteRejectsNonRegularTargetsWithoutBlocking() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let fifo = root.appendingPathComponent("pipe")
+        XCTAssertEqual(mkfifo(fifo.path, S_IRUSR | S_IWUSR), 0)
+
+        XCTAssertThrowsError(
+            try TUIArtifactActions.save(Data("unsafe".utf8), to: fifo, overwrite: true)
+        )
+        var info = stat()
+        XCTAssertEqual(lstat(fifo.path, &info), 0)
+        XCTAssertEqual(info.st_mode & S_IFMT, S_IFIFO)
+    }
+
     func testJavaScriptBrowserArtifactHasLocalCSPAndDoesNotRunDuringPreparation() throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -496,6 +496,62 @@ final class FoundationStopSequenceFilterTests: XCTestCase {
     #endif
 }
 
+private actor FoundationOperationProbe {
+    private var active = 0
+    private var maximumActive = 0
+    private var events: [String] = []
+
+    func start(_ name: String) {
+        active += 1
+        maximumActive = max(maximumActive, active)
+        events.append("start:\(name)")
+    }
+
+    func finish(_ name: String) {
+        events.append("finish:\(name)")
+        active -= 1
+    }
+
+    func snapshot() -> (events: [String], maximumActive: Int) {
+        (events, maximumActive)
+    }
+}
+
+final class FoundationSessionOperationGateTests: XCTestCase {
+    func testEarlierStreamReservationBlocksLaterResetAndExcludesConcurrentUse() async throws {
+        let gate = FoundationSessionOperationGate()
+        let streamReservation = gate.reserve()
+        let resetReservation = gate.reserve()
+        let probe = FoundationOperationProbe()
+
+        let resetTask = Task {
+            try await resetReservation.perform {
+                await probe.start("reset")
+                await probe.finish("reset")
+            }
+        }
+        for _ in 0..<10 { await Task.yield() }
+        let beforeStreamStarts = await probe.snapshot()
+        XCTAssertTrue(beforeStreamStarts.events.isEmpty)
+
+        let streamTask = Task {
+            try await streamReservation.perform {
+                await probe.start("stream")
+                try await Task.sleep(for: .milliseconds(20))
+                await probe.finish("stream")
+            }
+        }
+
+        try await streamTask.value
+        try await resetTask.value
+        let snapshot = await probe.snapshot()
+        XCTAssertEqual(snapshot.maximumActive, 1)
+        XCTAssertEqual(snapshot.events, [
+            "start:stream", "finish:stream", "start:reset", "finish:reset"
+        ])
+    }
+}
+
 final class TUIConversationPolicyTests: XCTestCase {
     func testFoundationTurnsAreIncrementalWhileStatelessTurnsRetainHistory() {
         let transcript = [

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -402,29 +402,148 @@ final class TUISessionStoreTests: XCTestCase {
         XCTAssertEqual(try store.load(id: session.id).title, "original")
     }
 
-    func testOversizedPersistenceExportsRecoveryTranscriptAndRetainsLastSavedSession() throws {
+    func testOversizedPersistenceWritesFullFidelityJSONAndRetainsLastSavedSession() throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: root) }
-        let store = TUISessionStore(directory: root, maximumSessionBytes: 1_024)
+        let store = TUISessionStore(
+            directory: root,
+            maximumSessionBytes: 1_024,
+            maximumRecoveryBytes: 16_000
+        )
         var session = TUISession(title: "saved version", backend: "MLX", model: "test/model")
         try store.save(session)
 
         session.title = "unsaved version"
         session.messages = [
-            .init(role: "user", content: "latest turn " + String(repeating: "x", count: 2_000))
+            Message(role: "user", content: .parts([
+                ContentPart(type: "text", text: "latest turn " + String(repeating: "x", count: 1_100)),
+                ContentPart(
+                    type: "image_url",
+                    image_url: ImageURL(url: "data:image/png;base64,AQIDBA==", detail: "high")
+                ),
+                ContentPart(
+                    type: "input_audio",
+                    input_audio: InputAudio(data: "BQYHCA==", format: "wav", language: "en-CA")
+                )
+            ])),
+            Message(
+                role: "assistant",
+                content: nil,
+                toolCalls: [MessageToolCall(
+                    id: "call-1",
+                    type: "function",
+                    function: MessageToolCallFunction(
+                        name: "lookup",
+                        arguments: #"{"query":"swift"}"#
+                    )
+                )]
+            ),
+            Message(
+                role: "tool",
+                content: .text("result"),
+                toolCallId: "call-1",
+                name: "lookup"
+            )
         ]
-        let result = store.persistRecoveringTranscript(session)
-        guard case .recovered(let saveError, let transcriptURL) = result else {
-            return XCTFail("Expected an oversized save to produce a recovery transcript")
+        let result = store.persistRecoveringSession(session)
+        guard case .recovered(let saveError, let recoveryURL) = result else {
+            return XCTFail("Expected an oversized save to produce a recovery session")
         }
 
         XCTAssertTrue(saveError.contains("save/load limit"))
         XCTAssertEqual(try store.load(id: session.id).title, "saved version")
-        let recovery = try String(contentsOf: transcriptURL, encoding: .utf8)
-        XCTAssertTrue(recovery.contains("unsaved version"))
-        XCTAssertTrue(recovery.contains("latest turn"))
-        let permissions = try FileManager.default.attributesOfItem(atPath: transcriptURL.path)[.posixPermissions] as? NSNumber
+        XCTAssertEqual(recoveryURL.pathExtension, "json")
+        XCTAssertEqual(
+            try canonicalSessionData(store.loadRecovery(id: session.id)),
+            try canonicalSessionData(session)
+        )
+        let permissions = try FileManager.default.attributesOfItem(atPath: recoveryURL.path)[.posixPermissions] as? NSNumber
         XCTAssertEqual(permissions?.intValue, 0o600)
+    }
+
+    func testRepeatedRecoveryAtomicallyReplacesThePreviousVersion() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = TUISessionStore(
+            directory: root,
+            maximumSessionBytes: 128,
+            maximumRecoveryBytes: 8_192
+        )
+        var session = TUISession(
+            title: "first " + String(repeating: "a", count: 256),
+            backend: "MLX",
+            model: "test/model"
+        )
+        guard case .recovered = store.persistRecoveringSession(session) else {
+            return XCTFail("Expected first recovery")
+        }
+
+        session.title = "second " + String(repeating: "b", count: 256)
+        session.messages = [.init(role: "assistant", content: "newest complete state")]
+        guard case .recovered = store.persistRecoveringSession(session) else {
+            return XCTFail("Expected replacement recovery")
+        }
+
+        XCTAssertEqual(try store.loadRecovery(id: session.id).title, session.title)
+        let recoveryFiles = try FileManager.default.contentsOfDirectory(
+            at: root.appendingPathComponent("recovery"),
+            includingPropertiesForKeys: nil
+        )
+        XCTAssertEqual(recoveryFiles.filter { $0.pathExtension == "json" }.count, 1)
+        XCTAssertFalse(recoveryFiles.contains { $0.pathExtension == "tmp" })
+    }
+
+    func testFailedRecoveryReplacementPreservesThePriorGoodRecovery() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = TUISessionStore(
+            directory: root,
+            maximumSessionBytes: 64,
+            maximumRecoveryBytes: 2_048
+        )
+        var session = TUISession(
+            title: "recoverable " + String(repeating: "a", count: 256),
+            backend: "MLX",
+            model: "test/model"
+        )
+        guard case .recovered = store.persistRecoveringSession(session) else {
+            return XCTFail("Expected initial recovery")
+        }
+        let prior = try canonicalSessionData(store.loadRecovery(id: session.id))
+
+        session.title = "too large " + String(repeating: "z", count: 4_096)
+        guard case .failed(_, let recoveryError) = store.persistRecoveringSession(session) else {
+            return XCTFail("Expected bounded recovery failure")
+        }
+
+        XCTAssertTrue(recoveryError.contains("recovery limit"))
+        XCTAssertEqual(try canonicalSessionData(store.loadRecovery(id: session.id)), prior)
+    }
+
+    func testInterruptedTemporaryRecoveryDoesNotReplaceLastGoodJSON() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = TUISessionStore(
+            directory: root,
+            maximumSessionBytes: 64,
+            maximumRecoveryBytes: 4_096
+        )
+        let session = TUISession(
+            title: "recoverable " + String(repeating: "a", count: 256),
+            backend: "MLX",
+            model: "test/model"
+        )
+        guard case .recovered(_, let recoveryURL) = store.persistRecoveringSession(session) else {
+            return XCTFail("Expected initial recovery")
+        }
+        let interrupted = recoveryURL.deletingLastPathComponent()
+            .appendingPathComponent(".interrupted.tmp")
+        try Data(#"{"title":"partial""#.utf8).write(to: interrupted)
+
+        XCTAssertEqual(
+            try canonicalSessionData(store.loadRecovery(id: session.id)),
+            try canonicalSessionData(session)
+        )
     }
 
     func testRecentHistoryUsesBoundedMetadataDecoding() throws {
@@ -518,6 +637,13 @@ final class TUISessionStoreTests: XCTestCase {
         let loaded = try stores[0].load(id: id)
         XCTAssertTrue(validTitles.contains(loaded.title))
         XCTAssertEqual(loaded.messages.count, 1)
+    }
+
+    private func canonicalSessionData(_ session: TUISession) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(session)
     }
 }
 
@@ -796,10 +922,10 @@ final class TUIConversationPolicyTests: XCTestCase {
     }
 
     func testPersistenceFailureNoticeIncludesRecoveryAndManualExportPaths() throws {
-        let recoveryURL = URL(fileURLWithPath: "/safe/recovery/session.md")
+        let recoveryURL = URL(fileURLWithPath: "/safe/recovery/session.json")
         let notice = try XCTUnwrap(AFMTerminalChat.persistenceNotice(for: .recovered(
             saveError: "Session exceeds limit",
-            transcriptURL: recoveryURL
+            recoveryURL: recoveryURL
         )))
 
         XCTAssertTrue(notice.contains("Session save failed: Session exceeds limit"))

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -220,6 +220,52 @@ final class TUISessionStoreTests: XCTestCase {
         try store.exportMarkdown(session, to: export)
         XCTAssertTrue(try String(contentsOf: export, encoding: .utf8).contains("## Assistant"))
     }
+
+    func testPersistsReasoningAndDecodesLegacySessions() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = TUISessionStore(directory: root)
+        var session = TUISession(backend: "MLX", model: "test/model")
+        session.messages = [.init(role: "assistant", content: "Answer")]
+        session.reasoningByMessage["0"] = "Private reasoning"
+
+        try store.save(session)
+        XCTAssertEqual(try store.load(id: session.id).reasoning(atMessageIndex: 0), "Private reasoning")
+        XCTAssertEqual(try store.search("private reasoning").first?.id, session.id)
+
+        let export = root.appendingPathComponent("reasoning.md")
+        try store.exportMarkdown(session, to: export)
+        let markdown = try String(contentsOf: export, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("<summary>Reasoning</summary>"))
+        XCTAssertTrue(markdown.contains("Private reasoning"))
+
+        let data = try JSONSerialization.data(withJSONObject: [
+            "id": session.id.uuidString,
+            "title": "Legacy",
+            "backend": "MLX",
+            "model": "test/model",
+            "createdAt": ISO8601DateFormatter().string(from: session.createdAt),
+            "updatedAt": ISO8601DateFormatter().string(from: session.updatedAt),
+            "messages": [["role": "assistant", "content": "Answer"]]
+        ])
+        try data.write(to: root.appendingPathComponent("\(session.id.uuidString).json"))
+        XCTAssertTrue(try store.load(id: session.id).reasoningByMessage.isEmpty)
+    }
+}
+
+final class GenerationBufferTests: XCTestCase {
+    func testCompletedBufferRejectsLateEventsAndSkipsUnchangedSnapshots() async {
+        let buffer = GenerationBuffer()
+        await buffer.accept(.text("one", tokenCount: 1))
+        await buffer.finish()
+        let completed = await buffer.snapshot()
+
+        await buffer.accept(.text("late", tokenCount: 2))
+        let unchanged = await buffer.snapshot(ifChangedSince: completed.revision)
+        let final = await buffer.snapshot()
+        XCTAssertNil(unchanged)
+        XCTAssertEqual(final.text, "one")
+    }
 }
 
 final class TerminalLifecycleAndInvocationTests: XCTestCase {

--- a/Tests/MacLocalAPITests/TerminalUITests.swift
+++ b/Tests/MacLocalAPITests/TerminalUITests.swift
@@ -2,6 +2,9 @@ import Darwin
 import XCTest
 import AFMKit
 import AFMOpenAICompat
+#if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
+import FoundationModels
+#endif
 @testable import AFMKitFoundationModels
 @testable import AFMTerminalUI
 
@@ -179,6 +182,8 @@ final class TUIArtifactActionsTests: XCTestCase {
         let html = try String(contentsOf: url, encoding: .utf8)
         XCTAssertTrue(html.contains("Content-Security-Policy"))
         XCTAssertTrue(html.contains("default-src 'none'"))
+        XCTAssertTrue(html.contains("form-action 'none'"))
+        XCTAssertTrue(html.contains("connect-src 'none'"))
         XCTAssertTrue(html.contains("querySelector"))
         XCTAssertTrue(html.contains("sandbox=\"allow-scripts\""))
         XCTAssertFalse(html.contains("<script>document.querySelector"))
@@ -194,7 +199,21 @@ final class TUIArtifactActionsTests: XCTestCase {
         let html = try String(contentsOf: url, encoding: .utf8)
         XCTAssertTrue(html.contains("sandbox=\"allow-scripts\""))
         XCTAssertTrue(html.contains("default-src 'none'"))
+        XCTAssertTrue(html.contains("form-action 'none'"))
         XCTAssertFalse(html.contains("<script>document.body"))
+    }
+
+    func testBrowserNavigationBoundaryRejectsOutboundAndSiblingNavigation() {
+        let artifact = URL(fileURLWithPath: "/Volumes/edata2/afm-preview/artifact.html")
+        let boundary = TUIBrowserNavigationBoundary(artifactURL: artifact)
+
+        XCTAssertTrue(boundary.allows(artifact))
+        XCTAssertTrue(boundary.allows(URL(string: "about:blank")))
+        XCTAssertTrue(boundary.allows(URL(string: "about:srcdoc")))
+        XCTAssertFalse(boundary.allows(URL(string: "https://example.com/exfiltrate")))
+        XCTAssertFalse(boundary.allows(URL(string: "data:text/html,escaped")))
+        XCTAssertFalse(boundary.allows(artifact.deletingLastPathComponent().appendingPathComponent("sibling.html")))
+        XCTAssertFalse(boundary.allows(URL(string: "custom-scheme://escape")))
     }
 
     func testBrowserPreparationRejectsExecutableLanguages() {
@@ -286,6 +305,105 @@ final class TUISessionStoreTests: XCTestCase {
         XCTAssertEqual(session.messages.count, 1)
         XCTAssertEqual(session.reasoningByMessage, ["0": "r1"])
     }
+
+    func testTwentyMegabyteImageSessionRoundTripsWithinSharedSaveLoadLimit() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = TUISessionStore(directory: root)
+        let imageData = Data(repeating: 0xA5, count: 20_000_000)
+        let imageURL = "data:image/png;base64,\(imageData.base64EncodedString())"
+        let session = TUISession(backend: "MLX", model: "test/model", messages: [
+            Message(role: "user", content: .parts([
+                ContentPart(type: "text", text: "inspect"),
+                ContentPart(type: "image_url", image_url: ImageURL(url: imageURL, detail: "auto"))
+            ]))
+        ])
+
+        let url = try store.save(session)
+        let fileSize = try XCTUnwrap(
+            (try FileManager.default.attributesOfItem(atPath: url.path)[.size] as? NSNumber)?.intValue
+        )
+        XCTAssertGreaterThan(fileSize, 10_000_000)
+        XCTAssertLessThanOrEqual(fileSize, TUISessionStore.defaultMaximumSessionBytes)
+        XCTAssertEqual(try store.load(id: session.id).messages.count, 1)
+    }
+
+    func testOversizedReplacementIsRejectedWithoutDestroyingLoadableSession() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = TUISessionStore(directory: root, maximumSessionBytes: 1_024)
+        var session = TUISession(title: "original", backend: "MLX", model: "test/model")
+        try store.save(session)
+
+        session.title = String(repeating: "x", count: 2_000)
+        XCTAssertThrowsError(try store.save(session)) { error in
+            XCTAssertEqual(
+                error as? TUISessionStoreError,
+                .sessionTooLarge(maximumBytes: 1_024)
+            )
+        }
+        XCTAssertEqual(try store.load(id: session.id).title, "original")
+    }
+
+    func testRecentHistoryUsesBoundedMetadataDecoding() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let ids = (0..<4).map { _ in UUID() }
+        for (index, id) in ids.enumerated() {
+            let updatedAt = Date(timeIntervalSince1970: TimeInterval(index + 1))
+            let malformedFullSession = try JSONSerialization.data(withJSONObject: [
+                "id": id.uuidString,
+                "title": "Metadata \(index)",
+                "updatedAt": ISO8601DateFormatter().string(from: updatedAt),
+                "messages": "intentionally not decodable as a session"
+            ])
+            let url = root.appendingPathComponent("\(id.uuidString).json")
+            try malformedFullSession.write(to: url)
+            try FileManager.default.setAttributes([.modificationDate: updatedAt], ofItemAtPath: url.path)
+        }
+        let store = TUISessionStore(directory: root)
+
+        let recent = try store.recent(limit: 2)
+        XCTAssertEqual(recent.map(\.id), [ids[3], ids[2]])
+        XCTAssertEqual(recent.map(\.title), ["Metadata 3", "Metadata 2"])
+        XCTAssertThrowsError(try store.load(id: ids[3]))
+        XCTAssertTrue(try store.recent(limit: 0).isEmpty)
+    }
+
+    func testConcurrentStoresAtomicallyReplaceTheSameSession() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let id = UUID()
+        let stores = (0..<6).map { _ in TUISessionStore(directory: root) }
+        let validTitles = Set((0..<6).map { "writer-\($0)" })
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for (index, store) in stores.enumerated() {
+                group.addTask {
+                    for iteration in 0..<20 {
+                        let session = TUISession(
+                            id: id,
+                            title: "writer-\(index)",
+                            backend: "MLX",
+                            model: "test/model",
+                            messages: [.init(role: "assistant", content: String(repeating: "\(iteration)", count: 200))]
+                        )
+                        try store.save(session)
+                        let loaded = try store.load(id: id)
+                        guard validTitles.contains(loaded.title), loaded.messages.count == 1 else {
+                            throw CocoaError(.fileReadCorruptFile)
+                        }
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        let loaded = try stores[0].load(id: id)
+        XCTAssertTrue(validTitles.contains(loaded.title))
+        XCTAssertEqual(loaded.messages.count, 1)
+    }
 }
 
 final class GenerationBufferTests: XCTestCase {
@@ -345,6 +463,37 @@ final class FoundationStopSequenceFilterTests: XCTestCase {
         XCTAssertEqual(filter.consume("hello<EN"), "hello")
         XCTAssertEqual(filter.finish(), "<EN")
     }
+
+    #if canImport(FoundationModels) && !DISABLE_FOUNDATION_MODELS
+    func testAcceptedTranscriptReplacesHiddenPostStopOutput() throws {
+        let original = Transcript(entries: [
+            .instructions(.init(
+                segments: [.text(.init(content: "Be concise"))],
+                toolDefinitions: []
+            )),
+            .prompt(.init(segments: [.text(.init(content: "Earlier question"))])),
+            .response(.init(assetIDs: [], segments: [.text(.init(content: "Earlier answer"))]))
+        ])
+
+        let accepted = FoundationModelService.acceptedTranscript(
+            from: original,
+            prompt: "User: continue\n\nAssistant: ",
+            response: "visible prefix",
+            options: GenerationOptions()
+        )
+
+        XCTAssertEqual(accepted.count, original.count + 2)
+        guard case .response(let response) = accepted[accepted.index(before: accepted.endIndex)] else {
+            return XCTFail("Expected the replacement transcript to end with a response")
+        }
+        let text = response.segments.compactMap { segment -> String? in
+            guard case .text(let value) = segment else { return nil }
+            return value.content
+        }.joined()
+        XCTAssertEqual(text, "visible prefix")
+        XCTAssertFalse(text.contains("hidden suffix"))
+    }
+    #endif
 }
 
 final class TUIConversationPolicyTests: XCTestCase {
@@ -371,6 +520,16 @@ final class TUIConversationPolicyTests: XCTestCase {
         XCTAssertThrowsError(try AFMTerminalChat.validateRestoredSession(session, backendName: "Foundation", modelName: "one"))
         XCTAssertThrowsError(try AFMTerminalChat.validateRestoredSession(session, backendName: "MLX", modelName: "two"))
     }
+
+    func testMLXMaximumLogprobsEnablesLogprobCollection() {
+        let enabled = TUILogprobConfiguration(maximum: 7)
+        XCTAssertTrue(enabled.enabled)
+        XCTAssertEqual(enabled.maximum, 7)
+
+        let disabled = TUILogprobConfiguration(maximum: nil)
+        XCTAssertFalse(disabled.enabled)
+        XCTAssertNil(disabled.maximum)
+    }
 }
 
 final class TerminalLifecycleAndInvocationTests: XCTestCase {
@@ -392,7 +551,8 @@ final class TerminalLifecycleAndInvocationTests: XCTestCase {
     func testNoColorAndDumbTerminalFallback() {
         let capabilities = TerminalCapabilities.detect(
             environment: ["TERM": "dumb", "NO_COLOR": "1", "TERM_PROGRAM": "Apple_Terminal"],
-            isTTY: true
+            inputIsTTY: true,
+            outputIsTTY: true
         )
         XCTAssertFalse(capabilities.color)
         XCTAssertFalse(capabilities.hyperlinks)
@@ -400,10 +560,38 @@ final class TerminalLifecycleAndInvocationTests: XCTestCase {
     }
 
     func testTUIArgumentConflictsAreRejected() {
-        XCTAssertNoThrow(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: false, pipedInput: false))
-        XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: true, singlePrompt: false, pipedInput: false))
-        XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: true, pipedInput: false))
-        XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: false, pipedInput: true))
+        XCTAssertNoThrow(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: false, inputIsTTY: true, outputIsTTY: true))
+        XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: true, singlePrompt: false, inputIsTTY: true, outputIsTTY: true))
+        XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: true, inputIsTTY: true, outputIsTTY: true))
+        XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: false, inputIsTTY: false, outputIsTTY: true))
+        XCTAssertThrowsError(try TUIInvocationPolicy.validate(tui: true, webUI: false, singlePrompt: false, inputIsTTY: true, outputIsTTY: false))
+    }
+
+    func testTerminalCapabilitiesRequirePTYInputAndOutput() throws {
+        var master: Int32 = 0
+        var slave: Int32 = 0
+        XCTAssertEqual(openpty(&master, &slave, nil, nil, nil), 0)
+        defer { close(master); close(slave) }
+        var descriptors: [Int32] = [0, 0]
+        XCTAssertEqual(pipe(&descriptors), 0)
+        defer { close(descriptors[0]); close(descriptors[1]) }
+
+        let environment = ["TERM": "xterm-256color", "TERM_PROGRAM": "iTerm.app"]
+        XCTAssertTrue(TerminalCapabilities.detect(
+            environment: environment,
+            inputFD: slave,
+            outputFD: slave
+        ).isInteractive)
+        XCTAssertFalse(TerminalCapabilities.detect(
+            environment: environment,
+            inputFD: slave,
+            outputFD: descriptors[1]
+        ).isInteractive)
+        XCTAssertFalse(TerminalCapabilities.detect(
+            environment: environment,
+            inputFD: descriptors[0],
+            outputFD: slave
+        ).isInteractive)
     }
 
 

--- a/Tests/TUIHarness/Package.resolved
+++ b/Tests/TUIHarness/Package.resolved
@@ -1,0 +1,559 @@
+{
+  "originHash" : "5470e765f1f10f330c8750580485c128e5aeeb3d1143dd0cfbfe199ba7bf0697",
+  "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client",
+      "state" : {
+        "revision" : "9544287b9416c0bc71e58b9f3aead8dd14b16103",
+        "version" : "1.36.0"
+      }
+    },
+    {
+      "identity" : "async-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/async-kit.git",
+      "state" : {
+        "revision" : "6bbb83cbf9d886623a967a965c8fb1b73e6566f9",
+        "version" : "1.22.0"
+      }
+    },
+    {
+      "identity" : "console-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/console-kit.git",
+      "state" : {
+        "revision" : "15121e1ec44a0a2064e43545d1390f02cc19b07d",
+        "version" : "4.16.1"
+      }
+    },
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "86b5096ac59ab46e66bd1f6377c604bc1dab0bc2",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
+      }
+    },
+    {
+      "identity" : "multipart-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/multipart-kit.git",
+      "state" : {
+        "revision" : "3498e60218e6003894ff95192d756e238c01f44e",
+        "version" : "4.7.1"
+      }
+    },
+    {
+      "identity" : "routing-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/routing-kit.git",
+      "state" : {
+        "revision" : "1a10ccea61e4248effd23b6e814999ce7bdf0ee0",
+        "version" : "4.9.3"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "449dbbecd0f31e82b510ada227ca152caa8b5e98",
+        "version" : "1.19.4"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "7d0b8880ef8e567dd4e0089f8b99fb354129017c",
+        "version" : "2.4.2"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-markdown.git",
+      "state" : {
+        "revision" : "3c6f9523da3a1ec2fd829673e472d95b8097a3b8",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
+        "version" : "1.45.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
+        "version" : "2.37.2"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle",
+      "state" : {
+        "revision" : "7f9326b0326ff86e3646295ea6e891f68c471c5e",
+        "version" : "2.12.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/swift-tree-sitter.git",
+      "state" : {
+        "revision" : "08ef81eb8620617b55b08868126707ad72bf754f",
+        "version" : "0.25.0"
+      }
+    },
+    {
+      "identity" : "swift-xet",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-xet.git",
+      "state" : {
+        "revision" : "341bfd4172f6a57119bfd49bafa11cf5d21fab75",
+        "version" : "0.2.3"
+      }
+    },
+    {
+      "identity" : "tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter.git",
+      "state" : {
+        "revision" : "da6fe9beb4f7f67beb75914ca8e0d48ae48d6406",
+        "version" : "0.25.10"
+      }
+    },
+    {
+      "identity" : "tree-sitter-bash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-bash.git",
+      "state" : {
+        "revision" : "a06c2e4415e9bc0346c6b86d401879ffb44058f7"
+      }
+    },
+    {
+      "identity" : "tree-sitter-c",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-c.git",
+      "state" : {
+        "revision" : "b780e47fc780ddc8da13afa35a3f4ed5c157823d"
+      }
+    },
+    {
+      "identity" : "tree-sitter-c-sharp",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-c-sharp.git",
+      "state" : {
+        "revision" : "9150f7d56bb47f1a809fa23623f1ba1413e93fa9"
+      }
+    },
+    {
+      "identity" : "tree-sitter-cpp",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-cpp.git",
+      "state" : {
+        "revision" : "8b5b49eb196bec7040441bee33b2c9a4838d6967"
+      }
+    },
+    {
+      "identity" : "tree-sitter-css",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-css.git",
+      "state" : {
+        "revision" : "dda5cfc5722c429eaba1c910ca32c2c0c5bb1a3f"
+      }
+    },
+    {
+      "identity" : "tree-sitter-diff",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/the-mikedavis/tree-sitter-diff.git",
+      "state" : {
+        "revision" : "ada384ac7bfc1307f32de474620120add29998fb"
+      }
+    },
+    {
+      "identity" : "tree-sitter-go",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-go.git",
+      "state" : {
+        "revision" : "2346a3ab1bb3857b48b29d779a1ef9799a248cd7"
+      }
+    },
+    {
+      "identity" : "tree-sitter-html",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-html.git",
+      "state" : {
+        "revision" : "73a3947324f6efddf9e17c0ea58d454843590cc0"
+      }
+    },
+    {
+      "identity" : "tree-sitter-java",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-java.git",
+      "state" : {
+        "revision" : "e10607b45ff745f5f876bfa3e94fbcc6b44bdc11"
+      }
+    },
+    {
+      "identity" : "tree-sitter-javascript",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-javascript.git",
+      "state" : {
+        "revision" : "58404d8cf191d69f2674a8fd507bd5776f46cb11"
+      }
+    },
+    {
+      "identity" : "tree-sitter-json",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-json.git",
+      "state" : {
+        "revision" : "254c42a6476413b776221e03982ac8ae159eeb72"
+      }
+    },
+    {
+      "identity" : "tree-sitter-kotlin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter-grammars/tree-sitter-kotlin.git",
+      "state" : {
+        "revision" : "3dea6dfa9c0129deb7c4315afbda806c85c41667"
+      }
+    },
+    {
+      "identity" : "tree-sitter-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter-grammars/tree-sitter-markdown.git",
+      "state" : {
+        "revision" : "a0a00f817d02412bd92c54d316f164d827b57b5c"
+      }
+    },
+    {
+      "identity" : "tree-sitter-php",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-php.git",
+      "state" : {
+        "revision" : "3fda2fb9577166c6399834917f9844f30370beea"
+      }
+    },
+    {
+      "identity" : "tree-sitter-python",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-python.git",
+      "state" : {
+        "revision" : "26855eabccb19c6abf499fbc5b8dc7cc9ab8bc64"
+      }
+    },
+    {
+      "identity" : "tree-sitter-ruby",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-ruby.git",
+      "state" : {
+        "revision" : "ad907a69da0c8a4f7a943a7fe012712208da6dee"
+      }
+    },
+    {
+      "identity" : "tree-sitter-rust",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-rust.git",
+      "state" : {
+        "revision" : "77a3747266f4d621d0757825e6b11edcbf991ca5"
+      }
+    },
+    {
+      "identity" : "tree-sitter-sql",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/DerekStride/tree-sitter-sql.git",
+      "state" : {
+        "revision" : "851e9cb257ba7c66cc8c14214a31c44d2f1e954e"
+      }
+    },
+    {
+      "identity" : "tree-sitter-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/alex-pinkus/tree-sitter-swift.git",
+      "state" : {
+        "revision" : "31d17fe7e818a2048c808b5c6fdc2dc792f4f5b5"
+      }
+    },
+    {
+      "identity" : "tree-sitter-toml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter-grammars/tree-sitter-toml.git",
+      "state" : {
+        "revision" : "64b56832c2cffe41758f28e05c756a3a98d16f41"
+      }
+    },
+    {
+      "identity" : "tree-sitter-typescript",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-typescript.git",
+      "state" : {
+        "revision" : "75b3874edb2dc714fb1fd77a32013d0f8699989f"
+      }
+    },
+    {
+      "identity" : "tree-sitter-yaml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter-grammars/tree-sitter-yaml.git",
+      "state" : {
+        "revision" : "a1c4812a73ec5e089de8e441fdea3a921e8d5079"
+      }
+    },
+    {
+      "identity" : "vapor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/vapor.git",
+      "state" : {
+        "revision" : "748ae8432a33e0965bbf0351fedd4e915e7f460c",
+        "version" : "4.122.0"
+      }
+    },
+    {
+      "identity" : "websocket-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/websocket-kit.git",
+      "state" : {
+        "revision" : "90bbbdab3ede12c803cfbe91646f291c092517a3",
+        "version" : "2.16.2"
+      }
+    },
+    {
+      "identity" : "xgrammar",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mlc-ai/xgrammar",
+      "state" : {
+        "revision" : "c1570cdb4f8c867a4dbd07b7ff90581f4a2a432b"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Tests/TUIHarness/Package.swift
+++ b/Tests/TUIHarness/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "AFMTerminalUIHarness",
+    platforms: [.macOS("26.0")],
+    dependencies: [
+        .package(name: "MacLocalAPI", path: "../..")
+    ],
+    targets: [
+        .testTarget(
+            name: "AFMTerminalUIHarnessTests",
+            dependencies: [
+                .product(name: "AFMTerminalUI", package: "MacLocalAPI")
+            ],
+            resources: [.copy("Snapshots")]
+        )
+    ]
+)

--- a/Tests/TUIHarness/Tests/AFMTerminalUIHarnessTests/Snapshots/calculus-regression.snap
+++ b/Tests/TUIHarness/Tests/AFMTerminalUIHarnessTests/Snapshots/calculus-regression.snap
@@ -1,0 +1,23 @@
+▸ Limits and continuity
+
+A limit lim_(x → c) f(x)=L means
+┌─ math
+│ ∀ ε > 0, ∃ δ > 0 such that |x-c|<δ ⇒ |f(x)-L|<ε.
+└─
+
+
+▸ Single-variable calculus
+
+
+┌─ math
+│ f'(a)=lim_(h→0)(f(a+h)-f(a))/(h),
+│ ∫ₐᵇ f(x) dx=lim_(n→∞)∑ᵢ₌₁ⁿ f(tᵢ)Δ xᵢ.
+└─
+
+
+▸ Multivariable calculus
+
+For f:ℝⁿ→ℝ, the gradient is
+┌─ math
+│ ∇ f(a)=((∂ f)/(∂ x₁),…,(∂ f)/(∂ xₙ)).
+└─

--- a/Tests/TUIHarness/Tests/AFMTerminalUIHarnessTests/Snapshots/feature-rich-turn.snap
+++ b/Tests/TUIHarness/Tests/AFMTerminalUIHarnessTests/Snapshots/feature-rich-turn.snap
@@ -1,0 +1,30 @@
+<ESC>[1;95m▌ Calculus workspace<ESC>[0m
+
+For <ESC>[96mf: D ⊆ ℝ → ℝ<ESC>[0m,
+
+
+<ESC>[96m┌─<ESC>[0m<ESC>[96m math <ESC>[0m
+<ESC>[96m│<ESC>[0m <ESC>[96mf'(a) = lim_(h → 0) (f(a+h)-f(a))/(h)<ESC>[0m
+<ESC>[96m└─<ESC>[0m
+
+
+<ESC>[96m│<ESC>[0m The same response can contain prose, math, source, and a patch.
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m swift <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[95mstruct<ESC>[0m <ESC>[94mGradient<ESC>[0m {
+<ESC>[2;37m│ 2 │<ESC>[0m     <ESC>[95mlet<ESC>[0m values<ESC>[93m: [Double]<ESC>[0m
+<ESC>[2;37m│ 3 │<ESC>[0m     <ESC>[95mfunc<ESC>[0m magnitude() <ESC>[96m-><ESC>[0m <ESC>[94mDouble<ESC>[0m { values.reduce(<ESC>[91m0<ESC>[0m) { $0 <ESC>[96m+<ESC>[0m $1 <ESC>[96m*<ESC>[0m $1 }.squareRoot() }
+<ESC>[2;37m│ 4 │<ESC>[0m }
+<ESC>[2;37m└─────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m diff <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[91m-let method = "finite differences"<ESC>[0m
+<ESC>[2;37m│ 2 │<ESC>[0m <ESC>[92m+let method = "automatic differentiation"<ESC>[0m
+<ESC>[2;37m└────────<ESC>[0m
+
+<ESC>[2;37m┌────────────┬──────────┐<ESC>[0m
+<ESC>[2;37m│<ESC>[0m <ESC>[1mSurface   <ESC>[0m <ESC>[2;37m│<ESC>[0m <ESC>[1mShortcut<ESC>[0m <ESC>[2;37m│<ESC>[0m
+<ESC>[2;37m├────────────┼──────────┤<ESC>[0m
+<ESC>[2;37m│<ESC>[0m Transcript <ESC>[2;37m│<ESC>[0m Ctrl-T   <ESC>[2;37m│<ESC>[0m
+<ESC>[2;37m│<ESC>[0m Blocks     <ESC>[2;37m│<ESC>[0m /blocks  <ESC>[2;37m│<ESC>[0m
+<ESC>[2;37m└────────────┴──────────┘<ESC>[0m

--- a/Tests/TUIHarness/Tests/AFMTerminalUIHarnessTests/Snapshots/popular-formats.snap
+++ b/Tests/TUIHarness/Tests/AFMTerminalUIHarnessTests/Snapshots/popular-formats.snap
@@ -1,0 +1,58 @@
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m swift <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[95mlet<ESC>[0m answer<ESC>[93m: Int<ESC>[0m <ESC>[96m=<ESC>[0m <ESC>[91m42<ESC>[0m
+<ESC>[2;37m└─────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m python <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[95mdef<ESC>[0m greet(name):
+<ESC>[2;37m│ 2 │<ESC>[0m     <ESC>[95mreturn<ESC>[0m <ESC>[92mf"Hello {name}"<ESC>[0m
+<ESC>[2;37m└──────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m javascript <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[95mconst<ESC>[0m greet <ESC>[96m=<ESC>[0m (name) <ESC>[96m=><ESC>[0m <ESC>[92m`Hello ${name}`<ESC>[0m;
+<ESC>[2;37m└──────────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m typescript <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[95minterface<ESC>[0m <ESC>[94mUser<ESC>[0m { <ESC>[93mid<ESC>[0m<ESC>[93m: number<ESC>[0m }
+<ESC>[2;37m└──────────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m rust <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[95mfn<ESC>[0m main() { <ESC>[96mprintln<ESC>[0m<ESC>[96m!<ESC>[0m(<ESC>[92m"hello"<ESC>[0m); }
+<ESC>[2;37m└────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m go <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[95mpackage<ESC>[0m main
+<ESC>[2;37m│ 2 │<ESC>[0m <ESC>[95mfunc<ESC>[0m main() { <ESC>[96mprintln<ESC>[0m(<ESC>[92m"hello"<ESC>[0m) }
+<ESC>[2;37m└────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m cpp <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m std<ESC>[96m::<ESC>[0m<ESC>[94mvector<ESC>[0m<ESC>[96m<<ESC>[0m<ESC>[94mint<ESC>[0m<ESC>[96m><ESC>[0m values{<ESC>[91m1<ESC>[0m, <ESC>[91m2<ESC>[0m, <ESC>[91m3<ESC>[0m};
+<ESC>[2;37m└────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m java <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[95mrecord<ESC>[0m User(<ESC>[95mlong<ESC>[0m id, <ESC>[94mString<ESC>[0m name) {}
+<ESC>[2;37m└────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m sql <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[95mSELECT<ESC>[0m id <ESC>[95mFROM<ESC>[0m users <ESC>[95mWHERE<ESC>[0m active <ESC>[96m=<ESC>[0m <ESC>[95mtrue<ESC>[0m;
+<ESC>[2;37m└────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m json <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m {<ESC>[92m"name"<ESC>[0m: <ESC>[92m"afm"<ESC>[0m, <ESC>[92m"ready"<ESC>[0m: <ESC>[95mtrue<ESC>[0m}
+<ESC>[2;37m└────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m yaml <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[92mname<ESC>[0m: <ESC>[92mafm<ESC>[0m
+<ESC>[2;37m│ 2 │<ESC>[0m <ESC>[92mready<ESC>[0m: <ESC>[92mtrue<ESC>[0m
+<ESC>[2;37m└────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m html <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[96m<<ESC>[0m<ESC>[95mmain<ESC>[0m <ESC>[93mclass="app"<ESC>[0m<ESC>[96m><ESC>[0mHello</<ESC>[95mmain<ESC>[0m<ESC>[96m><ESC>[0m
+<ESC>[2;37m└────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m css <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m .app { <ESC>[93mcolor<ESC>[0m: rebeccapurple; }
+<ESC>[2;37m└────────<ESC>[0m
+
+<ESC>[2;37m┌─<ESC>[0m<ESC>[96m bash <ESC>[0m
+<ESC>[2;37m│ 1 │<ESC>[0m <ESC>[95mif<ESC>[0m <ESC>[95mtrue<ESC>[0m; <ESC>[95mthen<ESC>[0m echo <ESC>[92m"ready"<ESC>[0m; <ESC>[95mfi<ESC>[0m
+<ESC>[2;37m└────────<ESC>[0m

--- a/Tests/TUIHarness/Tests/AFMTerminalUIHarnessTests/TUISnapshotTests.swift
+++ b/Tests/TUIHarness/Tests/AFMTerminalUIHarnessTests/TUISnapshotTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import XCTest
+import AFMTerminalUI
+
+final class TUISnapshotTests: XCTestCase {
+    func testFeatureRichAssistantTurnAtMacTerminalWidth() throws {
+        let markdown = #"""
+        # Calculus workspace
+
+        For $f: D \subseteq \mathbb{R} \to \mathbb{R}$,
+
+        $$
+        f'(a) = \lim_{h \to 0} \frac{f(a+h)-f(a)}{h}
+        $$
+
+        > The same response can contain prose, math, source, and a patch.
+
+        ```swift
+        struct Gradient {
+            let values: [Double]
+            func magnitude() -> Double { values.reduce(0) { $0 + $1 * $1 }.squareRoot() }
+        }
+        ```
+
+        ```diff
+        -let method = "finite differences"
+        +let method = "automatic differentiation"
+        ```
+
+        | Surface | Shortcut |
+        |---|---|
+        | Transcript | Ctrl-T |
+        | Blocks | `/blocks` |
+        """#
+
+        let rendered = TerminalMarkdownRenderer(color: true, theme: .dark)
+            .render(markdown, width: 88, hyperlinks: false)
+
+        try assertSnapshot(
+            named: "feature-rich-turn",
+            value: visibleEscapes(rendered.text)
+        )
+        XCTAssertEqual(rendered.codeBlocks.map(\.language), ["swift", "diff"])
+    }
+
+    func testCalculusRegressionPromptHasNoRawTeXLeakage() throws {
+        let response = #"""
+        ## Limits and continuity
+        A limit $\lim_{x \to c} f(x)=L$ means
+        $$\forall \epsilon > 0, \exists \delta > 0 \text{ such that } |x-c|<\delta \implies |f(x)-L|<\epsilon.$$
+
+        ## Single-variable calculus
+        $$f'(a)=\lim_{h\to0}\frac{f(a+h)-f(a)}{h}, \qquad
+        \int_a^b f(x)\,dx=\lim_{n\to\infty}\sum_{i=1}^n f(t_i)\Delta x_i.$$
+
+        ## Multivariable calculus
+        For $f:\mathbb{R}^n\to\mathbb{R}$, the gradient is
+        $$\nabla f(\mathbf a)=\left(\frac{\partial f}{\partial x_1},\dots,\frac{\partial f}{\partial x_n}\right).$$
+        """#
+
+        let text = TerminalMarkdownRenderer(color: false).render(response, width: 88).text
+        try assertSnapshot(named: "calculus-regression", value: text)
+
+        for token in ["$$", "\\mathbb", "\\lim", "\\frac", "\\partial", "\\mathbf", "\\text"] {
+            XCTAssertFalse(text.contains(token), "raw TeX leaked into terminal output: \(token)")
+        }
+    }
+
+    func testPopularFenceFormatsProduceStableHighlightedOutput() throws {
+        let fixtures: [(String, String)] = [
+            ("swift", "let answer: Int = 42"),
+            ("python", "def greet(name):\n    return f\"Hello {name}\""),
+            ("javascript", "const greet = (name) => `Hello ${name}`;"),
+            ("typescript", "interface User { id: number }"),
+            ("rust", "fn main() { println!(\"hello\"); }"),
+            ("go", "package main\nfunc main() { println(\"hello\") }"),
+            ("cpp", "std::vector<int> values{1, 2, 3};"),
+            ("java", "record User(long id, String name) {}"),
+            ("sql", "SELECT id FROM users WHERE active = true;"),
+            ("json", "{\"name\": \"afm\", \"ready\": true}"),
+            ("yaml", "name: afm\nready: true"),
+            ("html", "<main class=\"app\">Hello</main>"),
+            ("css", ".app { color: rebeccapurple; }"),
+            ("bash", "if true; then echo \"ready\"; fi")
+        ]
+        let markdown = fixtures.map { "```\($0.0)\n\($0.1)\n```" }.joined(separator: "\n\n")
+        let rendered = TerminalMarkdownRenderer(color: true, theme: .dark).render(markdown, width: 100)
+
+        try assertSnapshot(named: "popular-formats", value: visibleEscapes(rendered.text))
+        XCTAssertEqual(rendered.codeBlocks.map(\.language), fixtures.map(\.0))
+        XCTAssertEqual(rendered.codeBlocks.map(\.content), fixtures.map(\.1))
+    }
+
+    private func visibleEscapes(_ value: String) -> String {
+        value.replacingOccurrences(of: "\u{001B}", with: "<ESC>")
+    }
+
+    private func assertSnapshot(named name: String, value: String, file: StaticString = #filePath, line: UInt = #line) throws {
+        let normalizedValue = value
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map {
+                String($0).replacingOccurrences(
+                    of: #"\s+$"#,
+                    with: "",
+                    options: .regularExpression
+                )
+            }
+            .joined(separator: "\n")
+        let snapshotURL = Bundle.module.url(forResource: name, withExtension: "snap", subdirectory: "Snapshots")
+        let record = ProcessInfo.processInfo.environment["AFM_RECORD_TUI_SNAPSHOTS"] == "1"
+        if record {
+            let sourceDirectory = URL(fileURLWithPath: String(describing: file))
+                .deletingLastPathComponent()
+                .appendingPathComponent("Snapshots", isDirectory: true)
+            try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+            try (normalizedValue + "\n").write(to: sourceDirectory.appendingPathComponent("\(name).snap"), atomically: true, encoding: .utf8)
+            return
+        }
+        guard let snapshotURL else {
+            XCTFail("Missing snapshot \(name). Run Scripts/test-tui.sh --record.", file: file, line: line)
+            return
+        }
+        let expected = try String(contentsOf: snapshotURL, encoding: .utf8)
+        XCTAssertEqual(normalizedValue + "\n", expected, file: file, line: line)
+    }
+}

--- a/Tests/TUIHarness/Tests/AFMTerminalUIHarnessTests/TerminalPTYTests.swift
+++ b/Tests/TUIHarness/Tests/AFMTerminalUIHarnessTests/TerminalPTYTests.swift
@@ -1,0 +1,181 @@
+import Darwin
+import Foundation
+import XCTest
+import AFMTerminalUI
+
+final class TerminalPTYTests: XCTestCase {
+    func testMacKeyboardSequencesThroughARealPTY() throws {
+        let pty = try PTYFixture()
+        defer { pty.close() }
+        let terminal = TerminalIO(inputFD: pty.slave, outputFD: pty.slave)
+        try terminal.enter()
+        defer { terminal.restore() }
+
+        try pty.send([13])
+        XCTAssertEqual(terminal.readKey(), .enter)
+        try pty.send([27, 13])
+        XCTAssertEqual(terminal.readKey(), .newline)
+        try pty.send([20])
+        XCTAssertEqual(terminal.readKey(), .openTranscript)
+        try pty.send([21])
+        XCTAssertEqual(terminal.readKey(), .halfPageUp)
+        try pty.send([9])
+        XCTAssertEqual(terminal.readKey(), .tab)
+        try pty.send([27, 91, 65])
+        XCTAssertEqual(terminal.readKey(), .up)
+        try pty.send([27, 91, 66])
+        XCTAssertEqual(terminal.readKey(), .down)
+        try pty.send([27, 91, 67])
+        XCTAssertEqual(terminal.readKey(), .right)
+        try pty.send([27, 91, 68])
+        XCTAssertEqual(terminal.readKey(), .left)
+        try pty.send([27, 91, 72])
+        XCTAssertEqual(terminal.readKey(), .home)
+        try pty.send([27, 91, 70])
+        XCTAssertEqual(terminal.readKey(), .end)
+        try pty.send([27, 91, 53, 126])
+        XCTAssertEqual(terminal.readKey(), .pageUp)
+        try pty.send([27, 91, 54, 126])
+        XCTAssertEqual(terminal.readKey(), .pageDown)
+        try pty.send(Array("🧪".utf8))
+        XCTAssertEqual(terminal.readKey(), .text("🧪"))
+    }
+
+    func testRawModeAndAlternateScreenAreAlwaysRestored() throws {
+        let pty = try PTYFixture()
+        defer { pty.close() }
+        let before = try pty.attributes()
+        let terminal = TerminalIO(inputFD: pty.slave, outputFD: pty.slave)
+
+        try terminal.enter()
+        let raw = try pty.attributes()
+        XCTAssertEqual(raw.c_lflag & tcflag_t(ICANON), 0)
+        XCTAssertEqual(raw.c_lflag & tcflag_t(ECHO), 0)
+        terminal.enterAlternateScreen()
+        terminal.hideCursor()
+        // Drain the PTY before tcsetattr(TCSAFLUSH): a real terminal emulator is
+        // concurrently consuming these bytes, while an unattended PTY is not.
+        let enteredOutput = try pty.receiveUntilQuiet()
+        terminal.restore()
+        terminal.restore()
+
+        let restored = try pty.attributes()
+        XCTAssertEqual(restored.c_lflag & tcflag_t(ICANON), before.c_lflag & tcflag_t(ICANON))
+        XCTAssertEqual(restored.c_lflag & tcflag_t(ECHO), before.c_lflag & tcflag_t(ECHO))
+
+        let output = enteredOutput + (try pty.receiveUntilQuiet())
+        XCTAssertTrue(output.contains("\u{001B}[?1049h"), "alternate screen was never entered")
+        XCTAssertTrue(output.contains("\u{001B}[?1007h"), "alternate scroll was never enabled")
+        XCTAssertTrue(output.contains("\u{001B}[?1007l"), "alternate scroll was not disabled")
+        XCTAssertTrue(output.contains("\u{001B}[?25h"), "cursor was not restored")
+        XCTAssertTrue(output.contains("\u{001B}[?1049l"), "alternate screen was not left")
+    }
+
+    func testWindowDimensionsComeFromPTY() throws {
+        let pty = try PTYFixture(rows: 41, columns: 117)
+        defer { pty.close() }
+        let terminal = TerminalIO(inputFD: pty.slave, outputFD: pty.slave)
+        XCTAssertEqual(terminal.width(), 117)
+        XCTAssertEqual(terminal.height(), 41)
+    }
+
+    func testNonInteractiveInvocationFailsBeforeModelLoading() {
+        XCTAssertThrowsError(try TUIInvocationPolicy.validate(
+            tui: true,
+            webUI: false,
+            singlePrompt: false,
+            inputIsTTY: false,
+            outputIsTTY: true
+        )) { error in
+            XCTAssertEqual(
+                error as? TUIInvocationError,
+                .conflict("--tui requires interactive terminal input")
+            )
+        }
+        XCTAssertNoThrow(try TUIInvocationPolicy.validate(
+            tui: true,
+            webUI: false,
+            singlePrompt: false,
+            inputIsTTY: true,
+            outputIsTTY: true
+        ))
+    }
+
+    func testModelOutputCannotInjectTerminalControlSequences() {
+        XCTAssertEqual(
+            TerminalOutputSanitizer.sanitize("safe\u{001B}[2J\u{0007}text\tend"),
+            "safe�[2J�text    end"
+        )
+    }
+}
+
+private final class PTYFixture {
+    let master: Int32
+    let slave: Int32
+    private var isClosed = false
+
+    init(rows: UInt16 = 30, columns: UInt16 = 100) throws {
+        var master: Int32 = -1
+        var slave: Int32 = -1
+        var size = winsize(ws_row: rows, ws_col: columns, ws_xpixel: 0, ws_ypixel: 0)
+        guard openpty(&master, &slave, nil, nil, &size) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        self.master = master
+        self.slave = slave
+    }
+
+    func send(_ bytes: [UInt8]) throws {
+        let count = bytes.withUnsafeBytes { buffer in
+            Darwin.write(master, buffer.baseAddress, buffer.count)
+        }
+        guard count == bytes.count else { throw POSIXError(.EIO) }
+    }
+
+    func attributes() throws -> termios {
+        var value = termios()
+        guard tcgetattr(slave, &value) == 0 else { throw POSIXError(.EIO) }
+        return value
+    }
+
+    func receiveUntilQuiet() throws -> String {
+        var data = Data()
+        while true {
+            var readSet = fd_set()
+            readSet.zero()
+            readSet.set(master)
+            var timeout = timeval(tv_sec: 0, tv_usec: 50_000)
+            let ready = select(master + 1, &readSet, nil, nil, &timeout)
+            if ready == 0 { break }
+            guard ready > 0 else { throw POSIXError(.EIO) }
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            let count = Darwin.read(master, &buffer, buffer.count)
+            guard count > 0 else { break }
+            data.append(contentsOf: buffer.prefix(count))
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    func close() {
+        guard !isClosed else { return }
+        isClosed = true
+        Darwin.close(master)
+        Darwin.close(slave)
+    }
+
+    deinit { close() }
+}
+
+private extension fd_set {
+    mutating func zero() { self = fd_set() }
+
+    mutating func set(_ descriptor: Int32) {
+        let offset = Int(descriptor) / 32
+        let bit = Int(descriptor) % 32
+        withUnsafeMutablePointer(to: &fds_bits) { pointer in
+            pointer.withMemoryRebound(to: Int32.self, capacity: 32) { words in
+                words[offset] |= 1 << bit
+            }
+        }
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -406,6 +406,8 @@ if ! FINAL_BIN="$($SCRIPTS_DIR/find-afm-binary.sh "$BUILD_CONFIG")"; then
   exit 1
 fi
 
+"$SCRIPTS_DIR/check-tree-sitter-highlighting.sh" "$FINAL_BIN"
+
 if [ "$BUILD_CONFIG" = "release" ]; then
   strip "$FINAL_BIN"
   log_info "Stripped debug symbols"

--- a/docs/tui-syntax-highlighting.md
+++ b/docs/tui-syntax-highlighting.md
@@ -1,0 +1,48 @@
+# TUI syntax highlighting
+
+AFM's terminal UI uses Tree-sitter for grammar-backed code highlighting. The
+runtime, Swift binding, and each grammar are pinned in `Package.swift`; the
+parsers are compiled and linked into `afm`. There is no runtime download,
+external executable, JavaScript engine, optional import, or grammar lookup.
+
+Supported fence labels are Bash, C, C++, C#, CSS, diff, Go, HTML, Java,
+JavaScript/JSX, JSON, Kotlin, Markdown, PHP, Python, Ruby, Rust, SQL, Swift,
+TOML, TSX, TypeScript, and YAML. Common aliases such as `sh`, `zsh`, `c++`,
+`c#`, `jsx`, `py`, `rb`, `rs`, `ts`, and `yml` resolve to those parsers.
+Unknown labels retain the small safe fallback lexer.
+
+The breadth is not free: generated parser tables add tens of megabytes to the
+universal CLI compared with the former handwritten lexer. This is an explicit
+tradeoff for deterministic offline coverage; Homebrew users still receive a
+precompiled binary and do not compile or download grammars at runtime.
+
+## Why Tree-sitter
+
+- Tree-sitter is native, incremental, error-tolerant, and gives AFM syntax
+  structure without embedding a browser or JavaScript VM.
+- Shiki is an excellent modern TextMate-compatible highlighter, but its normal
+  execution model is JavaScript/Wasm plus Oniguruma and its output is aimed at
+  HTML rather than ANSI terminal spans.
+- highlight.js, used by llama.cpp's Web UI, is a strong browser choice but is a
+  lexical JavaScript highlighter. Embedding it in the native CLI would require
+  JavaScriptCore and HTML-to-ANSI translation.
+- Neon is a promising Swift Tree-sitter editor layer, but it is a broader text
+  system and its project still describes the main branch as not ready for a
+  release. AFM only needs deterministic, read-only code-block rendering.
+
+## Build integrity
+
+Direct imports make every promised grammar a compile-time dependency. Tests
+parse a sentinel with all 23 grammars and verify each grammar ABI against the
+pinned Tree-sitter runtime. Popular-language fixtures also cover malformed,
+multiline, and Unicode input.
+
+Four official grammar manifests use a working-directory-sensitive check that
+can omit their external C scanners when consumed transitively. AFM therefore
+pins licensed copies of those scanners in `AFMTreeSitterScanners`; missing
+scanner code is a hard final-link failure. See that target's README for source
+revisions and update requirements.
+
+The highlighter refuses blocks larger than 1 MB. This keeps adversarial or
+accidentally enormous generated blocks from monopolizing the interactive TUI;
+the original code remains displayed unmodified through the fallback path.


### PR DESCRIPTION
## Summary

Adds a native full-screen terminal chat mode exposed as `--tui` for Apple Foundation Models and `afm mlx -m <model>`. The UI reuses `AFMEngine` and the existing runtime/model configuration paths, so it does not duplicate inference logic or start an HTTP server.

## Architecture

- Adds `AFMTerminalUI` for terminal lifecycle/input, CommonMark rendering, persisted sessions, artifact actions, and the chat state machine.
- Parses Markdown/GFM with the Swift project’s cmark-gfm-backed `swift-markdown` package, then renders an AFM-owned inert ANSI representation.
- Extends Foundation streaming through `AFMEngine`, including cancellation propagation and guided JSON support.
- Plumbs normal Foundation and MLX runtime, sampling, cache, speculative decoding, grammar, tools, VLM, and media options into the existing engine.
- Keeps DwarfStar GGUF explicit: `--tui` currently rejects that backend because it is not represented by the shared `AFMEngine` backend.

## Terminal rendering and UX

- Full-screen streaming chat with multiline input, prompt navigation, cancellation, resize handling, Unicode-aware display width, status, tokens, and throughput.
- CommonMark/GFM syntax-tree rendering for headings, paragraphs, strong/emphasis/strike, inline code, links, images, quotes, nested ordered/unordered/task lists, thematic breaks, and width-aware tables.
- Dedicated terminal math rendering for inline and display LaTeX: fractions, roots, super/subscripts, common operators and Greek symbols, matrices, and cases. Unmatched dollar signs and currency remain intact.
- Fenced code panels with line numbers and token-aware highlighting for keywords, types, calls, strings, numbers, and comments. Unified diffs distinguish file headers, hunks, additions, deletions, and context.
- Reasoning, streamed answers, `/reasoning show`, and resumed transcripts all use the same renderer.
- Capability-gated OSC-8 links, no-color/mono fallbacks, and distinct dark/light palettes.
- Model control characters are made inert before parsing so output cannot inject terminal commands.
- Slash commands cover help, new/clear, retry/edit-last, persisted history/search/resume, transcript export, themes, attachments, code block listing/copy/save/browser preview, and image display.
- Sessions are searchable JSON under `~/.afm/sessions`; Terminal.app uses Quick Look for images while iTerm2 and Kitty use detected inline protocols.

## Security boundaries

- Model-produced code and HTML are never executed automatically.
- File saves use exclusive creation by default, require an explicit bang command for overwrites, reject symlink/non-regular overwrite targets, and use owner-only permissions.
- Only explicit HTML/JavaScript block actions create browser previews. HTML is placed in a sandboxed iframe and preview pages use a restrictive CSP.
- Clipboard, browser, and Quick Look actions use fixed system executable paths with argument arrays rather than a shell.
- Non-TTY, piped-input, WebUI, one-shot, raw/JSON, gateway, Telegram, and incompatible backend combinations fail before model loading.

## Validation

Passed on the final branch:

- `Scripts/swiftpm-reliable.sh build --target AFMTerminalUI`
- `Scripts/swiftpm-reliable.sh build --target AFMCLI`
- `Scripts/swiftpm-reliable.sh build -c release --product afm`
- Focused wrapper XCTest package: 19 tests, 19 passed, 0 failures.
- Renderer coverage includes CommonMark/GFM structures, nested/task lists, tables, links, local/remote images, typed/untyped/unclosed fences, currency-safe inline math, display matrices/fractions, syntax tokens, diffs, themes, capability-gated hyperlinks, and control-character neutralization.
- Existing focused coverage also validates artifact CSP/sandboxing/no-execution, exclusive and symlink-safe saves, session persistence/search/export, macOS key sequences and Unicode input, terminal cleanup, and invocation conflicts.
- `Scripts/check-mlx-source-selection.sh` resolves `vendor/mlx-swift-lm`.
- Release CLI smoke: both root and MLX help expose `--tui`; both reject noninteractive invocation with exit 64 before model resolution.
- `git diff --check`.

Full repository XCTest discovery was also attempted but remains blocked before tests by existing toolchain boundaries unrelated to this target: Xcode 26 cannot compile the repository FoundationModels27 API surface, while the available Xcode 27 beta reaches AFM compilation but the MLX generated Metal build fails before producing its diagnostic file. The focused XCTest package was run through the required wrapper to validate the complete TUI surface despite that baseline graph issue.

## Summary by Sourcery

Add a secure native terminal chat experience for Foundation Models and MLX with rich rendering, session controls, offline syntax highlighting, and focused validation.

New Features:
- Add a native full-screen terminal chat mode for Foundation Models and MLX through the `--tui` option.
- Provide rich inert terminal rendering for CommonMark/GFM, mathematics, code, diffs, tables, links, images, reasoning, and themes.
- Add persisted searchable sessions, transcript controls, attachments, artifact actions, and explicit browser/image previews with safety boundaries.
- Compile and link pinned Tree-sitter grammars for syntax highlighting across 23 languages with safe fallbacks for unknown or oversized blocks.

Bug Fixes:
- Improve Foundation Models streaming cancellation, stop-sequence handling, guided JSON responses, transcript restoration, and serialized session operations.
- Prevent terminal control-sequence injection and make artifact saves, previews, file reads, and media handling safer.
- Standardize the MLX default response-token limit at 8,192 across CLI and server paths.

Enhancements:
- Reuse AFMEngine and shared runtime configuration for interactive Foundation Models and MLX conversations without starting a server.
- Add terminal lifecycle management, pseudo-terminal input handling, resize-aware rendering, alternate-screen overlays, and output isolation for backend diagnostics.

Build:
- Add pinned Markdown and Tree-sitter dependencies, explicit scanner sources, grammar integrity checks, and build-time linked-symbol validation.

CI:
- Add a focused macOS Terminal UI workflow covering snapshot and pseudo-terminal tests.

Documentation:
- Document native terminal chat usage, commands, safety behavior, rendering capabilities, and Tree-sitter highlighting tradeoffs.

Tests:
- Add extensive renderer, artifact-security, session-persistence, engine-ordering, terminal-lifecycle, snapshot, and real-PTY coverage.

## Tree-sitter highlighting update

- Replaces the handwritten known-language lexer with source-compiled Tree-sitter 0.25.10 and SwiftTreeSitter 0.25.0.
- Pins every grammar revision and supports 23 compiled languages: Bash, C, C++, C#, CSS, diff, Go, HTML, Java, JavaScript/JSX, JSON, Kotlin, Markdown, PHP, Python, Ruby, Rust, SQL, Swift, TOML, TSX, TypeScript, and YAML.
- Keeps unknown fence labels on the safe fallback lexer and caps grammar parsing at 1 MB per block.
- Adds ABI/sentinel checks for all grammars, major-format fixtures, malformed/multiline/Unicode coverage, and a source-hash plus linked-symbol audit wired into make build and build.sh.
- Ships no runtime grammar download, optional import, external executable, JavaScript engine, or Tree-sitter resource bundle. A relocated standalone binary retains highlighting.
- Documents the choice against Shiki, highlight.js, and Neon in docs/tui-syntax-highlighting.md.
- Tradeoff: broad generated parser tables add tens of megabytes. The measured final stripped local binary is 93.5 MB; Homebrew users still receive it precompiled.

Additional validation: release afm build passed; focused renderer suite passed 18/18; all 23 linked symbols and pinned scanner hashes passed; relocated binary help/version smoke passed; MLX source-selection and git diff checks passed.
