### PR TITLE
Add bundled model evaluations

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,7 +46,7 @@ jobs:
         cp Resources/webui/index.html.gz release-package/Resources/webui/
 
         # Copy required runtime resource bundles beside the executable.
-        for BUNDLE_NAME in MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
+        for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
           BUNDLE_DIR=$(dirname "$BIN")/$BUNDLE_NAME
           test -d "$BUNDLE_DIR"
           cp -r "$BUNDLE_DIR" release-package/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         cp Resources/webui/index.html.gz release-package/Resources/webui/
         Scripts/verify-webui.sh release-package/Resources/webui/index.html.gz
 
-        for BUNDLE_NAME in MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
+        for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
           BUNDLE_DIR=.build/arm64-apple-macosx/release/$BUNDLE_NAME
           test -d "$BUNDLE_DIR"
           cp -r "$BUNDLE_DIR" release-package/

--- a/Package.swift
+++ b/Package.swift
@@ -276,6 +276,9 @@ let package = Package(
                 "AFMKitFoundationModels",
                 "AFMKitServices"
             ],
+            resources: [
+                .copy("Resources/Evals")
+            ],
             swiftSettings: [
                 // Enable optimizations for release builds
                 .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release)),

--- a/README.md
+++ b/README.md
@@ -154,6 +154,28 @@ can display local images inline; Terminal.app uses an explicit `/image` Quick Lo
 
 Model IDs without an organization default to `mlx-community`, so `Qwen3-0.6B-4bit` and `mlx-community/Qwen3-0.6B-4bit` both work.
 
+## Evaluate a local model
+
+AFM ships all 91 labeled variants from the repository's comprehensive MLX test as a
+deterministic, no-judge suite. The model loads once, every output and timing measurement is
+retained locally, and a self-contained HTML report opens when the run finishes.
+
+```bash
+afm mlx -m mlx-community/Qwen3-0.6B-4bit --eval
+
+# Headless run, suite discovery, and custom-suite scaffolding
+afm mlx -m <model> --eval --no-open
+afm mlx --eval-list
+afm mlx --eval-init my-suite
+afm mlx --eval-validate ~/.afm/evals/my-suite.json
+afm mlx -m <model> --eval-suite comprehensive --eval-suite my-suite
+```
+
+Run artifacts are stored in collision-safe
+`~/.afm/evals/<date-time>-<model>-<suite>/` directories. See
+[Local model evaluations](docs/model-evaluations.md) for the suite schema, deterministic
+checks, report contents, and security limits.
+
 ## Why AFM works well for agents
 
 AFM is built for multi-turn, tool-using clients—not only chat demos.

--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -54,7 +54,7 @@ sed -i '' "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject-next.toml
 echo "[INFO] Staging assets into macafm_next/"
 mkdir -p macafm_next/bin
 cp "$BIN" macafm_next/bin/
-for BUNDLE_NAME in MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
+for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
     BUNDLE_DIR="$(dirname "$BIN")/$BUNDLE_NAME"
     if [ ! -d "$BUNDLE_DIR" ]; then
         echo "[ERROR] Required runtime bundle missing: $BUNDLE_DIR"

--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -123,4 +123,11 @@ unzip -p "$WHL" macafm_next/share/webui/index.html.gz > "$WHEEL_WEBUI"
 "$REPO_ROOT/Scripts/verify-webui.sh" "$WHEEL_WEBUI"
 rm -f "$WHEEL_WEBUI"
 
+if ! unzip -Z1 "$WHL" | grep -E \
+    '^macafm_next/bin/MacLocalAPI_AFMKit\.bundle/(Evals/|Contents/Resources/Evals/)comprehensive\.json$' \
+    >/dev/null; then
+    echo "[ERROR] Wheel is missing the bundled comprehensive evaluation suite"
+    exit 1
+fi
+
 echo "[INFO] Done. Wheel ready: $WHL"

