### PR TITLE
Consume AFMKit DwarfStar bridge

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -364,6 +364,10 @@ let package = Package(
             dependencies: ["AFMKitServicesCompatibility"]
         ),
         .testTarget(
+            name: "AFMKitFoundationModels27DwarfStarCompatibilityTests",
+            dependencies: ["AFMKitFoundationModels27DwarfStar"]
+        ),
+        .testTarget(
             name: "MacLocalAPITests",
             dependencies: [
                 "AFMKit",

--- a/README.md
+++ b/README.md
@@ -340,6 +340,11 @@ publication policy. Release workflows fail closed until AFMKit is required by
 an exact public semantic version, or the source-package release surface is
 explicitly excluded.
 
+`AFMKitFoundationModels27DwarfStar` remains as a source-compatible re-export;
+the implementation and runtime lifetime management now live in AFMKit's
+`AFMKitFoundationModelsDwarfStar` product. This keeps AFM and independent
+AFMKit consumers on the same bridge while preserving a one-commit rollback.
+
 Start with the [AFMKit public API guide](docs/afmkit-public-api.md) and the
 [independent AFMKitCore consumer](Examples/AFMKitCoreOnlyConsumer/).
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -31,6 +31,8 @@ facade_files=(Sources/AFMKitFoundationModels/*.swift)
   fail "AFMKitFoundationModels must contain only its compatibility facade"
 grep -Fqx '@_exported import AFMKitApple' "${facade_files[0]}" || \
   fail "AFMKitFoundationModels must re-export the AFMKitApple product"
+grep -Fqx '#if compiler(>=6.4)' "${facade_files[0]}" || \
+  fail "AFMKitFoundationModels must compile to an empty compatibility surface on Xcode 26"
 if grep -Eq '\b(class|struct|enum|protocol|actor|func)[[:space:]]+' "${facade_files[0]}"; then
   fail "AFMKitFoundationModels facade contains a local implementation"
 fi

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -133,6 +133,7 @@ struct ServeCommand: ParsableCommand {
 
         // Validate randomness parameter
         if let rand = randomness {
+#if compiler(>=6.4)
             do {
                 _ = try RandomnessConfig.parse(rand)
             } catch let error as FoundationModelError {
@@ -140,6 +141,10 @@ struct ServeCommand: ParsableCommand {
             } catch {
                 throw ValidationError("Invalid randomness parameter format")
             }
+#else
+            throw ValidationError(
+                "--randomness requires the Swift 6.4 toolchain or newer")
+#endif
         }
 
         let defaultGuidedJsonSchema: ResponseFormat?
@@ -2133,6 +2138,7 @@ struct RootCommand: ParsableCommand {
 
         // Validate randomness parameter
         if let rand = randomness {
+#if compiler(>=6.4)
             do {
                 _ = try RandomnessConfig.parse(rand)
             } catch let error as FoundationModelError {
@@ -2140,6 +2146,10 @@ struct RootCommand: ParsableCommand {
             } catch {
                 throw ValidationError("Invalid randomness parameter format")
             }
+#else
+            throw ValidationError(
+                "--randomness requires the Swift 6.4 toolchain or newer")
+#endif
         }
 
         let hasTelegramOptions = TUIInvocationPolicy.hasTelegramOptions(
@@ -2766,6 +2776,7 @@ extension RootCommand {
         group.enter()
         Task {
             do {
+#if compiler(>=6.4)
                 if #available(macOS 26.0, *) {
                     debugLog("macOS 26+ detected, initializing FoundationModelService...")
                     let foundationService = try await FoundationModelService(instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails)
@@ -2785,6 +2796,9 @@ extension RootCommand {
                     debugLog("macOS 26+ not available")
                     result.value = .failure(FoundationModelError.notAvailable)
                 }
+#else
+                result.value = .failure(AFMEngineError.foundationModelsUnavailable)
+#endif
             } catch {
                 debugLog("Error occurred: \(error)")
                 result.value = .failure(error)
@@ -2798,11 +2812,15 @@ extension RootCommand {
         case .success(let response):
             print(response)
         case .failure(let error):
+#if compiler(>=6.4)
             if let foundationError = error as? FoundationModelError {
                 print("Error: \(foundationError.localizedDescription)")
             } else {
                 print("Error: \(error.localizedDescription)")
             }
+#else
+            print("Error: \(error.localizedDescription)")
+#endif
             throw ExitCode.failure
         case .none:
             print("Error: Unexpected error occurred")

--- a/Sources/AFMKit/AFMEngine.swift
+++ b/Sources/AFMKit/AFMEngine.swift
@@ -666,6 +666,7 @@ public actor AFMEngine {
     // MARK: - Foundation Models bridge (macOS 26+)
 
     private func ensureFoundation() async throws {
+#if compiler(>=6.4)
         if #available(macOS 26.0, *) {
             if foundationService == nil {
                 foundationService = try await FoundationModelService(
@@ -679,6 +680,9 @@ public actor AFMEngine {
         } else {
             throw AFMEngineError.foundationModelsUnavailable
         }
+#else
+        throw AFMEngineError.foundationModelsUnavailable
+#endif
     }
 
     private func performFoundationReset(with history: [Message]) async throws {
@@ -686,6 +690,7 @@ public actor AFMEngine {
             try await foundationDriver.resetConversation(history)
             return
         }
+#if compiler(>=6.4)
         try await ensureFoundation()
         if #available(macOS 26.0, *) {
             guard let service = foundationService as? FoundationModelService else {
@@ -693,6 +698,9 @@ public actor AFMEngine {
             }
             try await service.resetConversation(with: history)
         }
+#else
+        throw AFMEngineError.foundationModelsUnavailable
+#endif
     }
 
     private func prepareFoundationStreamTask() async {
@@ -703,6 +711,7 @@ public actor AFMEngine {
         if let foundationDriver {
             return try await foundationDriver.respond(messages, config)
         }
+#if compiler(>=6.4)
         try await ensureFoundation()
         if #available(macOS 26.0, *) {
             guard let svc = foundationService as? FoundationModelService else {
@@ -728,6 +737,9 @@ public actor AFMEngine {
             )
         }
         throw AFMEngineError.foundationModelsUnavailable
+#else
+        throw AFMEngineError.foundationModelsUnavailable
+#endif
     }
 
     private func foundationStream(
@@ -737,6 +749,7 @@ public actor AFMEngine {
         if let foundationDriver {
             return try await foundationDriver.stream(messages, config)
         }
+#if compiler(>=6.4)
         try await ensureFoundation()
         if #available(macOS 26.0, *) {
             guard let svc = foundationService as? FoundationModelService else {
@@ -766,6 +779,9 @@ public actor AFMEngine {
             )
         }
         throw AFMEngineError.foundationModelsUnavailable
+#else
+        throw AFMEngineError.foundationModelsUnavailable
+#endif
     }
 }
 

--- a/Sources/AFMKit/FoundationModelService+AFMLanguageModel.swift
+++ b/Sources/AFMKit/FoundationModelService+AFMLanguageModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import AFMOpenAICompat
 import AFMKitFoundationModels
 
+#if compiler(>=6.4)
 /// Adapts Apple's Foundation Models service to AFMKit's provider-neutral facade.
 @available(macOS 26.0, *)
 extension FoundationModelService: AFMLanguageModel {
@@ -29,3 +30,4 @@ extension FoundationModelService: AFMLanguageModel {
         )
     }
 }
+#endif

--- a/Sources/AFMServer/Controllers/ChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/ChatCompletionsController.swift
@@ -3,6 +3,7 @@ import AFMKit
 import AFMKitMLX
 import Foundation
 
+#if compiler(>=6.4)
 struct ChatCompletionsController: RouteCollection {
     private let streamingEnabled: Bool
     private let instructions: String
@@ -916,3 +917,41 @@ struct ChatCompletionsController: RouteCollection {
         return chunks.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
     }
 }
+#else
+/// Foundation Models is a compiler-gated provider. Older toolchains still
+/// build the MLX server and return a clear error if its Foundation route is used.
+struct ChatCompletionsController: RouteCollection {
+    init(
+        streamingEnabled: Bool = true,
+        instructions: String = "You are a helpful assistant",
+        adapter: String? = nil,
+        temperature: Double? = nil,
+        randomness: String? = nil,
+        permissiveGuardrails: Bool,
+        veryVerbose: Bool = false,
+        stop: String? = nil,
+        defaultGuidedJsonSchema: ResponseFormat? = nil
+    ) {}
+
+    func boot(routes: RoutesBuilder) throws {
+        let v1 = routes.grouped("v1")
+        v1.on(.POST, "chat", "completions", body: .collect(maxSize: "100mb"), use: unavailable)
+    }
+
+    static func resolveStrictJsonSchema(
+        requestFormat: ResponseFormat?,
+        serverDefault: ResponseFormat?
+    ) -> ResponseJsonSchema? {
+        OpenAIResponseFormatPolicy.effectiveStrictJsonSchema(
+            requestFormat: requestFormat,
+            serverDefault: serverDefault
+        )
+    }
+
+    private func unavailable(req: Request) async throws -> Response {
+        throw Abort(
+            .serviceUnavailable,
+            reason: "Apple Foundation Models require the Swift 6.4 toolchain or newer.")
+    }
+}
+#endif

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -557,6 +557,18 @@ public class Server: @unchecked Sendable {
         return nil
     }
 
+    /// Mirrors the chat-controller routing predicate without constructing a
+    /// service adapter. A model id plus either concrete model selects the
+    /// MLX-compatible path; every other configuration falls back to Apple's
+    /// Foundation Models controller.
+    static func usesAppleFoundationBackend(
+        mlxModelID: String?,
+        hasMLXModel: Bool,
+        hasProviderModel: Bool
+    ) -> Bool {
+        mlxModelID == nil || (!hasMLXModel && !hasProviderModel)
+    }
+
     private static func currentExecutableURL() -> URL {
         var size: UInt32 = 0
         _ = _NSGetExecutablePath(nil, &size)
@@ -2738,16 +2750,23 @@ public class Server: @unchecked Sendable {
         print("  \(brightCyan)╚════════════════════════════════════════════════════════════════════╝\(reset)")
         print("")
 
-        // Initialize the Foundation Model Service once at startup
+        // Initialize Foundation Models only for the Foundation route. MLX and
+        // provider-backed servers must remain usable with the Xcode 26 compiler.
+        if Self.usesAppleFoundationBackend(
+            mlxModelID: mlxModelID,
+            hasMLXModel: mlxModel != nil,
+            hasProviderModel: afmModel != nil
+        ) {
 #if compiler(>=6.4)
-        if #available(macOS 26.0, *) {
-            try await FoundationModelService.initialize(instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails, prewarm: prewarmEnabled)
-        }
+            if #available(macOS 26.0, *) {
+                try await FoundationModelService.initialize(instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails, prewarm: prewarmEnabled)
+            }
 #else
-        throw Abort(
-            .serviceUnavailable,
-            reason: "Apple Foundation Models require the Swift 6.4 toolchain or newer.")
+            throw Abort(
+                .serviceUnavailable,
+                reason: "Apple Foundation Models require the Swift 6.4 toolchain or newer.")
 #endif
+        }
 
         let repoURL = "https://github.com/scouzi1966/maclocal-api"
         let link = "\u{001B}]8;;\(repoURL)\u{001B}\\\(repoURL)\u{001B}]8;;\u{001B}\\"

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -2739,9 +2739,15 @@ public class Server: @unchecked Sendable {
         print("")
 
         // Initialize the Foundation Model Service once at startup
+#if compiler(>=6.4)
         if #available(macOS 26.0, *) {
             try await FoundationModelService.initialize(instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails, prewarm: prewarmEnabled)
         }
+#else
+        throw Abort(
+            .serviceUnavailable,
+            reason: "Apple Foundation Models require the Swift 6.4 toolchain or newer.")
+#endif
 
         let repoURL = "https://github.com/scouzi1966/maclocal-api"
         let link = "\u{001B}]8;;\(repoURL)\u{001B}\\\(repoURL)\u{001B}]8;;\u{001B}\\"

--- a/Tests/AFMKitFoundationModels27DwarfStarCompatibilityTests/AFMKitFoundationModels27DwarfStarCompatibilityTests.swift
+++ b/Tests/AFMKitFoundationModels27DwarfStarCompatibilityTests/AFMKitFoundationModels27DwarfStarCompatibilityTests.swift
@@ -1,0 +1,14 @@
+#if compiler(>=6.4) && canImport(FoundationModels)
+import XCTest
+import AFMKitFoundationModels27DwarfStar
+
+@available(macOS 27.0, *)
+final class AFMKitFoundationModels27DwarfStarCompatibilityTests: XCTestCase {
+    func testLegacyModuleReexportsDwarfStarModel() {
+        let model = DwarfStarLanguageModel(modelPath: "/tmp/model.gguf")
+
+        XCTAssertEqual(model.executorConfiguration.modelPath, "/tmp/model.gguf")
+        XCTAssertEqual(model.executorConfiguration.contextWindow, 32_768)
+    }
+}
+#endif

--- a/Tests/MacLocalAPITests/MLXFoundationLanguageModelTests.swift
+++ b/Tests/MacLocalAPITests/MLXFoundationLanguageModelTests.swift
@@ -1,4 +1,4 @@
-#if canImport(FoundationModels)
+#if compiler(>=6.4) && canImport(FoundationModels)
 import AFMKit
 @testable import AFMKitFoundationModels27
 @testable import AFMKitFoundationModels27DwarfStar

--- a/Tests/MacLocalAPITests/WebRuntimeControlTests.swift
+++ b/Tests/MacLocalAPITests/WebRuntimeControlTests.swift
@@ -2,6 +2,29 @@ import XCTest
 @testable import AFMServer
 
 final class WebRuntimeControlTests: XCTestCase {
+    func testExplicitModelRoutingSkipsAppleFoundationStartup() {
+        XCTAssertTrue(Server.usesAppleFoundationBackend(
+            mlxModelID: nil,
+            hasMLXModel: false,
+            hasProviderModel: false
+        ))
+        XCTAssertFalse(Server.usesAppleFoundationBackend(
+            mlxModelID: "mlx-community/model",
+            hasMLXModel: true,
+            hasProviderModel: false
+        ))
+        XCTAssertFalse(Server.usesAppleFoundationBackend(
+            mlxModelID: "provider/model",
+            hasMLXModel: false,
+            hasProviderModel: true
+        ))
+        XCTAssertTrue(Server.usesAppleFoundationBackend(
+            mlxModelID: "missing/model",
+            hasMLXModel: false,
+            hasProviderModel: false
+        ))
+    }
+
     func testWebControlAcceptsOnlyLoopbackAddressesAndOrigins() {
         XCTAssertTrue(Server.isLoopbackWebAddress("127.0.0.1"))
         XCTAssertTrue(Server.isLoopbackWebAddress("::1"))


### PR DESCRIPTION
## Problem

AFM carries a duplicate DwarfStar/Foundation Models bridge, and earlier compiler gating could prevent MLX/provider servers from starting under Xcode 26.

## Approach

- Replace the local bridge implementation with a compiler-gated compatibility re-export of AFMKitFoundationModelsDwarfStar.
- Preserve the legacy AFMKitFoundationModels27DwarfStar module surface.
- Gate concrete Foundation Models imports and dependencies for Xcode 26.
- Initialize Apple Foundation Models only when backend routing actually selects that backend.
- Keep MLX and provider-backed server startup available under Xcode 26.

## Independent review fixes

Independent review corrected a release-blocking executor lifetime issue in the provider stack and a consumer startup regression. The final routing fix matches controller selection exactly, covers model-ID-only fallback behavior, and adds four routing assertions.

## Validation

- Xcode 26 AFMServer release build passed.
- Xcode 27 Foundation Models compatibility target passed.
- WebRuntimeControlTests: 6/6.
- Full consumer suite: 229 XCTest + 138 Swift Testing, zero failures.
- Qwen3.8-27B-4bit with MTP, no AI judge:
  - assertions: 264/264;
  - bundled comprehensive: 91 cases, 15 deterministic quality misses, 0 infrastructure failures;
  - Promptfoo: 38 profiles / 406 cases, 386 pass, 20 deterministic quality misses, 0 errors.
- MLX source-selection and diff checks passed.

## Release sequencing

This PR is stacked on the Step 2 consumer branch. Merge/publish the matching AFMKit stack first, then update the consumer to a real exact AFMKit tag. The production exact-pin gate remains intentionally enforced.

## Summary by Sourcery

Adopt AFMKit's shared DwarfStar bridge and make Foundation Models support compiler-gated so MLX and provider servers remain usable under Xcode 26.

Bug Fixes:
- Keep MLX- and provider-backed servers available under Xcode 26 by avoiding unnecessary Foundation Models initialization.
- Correct backend startup routing so Apple Foundation Models are initialized only when that backend is selected.

Enhancements:
- Replace the local DwarfStar bridge implementation with AFMKit's shared Foundation Models bridge while preserving the legacy AFMKitFoundationModels27DwarfStar module surface.
- Add compiler-gated compatibility behavior for Foundation Models APIs and clear unsupported-toolchain errors.

Documentation:
- Document the shared DwarfStar bridge and compatibility re-export behavior.

Tests:
- Add compatibility coverage for the legacy DwarfStar module re-export and assertions for backend routing behavior.