### PR TITLE
Consume AFMKit Apple services

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -221,8 +221,7 @@ let package = Package(
             name: "AFMKitServicesCompatibility",
             dependencies: [
                 .product(name: "AFMKitServices", package: "AFMKit")
-            ],
-            path: "Sources/AFMKitServices"
+            ]
         ),
         // Core library — all reusable inference/service/server code. Importable via SPM.
         .target(
@@ -367,7 +366,7 @@ let package = Package(
                 "AFMKitFoundationModels",
                 "AFMKitFoundationModels27",
                 "AFMKitFoundationModels27DwarfStar",
-                "AFMKitServicesCompatibility",
+                .product(name: "AFMKitServices", package: "AFMKit"),
                 "AFMServer",
                 "AFMTerminalUI",
                 .product(name: "Jinja", package: "swift-jinja"),

--- a/Package.swift
+++ b/Package.swift
@@ -360,13 +360,17 @@ let package = Package(
             ]
         ),
         .testTarget(
+            name: "AFMKitServicesCompatibilityTests",
+            dependencies: ["AFMKitServicesCompatibility"]
+        ),
+        .testTarget(
             name: "MacLocalAPITests",
             dependencies: [
                 "AFMKit",
                 "AFMKitFoundationModels",
                 "AFMKitFoundationModels27",
                 "AFMKitFoundationModels27DwarfStar",
-                .product(name: "AFMKitServices", package: "AFMKit"),
+                "AFMKitServicesCompatibility",
                 "AFMServer",
                 "AFMTerminalUI",
                 .product(name: "Jinja", package: "swift-jinja"),

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -9,7 +9,7 @@ fail() {
   exit 1
 }
 
-for shadow_target in AFMKitCore AFMKitMLX AFMKitDwarfStar AFMOpenAICompat; do
+for shadow_target in AFMKitCore AFMKitMLX AFMKitDwarfStar AFMOpenAICompat AFMKitServices; do
   [[ ! -d "Sources/$shadow_target" ]] || \
     fail "consumer shadow target still exists: Sources/$shadow_target"
 done
@@ -33,6 +33,15 @@ grep -Fqx '@_exported import AFMKitApple' "${facade_files[0]}" || \
   fail "AFMKitFoundationModels must re-export the AFMKitApple product"
 if grep -Eq '\b(class|struct|enum|protocol|actor|func)[[:space:]]+' "${facade_files[0]}"; then
   fail "AFMKitFoundationModels facade contains a local implementation"
+fi
+
+service_facade_files=(Sources/AFMKitServicesCompatibility/*.swift)
+[[ ${#service_facade_files[@]} -eq 1 && -f "${service_facade_files[0]}" ]] || \
+  fail "AFMKitServicesCompatibility must contain only its compatibility facade"
+grep -Fqx '@_exported import AFMKitServices' "${service_facade_files[0]}" || \
+  fail "AFMKitServicesCompatibility must re-export the AFMKitServices product"
+if grep -Eq '\b(class|struct|enum|protocol|actor|func)[[:space:]]+' "${service_facade_files[0]}"; then
+  fail "AFMKitServicesCompatibility facade contains a local implementation"
 fi
 
 [[ -f Package.resolved ]] || \
@@ -192,7 +201,7 @@ for line in declared_paths:
 PY
 
 if grep -ERn \
-  '@testable import (AFMKitCore|AFMKitMLX|AFMKitDwarfStar|AFMOpenAICompat|AFMKitApple)' \
+  '@testable import (AFMKitCore|AFMKitMLX|AFMKitDwarfStar|AFMOpenAICompat|AFMKitApple|AFMKitEmbeddings|AFMKitSpeech|AFMKitSpeechSynthesis|AFMKitVision|AFMKitServices)' \
   Tests --include='*.swift' >/dev/null; then
   fail "consumer tests reach into AFMKit provider internals"
 fi
@@ -293,6 +302,12 @@ owned_types = {
     "OpenAIRequest",
     "OpenAIResponse",
     "OpenAIResponseFormatPolicy",
+    "EmbeddingBackend",
+    "EmbeddingModelRegistry",
+    "NLContextualEmbeddingBackend",
+    "SpeechService",
+    "SpeechSynthesisService",
+    "VisionService",
 }
 declaration = re.compile(
     r"\b(?:class|struct|enum|protocol|actor)\s+(" + "|".join(owned_types) + r")\b"
@@ -313,6 +328,11 @@ if checkout.is_dir():
     provider_roots = [
         checkout / "Sources/AFMKitApple",
         checkout / "Sources/AFMOpenAICompat",
+        checkout / "Sources/AFMKitEmbeddings",
+        checkout / "Sources/AFMKitSpeech",
+        checkout / "Sources/AFMKitSpeechSynthesis",
+        checkout / "Sources/AFMKitVision",
+        checkout / "Sources/AFMKitServices",
         checkout / "Packages/AFMKitMLX/Sources/AFMKitMLX",
         checkout / "Packages/AFMKitDwarfStar/Sources/AFMKitDwarfStar",
         checkout / "Packages/AFMKitDwarfStar/Sources/CDwarfStar",

--- a/Sources/AFMKitServices/Exports.swift
+++ b/Sources/AFMKitServices/Exports.swift
@@ -1,1 +1,0 @@
-@_exported import AFMKitServices

--- a/Sources/AFMKitServicesCompatibility/Exports.swift
+++ b/Sources/AFMKitServicesCompatibility/Exports.swift
@@ -1,0 +1,3 @@
+// Compatibility facade for applications that selected maclocal-api's service
+// product before the reusable Apple services moved to the standalone AFMKit SDK.
+@_exported import AFMKitServices

--- a/Tests/AFMKitServicesCompatibilityTests/AFMKitServicesCompatibilityTests.swift
+++ b/Tests/AFMKitServicesCompatibilityTests/AFMKitServicesCompatibilityTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import AFMKitServices
+import AFMKitServicesCompatibility
 
 final class AFMKitServicesCompatibilityTests: XCTestCase {
     func testLegacyProductMakesUpstreamServiceModuleImportable() {

--- a/Tests/AFMKitServicesCompatibilityTests/AFMKitServicesCompatibilityTests.swift
+++ b/Tests/AFMKitServicesCompatibilityTests/AFMKitServicesCompatibilityTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+import AFMKitServices
+
+final class AFMKitServicesCompatibilityTests: XCTestCase {
+    func testLegacyProductMakesUpstreamServiceModuleImportable() {
+        let registry = EmbeddingModelRegistry()
+        XCTAssertEqual(
+            registry.resolve(modelID: EmbeddingModelRegistry.defaultModelID)?.id,
+            EmbeddingModelRegistry.defaultModelID
+        )
+    }
+}

--- a/Tests/MacLocalAPITests/EmbeddingModelRegistryTests.swift
+++ b/Tests/MacLocalAPITests/EmbeddingModelRegistryTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 @testable import AFMKit
-@testable import AFMKitServices
+import AFMKitServices
 @testable import AFMServer
 
 final class EmbeddingModelRegistryTests: XCTestCase {
@@ -9,11 +9,11 @@ final class EmbeddingModelRegistryTests: XCTestCase {
         let registry = EmbeddingModelRegistry()
 
         let english = registry.resolve(modelID: EmbeddingModelRegistry.defaultModelID)
-        let multilingual = registry.resolve(modelID: EmbeddingModelRegistry.multilingualModelID)
+        let multilingual = registry.resolve(modelID: "apple-nl-contextual-multi")
 
         XCTAssertEqual(english?.id, EmbeddingModelRegistry.defaultModelID)
         XCTAssertEqual(english?.backend, .nlContextual)
-        XCTAssertEqual(multilingual?.id, EmbeddingModelRegistry.multilingualModelID)
+        XCTAssertEqual(multilingual?.id, "apple-nl-contextual-multi")
         XCTAssertEqual(multilingual?.backend, .nlContextual)
     }
 

--- a/Tests/MacLocalAPITests/EmbeddingsControllerTests.swift
+++ b/Tests/MacLocalAPITests/EmbeddingsControllerTests.swift
@@ -3,7 +3,7 @@ import Vapor
 import XCTVapor
 
 @testable import AFMKit
-@testable import AFMKitServices
+import AFMKitServices
 @testable import AFMServer
 
 final class EmbeddingsControllerTests: XCTestCase {

--- a/Tests/MacLocalAPITests/VisionAPIControllerTests.swift
+++ b/Tests/MacLocalAPITests/VisionAPIControllerTests.swift
@@ -3,7 +3,7 @@ import Vapor
 import XCTVapor
 
 @testable import AFMKit
-@testable import AFMKitServices
+import AFMKitServices
 @testable import AFMServer
 
 final class VisionAPIControllerTests: XCTestCase {


### PR DESCRIPTION
## Problem

AFM maintained duplicate implementations of Vision, Speech, TTS, and embeddings after those services became suitable for the standalone AFMKit package. That creates a permanent dual-development path.

## Approach

- consume the independently selectable AFMKit service products
- remove 2,144 lines of duplicate local service implementations
- preserve the existing `AFMKitServices` product/module through a thin re-export compatibility target
- update controller/tests to use the public standalone APIs
- strengthen the consumer-boundary gate and add a compatibility-facade test

This PR is stacked on the Step 1 consumer PR and pairs with AFMKit PR #4.

## Independent review fixes

Independent review added direct coverage for the compatibility facade and verified that the service migration does not pull optional products through the generic inference layer. The paired AFMKit review also fixed speech/TTS timeout hangs and qualification omissions before this PR was opened.

## Validation

- release `afm` build passed
- full deterministic AFM suite: 229 XCTest + 138 Swift Testing, 0 failures
- Qwen 3.8 MLX MTP assertions: 264/264
- bundled comprehensive suite: 91 cases, 15 deterministic model-quality misses, 0 infrastructure errors
- Promptfoo deterministic matrix: 38 profiles / 406 cases, 386 pass, 20 deterministic model-choice misses, 0 errors
- service/controller and compatibility-target tests passed
- AFMKit service suite and package gates passed independently
- no AI judge used

## Merge order / rollback

AFMKit PR #4 and its Step 1 base must be published/tagged first. Then update this repository to the immutable exact AFMKit version and regenerate the lock before merging. Until then the consumer boundary intentionally refuses the unpublished product set. Reverting this consumer commit restores the local implementations from git history. The installed Xcode beta required validation-only SDK compatibility edits; none are committed. GitHub-hosted checks may remain blocked by the account Actions billing/spending limit rather than code.

## Summary by Sourcery

Migrate Apple service consumption to standalone AFMKit products while preserving compatibility for existing AFMKitServices consumers.

Enhancements:
- Consume standalone AFMKit products for Apple embeddings, speech, speech synthesis, and vision services instead of maintaining local implementations.
- Retain the AFMKitServices product through a thin re-export compatibility facade and add coverage for legacy imports.

CI:
- Strengthen the AFMKit consumer-boundary checks to prevent local service implementations, unauthorized internal imports, and accidental provider ownership.

Tests:
- Update service and controller tests to use the public standalone AFMKit APIs.

Chores:
- Remove the duplicated local AFMKit service implementation.