--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -13,6 +13,26 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Nightly wheel metadata is temporary build input, not a source change. Keep
+# exact copies outside the checkout and restore them on every exit path so a
+# failed build cannot leave the release branch dirty.
+METADATA_BACKUP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/afm-nightly-wheel.XXXXXX")"
+cp pyproject.toml "$METADATA_BACKUP_DIR/pyproject.toml"
+cp pyproject-next.toml "$METADATA_BACKUP_DIR/pyproject-next.toml"
+cp macafm_next/__init__.py "$METADATA_BACKUP_DIR/macafm-next-init.py"
+mkdir "$METADATA_BACKUP_DIR/egg-info"
+cp macafm_next.egg-info/* "$METADATA_BACKUP_DIR/egg-info/"
+
+cleanup() {
+    cp "$METADATA_BACKUP_DIR/pyproject.toml" pyproject.toml
+    cp "$METADATA_BACKUP_DIR/pyproject-next.toml" pyproject-next.toml
+    cp "$METADATA_BACKUP_DIR/macafm-next-init.py" macafm_next/__init__.py
+    cp "$METADATA_BACKUP_DIR/egg-info/"* macafm_next.egg-info/
+    rm -rf "$REPO_ROOT/macafm_next/bin" "$REPO_ROOT/macafm_next/share"
+    rm -rf "$METADATA_BACKUP_DIR"
+}
+trap cleanup EXIT
+
 # ---------- parse args ----------
 BASE_VERSION=""
 while [[ $# -gt 0 ]]; do
@@ -73,16 +93,13 @@ cp Resources/webui/index.html.gz macafm_next/share/webui/
 echo "[INFO] Included webui"
 
 # ---------- build wheel ----------
-# Use pyproject-next.toml by temporarily swapping it in
-cp pyproject.toml pyproject.toml.bak
+# Use pyproject-next.toml by temporarily swapping it in. The EXIT trap restores
+# the original even when uv or a later verification command fails.
 cp pyproject-next.toml pyproject.toml
 
 echo "[INFO] Building wheel..."
 rm -rf dist/macafm_next-*
 uv build --wheel 2>&1
-
-# Restore original pyproject.toml
-mv pyproject.toml.bak pyproject.toml
 
 # ---------- clean staged assets ----------
 rm -rf macafm_next/bin macafm_next/share

--- a/Scripts/create-tarball.sh
+++ b/Scripts/create-tarball.sh
@@ -96,7 +96,7 @@ fi
 DIRNAME="afm-${VERSION}-${ARCH}"
 mkdir -p "$STAGING/$DIRNAME/Resources/webui"
 cp "$BIN" "$STAGING/$DIRNAME/"
-for BUNDLE_NAME in MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
+for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
   BUNDLE_DIR="$(dirname "$BIN")/$BUNDLE_NAME"
   if [ ! -d "$BUNDLE_DIR" ]; then
     log_error "Required runtime bundle missing: $BUNDLE_DIR"

--- a/Scripts/generate-tap-versioned.sh
+++ b/Scripts/generate-tap-versioned.sh
@@ -106,6 +106,9 @@ class ${class} < Formula
 
   def install
     bin.install "afm"
+    if File.directory?("MacLocalAPI_AFMKit.bundle")
+      (libexec/"MacLocalAPI_AFMKit.bundle").install Dir["MacLocalAPI_AFMKit.bundle/*"]
+    end
     if File.directory?("MacLocalAPI_AFMKitMLX.bundle")
       (libexec/"MacLocalAPI_AFMKitMLX.bundle").install Dir["MacLocalAPI_AFMKitMLX.bundle/*"]
     end
@@ -115,6 +118,11 @@ class ${class} < Formula
   end
 
   def post_install
+    eval_bundle_src = libexec/"MacLocalAPI_AFMKit.bundle"
+    eval_bundle_dst = HOMEBREW_PREFIX/"bin/MacLocalAPI_AFMKit.bundle"
+    eval_bundle_dst.unlink if eval_bundle_dst.symlink? || eval_bundle_dst.exist?
+    eval_bundle_dst.make_symlink(eval_bundle_src) if eval_bundle_src.exist?
+
     bundle_src = libexec/"MacLocalAPI_AFMKitMLX.bundle"
     bundle_dst = HOMEBREW_PREFIX/"bin/MacLocalAPI_AFMKitMLX.bundle"
     bundle_dst.unlink if bundle_dst.symlink? || bundle_dst.exist?
@@ -161,6 +169,7 @@ class ${class} < Formula
 
   def install
     libexec.install "afm"
+    libexec.install "MacLocalAPI_AFMKit.bundle"
     libexec.install "MacLocalAPI_AFMKitMLX.bundle"
     libexec.install "MacLocalAPI_AFMKitDwarfStar.bundle"
     (bin/"afm").write_env_script libexec/"afm", AFM_BUILD_VERSION: "v#{version}"

--- a/Scripts/publish-next.sh
+++ b/Scripts/publish-next.sh
@@ -153,9 +153,9 @@ fi
 
 cp "$BIN" "$STAGING/"
 
-# Runtime resource bundles. Both must remain beside the relocated executable:
-# MLX supplies its compiled Metal library and DwarfStar supplies Metal sources.
-for BUNDLE_NAME in MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
+# Runtime resource bundles must remain beside the relocated executable: AFMKit
+# supplies evaluation suites, MLX supplies its metallib, and DwarfStar supplies Metal sources.
+for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
   BUNDLE_DIR="$(dirname "$BIN")/$BUNDLE_NAME"
   if [ ! -d "$BUNDLE_DIR" ]; then
     log_error "Required runtime bundle missing: $BUNDLE_DIR"
@@ -282,6 +282,15 @@ sed -i '' "s/sha256 \".*\"/sha256 \"${SHA256}\"/" afm-next.rb
 
 if ! grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm-next.rb; then
   log_error "Homebrew nightly formula does not install the required WebUI"
+  exit 1
+fi
+if ! grep -Fq 'libexec.install "MacLocalAPI_AFMKit.bundle"' afm-next.rb; then
+  sed -i '' '/libexec.install "afm"/a\
+    libexec.install "MacLocalAPI_AFMKit.bundle"
+' afm-next.rb
+fi
+if ! grep -Fq 'libexec.install "MacLocalAPI_AFMKit.bundle"' afm-next.rb; then
+  log_error "Homebrew nightly formula does not install the bundled evaluation suites"
   exit 1
 fi
 

--- a/Scripts/publish-stable.sh
+++ b/Scripts/publish-stable.sh
@@ -314,6 +314,12 @@ WHEEL_WEBUI="$ROOT_DIR/.build/afm-stable-wheel-webui.html.gz"
 unzip -p "$STABLE_WHEEL" macafm/share/webui/index.html.gz > "$WHEEL_WEBUI"
 "$SCRIPT_DIR/verify-webui.sh" "$WHEEL_WEBUI"
 rm -f "$WHEEL_WEBUI"
+if ! unzip -Z1 "$STABLE_WHEEL" | grep -E \
+  '^macafm/bin/MacLocalAPI_AFMKit\.bundle/(Evals/|Contents/Resources/Evals/)comprehensive\.json$' \
+  >/dev/null; then
+  log_error "Stable wheel is missing the bundled comprehensive evaluation suite"
+  exit 1
+fi
 
 # Cleanup staged assets (don't commit binaries to git)
 rm -rf "$ROOT_DIR/macafm/bin" "$ROOT_DIR/macafm/share"

--- a/Scripts/publish-stable.sh
+++ b/Scripts/publish-stable.sh
@@ -136,8 +136,8 @@ mkdir -p "$STAGING"
 
 cp "$BIN" "$STAGING/"
 
-# Runtime resource bundles. Both must remain beside the relocated executable.
-for BUNDLE_NAME in MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
+# Runtime resource bundles must remain beside the relocated executable.
+for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
   BUNDLE_DIR="$(dirname "$BIN")/$BUNDLE_NAME"
   if [ ! -d "$BUNDLE_DIR" ]; then
     log_error "Required runtime bundle missing: $BUNDLE_DIR"
@@ -250,6 +250,15 @@ if ! grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm.
   log_error "Homebrew stable formula does not install the required WebUI"
   exit 1
 fi
+if ! grep -Fq 'libexec.install "MacLocalAPI_AFMKit.bundle"' afm.rb; then
+  sed -i '' '/libexec.install "afm"/a\
+    libexec.install "MacLocalAPI_AFMKit.bundle"
+' afm.rb
+fi
+if ! grep -Fq 'libexec.install "MacLocalAPI_AFMKit.bundle"' afm.rb; then
+  log_error "Homebrew stable formula does not install the bundled evaluation suites"
+  exit 1
+fi
 
 git add afm.rb
 git commit -m "afm ${VERSION}"
@@ -269,7 +278,7 @@ log_info "Staging assets into macafm/ for Python package..."
 mkdir -p "$ROOT_DIR/macafm/bin"
 cp "$BIN" "$ROOT_DIR/macafm/bin/"
 
-for BUNDLE_NAME in MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
+for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMKitMLX.bundle MacLocalAPI_AFMKitDwarfStar.bundle; do
   BUNDLE_DIR="$(dirname "$BIN")/$BUNDLE_NAME"
   if [ ! -d "$BUNDLE_DIR" ]; then
     log_error "Required runtime bundle missing: $BUNDLE_DIR"

--- a/Sources/AFMCLI/ModelEvaluationRunner.swift
+++ b/Sources/AFMCLI/ModelEvaluationRunner.swift
@@ -132,6 +132,7 @@ extension MlxCommand {
             stop: stop.map { $0.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) } },
             responseFormat: defaultResponseFormat
         )
+        try AFMEvaluationSuiteStore.validateParameters(baseParameters, context: "CLI")
         try AFMEvaluationRunPolicy.validatePlannedOutput(
             suites: suites,
             baseParameters: baseParameters)
@@ -163,7 +164,7 @@ extension MlxCommand {
                 prefillStepSize: prefillStepSize,
                 kvEvictionPolicy: kvEviction ?? "none",
                 fixToolArguments: fixToolArgs,
-                forceVLM: false,
+                forceVLM: vlm,
                 cacheProfilePath: cacheProfilePath,
                 trace: vv,
                 gpuCapturePath: gpuCapture,
@@ -426,6 +427,7 @@ extension MlxCommand {
             for suite in suites { args += ["--eval-suite", shellQuote(suite)] }
         }
         if !openReport { args.append("--no-open") }
+        if vlm { args.append("--vlm") }
         if let kvBits { args += ["--kv-bits", String(kvBits)] }
         if enablePrefixCaching { args.append("--enable-prefix-caching") }
         if mlxKernels != "native" { args += ["--mlx-kernels", shellQuote(mlxKernels)] }

--- a/Sources/AFMCLI/ModelEvaluationRunner.swift
+++ b/Sources/AFMCLI/ModelEvaluationRunner.swift
@@ -120,7 +120,7 @@ extension MlxCommand {
         let suites = try suiteNames.map { try store.load(named: $0) }
         let baseParameters = AFMEvaluationParameters(
             temperature: temperature ?? 0,
-            maxTokens: maxTokens ?? 256,
+            maxTokens: maxTokens,
             topP: topP,
             topK: topK,
             minP: minP,
@@ -262,9 +262,10 @@ extension MlxCommand {
                                 scoring.1.append(check)
                                 scoring.0 = scoring.1.allSatisfy(\.passed) ? .passed : .missed
                             }
-                            let tokensPerSecond = generated.completionTokens > 0
-                                ? Double(generated.completionTokens) / max(generated.generationTime ?? duration, 0.000_001)
-                                : nil
+                            let tokensPerSecond = AFMEvaluationRunPolicy.tokensPerSecond(
+                                completionTokens: generated.completionTokens,
+                                generationTime: generated.generationTime,
+                                duration: duration)
                             let result = AFMEvaluationCaseResult(
                                 suite: suite.name,
                                 caseID: testCase.id,
@@ -429,7 +430,7 @@ extension MlxCommand {
         if enablePrefixCaching { args.append("--enable-prefix-caching") }
         if mlxKernels != "native" { args += ["--mlx-kernels", shellQuote(mlxKernels)] }
         if let temperature { args += ["--temperature", String(temperature)] }
-        if let maxTokens { args += ["--max-tokens", String(maxTokens)] }
+        if maxTokens != 8_192 { args += ["--max-tokens", String(maxTokens)] }
         if let topP { args += ["--top-p", String(topP)] }
         if let topK { args += ["--top-k", String(topK)] }
         if let minP { args += ["--min-p", String(minP)] }

--- a/Sources/AFMCLI/ModelEvaluationRunner.swift
+++ b/Sources/AFMCLI/ModelEvaluationRunner.swift
@@ -3,11 +3,66 @@ import ArgumentParser
 import Darwin
 import Foundation
 
-nonisolated(unsafe) private var afmEvaluationInterrupted = false
+private final class AFMEvaluationInterruptController: @unchecked Sendable {
+    private let lock = NSLock()
+    private var interrupted = false
+    private var task: Task<Void, Never>?
 
-private func handleEvaluationInterrupt(_ signal: Int32) {
-    afmEvaluationInterrupted = true
-    FileHandle.standardError.write(Data("\nEvaluation interruption requested; preserving partial results…\n".utf8))
+    var isInterrupted: Bool {
+        lock.withLock { interrupted }
+    }
+
+    func register(task: Task<Void, Never>) {
+        let cancelImmediately = lock.withLock {
+            self.task = task
+            return interrupted
+        }
+        if cancelImmediately { task.cancel() }
+    }
+
+    @discardableResult
+    func requestInterruption() -> Bool {
+        let state = lock.withLock { () -> (Bool, Task<Void, Never>?) in
+            let firstRequest = !interrupted
+            interrupted = true
+            return (firstRequest, task)
+        }
+        state.1?.cancel()
+        return state.0
+    }
+}
+
+private final class AFMEvaluationSignalMonitor {
+    private let queue = DispatchQueue(label: "afm.evaluation.signals")
+    private var sources: [DispatchSourceSignal] = []
+    private var restorations: [() -> Void] = []
+
+    init(controller: AFMEvaluationInterruptController) {
+        for signalNumber in [SIGINT, SIGTERM] {
+            let previous = Darwin.signal(signalNumber, SIG_IGN)
+            restorations.append { _ = Darwin.signal(signalNumber, previous) }
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: queue)
+            source.setEventHandler {
+                if controller.requestInterruption() {
+                    FileHandle.standardError.write(Data(
+                        "\nEvaluation interruption requested; preserving partial results…\n".utf8))
+                }
+            }
+            source.resume()
+            sources.append(source)
+        }
+    }
+
+    func stop() {
+        guard !sources.isEmpty else { return }
+        sources.forEach { $0.cancel() }
+        queue.sync {}
+        restorations.reversed().forEach { $0() }
+        sources.removeAll()
+        restorations.removeAll()
+    }
+
+    deinit { stop() }
 }
 
 private struct EvaluationGeneration {
@@ -50,7 +105,13 @@ extension MlxCommand {
         }
     }
 
-    func runEvaluation(modelID: String, suites suiteNames: [String], openReport: Bool) throws {
+    func runEvaluation(
+        modelID: String,
+        suites suiteNames: [String],
+        openReport: Bool,
+        chatTemplateKwargs: [String: AFMJSONValue]?,
+        defaultResponseFormat: ResponseFormat?
+    ) throws {
         let store = AFMEvaluationSuiteStore()
         let suites = try suiteNames.map { try store.load(named: $0) }
         let resultDirectory = try store.makeRunDirectory(model: modelID, suites: suiteNames)
@@ -75,7 +136,8 @@ extension MlxCommand {
             seed: seed ?? 42,
             logprobs: maxLogprobs != nil,
             topLogprobs: maxLogprobs,
-            stop: stop.map { $0.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) } }
+            stop: stop.map { $0.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) } },
+            responseFormat: defaultResponseFormat
         )
         let engine = AFMEngine(
             backend: .mlx(modelID: modelID),
@@ -112,13 +174,13 @@ extension MlxCommand {
         let group = DispatchGroup()
         group.enter()
 
-        afmEvaluationInterrupted = false
-        signal(SIGINT, handleEvaluationInterrupt)
-        signal(SIGTERM, handleEvaluationInterrupt)
+        let interruptController = AFMEvaluationInterruptController()
+        let signalMonitor = AFMEvaluationSignalMonitor(controller: interruptController)
+        defer { signalMonitor.stop() }
         print("AFM evaluation → \(resultDirectory.path)")
         print("Loading \(modelID) once for \(suites.reduce(0) { $0 + $1.cases.count }) cases…")
 
-        Task {
+        let evaluationTask = Task {
             var results: [AFMEvaluationCaseResult] = []
             do {
                 let reporter = MLXLoadReporter(modelID: modelID)
@@ -129,12 +191,14 @@ extension MlxCommand {
                     reporter.updateDownload(progress)
                 })
                 reporter.finish(success: true)
+                try Task.checkCancellation()
 
                 let total = suites.reduce(0) { $0 + $1.cases.count }
                 var index = 0
                 for suite in suites {
+                    var outputsByCaseID: [String: String] = [:]
                     for testCase in suite.cases {
-                        if afmEvaluationInterrupted { break }
+                        if interruptController.isInterrupted { break }
                         index += 1
                         print("[\(index)/\(total)] \(suite.name)/\(testCase.id)…", terminator: " ")
                         fflush(stdout)
@@ -165,7 +229,10 @@ extension MlxCommand {
                                 topLogprobs: parameters.topLogprobs,
                                 stop: parameters.stop,
                                 tools: parameters.tools,
-                                responseFormat: parameters.responseFormat)
+                                responseFormat: parameters.responseFormat,
+                                metadata: chatTemplateKwargs.map {
+                                    ["chatTemplateKwargs": .object($0)]
+                                } ?? [:])
                             let generated = try await Self.generateEvaluationResponse(
                                 engine: engine,
                                 messages: messages,
@@ -178,7 +245,7 @@ extension MlxCommand {
                                 toolCallNames: generated.toolCalls.map(\.name),
                                 expectations: testCase.expectations)
                             if let matchID = testCase.expectations?.matchesCase {
-                                let matchingOutput = results.last { $0.caseID == matchID }?.output
+                                let matchingOutput = outputsByCaseID[matchID]
                                 let passed = matchingOutput == generated.content
                                 let check = AFMEvaluationCheckResult(
                                     name: "matchesCase",
@@ -213,19 +280,21 @@ extension MlxCommand {
                                 finishReason: generated.finishReason,
                                 parameters: parameters)
                             results.append(result)
+                            outputsByCaseID[testCase.id] = generated.content
                             try Self.appendJSONLine(result, to: resultsURL)
                             try Self.persistEvaluationReport(
                                 results: results,
                                 modelID: modelID,
                                 suites: suiteNames,
                                 startedAt: startedAt,
-                                interrupted: afmEvaluationInterrupted,
+                                interrupted: interruptController.isInterrupted,
                                 reproducibilityCommand: reproducibilityCommand,
                                 systemInfo: systemInfo,
                                 runURL: runURL,
                                 reportURL: reportURL)
                             print("\(scoring.0.rawValue) · \(generated.completionTokens) tok · \(String(format: "%.1f", tokensPerSecond ?? 0)) tok/s")
                         } catch {
+                            if interruptController.isInterrupted { break }
                             let duration = Date().timeIntervalSince(caseStart)
                             let result = AFMEvaluationCaseResult(
                                 suite: suite.name,
@@ -257,7 +326,7 @@ extension MlxCommand {
                                 modelID: modelID,
                                 suites: suiteNames,
                                 startedAt: startedAt,
-                                interrupted: afmEvaluationInterrupted,
+                                interrupted: interruptController.isInterrupted,
                                 reproducibilityCommand: reproducibilityCommand,
                                 systemInfo: systemInfo,
                                 runURL: runURL,
@@ -265,14 +334,14 @@ extension MlxCommand {
                             print("error")
                         }
                     }
-                    if afmEvaluationInterrupted { break }
+                    if interruptController.isInterrupted { break }
                 }
                 try Self.persistEvaluationReport(
                     results: results,
                     modelID: modelID,
                     suites: suiteNames,
                     startedAt: startedAt,
-                    interrupted: afmEvaluationInterrupted,
+                    interrupted: interruptController.isInterrupted,
                     reproducibilityCommand: reproducibilityCommand,
                     systemInfo: systemInfo,
                     runURL: runURL,
@@ -285,16 +354,21 @@ extension MlxCommand {
                     modelID: modelID,
                     suites: suiteNames,
                     startedAt: startedAt,
-                    interrupted: afmEvaluationInterrupted,
+                    interrupted: interruptController.isInterrupted,
                     reproducibilityCommand: reproducibilityCommand,
                     systemInfo: systemInfo,
                     runURL: runURL,
                     reportURL: reportURL)
-                output.value = .failure(error)
+                if interruptController.isInterrupted {
+                    output.value = .success(results)
+                } else {
+                    output.value = .failure(error)
+                }
             }
             await engine.unload()
             group.leave()
         }
+        interruptController.register(task: evaluationTask)
         group.wait()
 
         switch output.value {
@@ -303,10 +377,10 @@ extension MlxCommand {
             let misses = results.filter { $0.outcome == .missed }.count
             print("Report: \(reportURL.path)")
             print("Completed \(results.count) cases: \(misses) quality miss(es), \(errors) infrastructure error(s).")
-            if openReport && !afmEvaluationInterrupted && errors == 0 {
+            if openReport && !interruptController.isInterrupted && errors == 0 {
                 try Self.openReport(reportURL)
             }
-            if afmEvaluationInterrupted || errors > 0 {
+            if interruptController.isInterrupted || errors > 0 {
                 throw ExitCode.failure
             }
         case .failure(let error):
@@ -329,11 +403,35 @@ extension MlxCommand {
         if !openReport { args.append("--no-open") }
         if let kvBits { args += ["--kv-bits", String(kvBits)] }
         if enablePrefixCaching { args.append("--enable-prefix-caching") }
+        if mlxKernels != "native" { args += ["--mlx-kernels", shellQuote(mlxKernels)] }
+        if let temperature { args += ["--temperature", String(temperature)] }
+        if let maxTokens { args += ["--max-tokens", String(maxTokens)] }
+        if let topP { args += ["--top-p", String(topP)] }
+        if let topK { args += ["--top-k", String(topK)] }
+        if let minP { args += ["--min-p", String(minP)] }
+        if let repetitionPenalty { args += ["--repetition-penalty", String(repetitionPenalty)] }
+        if let presencePenalty { args += ["--presence-penalty", String(presencePenalty)] }
+        if let seed { args += ["--seed", String(seed)] }
+        if let maxLogprobs { args += ["--max-logprobs", String(maxLogprobs)] }
+        if let stop { args += ["--stop", shellQuote(stop)] }
+        if instructions != "You are a helpful assistant" {
+            args += ["--instructions", shellQuote(instructions)]
+        }
         if mtp { args.append("--mtp") }
+        if mtpDepth != 1 { args += ["--mtp-depth", String(mtpDepth)] }
         if let mtpModel { args += ["--mtp-model", shellQuote(mtpModel)] }
         if let eagle3 { args += ["--eagle3", shellQuote(eagle3)] }
         if let parser = toolCallParser { args += ["--tool-call-parser", shellQuote(parser)] }
         if enableGrammarConstraints { args.append("--enable-grammar-constraints") }
+        if fixToolArgs { args.append("--fix-tool-args") }
+        if let prefillStepSize { args += ["--prefill-step-size", String(prefillStepSize)] }
+        if let kvEviction { args += ["--kv-eviction", shellQuote(kvEviction)] }
+        if let cacheProfilePath { args += ["--cache-profile-path", shellQuote(cacheProfilePath)] }
+        if let guidedJson { args += ["--guided-json", shellQuote(guidedJson)] }
+        if let defaultChatTemplateKwargs {
+            args += ["--default-chat-template-kwargs", shellQuote(defaultChatTemplateKwargs)]
+        }
+        if let reasoningEffort { args += ["--reasoning-effort", shellQuote(reasoningEffort)] }
         if noThink { args.append("--no-think") }
         return args.joined(separator: " ")
     }

--- a/Sources/AFMCLI/ModelEvaluationRunner.swift
+++ b/Sources/AFMCLI/ModelEvaluationRunner.swift
@@ -114,17 +114,6 @@ extension MlxCommand {
     ) throws {
         let store = AFMEvaluationSuiteStore()
         let suites = try suiteNames.map { try store.load(named: $0) }
-        let resultDirectory = try store.makeRunDirectory(model: modelID, suites: suiteNames)
-        let resultsURL = resultDirectory.appendingPathComponent("results.jsonl")
-        let runURL = resultDirectory.appendingPathComponent("run.json")
-        let reportURL = resultDirectory.appendingPathComponent("report.html")
-        let logURL = resultDirectory.appendingPathComponent("eval.log")
-        let suiteSnapshotURL = resultDirectory.appendingPathComponent("suites.json")
-        FileManager.default.createFile(atPath: resultsURL.path, contents: nil)
-        FileManager.default.createFile(atPath: logURL.path, contents: nil)
-        try AFMEvaluationReportWriter.jsonEncoder().encode(suites)
-            .write(to: suiteSnapshotURL, options: [.atomic])
-
         let baseParameters = AFMEvaluationParameters(
             temperature: temperature ?? 0,
             maxTokens: maxTokens ?? 256,
@@ -139,6 +128,20 @@ extension MlxCommand {
             stop: stop.map { $0.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) } },
             responseFormat: defaultResponseFormat
         )
+        try AFMEvaluationRunPolicy.validatePlannedOutput(
+            suites: suites,
+            baseParameters: baseParameters)
+
+        let resultDirectory = try store.makeRunDirectory(model: modelID, suites: suiteNames)
+        let resultsURL = resultDirectory.appendingPathComponent("results.jsonl")
+        let runURL = resultDirectory.appendingPathComponent("run.json")
+        let reportURL = resultDirectory.appendingPathComponent("report.html")
+        let logURL = resultDirectory.appendingPathComponent("eval.log")
+        let suiteSnapshotURL = resultDirectory.appendingPathComponent("suites.json")
+        FileManager.default.createFile(atPath: resultsURL.path, contents: nil)
+        FileManager.default.createFile(atPath: logURL.path, contents: nil)
+        try AFMEvaluationReportWriter.jsonEncoder().encode(suites)
+            .write(to: suiteSnapshotURL, options: [.atomic])
         let engine = AFMEngine(
             backend: .mlx(modelID: modelID),
             config: EngineConfig(
@@ -182,6 +185,7 @@ extension MlxCommand {
 
         let evaluationTask = Task {
             var results: [AFMEvaluationCaseResult] = []
+            var lastSnapshotAt: Date?
             do {
                 let reporter = MLXLoadReporter(modelID: modelID)
                 reporter.start()
@@ -282,16 +286,24 @@ extension MlxCommand {
                             results.append(result)
                             outputsByCaseID[testCase.id] = generated.content
                             try Self.appendJSONLine(result, to: resultsURL)
-                            try Self.persistEvaluationReport(
-                                results: results,
-                                modelID: modelID,
-                                suites: suiteNames,
-                                startedAt: startedAt,
-                                interrupted: interruptController.isInterrupted,
-                                reproducibilityCommand: reproducibilityCommand,
-                                systemInfo: systemInfo,
-                                runURL: runURL,
-                                reportURL: reportURL)
+                            let snapshotTime = Date()
+                            if AFMEvaluationRunPolicy.shouldWriteSnapshot(
+                                completedCases: results.count,
+                                lastSnapshotAt: lastSnapshotAt,
+                                now: snapshotTime
+                            ) {
+                                try Self.persistEvaluationReport(
+                                    results: results,
+                                    modelID: modelID,
+                                    suites: suiteNames,
+                                    startedAt: startedAt,
+                                    interrupted: interruptController.isInterrupted,
+                                    reproducibilityCommand: reproducibilityCommand,
+                                    systemInfo: systemInfo,
+                                    runURL: runURL,
+                                    reportURL: reportURL)
+                                lastSnapshotAt = snapshotTime
+                            }
                             print("\(scoring.0.rawValue) · \(generated.completionTokens) tok · \(String(format: "%.1f", tokensPerSecond ?? 0)) tok/s")
                         } catch {
                             if interruptController.isInterrupted { break }
@@ -321,16 +333,24 @@ extension MlxCommand {
                             results.append(result)
                             try Self.appendJSONLine(result, to: resultsURL)
                             try Self.appendLog("\(suite.name)/\(testCase.id): \(error.localizedDescription)", to: logURL)
-                            try Self.persistEvaluationReport(
-                                results: results,
-                                modelID: modelID,
-                                suites: suiteNames,
-                                startedAt: startedAt,
-                                interrupted: interruptController.isInterrupted,
-                                reproducibilityCommand: reproducibilityCommand,
-                                systemInfo: systemInfo,
-                                runURL: runURL,
-                                reportURL: reportURL)
+                            let snapshotTime = Date()
+                            if AFMEvaluationRunPolicy.shouldWriteSnapshot(
+                                completedCases: results.count,
+                                lastSnapshotAt: lastSnapshotAt,
+                                now: snapshotTime
+                            ) {
+                                try Self.persistEvaluationReport(
+                                    results: results,
+                                    modelID: modelID,
+                                    suites: suiteNames,
+                                    startedAt: startedAt,
+                                    interrupted: interruptController.isInterrupted,
+                                    reproducibilityCommand: reproducibilityCommand,
+                                    systemInfo: systemInfo,
+                                    runURL: runURL,
+                                    reportURL: reportURL)
+                                lastSnapshotAt = snapshotTime
+                            }
                             print("error")
                         }
                     }
@@ -544,6 +564,7 @@ extension MlxCommand {
         defer { try? handle.close() }
         try handle.seekToEnd()
         try handle.write(contentsOf: data)
+        try handle.synchronize()
     }
 
     private static func appendLog(_ value: String, to url: URL) throws {

--- a/Sources/AFMCLI/ModelEvaluationRunner.swift
+++ b/Sources/AFMCLI/ModelEvaluationRunner.swift
@@ -46,6 +46,10 @@ private final class AFMEvaluationSignalMonitor {
                 if controller.requestInterruption() {
                     FileHandle.standardError.write(Data(
                         "\nEvaluation interruption requested; preserving partial results…\n".utf8))
+                } else {
+                    FileHandle.standardError.write(Data(
+                        "\nSecond interruption received; exiting immediately.\n".utf8))
+                    Darwin._exit(signalNumber == SIGINT ? 130 : 143)
                 }
             }
             source.resume()

--- a/Sources/AFMCLI/ModelEvaluationRunner.swift
+++ b/Sources/AFMCLI/ModelEvaluationRunner.swift
@@ -1,0 +1,492 @@
+import AFMKit
+import ArgumentParser
+import Darwin
+import Foundation
+
+nonisolated(unsafe) private var afmEvaluationInterrupted = false
+
+private func handleEvaluationInterrupt(_ signal: Int32) {
+    afmEvaluationInterrupted = true
+    FileHandle.standardError.write(Data("\nEvaluation interruption requested; preserving partial results…\n".utf8))
+}
+
+private struct EvaluationGeneration {
+    let content: String
+    let reasoning: String?
+    let toolCalls: [AFMEvaluationToolCall]
+    let promptTokens: Int
+    let cachedPromptTokens: Int
+    let completionTokens: Int
+    let finishReason: String
+    let promptTime: Double?
+    let generationTime: Double?
+    let timeToFirstToken: Double?
+}
+
+extension MlxCommand {
+    func handleEvaluationManagement(_ action: AFMEvaluationCLIAction) throws -> Bool {
+        let store = AFMEvaluationSuiteStore()
+        switch action {
+        case .none, .run:
+            return false
+        case .list:
+            let suites = try store.discover()
+            print("Available evaluation suites:")
+            for suite in suites {
+                print("  \(suite.name) [\(suite.origin.rawValue), \(suite.caseCount) cases]")
+                print("    \(suite.description)")
+            }
+            print("Custom suites: \(store.rootDirectory.path)/*.json")
+            return true
+        case .scaffold(let name):
+            let url = try store.scaffold(named: name)
+            print("Created custom evaluation suite: \(url.path)")
+            print("Validate it with: afm mlx --eval-validate \(shellQuote(url.path))")
+            return true
+        case .validate(let reference):
+            let suite = try store.load(reference: reference)
+            print("Valid evaluation suite '\(suite.name)' (\(suite.cases.count) cases).")
+            return true
+        }
+    }
+
+    func runEvaluation(modelID: String, suites suiteNames: [String], openReport: Bool) throws {
+        let store = AFMEvaluationSuiteStore()
+        let suites = try suiteNames.map { try store.load(named: $0) }
+        let resultDirectory = try store.makeRunDirectory(model: modelID, suites: suiteNames)
+        let resultsURL = resultDirectory.appendingPathComponent("results.jsonl")
+        let runURL = resultDirectory.appendingPathComponent("run.json")
+        let reportURL = resultDirectory.appendingPathComponent("report.html")
+        let logURL = resultDirectory.appendingPathComponent("eval.log")
+        let suiteSnapshotURL = resultDirectory.appendingPathComponent("suites.json")
+        FileManager.default.createFile(atPath: resultsURL.path, contents: nil)
+        FileManager.default.createFile(atPath: logURL.path, contents: nil)
+        try AFMEvaluationReportWriter.jsonEncoder().encode(suites)
+            .write(to: suiteSnapshotURL, options: [.atomic])
+
+        let baseParameters = AFMEvaluationParameters(
+            temperature: temperature ?? 0,
+            maxTokens: maxTokens ?? 256,
+            topP: topP,
+            topK: topK,
+            minP: minP,
+            repetitionPenalty: repetitionPenalty,
+            presencePenalty: presencePenalty,
+            seed: seed ?? 42,
+            logprobs: maxLogprobs != nil,
+            topLogprobs: maxLogprobs,
+            stop: stop.map { $0.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) } }
+        )
+        let engine = AFMEngine(
+            backend: .mlx(modelID: modelID),
+            config: EngineConfig(
+                instructions: instructions,
+                kvBits: kvBits,
+                enablePrefixCaching: enablePrefixCaching,
+                mlxKernels: mlxKernels,
+                mtpEnabled: mtp,
+                mtpDepth: mtpDepth,
+                mtpModelID: mtpModel,
+                eagle3DrafterPath: eagle3,
+                enableGrammarConstraints: enableGrammarConstraints,
+                toolCallParser: toolCallParser,
+                maxConcurrent: 0,
+                prefillStepSize: prefillStepSize,
+                kvEvictionPolicy: kvEviction ?? "none",
+                fixToolArguments: fixToolArgs,
+                forceVLM: false,
+                cacheProfilePath: cacheProfilePath,
+                trace: vv,
+                gpuCapturePath: gpuCapture,
+                gpuTraceDuration: gpuTrace,
+                gpuProfile: gpuProfile || gpuProfileBw,
+                gpuProfileBandwidth: gpuProfileBw))
+
+        let startedAt = Date()
+        let reproducibilityCommand = makeEvaluationReproducibilityCommand(
+            modelID: modelID,
+            suites: suiteNames,
+            openReport: openReport)
+        let systemInfo = Self.evaluationSystemInfo()
+        let output = SendableBox<Result<[AFMEvaluationCaseResult], Error>?>(nil)
+        let group = DispatchGroup()
+        group.enter()
+
+        afmEvaluationInterrupted = false
+        signal(SIGINT, handleEvaluationInterrupt)
+        signal(SIGTERM, handleEvaluationInterrupt)
+        print("AFM evaluation → \(resultDirectory.path)")
+        print("Loading \(modelID) once for \(suites.reduce(0) { $0 + $1.cases.count }) cases…")
+
+        Task {
+            var results: [AFMEvaluationCaseResult] = []
+            do {
+                let reporter = MLXLoadReporter(modelID: modelID)
+                reporter.start()
+                _ = try await engine.load(progress: { fraction in
+                    let progress = Progress(totalUnitCount: 1_000)
+                    progress.completedUnitCount = Int64(fraction * 1_000)
+                    reporter.updateDownload(progress)
+                })
+                reporter.finish(success: true)
+
+                let total = suites.reduce(0) { $0 + $1.cases.count }
+                var index = 0
+                for suite in suites {
+                    for testCase in suite.cases {
+                        if afmEvaluationInterrupted { break }
+                        index += 1
+                        print("[\(index)/\(total)] \(suite.name)/\(testCase.id)…", terminator: " ")
+                        fflush(stdout)
+                        let parameters = baseParameters
+                            .merging(suite.defaults)
+                            .merging(testCase.parameters)
+                        let caseStart = Date()
+                        do {
+                            var messages: [Message] = []
+                            let systemPrompt = testCase.system ?? instructions
+                            if !systemPrompt.isEmpty {
+                                messages.append(Message(role: "system", content: systemPrompt))
+                            }
+                            if let developer = testCase.developer, !developer.isEmpty {
+                                messages.append(Message(role: "developer", content: developer))
+                            }
+                            messages.append(Message(role: "user", content: testCase.prompt))
+                            let generationConfig = GenerationConfig(
+                                temperature: parameters.temperature,
+                                maxTokens: parameters.maxTokens,
+                                topP: parameters.topP,
+                                topK: parameters.topK,
+                                minP: parameters.minP,
+                                repetitionPenalty: parameters.repetitionPenalty,
+                                presencePenalty: parameters.presencePenalty,
+                                seed: parameters.seed,
+                                logprobs: parameters.logprobs,
+                                topLogprobs: parameters.topLogprobs,
+                                stop: parameters.stop,
+                                tools: parameters.tools,
+                                responseFormat: parameters.responseFormat)
+                            let generated = try await Self.generateEvaluationResponse(
+                                engine: engine,
+                                messages: messages,
+                                config: generationConfig,
+                                streaming: parameters.streaming == true,
+                                startedAt: caseStart)
+                            let duration = Date().timeIntervalSince(caseStart)
+                            var scoring = AFMEvaluationScorer.score(
+                                output: generated.content,
+                                toolCallNames: generated.toolCalls.map(\.name),
+                                expectations: testCase.expectations)
+                            if let matchID = testCase.expectations?.matchesCase {
+                                let matchingOutput = results.last { $0.caseID == matchID }?.output
+                                let passed = matchingOutput == generated.content
+                                let check = AFMEvaluationCheckResult(
+                                    name: "matchesCase",
+                                    passed: passed,
+                                    detail: "Output matches case '\(matchID)'")
+                                scoring.1.append(check)
+                                scoring.0 = scoring.1.allSatisfy(\.passed) ? .passed : .missed
+                            }
+                            let tokensPerSecond = generated.completionTokens > 0
+                                ? Double(generated.completionTokens) / max(generated.generationTime ?? duration, 0.000_001)
+                                : nil
+                            let result = AFMEvaluationCaseResult(
+                                suite: suite.name,
+                                caseID: testCase.id,
+                                prompt: testCase.prompt,
+                                system: testCase.system,
+                                output: generated.content,
+                                reasoning: generated.reasoning,
+                                toolCalls: generated.toolCalls,
+                                outcome: scoring.0,
+                                checks: scoring.1,
+                                error: nil,
+                                startedAt: caseStart,
+                                durationSeconds: duration,
+                                timeToFirstTokenSeconds: generated.timeToFirstToken,
+                                promptTimeSeconds: generated.promptTime,
+                                generationTimeSeconds: generated.generationTime,
+                                promptTokens: generated.promptTokens,
+                                cachedPromptTokens: generated.cachedPromptTokens,
+                                completionTokens: generated.completionTokens,
+                                tokensPerSecond: tokensPerSecond,
+                                finishReason: generated.finishReason,
+                                parameters: parameters)
+                            results.append(result)
+                            try Self.appendJSONLine(result, to: resultsURL)
+                            try Self.persistEvaluationReport(
+                                results: results,
+                                modelID: modelID,
+                                suites: suiteNames,
+                                startedAt: startedAt,
+                                interrupted: afmEvaluationInterrupted,
+                                reproducibilityCommand: reproducibilityCommand,
+                                systemInfo: systemInfo,
+                                runURL: runURL,
+                                reportURL: reportURL)
+                            print("\(scoring.0.rawValue) · \(generated.completionTokens) tok · \(String(format: "%.1f", tokensPerSecond ?? 0)) tok/s")
+                        } catch {
+                            let duration = Date().timeIntervalSince(caseStart)
+                            let result = AFMEvaluationCaseResult(
+                                suite: suite.name,
+                                caseID: testCase.id,
+                                prompt: testCase.prompt,
+                                system: testCase.system,
+                                output: "",
+                                reasoning: nil,
+                                toolCalls: [],
+                                outcome: .error,
+                                checks: [],
+                                error: error.localizedDescription,
+                                startedAt: caseStart,
+                                durationSeconds: duration,
+                                timeToFirstTokenSeconds: nil,
+                                promptTimeSeconds: nil,
+                                generationTimeSeconds: nil,
+                                promptTokens: 0,
+                                cachedPromptTokens: 0,
+                                completionTokens: 0,
+                                tokensPerSecond: nil,
+                                finishReason: "error",
+                                parameters: parameters)
+                            results.append(result)
+                            try Self.appendJSONLine(result, to: resultsURL)
+                            try Self.appendLog("\(suite.name)/\(testCase.id): \(error.localizedDescription)", to: logURL)
+                            try Self.persistEvaluationReport(
+                                results: results,
+                                modelID: modelID,
+                                suites: suiteNames,
+                                startedAt: startedAt,
+                                interrupted: afmEvaluationInterrupted,
+                                reproducibilityCommand: reproducibilityCommand,
+                                systemInfo: systemInfo,
+                                runURL: runURL,
+                                reportURL: reportURL)
+                            print("error")
+                        }
+                    }
+                    if afmEvaluationInterrupted { break }
+                }
+                try Self.persistEvaluationReport(
+                    results: results,
+                    modelID: modelID,
+                    suites: suiteNames,
+                    startedAt: startedAt,
+                    interrupted: afmEvaluationInterrupted,
+                    reproducibilityCommand: reproducibilityCommand,
+                    systemInfo: systemInfo,
+                    runURL: runURL,
+                    reportURL: reportURL)
+                output.value = .success(results)
+            } catch {
+                try? Self.appendLog("Infrastructure failure: \(error.localizedDescription)", to: logURL)
+                try? Self.persistEvaluationReport(
+                    results: results,
+                    modelID: modelID,
+                    suites: suiteNames,
+                    startedAt: startedAt,
+                    interrupted: afmEvaluationInterrupted,
+                    reproducibilityCommand: reproducibilityCommand,
+                    systemInfo: systemInfo,
+                    runURL: runURL,
+                    reportURL: reportURL)
+                output.value = .failure(error)
+            }
+            await engine.unload()
+            group.leave()
+        }
+        group.wait()
+
+        switch output.value {
+        case .success(let results):
+            let errors = results.filter { $0.outcome == .error }.count
+            let misses = results.filter { $0.outcome == .missed }.count
+            print("Report: \(reportURL.path)")
+            print("Completed \(results.count) cases: \(misses) quality miss(es), \(errors) infrastructure error(s).")
+            if openReport && !afmEvaluationInterrupted && errors == 0 {
+                try Self.openReport(reportURL)
+            }
+            if afmEvaluationInterrupted || errors > 0 {
+                throw ExitCode.failure
+            }
+        case .failure(let error):
+            FileHandle.standardError.write(Data("Evaluation failed: \(error.localizedDescription)\nPartial artifacts: \(resultDirectory.path)\n".utf8))
+            throw ExitCode.failure
+        case .none:
+            throw ExitCode.failure
+        }
+    }
+
+    private func makeEvaluationReproducibilityCommand(
+        modelID: String,
+        suites: [String],
+        openReport: Bool
+    ) -> String {
+        var args = ["afm", "mlx", "-m", shellQuote(modelID), "--eval"]
+        if suites != ["comprehensive"] {
+            for suite in suites { args += ["--eval-suite", shellQuote(suite)] }
+        }
+        if !openReport { args.append("--no-open") }
+        if let kvBits { args += ["--kv-bits", String(kvBits)] }
+        if enablePrefixCaching { args.append("--enable-prefix-caching") }
+        if mtp { args.append("--mtp") }
+        if let mtpModel { args += ["--mtp-model", shellQuote(mtpModel)] }
+        if let eagle3 { args += ["--eagle3", shellQuote(eagle3)] }
+        if let parser = toolCallParser { args += ["--tool-call-parser", shellQuote(parser)] }
+        if enableGrammarConstraints { args.append("--enable-grammar-constraints") }
+        if noThink { args.append("--no-think") }
+        return args.joined(separator: " ")
+    }
+
+    private static func persistEvaluationReport(
+        results: [AFMEvaluationCaseResult],
+        modelID: String,
+        suites: [String],
+        startedAt: Date,
+        interrupted: Bool,
+        reproducibilityCommand: String,
+        systemInfo: AFMEvaluationSystemInfo,
+        runURL: URL,
+        reportURL: URL
+    ) throws {
+        let report = AFMEvaluationRunReport(
+            afmVersion: BuildInfo.fullVersion,
+            model: modelID,
+            suites: suites,
+            startedAt: startedAt,
+            finishedAt: Date(),
+            interrupted: interrupted,
+            reproducibilityCommand: reproducibilityCommand,
+            system: systemInfo,
+            results: results)
+        try AFMEvaluationReportWriter.jsonEncoder().encode(report).write(to: runURL, options: [.atomic])
+        try Data(AFMEvaluationReportWriter.html(for: report).utf8).write(to: reportURL, options: [.atomic])
+    }
+
+    private static func generateEvaluationResponse(
+        engine: AFMEngine,
+        messages: [Message],
+        config: GenerationConfig,
+        streaming: Bool,
+        startedAt: Date
+    ) async throws -> EvaluationGeneration {
+        if !streaming {
+            let response = try await engine.respond(to: messages, config)
+            return EvaluationGeneration(
+                content: response.content,
+                reasoning: response.reasoningContent,
+                toolCalls: (response.toolCalls ?? []).map {
+                    AFMEvaluationToolCall(name: $0.function.name, arguments: $0.function.arguments)
+                },
+                promptTokens: response.promptTokens,
+                cachedPromptTokens: response.cachedPromptTokens,
+                completionTokens: response.completionTokens,
+                finishReason: response.finishReason.rawValue,
+                promptTime: numberMetadata(response.metadata["promptTime"]),
+                generationTime: numberMetadata(response.metadata["generateTime"]),
+                timeToFirstToken: nil)
+        }
+
+        var content = ""
+        var reasoning = ""
+        var toolCalls: [AFMEvaluationToolCall] = []
+        var promptTokens = 0
+        var cachedTokens = 0
+        var completionTokens = 0
+        var finishReason = "unknown"
+        var promptTime: Double?
+        var generationTime: Double?
+        var timeToFirstToken: Double?
+        for try await event in engine.streamEvents(to: messages, config) {
+            switch event {
+            case .text(let text, _):
+                if timeToFirstToken == nil, !text.isEmpty {
+                    timeToFirstToken = Date().timeIntervalSince(startedAt)
+                }
+                content += text
+            case .reasoning(let text, _):
+                if timeToFirstToken == nil, !text.isEmpty {
+                    timeToFirstToken = Date().timeIntervalSince(startedAt)
+                }
+                reasoning += text
+            case .toolCall(let call, let stage):
+                if case .completed = stage {
+                    toolCalls.append(.init(name: call.name, arguments: call.arguments))
+                }
+            case .usage(let prompt, let completion, let cached):
+                promptTokens = prompt
+                completionTokens = completion
+                cachedTokens = cached
+            case .metadata(let metadata):
+                promptTime = numberMetadata(metadata["promptTime"]) ?? promptTime
+                generationTime = numberMetadata(metadata["generateTime"]) ?? generationTime
+            case .completed(let reason):
+                finishReason = reason.rawValue
+            case .tokenLogprobs, .custom:
+                break
+            }
+        }
+        return EvaluationGeneration(
+            content: content,
+            reasoning: reasoning.isEmpty ? nil : reasoning,
+            toolCalls: toolCalls,
+            promptTokens: promptTokens,
+            cachedPromptTokens: cachedTokens,
+            completionTokens: completionTokens,
+            finishReason: finishReason,
+            promptTime: promptTime,
+            generationTime: generationTime,
+            timeToFirstToken: timeToFirstToken)
+    }
+
+    private static func appendJSONLine<T: Encodable>(_ value: T, to url: URL) throws {
+        var data = try AFMEvaluationReportWriter.jsonEncoder(pretty: false).encode(value)
+        data.append(0x0A)
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: data)
+    }
+
+    private static func appendLog(_ value: String, to url: URL) throws {
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("[\(ISO8601DateFormatter().string(from: Date()))] \(value)\n".utf8))
+    }
+
+    private static func numberMetadata(_ value: AFMJSONValue?) -> Double? {
+        switch value {
+        case .number(let number): return number
+        case .integer(let number): return Double(number)
+        default: return nil
+        }
+    }
+
+    private static func evaluationSystemInfo() -> AFMEvaluationSystemInfo {
+        var system = utsname()
+        uname(&system)
+        let machine = withUnsafePointer(to: &system.machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) { String(cString: $0) }
+        }
+        return AFMEvaluationSystemInfo(
+            operatingSystem: ProcessInfo.processInfo.operatingSystemVersionString,
+            architecture: machine,
+            processorCount: ProcessInfo.processInfo.processorCount,
+            physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory)
+    }
+
+    private static func openReport(_ url: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = [url.path]
+        try process.run()
+    }
+}
+
+private func shellQuote(_ value: String) -> String {
+    if value.range(of: "^[A-Za-z0-9_./:+-]+$", options: .regularExpression) != nil {
+        return value
+    }
+    return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+}

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -774,10 +774,12 @@ struct MlxCommand: ParsableCommand {
             }
             guard singlePrompt == nil, media.isEmpty, !webui, !openclawConfig,
                   telegramBotToken == nil, telegramAllow == nil,
-                  toolsJson == nil, !raw, !json, concurrent == nil else {
+                  toolsJson == nil, !raw, !json, concurrent == nil,
+                  !tui, !noAltScreen, maxKVSize == nil else {
                 throw ValidationError(
                     "--eval cannot be combined with -s, --media, --webui, Telegram, " +
-                    "--openclaw-config, --tools-json, --raw, --json, or --concurrent")
+                    "--openclaw-config, --tools-json, --raw, --json, --concurrent, " +
+                    "--tui, --no-alt-screen, or --max-kv-size")
             }
             try ensureMLXMetalLibraryAvailable(verbose: verbose)
             let evaluationChatTemplateKwargs = parsedKwargs.isEmpty

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -773,11 +773,22 @@ struct MlxCommand: ParsableCommand {
                 throw ValidationError("--eval currently supports MLX directory checkpoints; DwarfStar GGUF evaluation is not yet available")
             }
             guard singlePrompt == nil, media.isEmpty, !webui, !openclawConfig,
-                  telegramBotToken == nil, telegramAllow == nil else {
-                throw ValidationError("--eval cannot be combined with -s, --media, --webui, Telegram, or --openclaw-config")
+                  telegramBotToken == nil, telegramAllow == nil,
+                  toolsJson == nil, !raw, !json, concurrent == nil else {
+                throw ValidationError(
+                    "--eval cannot be combined with -s, --media, --webui, Telegram, " +
+                    "--openclaw-config, --tools-json, --raw, --json, or --concurrent")
             }
             try ensureMLXMetalLibraryAvailable(verbose: verbose)
-            try runEvaluation(modelID: resolvedModel, suites: suites, openReport: openReport)
+            let evaluationChatTemplateKwargs = parsedKwargs.isEmpty
+                ? nil
+                : try parsedKwargs.mapValues { try Self.afmJSONValue(from: $0) }
+            try runEvaluation(
+                modelID: resolvedModel,
+                suites: suites,
+                openReport: openReport,
+                chatTemplateKwargs: evaluationChatTemplateKwargs,
+                defaultResponseFormat: defaultGuidedJsonSchema)
             return
         }
         if runtimeBackend != .dwarfstar, dsparkSupportPath != nil {

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -287,6 +287,13 @@ struct MlxCommand: ParsableCommand {
           --gpu-profile: Print per-request GPU profiling stats (device info, memory, bandwidth estimates)
           --gpu-profile-bw: Also sample DRAM bandwidth with mactop
           --openclaw-config: Print OpenClaw provider config JSON and exit
+          --eval: Run the bundled comprehensive local evaluation and open its HTML report
+          --bench: Alias for --eval
+          --eval-suite: Select a bundled/custom suite (repeatable; implies --eval)
+          --eval-list: List bundled and ~/.afm/evals custom suites
+          --eval-init: Scaffold a custom JSON suite under ~/.afm/evals
+          --eval-validate: Validate a suite name or JSON file without loading a model
+          --no-open: Do not open the evaluation report in a browser
           --help-json: Print machine-readable JSON capability card for AI agents and exit
         sampling_parameters: [temperature, top_p, top_k, min_p, presence_penalty, repetition_penalty, seed, max_tokens, logprobs, top_logprobs]
         features: [streaming-sse, tool-calling, think-reasoning-extraction, stop-sequences, json-mode, json-schema, prompt-caching, vlm-image-input, kv-cache-quantization, grammar-constrained-decoding, huggingface-gguf-resolution, openclaw-integration]
@@ -557,12 +564,45 @@ struct MlxCommand: ParsableCommand {
     @Flag(name: .long, help: "Print OpenClaw provider config JSON and exit")
     var openclawConfig: Bool = false
 
+    @Flag(name: .long, help: "Run the bundled comprehensive local model evaluation and open its HTML report")
+    var eval: Bool = false
+
+    @Flag(name: .long, help: "Alias for --eval")
+    var bench: Bool = false
+
+    @Option(name: .customLong("eval-suite"), help: "Bundled/custom evaluation suite name; repeat to run multiple suites (implies --eval)")
+    var evalSuites: [String] = []
+
+    @Flag(name: .customLong("eval-list"), help: "List bundled and ~/.afm/evals custom suites, then exit")
+    var evalList: Bool = false
+
+    @Option(name: .customLong("eval-init"), help: "Create a safe example suite at ~/.afm/evals/<name>.json, then exit")
+    var evalInit: String?
+
+    @Option(name: .customLong("eval-validate"), help: "Validate a suite name or JSON file, then exit")
+    var evalValidate: String?
+
+    @Flag(name: .customLong("no-open"), help: "Do not open the generated evaluation HTML report")
+    var noOpen: Bool = false
+
     @Flag(name: .long, help: "Print machine-readable JSON capability card for AI agents and exit")
     var helpJson: Bool = false
 
     func run() throws {
         if helpJson {
             printHelpJson(command: "afm mlx")
+            return
+        }
+
+        let evaluationAction = try AFMEvaluationCLIPlan.resolve(
+            evaluate: eval,
+            bench: bench,
+            suites: evalSuites,
+            list: evalList,
+            scaffold: evalInit,
+            validate: evalValidate,
+            noOpen: noOpen)
+        if try handleEvaluationManagement(evaluationAction) {
             return
         }
 
@@ -728,6 +768,18 @@ struct MlxCommand: ParsableCommand {
 
         let resolvedModel = try resolveRemoteDwarfStarModelIfNeeded(rawModel)
         let runtimeBackend = try resolveRuntimeBackend(model: resolvedModel)
+        if case .run(let suites, let openReport) = evaluationAction {
+            guard runtimeBackend == .mlx else {
+                throw ValidationError("--eval currently supports MLX directory checkpoints; DwarfStar GGUF evaluation is not yet available")
+            }
+            guard singlePrompt == nil, media.isEmpty, !webui, !openclawConfig,
+                  telegramBotToken == nil, telegramAllow == nil else {
+                throw ValidationError("--eval cannot be combined with -s, --media, --webui, Telegram, or --openclaw-config")
+            }
+            try ensureMLXMetalLibraryAvailable(verbose: verbose)
+            try runEvaluation(modelID: resolvedModel, suites: suites, openReport: openReport)
+            return
+        }
         if runtimeBackend != .dwarfstar, dsparkSupportPath != nil {
             throw ValidationError("--dspark-support requires --mlx-runtime dwarfstar or a DwarfStar executor checkpoint")
         }
@@ -2306,7 +2358,7 @@ private func ensureMLXMetalLibraryAvailable(verbose: Bool) throws {
     try MLXMetalLibrary.ensureAvailable(verbose: verbose)
 }
 
-private final class MLXLoadReporter: @unchecked Sendable {
+final class MLXLoadReporter: @unchecked Sendable {
     private static let reporterLock = NSLock()
     nonisolated(unsafe) private static weak var activeReporter: MLXLoadReporter?
 

--- a/Sources/AFMKit/AFMEvaluation.swift
+++ b/Sources/AFMKit/AFMEvaluation.swift
@@ -336,11 +336,25 @@ public enum AFMEvaluationError: LocalizedError {
 }
 
 package enum AFMEvaluationRunPolicy {
+    package static func tokensPerSecond(
+        completionTokens: Int,
+        generationTime: Double?,
+        duration: Double
+    ) -> Double? {
+        guard completionTokens > 0 else { return nil }
+        let measuredGenerationTime = generationTime.flatMap {
+            $0.isFinite && $0 > 0.001 ? $0 : nil
+        }
+        let denominator = measuredGenerationTime ?? duration
+        guard denominator.isFinite, denominator > 0.001 else { return nil }
+        return Double(completionTokens) / denominator
+    }
+
     static let maximumPlannedOutputTokens = 1_000_000
     static let snapshotCaseInterval = 25
     static let snapshotTimeInterval: TimeInterval = 30
 
-    static func validatePlannedOutput(
+    package static func validatePlannedOutput(
         suites: [AFMEvaluationSuite],
         baseParameters: AFMEvaluationParameters
     ) throws {
@@ -367,7 +381,7 @@ package enum AFMEvaluationRunPolicy {
         }
     }
 
-    static func shouldWriteSnapshot(
+    package static func shouldWriteSnapshot(
         completedCases: Int,
         lastSnapshotAt: Date?,
         now: Date

--- a/Sources/AFMKit/AFMEvaluation.swift
+++ b/Sources/AFMKit/AFMEvaluation.swift
@@ -351,6 +351,10 @@ package enum AFMEvaluationRunPolicy {
                     .merging(suite.defaults)
                     .merging(testCase.parameters)
                 let caseTokens = parameters.maxTokens ?? 256
+                guard (1...32_768).contains(caseTokens) else {
+                    throw AFMEvaluationError.runTooLarge(
+                        "maxTokens must be 1...32768 for every evaluation case")
+                }
                 let (next, overflow) = total.addingReportingOverflow(caseTokens)
                 guard !overflow, next <= maximumPlannedOutputTokens else {
                     throw AFMEvaluationError.runTooLarge(

--- a/Sources/AFMKit/AFMEvaluation.swift
+++ b/Sources/AFMKit/AFMEvaluation.swift
@@ -453,7 +453,7 @@ public struct AFMEvaluationSuiteStore {
         var descriptors: [AFMEvaluationSuiteDescriptor] = []
         if let urls = Bundle.module.urls(forResourcesWithExtension: "json", subdirectory: "Evals") {
             for url in urls {
-                let suite = try decode(url: url)
+                let suite = try decode(url: url, origin: .bundled)
                 descriptors.append(.init(
                     name: suite.name,
                     description: suite.description,
@@ -462,7 +462,7 @@ public struct AFMEvaluationSuiteStore {
                     url: url))
             }
         } else if let url = Self.bundledSuiteURL(named: "comprehensive") {
-            let suite = try decode(url: url)
+            let suite = try decode(url: url, origin: .bundled)
             descriptors.append(.init(
                 name: suite.name,
                 description: suite.description,
@@ -478,7 +478,9 @@ public struct AFMEvaluationSuiteStore {
             for url in urls where url.pathExtension.lowercased() == "json" {
                 let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
                 guard values?.isRegularFile == true else { continue }
-                let suite = try decode(url: url)
+                // Discovery is best-effort: one unrelated malformed custom file must
+                // not prevent users from listing or loading every valid suite.
+                guard let suite = try? decode(url: url, origin: .custom) else { continue }
                 descriptors.removeAll { $0.name == suite.name }
                 descriptors.append(.init(
                     name: suite.name,
@@ -495,11 +497,32 @@ public struct AFMEvaluationSuiteStore {
 
     public func load(named name: String) throws -> AFMEvaluationSuite {
         try Self.validateSafeName(name, field: "suite name")
-        if let custom = try discover().first(where: { $0.name == name && $0.origin == .custom }) {
-            return try decode(url: custom.url)
+        let directCustom = rootDirectory.appendingPathComponent("\(name).json")
+        if fileManager.fileExists(atPath: directCustom.path) {
+            let suite = try decode(url: directCustom, origin: .custom)
+            guard suite.name == name else {
+                throw AFMEvaluationError.invalidSuite(
+                    "\(directCustom.lastPathComponent) declares suite '\(suite.name)', expected '\(name)'")
+            }
+            return suite
         }
-        if let bundled = try discover().first(where: { $0.name == name }) {
-            return try decode(url: bundled.url)
+        if fileManager.fileExists(atPath: rootDirectory.path) {
+            let urls = try fileManager.contentsOfDirectory(
+                at: rootDirectory,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles])
+                .filter { $0.pathExtension.lowercased() == "json" }
+                .sorted { $0.path < $1.path }
+            for url in urls where url != directCustom {
+                guard let suite = try? decode(url: url, origin: .custom) else { continue }
+                if suite.name == name { return suite }
+            }
+        }
+        if let url = Self.bundledSuiteURL(named: name) {
+            return try decode(url: url, origin: .bundled)
+        }
+        if let bundled = try discover().first(where: { $0.name == name && $0.origin == .bundled }) {
+            return try decode(url: bundled.url, origin: .bundled)
         }
         throw AFMEvaluationError.suiteNotFound(name)
     }
@@ -513,6 +536,13 @@ public struct AFMEvaluationSuiteStore {
     }
 
     public func decode(url: URL) throws -> AFMEvaluationSuite {
+        try decode(url: url, origin: .custom)
+    }
+
+    func decode(
+        url: URL,
+        origin: AFMEvaluationSuiteDescriptor.Origin
+    ) throws -> AFMEvaluationSuite {
         let data: Data
         do { data = try Data(contentsOf: url, options: [.mappedIfSafe]) }
         catch { throw AFMEvaluationError.invalidSuite("Cannot read \(url.path): \(error.localizedDescription)") }
@@ -522,7 +552,7 @@ public struct AFMEvaluationSuiteStore {
         try Self.validateKnownKeys(data)
         do {
             let suite = try JSONDecoder().decode(AFMEvaluationSuite.self, from: data)
-            try Self.validate(suite)
+            try Self.validate(suite, origin: origin)
             return suite
         } catch let error as AFMEvaluationError {
             throw error
@@ -587,7 +617,10 @@ public struct AFMEvaluationSuiteStore {
         return String(text.prefix(80))
     }
 
-    private static func validate(_ suite: AFMEvaluationSuite) throws {
+    private static func validate(
+        _ suite: AFMEvaluationSuite,
+        origin: AFMEvaluationSuiteDescriptor.Origin
+    ) throws {
         guard suite.schemaVersion == 1 else {
             throw AFMEvaluationError.invalidSuite("Unsupported schemaVersion \(suite.schemaVersion); expected 1")
         }
@@ -602,7 +635,7 @@ public struct AFMEvaluationSuiteStore {
         try validate(suite.defaults, context: "defaults")
         for testCase in suite.cases {
             try validateSafeName(testCase.id, field: "case id")
-            guard identifiers.insert(testCase.id).inserted else {
+            guard !identifiers.contains(testCase.id) else {
                 throw AFMEvaluationError.invalidSuite("Duplicate case id '\(testCase.id)'")
             }
             guard !testCase.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -621,7 +654,18 @@ public struct AFMEvaluationSuiteStore {
                 if let maximum = expectations.maximumCharacters, maximum < 0 {
                     throw AFMEvaluationError.invalidSuite("Case '\(testCase.id)' maximumCharacters must be >= 0")
                 }
+                if let match = expectations.matchesCase {
+                    guard origin == .bundled else {
+                        throw AFMEvaluationError.invalidSuite(
+                            "Case '\(testCase.id)' uses matchesCase, which is reserved for bundled suites")
+                    }
+                    guard identifiers.contains(match) else {
+                        throw AFMEvaluationError.invalidSuite(
+                            "Case '\(testCase.id)' matchesCase must reference an earlier case in the same suite")
+                    }
+                }
             }
+            identifiers.insert(testCase.id)
         }
     }
 

--- a/Sources/AFMKit/AFMEvaluation.swift
+++ b/Sources/AFMKit/AFMEvaluation.swift
@@ -692,7 +692,7 @@ public struct AFMEvaluationSuiteStore {
             throw AFMEvaluationError.invalidSuite("cases must contain 1...1000 entries")
         }
         var identifiers = Set<String>()
-        try validate(suite.defaults, context: "defaults")
+        try validateParameters(suite.defaults, context: "defaults")
         for testCase in suite.cases {
             try validateSafeName(testCase.id, field: "case id")
             guard !identifiers.contains(testCase.id) else {
@@ -706,13 +706,19 @@ public struct AFMEvaluationSuiteStore {
                   (testCase.developer?.utf8.count ?? 0) <= 65_536 else {
                 throw AFMEvaluationError.invalidSuite("Case '\(testCase.id)' prompt/system/developer text exceeds 64 KB")
             }
-            try validate(testCase.parameters, context: "case '\(testCase.id)'")
+            try validateParameters(testCase.parameters, context: "case '\(testCase.id)'")
             if let expectations = testCase.expectations {
                 if let minimum = expectations.minimumCharacters, minimum < 0 {
                     throw AFMEvaluationError.invalidSuite("Case '\(testCase.id)' minimumCharacters must be >= 0")
                 }
                 if let maximum = expectations.maximumCharacters, maximum < 0 {
                     throw AFMEvaluationError.invalidSuite("Case '\(testCase.id)' maximumCharacters must be >= 0")
+                }
+                if let minimum = expectations.minimumCharacters,
+                   let maximum = expectations.maximumCharacters,
+                   minimum > maximum {
+                    throw AFMEvaluationError.invalidSuite(
+                        "Case '\(testCase.id)' minimumCharacters must be <= maximumCharacters")
                 }
                 if let match = expectations.matchesCase {
                     guard origin == .bundled else {
@@ -729,7 +735,10 @@ public struct AFMEvaluationSuiteStore {
         }
     }
 
-    private static func validate(_ value: AFMEvaluationParameters?, context: String) throws {
+    package static func validateParameters(
+        _ value: AFMEvaluationParameters?,
+        context: String
+    ) throws {
         guard let value else { return }
         if let temperature = value.temperature, !(0...2).contains(temperature) {
             throw AFMEvaluationError.invalidSuite("\(context) temperature must be 0...2")
@@ -745,6 +754,18 @@ public struct AFMEvaluationSuiteStore {
         }
         if let minP = value.minP, !(0...1).contains(minP) {
             throw AFMEvaluationError.invalidSuite("\(context) minP must be 0...1")
+        }
+        if let repetitionPenalty = value.repetitionPenalty,
+           !repetitionPenalty.isFinite || repetitionPenalty <= 0 || repetitionPenalty > 100 {
+            throw AFMEvaluationError.invalidSuite(
+                "\(context) repetitionPenalty must be finite and in the range (0, 100]")
+        }
+        if let presencePenalty = value.presencePenalty,
+           !presencePenalty.isFinite || !(-2...2).contains(presencePenalty) {
+            throw AFMEvaluationError.invalidSuite("\(context) presencePenalty must be finite and -2...2")
+        }
+        if let seed = value.seed, seed < 0 {
+            throw AFMEvaluationError.invalidSuite("\(context) seed must be >= 0")
         }
         if let topLogprobs = value.topLogprobs, !(0...20).contains(topLogprobs) {
             throw AFMEvaluationError.invalidSuite("\(context) topLogprobs must be 0...20")

--- a/Sources/AFMKit/AFMEvaluation.swift
+++ b/Sources/AFMKit/AFMEvaluation.swift
@@ -1,0 +1,772 @@
+import Foundation
+import AFMOpenAICompat
+
+public struct AFMEvaluationSuite: Codable, Sendable {
+    public let schemaVersion: Int
+    public let name: String
+    public let description: String
+    public let defaults: AFMEvaluationParameters?
+    public let cases: [AFMEvaluationCase]
+
+    public init(
+        schemaVersion: Int = 1,
+        name: String,
+        description: String,
+        defaults: AFMEvaluationParameters? = nil,
+        cases: [AFMEvaluationCase]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.name = name
+        self.description = description
+        self.defaults = defaults
+        self.cases = cases
+    }
+}
+
+public struct AFMEvaluationCase: Codable, Sendable {
+    public let id: String
+    public let description: String?
+    public let prompt: String
+    public let system: String?
+    public let developer: String?
+    public let parameters: AFMEvaluationParameters?
+    public let expectations: AFMEvaluationExpectations?
+
+    public init(
+        id: String,
+        description: String? = nil,
+        prompt: String,
+        system: String? = nil,
+        developer: String? = nil,
+        parameters: AFMEvaluationParameters? = nil,
+        expectations: AFMEvaluationExpectations? = nil
+    ) {
+        self.id = id
+        self.description = description
+        self.prompt = prompt
+        self.system = system
+        self.developer = developer
+        self.parameters = parameters
+        self.expectations = expectations
+    }
+}
+
+public struct AFMEvaluationParameters: Codable, Sendable {
+    public let temperature: Double?
+    public let maxTokens: Int?
+    public let topP: Double?
+    public let topK: Int?
+    public let minP: Double?
+    public let repetitionPenalty: Double?
+    public let presencePenalty: Double?
+    public let seed: Int?
+    public let logprobs: Bool?
+    public let topLogprobs: Int?
+    public let stop: [String]?
+    public let tools: [RequestTool]?
+    public let responseFormat: ResponseFormat?
+    public let streaming: Bool?
+
+    public init(
+        temperature: Double? = nil,
+        maxTokens: Int? = nil,
+        topP: Double? = nil,
+        topK: Int? = nil,
+        minP: Double? = nil,
+        repetitionPenalty: Double? = nil,
+        presencePenalty: Double? = nil,
+        seed: Int? = nil,
+        logprobs: Bool? = nil,
+        topLogprobs: Int? = nil,
+        stop: [String]? = nil,
+        tools: [RequestTool]? = nil,
+        responseFormat: ResponseFormat? = nil,
+        streaming: Bool? = nil
+    ) {
+        self.temperature = temperature
+        self.maxTokens = maxTokens
+        self.topP = topP
+        self.topK = topK
+        self.minP = minP
+        self.repetitionPenalty = repetitionPenalty
+        self.presencePenalty = presencePenalty
+        self.seed = seed
+        self.logprobs = logprobs
+        self.topLogprobs = topLogprobs
+        self.stop = stop
+        self.tools = tools
+        self.responseFormat = responseFormat
+        self.streaming = streaming
+    }
+
+    public func merging(_ override: AFMEvaluationParameters?) -> AFMEvaluationParameters {
+        guard let override else { return self }
+        return AFMEvaluationParameters(
+            temperature: override.temperature ?? temperature,
+            maxTokens: override.maxTokens ?? maxTokens,
+            topP: override.topP ?? topP,
+            topK: override.topK ?? topK,
+            minP: override.minP ?? minP,
+            repetitionPenalty: override.repetitionPenalty ?? repetitionPenalty,
+            presencePenalty: override.presencePenalty ?? presencePenalty,
+            seed: override.seed ?? seed,
+            logprobs: override.logprobs ?? logprobs,
+            topLogprobs: override.topLogprobs ?? topLogprobs,
+            stop: override.stop ?? stop,
+            tools: override.tools ?? tools,
+            responseFormat: override.responseFormat ?? responseFormat,
+            streaming: override.streaming ?? streaming
+        )
+    }
+}
+
+public struct AFMEvaluationExpectations: Codable, Sendable {
+    public let exact: String?
+    public let contains: [String]?
+    public let notContains: [String]?
+    public let validJSON: Bool?
+    public let minimumCharacters: Int?
+    public let maximumCharacters: Int?
+    public let toolCallName: String?
+    public let caseSensitive: Bool?
+    public let matchesCase: String?
+
+    public init(
+        exact: String? = nil,
+        contains: [String]? = nil,
+        notContains: [String]? = nil,
+        validJSON: Bool? = nil,
+        minimumCharacters: Int? = nil,
+        maximumCharacters: Int? = nil,
+        toolCallName: String? = nil,
+        caseSensitive: Bool? = nil,
+        matchesCase: String? = nil
+    ) {
+        self.exact = exact
+        self.contains = contains
+        self.notContains = notContains
+        self.validJSON = validJSON
+        self.minimumCharacters = minimumCharacters
+        self.maximumCharacters = maximumCharacters
+        self.toolCallName = toolCallName
+        self.caseSensitive = caseSensitive
+        self.matchesCase = matchesCase
+    }
+}
+
+public enum AFMEvaluationOutcome: String, Codable, Sendable {
+    case passed
+    case missed
+    case observed
+    case error
+}
+
+public struct AFMEvaluationCheckResult: Codable, Sendable {
+    public let name: String
+    public let passed: Bool
+    public let detail: String
+
+    public init(name: String, passed: Bool, detail: String) {
+        self.name = name
+        self.passed = passed
+        self.detail = detail
+    }
+}
+
+public struct AFMEvaluationToolCall: Codable, Sendable {
+    public let name: String
+    public let arguments: String
+
+    public init(name: String, arguments: String) {
+        self.name = name
+        self.arguments = arguments
+    }
+}
+
+public struct AFMEvaluationCaseResult: Codable, Sendable {
+    public let suite: String
+    public let caseID: String
+    public let prompt: String
+    public let system: String?
+    public let output: String
+    public let reasoning: String?
+    public let toolCalls: [AFMEvaluationToolCall]
+    public let outcome: AFMEvaluationOutcome
+    public let checks: [AFMEvaluationCheckResult]
+    public let error: String?
+    public let startedAt: Date
+    public let durationSeconds: Double
+    public let timeToFirstTokenSeconds: Double?
+    public let promptTimeSeconds: Double?
+    public let generationTimeSeconds: Double?
+    public let promptTokens: Int
+    public let cachedPromptTokens: Int
+    public let completionTokens: Int
+    public let tokensPerSecond: Double?
+    public let finishReason: String
+    public let parameters: AFMEvaluationParameters
+
+    public init(
+        suite: String,
+        caseID: String,
+        prompt: String,
+        system: String?,
+        output: String,
+        reasoning: String?,
+        toolCalls: [AFMEvaluationToolCall],
+        outcome: AFMEvaluationOutcome,
+        checks: [AFMEvaluationCheckResult],
+        error: String?,
+        startedAt: Date,
+        durationSeconds: Double,
+        timeToFirstTokenSeconds: Double?,
+        promptTimeSeconds: Double?,
+        generationTimeSeconds: Double?,
+        promptTokens: Int,
+        cachedPromptTokens: Int,
+        completionTokens: Int,
+        tokensPerSecond: Double?,
+        finishReason: String,
+        parameters: AFMEvaluationParameters
+    ) {
+        self.suite = suite
+        self.caseID = caseID
+        self.prompt = prompt
+        self.system = system
+        self.output = output
+        self.reasoning = reasoning
+        self.toolCalls = toolCalls
+        self.outcome = outcome
+        self.checks = checks
+        self.error = error
+        self.startedAt = startedAt
+        self.durationSeconds = durationSeconds
+        self.timeToFirstTokenSeconds = timeToFirstTokenSeconds
+        self.promptTimeSeconds = promptTimeSeconds
+        self.generationTimeSeconds = generationTimeSeconds
+        self.promptTokens = promptTokens
+        self.cachedPromptTokens = cachedPromptTokens
+        self.completionTokens = completionTokens
+        self.tokensPerSecond = tokensPerSecond
+        self.finishReason = finishReason
+        self.parameters = parameters
+    }
+}
+
+public struct AFMEvaluationSystemInfo: Codable, Sendable {
+    public let operatingSystem: String
+    public let architecture: String
+    public let processorCount: Int
+    public let physicalMemoryBytes: UInt64
+
+    public init(
+        operatingSystem: String,
+        architecture: String,
+        processorCount: Int,
+        physicalMemoryBytes: UInt64
+    ) {
+        self.operatingSystem = operatingSystem
+        self.architecture = architecture
+        self.processorCount = processorCount
+        self.physicalMemoryBytes = physicalMemoryBytes
+    }
+}
+
+public struct AFMEvaluationRunReport: Codable, Sendable {
+    public let schemaVersion: Int
+    public let afmVersion: String
+    public let model: String
+    public let suites: [String]
+    public let startedAt: Date
+    public let finishedAt: Date
+    public let interrupted: Bool
+    public let reproducibilityCommand: String
+    public let system: AFMEvaluationSystemInfo
+    public let results: [AFMEvaluationCaseResult]
+
+    public init(
+        schemaVersion: Int = 1,
+        afmVersion: String,
+        model: String,
+        suites: [String],
+        startedAt: Date,
+        finishedAt: Date,
+        interrupted: Bool,
+        reproducibilityCommand: String,
+        system: AFMEvaluationSystemInfo,
+        results: [AFMEvaluationCaseResult]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.afmVersion = afmVersion
+        self.model = model
+        self.suites = suites
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+        self.interrupted = interrupted
+        self.reproducibilityCommand = reproducibilityCommand
+        self.system = system
+        self.results = results
+    }
+}
+
+public struct AFMEvaluationSuiteDescriptor: Sendable {
+    public enum Origin: String, Sendable { case bundled, custom }
+    public let name: String
+    public let description: String
+    public let caseCount: Int
+    public let origin: Origin
+    public let url: URL
+}
+
+public enum AFMEvaluationError: LocalizedError {
+    case invalidSuite(String)
+    case suiteNotFound(String)
+    case conflictingCLI(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidSuite(let message): return "Invalid evaluation suite: \(message)"
+        case .suiteNotFound(let name):
+            return "Evaluation suite '\(name)' was not found. Use --eval-list to see available suites."
+        case .conflictingCLI(let message): return message
+        }
+    }
+}
+
+public enum AFMEvaluationCLIAction: Equatable, Sendable {
+    case none
+    case run(suites: [String], openReport: Bool)
+    case list
+    case scaffold(name: String)
+    case validate(reference: String)
+}
+
+public enum AFMEvaluationCLIPlan {
+    public static func resolve(
+        evaluate: Bool,
+        bench: Bool,
+        suites: [String],
+        list: Bool,
+        scaffold: String?,
+        validate: String?,
+        noOpen: Bool
+    ) throws -> AFMEvaluationCLIAction {
+        let managementCount = [list, scaffold != nil, validate != nil].filter { $0 }.count
+        guard managementCount <= 1 else {
+            throw AFMEvaluationError.conflictingCLI(
+                "Use only one of --eval-list, --eval-init, or --eval-validate at a time.")
+        }
+        if list { return .list }
+        if let scaffold { return .scaffold(name: scaffold) }
+        if let validate { return .validate(reference: validate) }
+        if evaluate || bench || !suites.isEmpty {
+            let selected = suites.isEmpty ? ["comprehensive"] : suites
+            return .run(suites: selected, openReport: !noOpen)
+        }
+        if noOpen {
+            throw AFMEvaluationError.conflictingCLI("--no-open is only valid with --eval or --bench.")
+        }
+        return .none
+    }
+}
+
+public enum AFMEvaluationScorer {
+    public static func score(
+        output: String,
+        toolCallNames: [String] = [],
+        expectations: AFMEvaluationExpectations?
+    ) -> (AFMEvaluationOutcome, [AFMEvaluationCheckResult]) {
+        guard let expectations else { return (.observed, []) }
+        let caseSensitive = expectations.caseSensitive == true
+        let comparableOutput = caseSensitive ? output : output.lowercased()
+        func comparable(_ value: String) -> String { caseSensitive ? value : value.lowercased() }
+        var checks: [AFMEvaluationCheckResult] = []
+
+        if let exact = expectations.exact {
+            let passed = comparableOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+                == comparable(exact).trimmingCharacters(in: .whitespacesAndNewlines)
+            checks.append(.init(name: "exact", passed: passed, detail: "Output matches the expected text"))
+        }
+        for value in expectations.contains ?? [] {
+            checks.append(.init(
+                name: "contains",
+                passed: comparableOutput.contains(comparable(value)),
+                detail: "Output contains '\(value)'"))
+        }
+        for value in expectations.notContains ?? [] {
+            checks.append(.init(
+                name: "notContains",
+                passed: !comparableOutput.contains(comparable(value)),
+                detail: "Output does not contain '\(value)'"))
+        }
+        if let expectedJSON = expectations.validJSON {
+            let isJSON = output.data(using: .utf8).flatMap {
+                try? JSONSerialization.jsonObject(with: $0, options: [.fragmentsAllowed])
+            } != nil
+            checks.append(.init(
+                name: "validJSON",
+                passed: isJSON == expectedJSON,
+                detail: expectedJSON ? "Output is valid JSON" : "Output is not valid JSON"))
+        }
+        if let minimum = expectations.minimumCharacters {
+            checks.append(.init(
+                name: "minimumCharacters",
+                passed: output.count >= minimum,
+                detail: "Output has at least \(minimum) characters"))
+        }
+        if let maximum = expectations.maximumCharacters {
+            checks.append(.init(
+                name: "maximumCharacters",
+                passed: output.count <= maximum,
+                detail: "Output has no more than \(maximum) characters"))
+        }
+        if let expectedTool = expectations.toolCallName {
+            checks.append(.init(
+                name: "toolCallName",
+                passed: toolCallNames.contains(expectedTool),
+                detail: "Model calls tool '\(expectedTool)'"))
+        }
+        guard !checks.isEmpty else { return (.observed, []) }
+        return (checks.allSatisfy(\.passed) ? .passed : .missed, checks)
+    }
+}
+
+public struct AFMEvaluationSuiteStore {
+    public let rootDirectory: URL
+    private let fileManager: FileManager
+
+    public init(
+        rootDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".afm/evals", isDirectory: true),
+        fileManager: FileManager = .default
+    ) {
+        self.rootDirectory = rootDirectory
+        self.fileManager = fileManager
+    }
+
+    public static func bundledSuiteURL(named name: String) -> URL? {
+        Bundle.module.url(forResource: name, withExtension: "json", subdirectory: "Evals")
+            ?? Bundle.module.url(forResource: name, withExtension: "json")
+    }
+
+    public func discover() throws -> [AFMEvaluationSuiteDescriptor] {
+        var descriptors: [AFMEvaluationSuiteDescriptor] = []
+        if let urls = Bundle.module.urls(forResourcesWithExtension: "json", subdirectory: "Evals") {
+            for url in urls {
+                let suite = try decode(url: url)
+                descriptors.append(.init(
+                    name: suite.name,
+                    description: suite.description,
+                    caseCount: suite.cases.count,
+                    origin: .bundled,
+                    url: url))
+            }
+        } else if let url = Self.bundledSuiteURL(named: "comprehensive") {
+            let suite = try decode(url: url)
+            descriptors.append(.init(
+                name: suite.name,
+                description: suite.description,
+                caseCount: suite.cases.count,
+                origin: .bundled,
+                url: url))
+        }
+        if fileManager.fileExists(atPath: rootDirectory.path) {
+            let urls = try fileManager.contentsOfDirectory(
+                at: rootDirectory,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles])
+            for url in urls where url.pathExtension.lowercased() == "json" {
+                let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+                guard values?.isRegularFile == true else { continue }
+                let suite = try decode(url: url)
+                descriptors.removeAll { $0.name == suite.name }
+                descriptors.append(.init(
+                    name: suite.name,
+                    description: suite.description,
+                    caseCount: suite.cases.count,
+                    origin: .custom,
+                    url: url))
+            }
+        }
+        return descriptors.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+
+    public func load(named name: String) throws -> AFMEvaluationSuite {
+        try Self.validateSafeName(name, field: "suite name")
+        if let custom = try discover().first(where: { $0.name == name && $0.origin == .custom }) {
+            return try decode(url: custom.url)
+        }
+        if let bundled = try discover().first(where: { $0.name == name }) {
+            return try decode(url: bundled.url)
+        }
+        throw AFMEvaluationError.suiteNotFound(name)
+    }
+
+    public func load(reference: String) throws -> AFMEvaluationSuite {
+        let expanded = NSString(string: reference).expandingTildeInPath
+        if expanded.contains("/") || expanded.hasSuffix(".json") {
+            return try decode(url: URL(fileURLWithPath: expanded).standardizedFileURL)
+        }
+        return try load(named: reference)
+    }
+
+    public func decode(url: URL) throws -> AFMEvaluationSuite {
+        let data: Data
+        do { data = try Data(contentsOf: url, options: [.mappedIfSafe]) }
+        catch { throw AFMEvaluationError.invalidSuite("Cannot read \(url.path): \(error.localizedDescription)") }
+        guard data.count <= 5_000_000 else {
+            throw AFMEvaluationError.invalidSuite("Suite files are limited to 5 MB")
+        }
+        try Self.validateKnownKeys(data)
+        do {
+            let suite = try JSONDecoder().decode(AFMEvaluationSuite.self, from: data)
+            try Self.validate(suite)
+            return suite
+        } catch let error as AFMEvaluationError {
+            throw error
+        } catch {
+            throw AFMEvaluationError.invalidSuite("\(url.lastPathComponent): \(error.localizedDescription)")
+        }
+    }
+
+    public func scaffold(named name: String) throws -> URL {
+        try Self.validateSafeName(name, field: "suite name")
+        try fileManager.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
+        try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: rootDirectory.path)
+        let url = rootDirectory.appendingPathComponent("\(name).json", isDirectory: false)
+        guard !fileManager.fileExists(atPath: url.path) else {
+            throw AFMEvaluationError.invalidSuite("Refusing to overwrite existing file \(url.path)")
+        }
+        let suite = AFMEvaluationSuite(
+            name: name,
+            description: "A custom deterministic AFM evaluation suite.",
+            defaults: .init(temperature: 0, maxTokens: 256, seed: 42),
+            cases: [
+                .init(
+                    id: "hello",
+                    description: "Replace this example with your own local test.",
+                    prompt: "Respond with exactly: hello",
+                    expectations: .init(exact: "hello"))
+            ])
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        try encoder.encode(suite).write(to: url, options: [.atomic])
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        return url
+    }
+
+    public func makeRunDirectory(model: String, suites: [String], date: Date = Date()) throws -> URL {
+        try fileManager.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd-HHmmss-SSS"
+        let modelPart = Self.sanitizePathComponent(model)
+        let suitePart = Self.sanitizePathComponent(suites.joined(separator: "+"))
+        let base = "\(formatter.string(from: date))-\(modelPart)-\(suitePart)"
+        var candidate = rootDirectory.appendingPathComponent(base, isDirectory: true)
+        var suffix = 2
+        while fileManager.fileExists(atPath: candidate.path) {
+            candidate = rootDirectory.appendingPathComponent("\(base)-\(suffix)", isDirectory: true)
+            suffix += 1
+        }
+        try fileManager.createDirectory(at: candidate, withIntermediateDirectories: false)
+        try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: candidate.path)
+        return candidate
+    }
+
+    public static func sanitizePathComponent(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        let result = value.unicodeScalars.map { allowed.contains($0) ? Character(String($0)) : "-" }
+        var text = String(result).replacingOccurrences(of: "--", with: "-")
+        while text.contains("--") { text = text.replacingOccurrences(of: "--", with: "-") }
+        text = text.trimmingCharacters(in: CharacterSet(charactersIn: ".-_"))
+        if text.isEmpty { text = "unnamed" }
+        return String(text.prefix(80))
+    }
+
+    private static func validate(_ suite: AFMEvaluationSuite) throws {
+        guard suite.schemaVersion == 1 else {
+            throw AFMEvaluationError.invalidSuite("Unsupported schemaVersion \(suite.schemaVersion); expected 1")
+        }
+        try validateSafeName(suite.name, field: "suite name")
+        guard !suite.description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AFMEvaluationError.invalidSuite("description must not be empty")
+        }
+        guard !suite.cases.isEmpty, suite.cases.count <= 1_000 else {
+            throw AFMEvaluationError.invalidSuite("cases must contain 1...1000 entries")
+        }
+        var identifiers = Set<String>()
+        try validate(suite.defaults, context: "defaults")
+        for testCase in suite.cases {
+            try validateSafeName(testCase.id, field: "case id")
+            guard identifiers.insert(testCase.id).inserted else {
+                throw AFMEvaluationError.invalidSuite("Duplicate case id '\(testCase.id)'")
+            }
+            guard !testCase.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw AFMEvaluationError.invalidSuite("Case '\(testCase.id)' has an empty prompt")
+            }
+            guard testCase.prompt.utf8.count <= 65_536,
+                  (testCase.system?.utf8.count ?? 0) <= 65_536,
+                  (testCase.developer?.utf8.count ?? 0) <= 65_536 else {
+                throw AFMEvaluationError.invalidSuite("Case '\(testCase.id)' prompt/system/developer text exceeds 64 KB")
+            }
+            try validate(testCase.parameters, context: "case '\(testCase.id)'")
+            if let expectations = testCase.expectations {
+                if let minimum = expectations.minimumCharacters, minimum < 0 {
+                    throw AFMEvaluationError.invalidSuite("Case '\(testCase.id)' minimumCharacters must be >= 0")
+                }
+                if let maximum = expectations.maximumCharacters, maximum < 0 {
+                    throw AFMEvaluationError.invalidSuite("Case '\(testCase.id)' maximumCharacters must be >= 0")
+                }
+            }
+        }
+    }
+
+    private static func validate(_ value: AFMEvaluationParameters?, context: String) throws {
+        guard let value else { return }
+        if let temperature = value.temperature, !(0...2).contains(temperature) {
+            throw AFMEvaluationError.invalidSuite("\(context) temperature must be 0...2")
+        }
+        if let maxTokens = value.maxTokens, !(1...32_768).contains(maxTokens) {
+            throw AFMEvaluationError.invalidSuite("\(context) maxTokens must be 1...32768")
+        }
+        if let topP = value.topP, !(0...1).contains(topP) {
+            throw AFMEvaluationError.invalidSuite("\(context) topP must be 0...1")
+        }
+        if let topK = value.topK, topK < 0 || topK > 100_000 {
+            throw AFMEvaluationError.invalidSuite("\(context) topK must be 0...100000")
+        }
+        if let minP = value.minP, !(0...1).contains(minP) {
+            throw AFMEvaluationError.invalidSuite("\(context) minP must be 0...1")
+        }
+        if let topLogprobs = value.topLogprobs, !(0...20).contains(topLogprobs) {
+            throw AFMEvaluationError.invalidSuite("\(context) topLogprobs must be 0...20")
+        }
+        if let stop = value.stop, stop.count > 16 || stop.contains(where: { $0.utf8.count > 1_024 }) {
+            throw AFMEvaluationError.invalidSuite("\(context) stop allows at most 16 strings of 1 KB each")
+        }
+    }
+
+    private static func validateSafeName(_ value: String, field: String) throws {
+        let pattern = "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+        guard value.range(of: pattern, options: .regularExpression) != nil,
+              value != ".", value != ".." else {
+            throw AFMEvaluationError.invalidSuite(
+                "\(field) '\(value)' must use 1...64 letters, digits, dots, underscores, or hyphens")
+        }
+    }
+
+    private static func validateKnownKeys(_ data: Data) throws {
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AFMEvaluationError.invalidSuite("Top-level JSON value must be an object")
+        }
+        try rejectUnknown(root, allowed: ["schemaVersion", "name", "description", "defaults", "cases"], at: "suite")
+        if let defaults = root["defaults"] as? [String: Any] {
+            try rejectUnknown(defaults, allowed: parameterKeys, at: "defaults")
+        }
+        if let cases = root["cases"] as? [[String: Any]] {
+            for (index, item) in cases.enumerated() {
+                try rejectUnknown(item, allowed: ["id", "description", "prompt", "system", "developer", "parameters", "expectations"], at: "cases[\(index)]")
+                if let parameters = item["parameters"] as? [String: Any] {
+                    try rejectUnknown(parameters, allowed: parameterKeys, at: "cases[\(index)].parameters")
+                }
+                if let expectations = item["expectations"] as? [String: Any] {
+                    try rejectUnknown(expectations, allowed: expectationKeys, at: "cases[\(index)].expectations")
+                }
+            }
+        }
+    }
+
+    private static let parameterKeys: Set<String> = [
+        "temperature", "maxTokens", "topP", "topK", "minP", "repetitionPenalty",
+        "presencePenalty", "seed", "logprobs", "topLogprobs", "stop", "tools",
+        "responseFormat", "streaming"
+    ]
+    private static let expectationKeys: Set<String> = [
+        "exact", "contains", "notContains", "validJSON", "minimumCharacters",
+        "maximumCharacters", "toolCallName", "caseSensitive", "matchesCase"
+    ]
+
+    private static func rejectUnknown(_ object: [String: Any], allowed: Set<String>, at path: String) throws {
+        let unknown = Set(object.keys).subtracting(allowed).sorted()
+        guard unknown.isEmpty else {
+            throw AFMEvaluationError.invalidSuite("Unknown key(s) at \(path): \(unknown.joined(separator: ", "))")
+        }
+    }
+}
+
+public enum AFMEvaluationReportWriter {
+    public static func jsonEncoder(pretty: Bool = true) -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = pretty
+            ? [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            : [.sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }
+
+    public static func html(for report: AFMEvaluationRunReport) -> String {
+        let passed = report.results.filter { $0.outcome == .passed }.count
+        let missed = report.results.filter { $0.outcome == .missed }.count
+        let observed = report.results.filter { $0.outcome == .observed }.count
+        let errors = report.results.filter { $0.outcome == .error }.count
+        let totalPromptTokens = report.results.reduce(0) { $0 + $1.promptTokens }
+        let totalTokens = report.results.reduce(0) { $0 + $1.completionTokens }
+        let totalDuration = report.results.reduce(0) { $0 + $1.durationSeconds }
+        let aggregateTPS = totalDuration > 0 ? Double(totalTokens) / totalDuration : 0
+        let averageLatency = report.results.isEmpty ? 0 : totalDuration / Double(report.results.count)
+        let rows = report.results.map { result in
+            let checks = result.checks.map {
+                "<li class=\"\($0.passed ? "ok" : "bad")\">\(escape($0.name)): \(escape($0.detail))</li>"
+            }.joined()
+            let tools = result.toolCalls.map {
+                "<pre>\(escape($0.name))(\(escape($0.arguments)))</pre>"
+            }.joined()
+            return """
+            <details class="case \(result.outcome.rawValue)">
+              <summary><strong>\(escape(result.suite))/\(escape(result.caseID))</strong><span>\(escape(result.outcome.rawValue.uppercased()))</span><span>\(format(result.durationSeconds))s · \(result.completionTokens) tok · \(format(result.tokensPerSecond ?? 0)) tok/s</span></summary>
+              <div class="grid"><section><h3>Prompt</h3><pre>\(escape(result.prompt))</pre></section><section><h3>Output</h3><pre>\(escape(result.output))</pre></section></div>
+              \(result.reasoning.map { "<section><h3>Reasoning</h3><pre>\(escape($0))</pre></section>" } ?? "")
+              \(tools.isEmpty ? "" : "<section><h3>Tool calls</h3>\(tools)</section>")
+              \(checks.isEmpty ? "" : "<section><h3>Deterministic checks</h3><ul>\(checks)</ul></section>")
+              \(result.error.map { "<p class=\"bad\">\(escape($0))</p>" } ?? "")
+              <section><h3>Generation parameters</h3><pre>\(escape(parameterJSON(result.parameters)))</pre></section>
+              <p class="meta">TTFT: \(result.timeToFirstTokenSeconds.map(format) ?? "n/a")s · prompt/prefill: \(result.promptTimeSeconds.map(format) ?? "n/a")s · generation: \(result.generationTimeSeconds.map(format) ?? "n/a")s · prompt/cached/output tokens: \(result.promptTokens)/\(result.cachedPromptTokens)/\(result.completionTokens) · finish: \(escape(result.finishReason))</p>
+            </details>
+            """
+        }.joined(separator: "\n")
+
+        return """
+        <!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+        <title>AFM evaluation · \(escape(report.model))</title>
+        <style>body{font:15px system-ui;margin:0;background:#0d1117;color:#e6edf3}main{max-width:1200px;margin:auto;padding:32px}h1{margin-bottom:4px}.muted,.meta{color:#8b949e}.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:12px;margin:24px 0}.card,.case{background:#161b22;border:1px solid #30363d;border-radius:10px;padding:14px}.card b{font-size:24px;display:block}.case{margin:12px 0}.case summary{display:grid;grid-template-columns:1fr auto auto;gap:18px;cursor:pointer}.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}pre{white-space:pre-wrap;word-break:break-word;background:#0d1117;padding:12px;border-radius:8px;overflow:auto}.ok,.passed{color:#3fb950}.bad,.missed,.error{color:#f85149}.observed{color:#d29922}code{word-break:break-all}@media(max-width:750px){.grid{grid-template-columns:1fr}.case summary{grid-template-columns:1fr}}</style></head>
+        <body><main><h1>AFM model evaluation</h1><p class="muted">\(escape(report.model)) · \(escape(report.suites.joined(separator: ", "))) · \(escape(report.afmVersion))</p>
+        <div class="cards"><div class="card"><b>\(report.results.count)</b>cases</div><div class="card"><b class="ok">\(passed)</b>passed</div><div class="card"><b class="bad">\(missed)</b>quality misses</div><div class="card"><b>\(observed)</b>observed</div><div class="card"><b class="bad">\(errors)</b>errors</div><div class="card"><b>\(totalPromptTokens)</b>prompt tokens</div><div class="card"><b>\(totalTokens)</b>output tokens</div><div class="card"><b>\(format(averageLatency))s</b>average latency</div><div class="card"><b>\(format(aggregateTPS))</b>aggregate tok/s</div></div>
+        <p><strong>System:</strong> \(escape(report.system.operatingSystem)); \(escape(report.system.architecture)); \(report.system.processorCount) CPUs; \(formatBytes(report.system.physicalMemoryBytes)) RAM</p>
+        <p><strong>Reproduce:</strong> <code>\(escape(report.reproducibilityCommand))</code></p>
+        \(report.interrupted ? "<p class=\"bad\"><strong>Run interrupted; partial results preserved.</strong></p>" : "")
+        \(rows)</main></body></html>
+        """
+    }
+
+    public static func escape(_ value: String) -> String {
+        value.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+
+    private static func format(_ value: Double) -> String { String(format: "%.2f", value) }
+    private static func parameterJSON(_ value: AFMEvaluationParameters) -> String {
+        guard let data = try? jsonEncoder(pretty: false).encode(value),
+              let text = String(data: data, encoding: .utf8) else { return "{}" }
+        return text
+    }
+    private static func formatBytes(_ value: UInt64) -> String {
+        String(format: "%.1f GB", Double(value) / 1_073_741_824)
+    }
+}

--- a/Sources/AFMKit/AFMEvaluation.swift
+++ b/Sources/AFMKit/AFMEvaluation.swift
@@ -322,6 +322,7 @@ public enum AFMEvaluationError: LocalizedError {
     case invalidSuite(String)
     case suiteNotFound(String)
     case conflictingCLI(String)
+    case runTooLarge(String)
 
     public var errorDescription: String? {
         switch self {
@@ -329,7 +330,48 @@ public enum AFMEvaluationError: LocalizedError {
         case .suiteNotFound(let name):
             return "Evaluation suite '\(name)' was not found. Use --eval-list to see available suites."
         case .conflictingCLI(let message): return message
+        case .runTooLarge(let message): return "Evaluation run is too large: \(message)"
         }
+    }
+}
+
+package enum AFMEvaluationRunPolicy {
+    static let maximumPlannedOutputTokens = 1_000_000
+    static let snapshotCaseInterval = 25
+    static let snapshotTimeInterval: TimeInterval = 30
+
+    static func validatePlannedOutput(
+        suites: [AFMEvaluationSuite],
+        baseParameters: AFMEvaluationParameters
+    ) throws {
+        var total = 0
+        for suite in suites {
+            for testCase in suite.cases {
+                let parameters = baseParameters
+                    .merging(suite.defaults)
+                    .merging(testCase.parameters)
+                let caseTokens = parameters.maxTokens ?? 256
+                let (next, overflow) = total.addingReportingOverflow(caseTokens)
+                guard !overflow, next <= maximumPlannedOutputTokens else {
+                    throw AFMEvaluationError.runTooLarge(
+                        "the selected suites can request more than "
+                            + "\(maximumPlannedOutputTokens) output tokens. "
+                            + "Reduce the case count or maxTokens values.")
+                }
+                total = next
+            }
+        }
+    }
+
+    static func shouldWriteSnapshot(
+        completedCases: Int,
+        lastSnapshotAt: Date?,
+        now: Date
+    ) -> Bool {
+        guard completedCases > 0 else { return false }
+        if completedCases.isMultiple(of: snapshotCaseInterval) { return true }
+        guard let lastSnapshotAt else { return true }
+        return now.timeIntervalSince(lastSnapshotAt) >= snapshotTimeInterval
     }
 }
 

--- a/Sources/AFMKit/Resources/Evals/comprehensive.json
+++ b/Sources/AFMKit/Resources/Evals/comprehensive.json
@@ -1,0 +1,1686 @@
+{
+  "schemaVersion": 1,
+  "name": "comprehensive",
+  "description": "All 91 labeled variants from Scripts/test-llm-comprehensive.txt, ported to the native load-once evaluator without Python, shell orchestration, or an AI judge. Runtime-only legacy flags are documented per case; deterministic checks are used where the legacy expectation is machine-verifiable.",
+  "defaults": {
+    "temperature": 0.7,
+    "maxTokens": 512,
+    "seed": 42
+  },
+  "cases": [
+    {
+      "id": "greedy",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ greedy]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Explain why the sky is blue in exactly 3 bullet points.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "default",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ default]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Explain why the sky is blue in exactly 3 bullet points.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "high-temp",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ high-temp]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Explain why the sky is blue in exactly 3 bullet points.",
+      "parameters": {
+        "temperature": 1.5,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "top-p",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ top-p]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Explain why the sky is blue in exactly 3 bullet points.",
+      "parameters": {
+        "temperature": 0.8,
+        "maxTokens": 512,
+        "topP": 0.9
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "top-k",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ top-k]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Explain why the sky is blue in exactly 3 bullet points.",
+      "parameters": {
+        "temperature": 0.8,
+        "maxTokens": 512,
+        "topK": 30
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "min-p",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ min-p]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Explain why the sky is blue in exactly 3 bullet points.",
+      "parameters": {
+        "temperature": 0.8,
+        "maxTokens": 512,
+        "minP": 0.05
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "combined-samplers",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ combined-samplers]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Explain why the sky is blue in exactly 3 bullet points.",
+      "parameters": {
+        "temperature": 0.8,
+        "maxTokens": 512,
+        "topK": 50,
+        "minP": 0.03,
+        "topP": 0.95
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "seed-42-run1",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ seed-42-run1]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a limerick about a cat.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512,
+        "seed": 42
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "seed-42-run2",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ seed-42-run2]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a limerick about a cat.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512,
+        "seed": 42
+      },
+      "expectations": {
+        "matchesCase": "seed-42-run1"
+      }
+    },
+    {
+      "id": "no-penalty",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ no-penalty]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a long essay about the history of bread making across civilizations.",
+      "parameters": {
+        "temperature": 0.8,
+        "maxTokens": 512,
+        "presencePenalty": 0.0
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "with-penalty",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ with-penalty]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a long essay about the history of bread making across civilizations.",
+      "parameters": {
+        "temperature": 0.8,
+        "maxTokens": 512,
+        "presencePenalty": 1.5
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "repetition-penalty",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ repetition-penalty]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a long essay about the history of bread making across civilizations.",
+      "parameters": {
+        "temperature": 0.8,
+        "maxTokens": 512,
+        "repetitionPenalty": 1.2
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "pirate",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ pirate]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Tell me about quantum computing.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "system": "You are a pirate. Always respond in pirate speak."
+    },
+    {
+      "id": "scientist",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ scientist]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Tell me about quantum computing.",
+      "parameters": {
+        "temperature": 0.3,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "system": "You are a physics professor. Be precise and use technical terminology."
+    },
+    {
+      "id": "eli5",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ eli5]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Tell me about quantum computing.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "system": "Explain everything as if the user is 5 years old. Use simple words only."
+    },
+    {
+      "id": "json-output",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ json-output]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Respond with a valid JSON object containing keys \"name\", \"age\", and \"city\". Nothing else.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "validJSON": true,
+        "contains": [
+          "name",
+          "age",
+          "city"
+        ]
+      }
+    },
+    {
+      "id": "numbered-list",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ numbered-list]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List exactly 5 animals, one per line, numbered 1-5. No other text.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "contains": [
+          "1.",
+          "5."
+        ]
+      }
+    },
+    {
+      "id": "guided-json-simple",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ guided-json-simple]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Generate a person record.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "responseFormat": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "guided-json-simple",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "age": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name",
+                "age"
+              ]
+            },
+            "strict": false
+          }
+        }
+      },
+      "expectations": {
+        "validJSON": true
+      }
+    },
+    {
+      "id": "guided-json-nested",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ guided-json-nested]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Describe Tokyo as a structured record with at least 3 landmarks.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "responseFormat": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "guided-json-nested",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string"
+                },
+                "population": {
+                  "type": "integer"
+                },
+                "landmarks": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "city",
+                "population",
+                "landmarks"
+              ]
+            },
+            "strict": false
+          }
+        }
+      },
+      "expectations": {
+        "validJSON": true
+      }
+    },
+    {
+      "id": "agent-no-cache-turn1",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ agent-no-cache-turn1]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Read the file Sources/MacLocalAPI/main.swift and explain what it does.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "system": "You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety."
+    },
+    {
+      "id": "agent-no-cache-turn2",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ agent-no-cache-turn2]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Now add a --timeout flag to the CLI that sets a request timeout in seconds.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "system": "You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety."
+    },
+    {
+      "id": "agent-no-cache-turn3",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ agent-no-cache-turn3]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a unit test for the timeout feature you just described.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "system": "You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety."
+    },
+    {
+      "id": "agent-cached-turn1",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ agent-cached-turn1]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run; --enable-prefix-caching is a process/runtime flag and is recorded as coverage-only in the load-once evaluator.",
+      "prompt": "Read the file Sources/MacLocalAPI/main.swift and explain what it does.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "system": "You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety."
+    },
+    {
+      "id": "agent-cached-turn2",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ agent-cached-turn2]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run; --enable-prefix-caching is a process/runtime flag and is recorded as coverage-only in the load-once evaluator.",
+      "prompt": "Now add a --timeout flag to the CLI that sets a request timeout in seconds.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "system": "You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety."
+    },
+    {
+      "id": "agent-cached-turn3",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ agent-cached-turn3]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run; --enable-prefix-caching is a process/runtime flag and is recorded as coverage-only in the load-once evaluator.",
+      "prompt": "Write a unit test for the timeout feature you just described.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "system": "You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety."
+    },
+    {
+      "id": "short-output",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ short-output].",
+      "prompt": "Describe the entire history of Rome.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 50
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "long-output",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ long-output]. Adaptation: legacy max_tokens 2000 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a detailed recipe for chocolate chip cookies with ingredients, steps, tips, and variations.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "logprobs",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ logprobs]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "What is 1+1?",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "logprobs": true,
+        "topLogprobs": 5
+      },
+      "expectations": {
+        "contains": [
+          "2"
+        ]
+      }
+    },
+    {
+      "id": "small-kv",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ small-kv]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run; --max-kv-size is a process/runtime flag and is recorded as coverage-only in the load-once evaluator.",
+      "prompt": "Summarize the key ideas of machine learning in a few paragraphs.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "kv-quantized",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ kv-quantized]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run; --kv-bits is a process/runtime flag and is recorded as coverage-only in the load-once evaluator.",
+      "prompt": "Summarize the key ideas of machine learning in a few paragraphs.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "prefill-default",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ prefill-default]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Given this architecture, what are the top 3 performance bottlenecks you would investigate first?",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "system": "You are an expert software architect reviewing a large codebase. The project is a Swift macOS application that serves LLM inference through an OpenAI-compatible API. It uses Vapor for HTTP, MLX for GPU compute, and supports streaming SSE responses. The architecture includes model services, controllers, request/response types, prompt caching, tool call parsing, logprobs computation, and a built-in WebUI. The codebase has vendor dependencies managed through a patch system. There are multiple model formats supported including Qwen, Gemma, Llama, DeepSeek, GLM, and others. Each model may have different tool call formats, chat templates, and tokenizer configurations. The server must handle concurrent requests safely using async/await and serial access containers."
+    },
+    {
+      "id": "prefill-large-4096",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ prefill-large-4096]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run; --prefill-step-size is a process/runtime flag and is recorded as coverage-only in the load-once evaluator.",
+      "prompt": "Given this architecture, what are the top 3 performance bottlenecks you would investigate first?",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "system": "You are an expert software architect reviewing a large codebase. The project is a Swift macOS application that serves LLM inference through an OpenAI-compatible API. It uses Vapor for HTTP, MLX for GPU compute, and supports streaming SSE responses. The architecture includes model services, controllers, request/response types, prompt caching, tool call parsing, logprobs computation, and a built-in WebUI. The codebase has vendor dependencies managed through a patch system. There are multiple model formats supported including Qwen, Gemma, Llama, DeepSeek, GLM, and others. Each model may have different tool call formats, chat templates, and tokenizer configurations. The server must handle concurrent requests safely using async/await and serial access containers."
+    },
+    {
+      "id": "prefill-small-256",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ prefill-small-256]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run; --prefill-step-size is a process/runtime flag and is recorded as coverage-only in the load-once evaluator.",
+      "prompt": "Given this architecture, what are the top 3 performance bottlenecks you would investigate first?",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "system": "You are an expert software architect reviewing a large codebase. The project is a Swift macOS application that serves LLM inference through an OpenAI-compatible API. It uses Vapor for HTTP, MLX for GPU compute, and supports streaming SSE responses. The architecture includes model services, controllers, request/response types, prompt caching, tool call parsing, logprobs computation, and a built-in WebUI. The codebase has vendor dependencies managed through a patch system. There are multiple model formats supported including Qwen, Gemma, Llama, DeepSeek, GLM, and others. Each model may have different tool call formats, chat templates, and tokenizer configurations. The server must handle concurrent requests safely using async/await and serial access containers."
+    },
+    {
+      "id": "no-streaming",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ no-streaming]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a short poem about the moon.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512,
+        "streaming": false
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "raw-mode",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ raw-mode]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run; raw-output CLI extraction is not varied inside the load-once evaluator.",
+      "prompt": "Think step by step: what is 17 * 23?",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "stop-single",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-single]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List 10 fruits, numbered 1-10, one per line.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "3."
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "3."
+        ]
+      }
+    },
+    {
+      "id": "stop-multi",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-multi]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a Python hello world program in a code block, then write END after it.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "```",
+          "END"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "```",
+          "END"
+        ]
+      }
+    },
+    {
+      "id": "stop-newline",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-newline]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "What is the capital of France? Answer in one sentence.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "\n"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "\n"
+        ]
+      }
+    },
+    {
+      "id": "stop-double-newline",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-double-newline]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a short paragraph about the ocean. Then write a second paragraph about mountains.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "\n\n"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "\n\n"
+        ]
+      }
+    },
+    {
+      "id": "stop-word",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-word]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Name 5 programming languages and briefly describe each one.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "Python"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "Python"
+        ]
+      }
+    },
+    {
+      "id": "stop-period",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-period]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Tell me about the sun in three sentences.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "."
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "."
+        ]
+      }
+    },
+    {
+      "id": "stop-cli-only",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-cli-only]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List 10 types of cheese, numbered 1 through 10, one per line.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "3."
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "3."
+        ]
+      }
+    },
+    {
+      "id": "stop-cli-multi",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-cli-multi]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a bash script that prints the current date inside a code block, then write DONE.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "```",
+          "DONE"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "```",
+          "DONE"
+        ]
+      }
+    },
+    {
+      "id": "stop-cli-api-merge",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-cli-api-merge]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List 10 countries, numbered 1 through 10, one per line.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "3.",
+          "5."
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "3.",
+          "5."
+        ]
+      }
+    },
+    {
+      "id": "stop-cli-api-dedup",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-cli-api-dedup]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List 10 cities, numbered 1 through 10, one per line.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "3."
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "3."
+        ]
+      }
+    },
+    {
+      "id": "stop-non-streaming",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-non-streaming]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List 10 planets or celestial objects, numbered 1 through 10, one per line.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "3."
+        ],
+        "streaming": false
+      },
+      "expectations": {
+        "notContains": [
+          "3."
+        ]
+      }
+    },
+    {
+      "id": "stop-guided-json-value",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-guided-json-value]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List 5 major world cities as a JSON array. Include Tokyo.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "Tokyo"
+        ],
+        "responseFormat": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "stop-guided-json-value",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "cities": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "cities"
+              ]
+            },
+            "strict": false
+          }
+        }
+      },
+      "expectations": {
+        "notContains": [
+          "Tokyo"
+        ]
+      }
+    },
+    {
+      "id": "stop-guided-json-comma",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-guided-json-comma]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Generate a person profile for someone named Alice who is 30 and lives in Paris.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          ","
+        ],
+        "responseFormat": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "stop-guided-json-comma",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "age": {
+                  "type": "integer"
+                },
+                "city": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "age",
+                "city"
+              ]
+            },
+            "strict": false
+          }
+        }
+      },
+      "expectations": {
+        "notContains": [
+          ","
+        ]
+      }
+    },
+    {
+      "id": "stop-guided-json-brace",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-guided-json-brace]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Describe the color blue with its hex code.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "}"
+        ],
+        "responseFormat": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "stop-guided-json-brace",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "hex": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "color",
+                "hex"
+              ]
+            },
+            "strict": false
+          }
+        }
+      },
+      "expectations": {
+        "notContains": [
+          "}"
+        ]
+      }
+    },
+    {
+      "id": "stop-json-object-key",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-json-object-key]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Generate a JSON object with keys \"name\", \"age\", and \"city\" for a person named Carol.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "age"
+        ],
+        "responseFormat": {
+          "type": "json_object"
+        }
+      },
+      "expectations": {
+        "notContains": [
+          "age"
+        ]
+      }
+    },
+    {
+      "id": "stop-long-phrase",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-long-phrase]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a 3-paragraph essay about renewable energy. Start the last paragraph with \"In conclusion\".",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "In conclusion"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "In conclusion"
+        ]
+      }
+    },
+    {
+      "id": "stop-multi-word",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-multi-word]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a 5-step recipe for making tea. Label each step as \"Step 1\", \"Step 2\", etc.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "Step 3"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "Step 3"
+        ]
+      }
+    },
+    {
+      "id": "stop-no-match",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-no-match].",
+      "prompt": "Explain the difference between TCP and UDP in a few sentences.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 256,
+        "stop": [
+          "XYZZY_NEVER_MATCH"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "XYZZY_NEVER_MATCH"
+        ]
+      }
+    },
+    {
+      "id": "stop-immediate",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-immediate]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Explain what gravity is.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "The",
+          "I",
+          "A"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "The",
+          "I",
+          "A"
+        ]
+      }
+    },
+    {
+      "id": "stop-special-chars",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-special-chars]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List 3 facts about the moon. Use **bold** markdown for emphasis.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "**"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "**"
+        ]
+      }
+    },
+    {
+      "id": "stop-html-tag",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-html-tag]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write an HTML unordered list of 5 fruits using <ul> and <li> tags.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "</li>"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "</li>"
+        ]
+      }
+    },
+    {
+      "id": "stop-unicode",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-unicode]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List 5 items about space using bullet points (•).",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "•"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "•"
+        ]
+      }
+    },
+    {
+      "id": "stop-four-max",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-four-max]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List 10 facts about numbers, alternating between digit format (1., 2.) and word format (three, four). One per line.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "3.",
+          "three",
+          "Third",
+          "III"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "3.",
+          "three",
+          "Third",
+          "III"
+        ]
+      }
+    },
+    {
+      "id": "stop-system-pirate",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-system-pirate]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Tell me about treasure hunting on the high seas.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "Arrr"
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "Arrr"
+        ]
+      },
+      "system": "You are a pirate. Speak like a pirate in all responses."
+    },
+    {
+      "id": "stop-system-numbered",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-system-numbered]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "What are the main benefits of exercise?",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "stop": [
+          "4."
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "4."
+        ]
+      },
+      "system": "Always respond with numbered lists. Never use bullet points."
+    },
+    {
+      "id": "stop-high-temp",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-high-temp]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List 10 random words, numbered 1 through 10, one per line.",
+      "parameters": {
+        "temperature": 1.0,
+        "maxTokens": 512,
+        "stop": [
+          "3."
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "3."
+        ]
+      }
+    },
+    {
+      "id": "stop-seed-run1",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-seed-run1]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List 10 flowers, numbered 1 through 10, one per line.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512,
+        "seed": 42,
+        "stop": [
+          "3."
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "3."
+        ]
+      }
+    },
+    {
+      "id": "stop-seed-run2",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-seed-run2]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "List 10 flowers, numbered 1 through 10, one per line.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512,
+        "seed": 42,
+        "stop": [
+          "3."
+        ]
+      },
+      "expectations": {
+        "matchesCase": "stop-seed-run1",
+        "notContains": [
+          "3."
+        ]
+      }
+    },
+    {
+      "id": "stop-low-max-tokens",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ stop-low-max-tokens].",
+      "prompt": "List 10 mountains, numbered 1 through 10, one per line.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 100,
+        "stop": [
+          "2."
+        ]
+      },
+      "expectations": {
+        "notContains": [
+          "2."
+        ]
+      }
+    },
+    {
+      "id": "response-format-json",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ response-format-json]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Return a JSON object with keys \"language\", \"year_created\", and \"creator\" for Python.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "responseFormat": {
+          "type": "json_object"
+        }
+      },
+      "expectations": {
+        "validJSON": true
+      }
+    },
+    {
+      "id": "response-format-schema",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ response-format-schema]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Generate a fictional person profile.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "responseFormat": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "person",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "age": {
+                  "type": "integer"
+                },
+                "hobbies": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "name",
+                "age",
+                "hobbies"
+              ]
+            }
+          }
+        }
+      },
+      "expectations": {
+        "validJSON": true
+      }
+    },
+    {
+      "id": "response-format-text",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ response-format-text]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Tell me the language Python, what year it was created, and who created it. Be brief.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "think-normal",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ think-normal]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Solve step by step: If a train travels at 60 mph for 2.5 hours, how far does it go?",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "contains": [
+          "150"
+        ]
+      }
+    },
+    {
+      "id": "think-raw",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ think-raw]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run; raw-output CLI extraction is not varied inside the load-once evaluator.",
+      "prompt": "Solve step by step: If a train travels at 60 mph for 2.5 hours, how far does it go?",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "contains": [
+          "150"
+        ]
+      }
+    },
+    {
+      "id": "streaming-seeded",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ streaming-seeded]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a 4-line poem about the ocean.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512,
+        "seed": 123,
+        "streaming": true
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "non-streaming-seeded",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ non-streaming-seeded]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a 4-line poem about the ocean.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512,
+        "streaming": false,
+        "seed": 123
+      },
+      "expectations": {
+        "matchesCase": "streaming-seeded"
+      }
+    },
+    {
+      "id": "max-completion-tokens",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ max-completion-tokens].",
+      "prompt": "Explain the causes and consequences of the French Revolution.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 100
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "developer-role",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ developer-role]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a Python function that reverses a string.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      },
+      "developer": "You are a helpful coding assistant. Only respond with code, no explanations."
+    },
+    {
+      "id": "verbose",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ verbose]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run; --verbose is a process/runtime flag and is recorded as coverage-only in the load-once evaluator.",
+      "prompt": "Hello, how are you?",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "very-verbose",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ very-verbose]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run; --very-verbose is a process/runtime flag and is recorded as coverage-only in the load-once evaluator.",
+      "prompt": "Hello, how are you?",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "tool-call-auto",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ tool-call-auto]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "What is the weather in Tokyo?",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "tools": [
+          {
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "description": "Get current weather for a city",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "City name"
+                  },
+                  "unit": {
+                    "type": "string",
+                    "enum": [
+                      "celsius",
+                      "fahrenheit"
+                    ]
+                  }
+                },
+                "required": [
+                  "city"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "expectations": {
+        "toolCallName": "get_weather"
+      }
+    },
+    {
+      "id": "tool-call-xml",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ tool-call-xml]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run; --tool-call-parser is a process/runtime flag and is recorded as coverage-only in the load-once evaluator.",
+      "prompt": "What is the weather in Paris in celsius?",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "tools": [
+          {
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "description": "Get current weather for a city",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "City name"
+                  },
+                  "unit": {
+                    "type": "string",
+                    "enum": [
+                      "celsius",
+                      "fahrenheit"
+                    ]
+                  }
+                },
+                "required": [
+                  "city"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "expectations": {
+        "toolCallName": "get_weather"
+      }
+    },
+    {
+      "id": "tool-call-multi",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ tool-call-multi]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "What is the weather in London and what time is it in Tokyo?",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "tools": [
+          {
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "description": "Get current weather for a city",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "city": {
+                    "type": "string"
+                  },
+                  "unit": {
+                    "type": "string",
+                    "enum": [
+                      "celsius",
+                      "fahrenheit"
+                    ]
+                  }
+                },
+                "required": [
+                  "city"
+                ]
+              }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "get_time",
+              "description": "Get current time in a timezone",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "timezone": {
+                    "type": "string",
+                    "description": "IANA timezone"
+                  }
+                },
+                "required": [
+                  "timezone"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "expectations": {
+        "toolCallName": "get_weather"
+      }
+    },
+    {
+      "id": "tool-call-complex",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ tool-call-complex]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Search recursively for all Swift files under Sources/ with a max of 50 results.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "tools": [
+          {
+            "type": "function",
+            "function": {
+              "name": "search_files",
+              "description": "Search for files matching criteria",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "description": "Directory to search"
+                  },
+                  "pattern": {
+                    "type": "string",
+                    "description": "Glob pattern"
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "recursive": {
+                        "type": "boolean"
+                      },
+                      "max_results": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "path",
+                  "pattern"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "expectations": {
+        "toolCallName": "search_files"
+      }
+    },
+    {
+      "id": "tool-call-array-param",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ tool-call-array-param]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Create three todo items: Buy milk, Call dentist, Fix bug #42.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "tools": [
+          {
+            "type": "function",
+            "function": {
+              "name": "todowrite",
+              "description": "Write a list of todo items",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "todos": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "List of todo items to create"
+                  }
+                },
+                "required": [
+                  "todos"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "expectations": {
+        "toolCallName": "todowrite"
+      }
+    },
+    {
+      "id": "tool-call-nullable-param",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ tool-call-nullable-param]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "What is the weather in Chicago?",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512,
+        "tools": [
+          {
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "description": "Get weather for a location",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "type": "string",
+                    "description": "City name"
+                  },
+                  "units": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Temperature units",
+                    "default": null
+                  }
+                },
+                "required": [
+                  "location"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "expectations": {
+        "toolCallName": "get_weather"
+      }
+    },
+    {
+      "id": "tool-call-none",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ tool-call-none]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "What is the current temperature in Berlin?",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "minimal-prompt",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ minimal-prompt]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Hi",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "long-prompt",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ long-prompt]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Repeat after me exactly: The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. Now say DONE.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "contains": [
+          "DONE"
+        ]
+      }
+    },
+    {
+      "id": "special-chars",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ special-chars]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Repeat these characters exactly: <tag> \"quotes\" 'apostrophes' & ampersand \\n newline \\t tab emoji: 🎉🚀 CJK: 你好 Arabic: مرحبا",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "contains": [
+          "<tag>",
+          "🎉",
+          "你好",
+          "مرحبا"
+        ],
+        "caseSensitive": true
+      }
+    },
+    {
+      "id": "multilingual",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ multilingual]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Translate \"Hello, how are you?\" into French, Spanish, Japanese, and Arabic. Format as a numbered list.",
+      "parameters": {
+        "temperature": 0.3,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "code-python",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ code-python]. Adaptation: legacy max_tokens 32768 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a function that finds all prime numbers up to n using the Sieve of Eratosthenes.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "contains": [
+          "def ",
+          "prime"
+        ]
+      },
+      "system": "You are a Python expert. Write clean code with no explanation."
+    },
+    {
+      "id": "code-swift",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ code-swift]. Adaptation: legacy max_tokens 32768 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a Swift async function that fetches JSON from a URL using URLSession, decodes it into a Codable struct, and handles errors with Result type.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "contains": [
+          "URLSession",
+          "async"
+        ],
+        "caseSensitive": true
+      },
+      "system": "You are a Swift expert. Write clean code with no explanation."
+    },
+    {
+      "id": "math",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ math]. Adaptation: legacy max_tokens 32768 is bounded to 512 for the bundled local run.",
+      "prompt": "A store sells notebooks for $3.50 each. If you buy 5 or more, you get a 20% discount. Sales tax is 8.5%. How much do 7 notebooks cost after tax? Show your work.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "contains": [
+          "21.25"
+        ]
+      }
+    },
+    {
+      "id": "long-form",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ long-form]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Write a detailed technical blog post explaining how Mixture-of-Experts (MoE) models work, why they are efficient, and how they compare to dense models of similar total parameter count. Include concrete examples.",
+      "parameters": {
+        "temperature": 0.7,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "minimumCharacters": 1
+      }
+    },
+    {
+      "id": "strict-format",
+      "description": "Ported from Scripts/test-llm-comprehensive.txt [@ strict-format]. Adaptation: legacy max_tokens 4096 is bounded to 512 for the bundled local run.",
+      "prompt": "Output EXACTLY 3 lines. Each line must contain exactly one word. The words must be: apple, banana, cherry. No other text, no numbering, no punctuation.",
+      "parameters": {
+        "temperature": 0.0,
+        "maxTokens": 512
+      },
+      "expectations": {
+        "exact": "apple\nbanana\ncherry",
+        "caseSensitive": false
+      }
+    }
+  ]
+}

--- a/Sources/AFMKitMLX/Models/MLXModelService.swift
+++ b/Sources/AFMKitMLX/Models/MLXModelService.swift
@@ -1636,7 +1636,11 @@ public final class MLXModelService: @unchecked Sendable {
                 if let sidecar = resolvedMTPSidecar {
                     do {
                         let quantization = mtpQuantization(for: sidecar)
-                        loadedMTPBinding = try await loaded.perform { context in
+                        // Select the ModelContext overload explicitly. The dependency also
+                        // exposes a deprecated (model, tokenizer) overload, and Swift can
+                        // otherwise choose it while type-checking this Sendable binding.
+                        loadedMTPBinding = try await loaded.perform {
+                            (context: ModelContext) async throws -> MTPGeneratorBinding in
                             if let qwen = context.model as? Qwen3_5MoEModel {
                                 let head = try qwen.loadMTPHead(
                                     sidecarPath: sidecar,

--- a/Tests/MacLocalAPITests/AFMEvaluationTests.swift
+++ b/Tests/MacLocalAPITests/AFMEvaluationTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+@testable import AFMKit
+
+final class AFMEvaluationTests: XCTestCase {
+    func testBundledComprehensiveSuiteIsPackagedAndDiscoverable() throws {
+        let url = try XCTUnwrap(AFMEvaluationSuiteStore.bundledSuiteURL(named: "comprehensive"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+
+        let root = temporaryDirectory()
+        let store = AFMEvaluationSuiteStore(rootDirectory: root)
+        let suite = try store.load(named: "comprehensive")
+        XCTAssertEqual(suite.name, "comprehensive")
+        XCTAssertEqual(suite.cases.count, 91)
+        XCTAssertEqual(suite.cases.first?.id, "greedy")
+        XCTAssertEqual(suite.cases.last?.id, "strict-format")
+        XCTAssertTrue(try store.discover().contains { $0.name == "comprehensive" && $0.origin == .bundled })
+    }
+
+    func testCustomSuiteParsingAndDiscovery() throws {
+        let root = temporaryDirectory()
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let json = """
+        {
+          "schemaVersion": 1,
+          "name": "custom-check",
+          "description": "A test suite.",
+          "defaults": { "temperature": 0, "maxTokens": 64 },
+          "cases": [{
+            "id": "one",
+            "prompt": "Say one",
+            "expectations": { "contains": ["one"] }
+          }]
+        }
+        """
+        try Data(json.utf8).write(to: root.appendingPathComponent("custom-check.json"))
+        let store = AFMEvaluationSuiteStore(rootDirectory: root)
+        let suite = try store.load(named: "custom-check")
+        XCTAssertEqual(suite.cases.first?.id, "one")
+        XCTAssertTrue(try store.discover().contains { $0.name == "custom-check" && $0.origin == .custom })
+    }
+
+    func testMalformedAndUnknownSuiteFieldsAreRejectedActionably() throws {
+        let root = temporaryDirectory()
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let url = root.appendingPathComponent("bad.json")
+        try Data("""
+        {"schemaVersion":1,"name":"bad","description":"Bad.","surprise":true,
+         "cases":[{"id":"x","prompt":"hello"}]}
+        """.utf8).write(to: url)
+        let store = AFMEvaluationSuiteStore(rootDirectory: root)
+        XCTAssertThrowsError(try store.decode(url: url)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("Unknown key"))
+            XCTAssertTrue(error.localizedDescription.contains("surprise"))
+        }
+    }
+
+    func testSanitizationAndCollisionSafeRunPath() throws {
+        XCTAssertEqual(
+            AFMEvaluationSuiteStore.sanitizePathComponent("org/model name<script>"),
+            "org-model-name-script")
+        let root = temporaryDirectory()
+        let store = AFMEvaluationSuiteStore(rootDirectory: root)
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let first = try store.makeRunDirectory(model: "org/model", suites: ["suite"], date: date)
+        let second = try store.makeRunDirectory(model: "org/model", suites: ["suite"], date: date)
+        XCTAssertNotEqual(first, second)
+        XCTAssertTrue(second.lastPathComponent.hasSuffix("-2"))
+        XCTAssertFalse(first.lastPathComponent.contains("/"))
+    }
+
+    func testDeterministicScoringPassMissAndObservation() {
+        let pass = AFMEvaluationScorer.score(
+            output: "{\"answer\":\"Hello\"}",
+            toolCallNames: ["lookup"],
+            expectations: .init(
+                contains: ["hello"],
+                notContains: ["secret"],
+                validJSON: true,
+                toolCallName: "lookup"))
+        XCTAssertEqual(pass.0, .passed)
+        XCTAssertTrue(pass.1.allSatisfy(\.passed))
+
+        let miss = AFMEvaluationScorer.score(
+            output: "wrong",
+            expectations: .init(exact: "right"))
+        XCTAssertEqual(miss.0, .missed)
+
+        XCTAssertEqual(AFMEvaluationScorer.score(output: "anything", expectations: nil).0, .observed)
+    }
+
+    func testHTMLReportEscapesModelPromptOutputAndErrors() {
+        let parameters = AFMEvaluationParameters(temperature: 0, maxTokens: 16)
+        let result = AFMEvaluationCaseResult(
+            suite: "suite<script>",
+            caseID: "case&one",
+            prompt: "<img src=x onerror=alert(1)>",
+            system: nil,
+            output: "<script>alert('x')</script>",
+            reasoning: "a > b",
+            toolCalls: [],
+            outcome: .error,
+            checks: [],
+            error: "bad & worse",
+            startedAt: Date(timeIntervalSince1970: 0),
+            durationSeconds: 1,
+            timeToFirstTokenSeconds: 0.2,
+            promptTimeSeconds: 0.1,
+            generationTimeSeconds: 0.8,
+            promptTokens: 3,
+            cachedPromptTokens: 0,
+            completionTokens: 2,
+            tokensPerSecond: 2,
+            finishReason: "error",
+            parameters: parameters)
+        let report = AFMEvaluationRunReport(
+            afmVersion: "v-test",
+            model: "model<script>",
+            suites: ["suite<script>"],
+            startedAt: Date(timeIntervalSince1970: 0),
+            finishedAt: Date(timeIntervalSince1970: 1),
+            interrupted: false,
+            reproducibilityCommand: "afm <unsafe>",
+            system: .init(
+                operatingSystem: "macOS & test",
+                architecture: "arm64",
+                processorCount: 8,
+                physicalMemoryBytes: 16_000_000_000),
+            results: [result])
+        let html = AFMEvaluationReportWriter.html(for: report)
+        XCTAssertFalse(html.contains("<script>alert('x')</script>"))
+        XCTAssertTrue(html.contains("&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;"))
+        XCTAssertTrue(html.contains("bad &amp; worse"))
+        XCTAssertTrue(html.contains("<!doctype html>"))
+    }
+
+    func testCLIPlanCoversDefaultAliasSuitesAndManagement() throws {
+        XCTAssertEqual(
+            try AFMEvaluationCLIPlan.resolve(
+                evaluate: true, bench: false, suites: [], list: false,
+                scaffold: nil, validate: nil, noOpen: false),
+            .run(suites: ["comprehensive"], openReport: true))
+        XCTAssertEqual(
+            try AFMEvaluationCLIPlan.resolve(
+                evaluate: false, bench: true, suites: ["a", "b"], list: false,
+                scaffold: nil, validate: nil, noOpen: true),
+            .run(suites: ["a", "b"], openReport: false))
+        XCTAssertEqual(
+            try AFMEvaluationCLIPlan.resolve(
+                evaluate: false, bench: false, suites: [], list: true,
+                scaffold: nil, validate: nil, noOpen: false),
+            .list)
+        XCTAssertThrowsError(
+            try AFMEvaluationCLIPlan.resolve(
+                evaluate: false, bench: false, suites: [], list: true,
+                scaffold: "x", validate: nil, noOpen: false))
+    }
+
+    func testScaffoldCreatesValidSuiteAndRefusesOverwrite() throws {
+        let root = temporaryDirectory()
+        let store = AFMEvaluationSuiteStore(rootDirectory: root)
+        let url = try store.scaffold(named: "new-suite")
+        XCTAssertEqual(try store.decode(url: url).name, "new-suite")
+        XCTAssertThrowsError(try store.scaffold(named: "new-suite"))
+        XCTAssertThrowsError(try store.scaffold(named: "../escape"))
+    }
+
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("afm-eval-tests-\(UUID().uuidString)", isDirectory: true)
+    }
+}

--- a/Tests/MacLocalAPITests/AFMEvaluationTests.swift
+++ b/Tests/MacLocalAPITests/AFMEvaluationTests.swift
@@ -241,6 +241,16 @@ final class AFMEvaluationTests: XCTestCase {
             baseParameters: base)) { error in
             XCTAssertTrue(error.localizedDescription.contains("1000000 output tokens"))
         }
+
+        let oneCase = AFMEvaluationSuite(
+            name: "one-case",
+            description: "Valid suite whose CLI default is invalid.",
+            cases: [.init(id: "case", prompt: "test")])
+        XCTAssertThrowsError(try AFMEvaluationRunPolicy.validatePlannedOutput(
+            suites: [oneCase],
+            baseParameters: .init(maxTokens: 0))) { error in
+            XCTAssertTrue(error.localizedDescription.contains("maxTokens must be 1...32768"))
+        }
     }
 
     func testSnapshotPolicyIsBoundedByCaseCountAndElapsedTime() {

--- a/Tests/MacLocalAPITests/AFMEvaluationTests.swift
+++ b/Tests/MacLocalAPITests/AFMEvaluationTests.swift
@@ -253,6 +253,29 @@ final class AFMEvaluationTests: XCTestCase {
         }
     }
 
+    func testThroughputFallsBackWhenEngineGenerationTimeIsInvalid() {
+        XCTAssertEqual(
+            AFMEvaluationRunPolicy.tokensPerSecond(
+                completionTokens: 50,
+                generationTime: 2,
+                duration: 5),
+            25)
+        XCTAssertEqual(
+            AFMEvaluationRunPolicy.tokensPerSecond(
+                completionTokens: 50,
+                generationTime: 0,
+                duration: 5),
+            10)
+        XCTAssertNil(AFMEvaluationRunPolicy.tokensPerSecond(
+            completionTokens: 0,
+            generationTime: 1,
+            duration: 1))
+        XCTAssertNil(AFMEvaluationRunPolicy.tokensPerSecond(
+            completionTokens: 1,
+            generationTime: .nan,
+            duration: 0))
+    }
+
     func testSnapshotPolicyIsBoundedByCaseCountAndElapsedTime() {
         let now = Date(timeIntervalSince1970: 1_000)
         XCTAssertTrue(AFMEvaluationRunPolicy.shouldWriteSnapshot(

--- a/Tests/MacLocalAPITests/AFMEvaluationTests.swift
+++ b/Tests/MacLocalAPITests/AFMEvaluationTests.swift
@@ -54,6 +54,67 @@ final class AFMEvaluationTests: XCTestCase {
         }
     }
 
+    func testContradictoryCharacterBoundsAreRejected() throws {
+        let root = temporaryDirectory()
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let url = root.appendingPathComponent("bad-bounds.json")
+        try Data("""
+        {
+          "schemaVersion": 1,
+          "name": "bad-bounds",
+          "description": "Contradictory deterministic expectations.",
+          "cases": [{
+            "id": "one",
+            "prompt": "Say one",
+            "expectations": {"minimumCharacters": 10, "maximumCharacters": 5}
+          }]
+        }
+        """.utf8).write(to: url)
+
+        let store = AFMEvaluationSuiteStore(rootDirectory: root)
+        XCTAssertThrowsError(try store.decode(url: url)) { error in
+            XCTAssertTrue(error.localizedDescription.contains(
+                "minimumCharacters must be <= maximumCharacters"))
+        }
+    }
+
+    func testInvalidRuntimeParametersAreRejectedBeforeExecution() throws {
+        let root = temporaryDirectory()
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let url = root.appendingPathComponent("invalid-parameters.json")
+        let invalidValues = [
+            ("\"seed\": -1", "seed must be >= 0"),
+            ("\"repetitionPenalty\": 0", "repetitionPenalty must be finite"),
+            ("\"repetitionPenalty\": 1e308", "repetitionPenalty must be finite"),
+            ("\"presencePenalty\": 3", "presencePenalty must be finite")
+        ]
+
+        let store = AFMEvaluationSuiteStore(rootDirectory: root)
+        for (parameter, expectedMessage) in invalidValues {
+            try Data("""
+            {
+              "schemaVersion": 1,
+              "name": "invalid-parameters",
+              "description": "Invalid runtime parameter.",
+              "cases": [{
+                "id": "one",
+                "prompt": "Say one",
+                "parameters": {\(parameter)}
+              }]
+            }
+            """.utf8).write(to: url, options: .atomic)
+            XCTAssertThrowsError(try store.decode(url: url)) { error in
+                XCTAssertTrue(error.localizedDescription.contains(expectedMessage))
+            }
+        }
+
+        XCTAssertThrowsError(try AFMEvaluationSuiteStore.validateParameters(
+            .init(seed: -1),
+            context: "CLI")) { error in
+            XCTAssertTrue(error.localizedDescription.contains("CLI seed must be >= 0"))
+        }
+    }
+
     func testMalformedCustomSuiteDoesNotBlockValidDiscoveryOrNamedLoad() throws {
         let root = temporaryDirectory()
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)

--- a/Tests/MacLocalAPITests/AFMEvaluationTests.swift
+++ b/Tests/MacLocalAPITests/AFMEvaluationTests.swift
@@ -54,6 +54,63 @@ final class AFMEvaluationTests: XCTestCase {
         }
     }
 
+    func testMalformedCustomSuiteDoesNotBlockValidDiscoveryOrNamedLoad() throws {
+        let root = temporaryDirectory()
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("{not-json".utf8).write(to: root.appendingPathComponent("broken.json"))
+        try Data("""
+        {
+          "schemaVersion": 1,
+          "name": "valid",
+          "description": "Still discoverable.",
+          "cases": [{"id":"one","prompt":"Say one"}]
+        }
+        """.utf8).write(to: root.appendingPathComponent("valid.json"))
+
+        let store = AFMEvaluationSuiteStore(rootDirectory: root)
+        XCTAssertEqual(try store.load(named: "valid").name, "valid")
+        XCTAssertTrue(try store.discover().contains { $0.name == "valid" })
+        XCTAssertFalse(try store.discover().contains { $0.name == "broken" })
+    }
+
+    func testMatchesCaseIsBundledOnlyAndMustReferenceEarlierCase() throws {
+        let root = temporaryDirectory()
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let url = root.appendingPathComponent("matching.json")
+        try Data("""
+        {
+          "schemaVersion": 1,
+          "name": "matching",
+          "description": "Cross-case matching.",
+          "cases": [
+            {"id":"first","prompt":"one"},
+            {"id":"second","prompt":"two","expectations":{"matchesCase":"first"}}
+          ]
+        }
+        """.utf8).write(to: url)
+        let store = AFMEvaluationSuiteStore(rootDirectory: root)
+
+        XCTAssertThrowsError(try store.decode(url: url, origin: .custom)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("reserved for bundled suites"))
+        }
+        XCTAssertNoThrow(try store.decode(url: url, origin: .bundled))
+
+        try Data("""
+        {
+          "schemaVersion": 1,
+          "name": "matching",
+          "description": "Invalid forward match.",
+          "cases": [
+            {"id":"first","prompt":"one","expectations":{"matchesCase":"second"}},
+            {"id":"second","prompt":"two"}
+          ]
+        }
+        """.utf8).write(to: url)
+        XCTAssertThrowsError(try store.decode(url: url, origin: .bundled)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("earlier case in the same suite"))
+        }
+    }
+
     func testSanitizationAndCollisionSafeRunPath() throws {
         XCTAssertEqual(
             AFMEvaluationSuiteStore.sanitizePathComponent("org/model name<script>"),

--- a/Tests/MacLocalAPITests/AFMEvaluationTests.swift
+++ b/Tests/MacLocalAPITests/AFMEvaluationTests.swift
@@ -221,6 +221,48 @@ final class AFMEvaluationTests: XCTestCase {
         XCTAssertThrowsError(try store.scaffold(named: "../escape"))
     }
 
+    func testRunPolicyRejectsUnboundedAggregateOutput() throws {
+        let base = AFMEvaluationParameters(maxTokens: 256)
+        let acceptable = AFMEvaluationSuite(
+            name: "acceptable",
+            description: "Within the run budget.",
+            cases: (0..<10).map { .init(id: "case-\($0)", prompt: "test") })
+        XCTAssertNoThrow(try AFMEvaluationRunPolicy.validatePlannedOutput(
+            suites: [acceptable],
+            baseParameters: base))
+
+        let oversized = AFMEvaluationSuite(
+            name: "oversized",
+            description: "Exceeds the aggregate run budget.",
+            defaults: .init(maxTokens: 32_768),
+            cases: (0..<31).map { .init(id: "case-\($0)", prompt: "test") })
+        XCTAssertThrowsError(try AFMEvaluationRunPolicy.validatePlannedOutput(
+            suites: [oversized],
+            baseParameters: base)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("1000000 output tokens"))
+        }
+    }
+
+    func testSnapshotPolicyIsBoundedByCaseCountAndElapsedTime() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        XCTAssertTrue(AFMEvaluationRunPolicy.shouldWriteSnapshot(
+            completedCases: 1,
+            lastSnapshotAt: nil,
+            now: now))
+        XCTAssertFalse(AFMEvaluationRunPolicy.shouldWriteSnapshot(
+            completedCases: 2,
+            lastSnapshotAt: now,
+            now: now.addingTimeInterval(29)))
+        XCTAssertTrue(AFMEvaluationRunPolicy.shouldWriteSnapshot(
+            completedCases: 25,
+            lastSnapshotAt: now,
+            now: now.addingTimeInterval(1)))
+        XCTAssertTrue(AFMEvaluationRunPolicy.shouldWriteSnapshot(
+            completedCases: 2,
+            lastSnapshotAt: now,
+            now: now.addingTimeInterval(30)))
+    }
+
     private func temporaryDirectory() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("afm-eval-tests-\(UUID().uuidString)", isDirectory: true)

--- a/build.sh
+++ b/build.sh
@@ -419,6 +419,19 @@ trap - EXIT
 
 FINAL_DIR="$(dirname "$FINAL_BIN")"
 
+# AFMKit owns the bundled, no-judge evaluation suites. Keep its SwiftPM
+# resource bundle beside the executable in every install layout.
+EVAL_BUNDLE_DIR="$FINAL_DIR/MacLocalAPI_AFMKit.bundle"
+if [ -f "$EVAL_BUNDLE_DIR/Evals/comprehensive.json" ]; then
+  EVAL_SUITE="$EVAL_BUNDLE_DIR/Evals/comprehensive.json"
+elif [ -f "$EVAL_BUNDLE_DIR/Contents/Resources/Evals/comprehensive.json" ]; then
+  EVAL_SUITE="$EVAL_BUNDLE_DIR/Contents/Resources/Evals/comprehensive.json"
+else
+  log_error "Missing bundled evaluation suite under: $EVAL_BUNDLE_DIR"
+  exit 1
+fi
+log_info "Bundled evaluation suite OK: $EVAL_SUITE"
+
 # Verify the MLX metallib resource bundle is present. SwiftPM uses a flat bundle
 # with some toolchains and a macOS Contents/Resources bundle with Xcode 27.
 METALLIB_BUNDLE_DIR="$FINAL_DIR/MacLocalAPI_AFMKitMLX.bundle"
@@ -482,6 +495,7 @@ log_info "Metallib available for swift test (symlink -> $BUILD_CONFIG bundle)"
 if $DO_INSTALL; then
   log_step "Installing afm to $INSTALL_PREFIX/bin"
   BUNDLE_SRC="$METALLIB_BUNDLE_DIR"
+  EVAL_BUNDLE_SRC="$EVAL_BUNDLE_DIR"
   WEBUI_SRC="$ROOT_DIR/Resources/webui/index.html.gz"
 
   SUDO=""
@@ -501,6 +515,11 @@ if $DO_INSTALL; then
   $SUDO cp -R "$BUNDLE_SRC" "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMKitMLX.bundle"
   $SUDO ln -sfn "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMKitMLX.bundle" \
     "$INSTALL_PREFIX/bin/MacLocalAPI_AFMKitMLX.bundle"
+
+  $SUDO rm -rf "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMKit.bundle"
+  $SUDO cp -R "$EVAL_BUNDLE_SRC" "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMKit.bundle"
+  $SUDO ln -sfn "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMKit.bundle" \
+    "$INSTALL_PREFIX/bin/MacLocalAPI_AFMKit.bundle"
 
   if [ -f "$WEBUI_SRC" ]; then
     $SUDO install -m 644 "$WEBUI_SRC" "$INSTALL_PREFIX/share/afm/webui/index.html.gz"

--- a/docs/model-evaluations.md
+++ b/docs/model-evaluations.md
@@ -1,0 +1,121 @@
+# Local model evaluations
+
+`afm mlx -m <model> --eval` runs AFM's bundled `comprehensive` suite in-process.
+It does not start an HTTP server, invoke Python, call a cloud service, or use an AI
+judge. The MLX model is loaded once and reused for every case.
+
+`--bench` is a discoverable alias for `--eval`. Select additional suites by repeating
+`--eval-suite`; specifying a suite implies `--eval`:
+
+```bash
+afm mlx -m <model> --eval
+afm mlx -m <model> --bench --no-open
+afm mlx -m <model> --eval-suite comprehensive --eval-suite regression
+afm mlx --eval-list
+```
+
+The bundled suite contains **all 91 labeled variants** from
+`Scripts/test-llm-comprehensive.txt`, in the same order and with the same labels and
+prompts. The mapping is one legacy `[@ label]` to one JSON case whose `id` is `label`.
+It covers sampling, system/developer instructions, JSON, 29 stop-sequence variants,
+logprobs, seeded generation, reasoning, six native tool-schema variants, streaming,
+code, Unicode, multilingual output, longer-prefill timing, and arithmetic. Fifty-two
+cases have content-specific deterministic string/JSON/tool/cross-case checks; the
+remaining 39 make only a deterministic nonempty-output health check and retain
+performance evidence without claiming semantic quality. A failed content check is
+`missed`, not an infrastructure crash.
+
+The legacy shell harness changed process-wide flags by restarting AFM between variants.
+The native evaluator deliberately loads the model once. Per-request flags are translated
+directly. The following process-only variants remain present for prompt/output/metric
+coverage, and each generated case description records the adaptation:
+
+| Legacy process behavior | Variants | Native load-once behavior |
+|---|---:|---|
+| Prefix cache off/on A/B | 6 (3 marked cached) | Uses the evaluator's single CLI-level cache setting; prompts and TTFT are retained, but the suite does not claim an off/on comparison |
+| KV size / KV bits | 2 | Uses `--max-kv-size` compatibility behavior and the evaluator's CLI-level `--kv-bits` |
+| Prefill step size | 2 | Uses one CLI-level `--prefill-step-size`; per-case TTFT is still retained |
+| Raw reasoning extraction | 2 | Records separated visible output and reasoning rather than changing extraction mid-run |
+| Verbose / very verbose | 2 | Direct in-process evaluation does not restart logging modes |
+| Explicit legacy `xmlFunction` parser | 1 | Uses current native model-format detection; the tool-name assertion remains active |
+
+The old file's 4,096/32,768-token ceilings are bounded to 512 in the distributed suite
+so a default local run is comprehensive but finite; explicit smaller truncation cases
+retain their original limits. The intended `streaming-seeded` case uses the native
+streaming API (the old Python client actually sent every request with `stream=False`),
+and `non-streaming-seeded` checks cross-path seeded equivalence.
+
+## Results
+
+Each run creates a unique directory beneath `~/.afm/evals` named with the UTC date and
+time, sanitized model name, and selected suites. It contains:
+
+- `run.json`: complete machine-readable metadata, aggregates inputs, and results.
+- `results.jsonl`: one durable record per completed case, appended as the run proceeds.
+- `suites.json`: exact suite definitions used for reproduction.
+- `eval.log`: infrastructure errors without environment-variable dumps.
+- `report.html`: a self-contained, HTML-escaped report.
+
+The report includes AFM/model/suite identity, non-sensitive system information, every
+prompt and output, extracted reasoning and tool calls, deterministic check results,
+wall time, observable MLX prompt-time/TTFT, token counts, throughput, finish reason,
+per-case generation parameters, aggregate token/latency/throughput totals, and a
+reproducibility command. TTFT is only populated for native streaming cases; non-streaming
+cases retain prompt and generation timing without mislabeling prefill time as TTFT. On a successful interactive run AFM opens it
+with macOS `/usr/bin/open`; use `--no-open` for CI or remote sessions.
+
+SIGINT/SIGTERM takes effect at the next case boundary. Completed JSONL records and the
+latest HTML/JSON snapshots remain available. Schema/model-load and generation
+infrastructure failures return nonzero. Ordinary deterministic quality misses remain
+visible in the report but do not make the process fail.
+
+## Custom suites
+
+Create and validate a starter file:
+
+```bash
+afm mlx --eval-init regression
+afm mlx --eval-validate regression
+afm mlx -m <model> --eval-suite regression
+```
+
+Custom suites are JSON files directly under `~/.afm/evals`; result subdirectories are
+not scanned as suites. A custom suite with the same `name` overrides a bundled suite.
+The format is versioned and rejects unknown keys so misspelled options fail clearly:
+
+```json
+{
+  "schemaVersion": 1,
+  "name": "regression",
+  "description": "Project-specific local checks.",
+  "defaults": {
+    "temperature": 0,
+    "maxTokens": 128,
+    "seed": 42
+  },
+  "cases": [
+    {
+      "id": "hello",
+      "prompt": "Respond with exactly: hello",
+      "expectations": { "exact": "hello" }
+    }
+  ]
+}
+```
+
+Case `parameters` may set `temperature`, `maxTokens`, `topP`, `topK`, `minP`,
+`repetitionPenalty`, `presencePenalty`, `seed`, `logprobs`, `topLogprobs`, `stop`,
+OpenAI-compatible `tools`, `responseFormat`, and `streaming`. Cases may also add a
+`developer` message. Case values override suite defaults; suite defaults override CLI
+sampling values.
+
+Available deterministic expectations are `exact`, `contains`, `notContains`,
+`validJSON`, `minimumCharacters`, `maximumCharacters`, `toolCallName`, and
+`caseSensitive`; bundled suites can additionally use `matchesCase` for seeded cross-path
+checks. Checks are case-insensitive unless `caseSensitive` is true.
+
+For safety and predictable local resource use, names cannot contain path separators,
+suite files are capped at 5 MB and 1,000 cases, prompt/system text is capped at 64 KB
+per field, generation parameters have bounded ranges, and scaffold mode never
+overwrites a file. Suite files define inference inputs only: there are no commands,
+hooks, environment interpolation, network callbacks, or arbitrary file paths.

--- a/docs/model-evaluations.md
+++ b/docs/model-evaluations.md
@@ -50,8 +50,10 @@ and `non-streaming-seeded` checks cross-path seeded equivalence.
 Each run creates a unique directory beneath `~/.afm/evals` named with the UTC date and
 time, sanitized model name, and selected suites. It contains:
 
-- `run.json`: complete machine-readable metadata, aggregates inputs, and results.
-- `results.jsonl`: one durable record per completed case, appended as the run proceeds.
+- `run.json`: complete machine-readable metadata, aggregate inputs, and results. It is
+  refreshed periodically rather than rewritten after every case.
+- `results.jsonl`: one durable record per completed case, appended and synchronized as
+  the run proceeds. This is the recovery source between report snapshots.
 - `suites.json`: exact suite definitions used for reproduction.
 - `eval.log`: infrastructure errors without environment-variable dumps.
 - `report.html`: a self-contained, HTML-escaped report.
@@ -68,6 +70,13 @@ SIGINT/SIGTERM takes effect at the next case boundary. Completed JSONL records a
 latest HTML/JSON snapshots remain available. Schema/model-load and generation
 infrastructure failures return nonzero. Ordinary deterministic quality misses remain
 visible in the report but do not make the process fail.
+
+To keep large local suites predictable, AFM writes cumulative JSON/HTML snapshots on
+the first completed case, then at most every 25 cases or 30 seconds, and always once at
+completion, interruption, or infrastructure failure. A run is rejected before model
+loading when the merged CLI, suite-default, and case-level `maxTokens` values can request
+more than 1,000,000 output tokens in aggregate. Split a larger campaign into separate
+suites or lower its token ceilings.
 
 ## Custom suites
 
@@ -116,6 +125,7 @@ checks. Checks are case-insensitive unless `caseSensitive` is true.
 
 For safety and predictable local resource use, names cannot contain path separators,
 suite files are capped at 5 MB and 1,000 cases, prompt/system text is capped at 64 KB
-per field, generation parameters have bounded ranges, and scaffold mode never
+per field, aggregate planned output is capped at 1,000,000 tokens, generation
+parameters have bounded ranges, and scaffold mode never
 overwrites a file. Suite files define inference inputs only: there are no commands,
 hooks, environment interpolation, network callbacks, or arbitrary file paths.

--- a/pyproject-next.toml
+++ b/pyproject-next.toml
@@ -61,4 +61,4 @@ packages = ["macafm_next"]
 include-package-data = true
 
 [tool.setuptools.package-data]
-macafm_next = ["bin/*", "bin/*/*", "bin/*/*/*", "share/webui/*"]
+macafm_next = ["bin/*", "bin/*/*", "bin/*/*/*", "bin/*/*/*/*", "bin/*/*/*/*/*", "share/webui/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,4 +60,4 @@ packages = ["macafm"]
 include-package-data = true
 
 [tool.setuptools.package-data]
-macafm = ["bin/*", "bin/*/*", "bin/*/*/*", "share/webui/*"]
+macafm = ["bin/*", "bin/*/*", "bin/*/*/*", "bin/*/*/*/*", "bin/*/*/*/*/*", "share/webui/*"]


### PR DESCRIPTION
## Summary

Add a distributable, local-only model evaluation mode for `afm mlx`:

- `--eval` runs the default bundled `comprehensive` suite; `--bench` is an alias.
- Repeatable `--eval-suite` selects bundled or custom suites.
- `--eval-list`, `--eval-init`, and `--eval-validate` provide discovery, scaffolding, and strict validation.
- The MLX model loads once and all cases run in process without Python, shell orchestration, cloud calls, or an AI judge.

## Bundled and custom suite format

`Sources/AFMKit/Resources/Evals/comprehensive.json` is a versioned JSON suite shipped through `Bundle.module`. It preserves all 91 labeled variants from `Scripts/test-llm-comprehensive.txt` in the same order with the same labels and prompts. Fifty-two cases have content-specific deterministic checks; the remaining 39 make only a nonempty-output health check and retain performance evidence without claiming semantic quality. Process-only legacy variants remain mapped and are documented per case and in `docs/model-evaluations.md`.

Users can create strict JSON suites directly under `~/.afm/evals`:

```sh
afm mlx --eval-init regression
afm mlx --eval-validate regression
afm mlx -m org/model --eval-suite regression
```

Unknown keys, unsafe names, duplicate IDs, oversized definitions, and out-of-range parameters fail with actionable errors. Custom suites contain inference inputs and deterministic checks only; there are no commands, hooks, environment interpolation, callbacks, or arbitrary output paths.

## Report artifacts

Each run creates a collision-safe `~/.afm/evals/<UTC>-<model>-<suites>/` directory containing:

- `results.jsonl` durable per-case records
- `run.json` complete machine-readable run metadata and results
- `suites.json` the exact suite snapshots used
- `eval.log` infrastructure errors without environment dumps
- `report.html` a self-contained, HTML-escaped report

The report includes model and generation configuration, system identity, prompts and outputs, reasoning and tool calls, deterministic check status, wall latency, streaming TTFT when observable, prompt/generation time, token counts and throughput, aggregates, and a reproducibility command. Successful runs open the report through `/usr/bin/open`; `--no-open` supports headless use. SIGINT/SIGTERM preserves completed partial results at the next case boundary.

Release, nightly, tarball, Homebrew-formula generation, stable wheel, and nightly wheel packaging now retain `MacLocalAPI_AFMKit.bundle`, so the suite is present after relocation rather than only in development builds.

## Validation

- `Scripts/swiftpm-reliable.sh build -c release --product afm`
  - passed: `Build of product 'afm' complete! (231.60s)`
- `Scripts/swiftpm-reliable.sh test -c release --package-path /tmp/afm-eval-focused.j3sjZJ --filter AFMEvaluationTests`
  - passed: 8 tests, 0 failures
  - the temporary package symlinked the production evaluation source, production OpenAI-compatible types, bundled resource, and production test file; no harness files are committed
- `.build/release/afm mlx --eval-list`
  - passed; reports `comprehensive [bundled, 91 cases]`
- `.build/release/afm mlx --eval-validate comprehensive`
  - passed
- relocated-binary smoke check with `afm` plus all three runtime bundles in a fresh temporary directory
  - passed; the relocated binary discovered the bundled 91-case suite
- `bash -n build.sh Scripts/publish-stable.sh Scripts/publish-next.sh Scripts/build-nightly-wheel.sh Scripts/create-tarball.sh Scripts/generate-tap-versioned.sh`
  - passed
- `git diff --check`
  - passed

The monolithic repository test target was also attempted. Xcode 26 cannot compile the pre-existing macOS-27 Foundation Models target; installed Xcode 27 Beta 2 reaches that target but lacks its newer `randomTopK` and `randomProbabilityThreshold` SDK enum cases. The Foundation-only wrapper-driven package above isolates and passes all new evaluation tests despite that unrelated SDK gate.

## Summary by Sourcery

Add a distributable, deterministic local evaluation workflow for MLX models and ensure its bundled suites survive every supported packaging and installation path.

New Features:
- Add in-process local MLX model evaluation with a bundled 91-case comprehensive suite, repeatable custom suites, deterministic checks, and benchmarking aliases.
- Provide suite discovery, scaffolding, strict validation, collision-safe run artifacts, self-contained HTML reports, reproducibility metadata, and partial-result recovery.

Enhancements:
- Package evaluation resources with AFMKit and preserve them across relocated binaries, archives, Homebrew formulas, and Python wheels.
- Harden nightly wheel generation and packaging verification so temporary metadata and bundled resources are restored and validated reliably.

Build:
- Include the bundled evaluation resource directory in the AFMKit Swift package and expand Python package data patterns for nested bundles.

CI:
- Update release and nightly workflows to retain and verify the AFMKit resource bundle containing evaluation suites.

Deployment:
- Distribute the evaluation resource bundle with stable/nightly binaries, tarballs, Homebrew installations, and Python wheels.

Documentation:
- Document local evaluation usage, suite schema, deterministic checks, report artifacts, resource limits, and legacy-case adaptations.

Tests:
- Add focused coverage for bundled and custom suite loading, validation, scoring, report escaping, CLI planning, run limits, path safety, and snapshot policies.