### PR TITLE
Fix evaluation bundle packaging

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,7 +46,7 @@ jobs:
         cp Resources/webui/index.html.gz release-package/Resources/webui/
 
         # Copy required runtime resource bundles beside the executable.
-        for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
+        for BUNDLE_NAME in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
           BUNDLE_DIR=$(dirname "$BIN")/$BUNDLE_NAME
           test -d "$BUNDLE_DIR"
           cp -r "$BUNDLE_DIR" release-package/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         cp Resources/webui/index.html.gz release-package/Resources/webui/
         Scripts/verify-webui.sh release-package/Resources/webui/index.html.gz
 
-        for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
+        for BUNDLE_NAME in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
           BUNDLE_DIR=.build/arm64-apple-macosx/release/$BUNDLE_NAME
           test -d "$BUNDLE_DIR"
           cp -r "$BUNDLE_DIR" release-package/

--- a/Scripts/build-native-wheel.sh
+++ b/Scripts/build-native-wheel.sh
@@ -85,7 +85,7 @@ fi
 
 mkdir -p "$PACKAGE_ROOT/bin" "$PACKAGE_ROOT/share/webui"
 cp "$BIN" "$PACKAGE_ROOT/bin/"
-for bundle in MacLocalAPI_AFMKit.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
+for bundle in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
   source_bundle="$(dirname "$BIN")/$bundle"
   [[ -d "$source_bundle" ]] || {
     echo "[wheel] Required runtime bundle missing: $source_bundle" >&2

--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -118,7 +118,7 @@ sed -i '' "s/^version = .*/version = \"${PYTHON_VERSION}\"/" pyproject-next.toml
 echo "[INFO] Staging assets into macafm_next/"
 mkdir -p macafm_next/bin
 cp "$BIN" macafm_next/bin/
-for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
+for BUNDLE_NAME in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
     BUNDLE_DIR="$(dirname "$BIN")/$BUNDLE_NAME"
     if [ ! -d "$BUNDLE_DIR" ]; then
         echo "[ERROR] Required runtime bundle missing: $BUNDLE_DIR"
@@ -227,7 +227,7 @@ rm -rf "$WHEEL_SMOKE"
 echo "[INFO] Verified wheel metadata version: $ACTUAL_PYTHON_VERSION"
 echo "[INFO] Verified wheel runtime version: $ACTUAL_VERSION"
 if ! unzip -Z1 "$WHL" | grep -E \
-    '(^|/)macafm_next/bin/MacLocalAPI_AFMKit\.bundle/(Evals/|Contents/Resources/Evals/)comprehensive\.json$' \
+    '(^|/)macafm_next/bin/MacLocalAPI_AFMEvaluationHost\.bundle/(Evals/|Contents/Resources/Evals/)comprehensive\.json$' \
     >/dev/null; then
     echo "[ERROR] Wheel is missing the bundled comprehensive evaluation suite"
     exit 1

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -240,6 +240,26 @@ if grep -ERn \
   fail "release packaging still references a maclocal-api-owned provider bundle"
 fi
 
+evaluation_bundle_consumers=(
+  build.sh
+  .github/workflows/nightly.yml
+  .github/workflows/release.yml
+  Scripts/build-native-wheel.sh
+  Scripts/build-nightly-wheel.sh
+  Scripts/create-tarball.sh
+  Scripts/generate-tap-versioned.sh
+  Scripts/publish-next.sh
+  Scripts/publish-stable.sh
+  Scripts/verify-native-wheel.sh
+)
+if grep -En 'MacLocalAPI_AFMKit\.bundle' "${evaluation_bundle_consumers[@]}" >/dev/null; then
+  fail "release packaging still references the pre-extraction evaluation bundle"
+fi
+for consumer in "${evaluation_bundle_consumers[@]}"; do
+  grep -Fq 'MacLocalAPI_AFMEvaluationHost.bundle' "$consumer" || \
+    fail "$consumer does not package the AFMEvaluationHost resource bundle"
+done
+
 for workflow in .github/workflows/nightly.yml .github/workflows/release.yml; do
   grep -Fq 'AFMKit_AFMKitMLX.bundle' "$workflow" || \
     fail "$workflow does not package the AFMKit MLX resource bundle"

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -241,7 +241,6 @@ if grep -ERn \
 fi
 
 evaluation_bundle_consumers=(
-  build.sh
   .github/workflows/nightly.yml
   .github/workflows/release.yml
   Scripts/build-native-wheel.sh
@@ -251,6 +250,7 @@ evaluation_bundle_consumers=(
   Scripts/publish-next.sh
   Scripts/publish-stable.sh
   Scripts/verify-native-wheel.sh
+  Scripts/verify-release-archive.sh
 )
 if grep -En 'MacLocalAPI_AFMKit\.bundle' "${evaluation_bundle_consumers[@]}" >/dev/null; then
   fail "release packaging still references the pre-extraction evaluation bundle"
@@ -259,6 +259,16 @@ for consumer in "${evaluation_bundle_consumers[@]}"; do
   grep -Fq 'MacLocalAPI_AFMEvaluationHost.bundle' "$consumer" || \
     fail "$consumer does not package the AFMEvaluationHost resource bundle"
 done
+for consumer in build.sh Scripts/uninstall.sh; do
+  grep -Fq 'MacLocalAPI_AFMEvaluationHost.bundle' "$consumer" || \
+    fail "$consumer does not manage the AFMEvaluationHost resource bundle"
+done
+grep -Fq 'rm -rf "$INSTALL_PREFIX/bin/MacLocalAPI_AFMKit.bundle"' build.sh || \
+  fail "build.sh does not remove the legacy evaluation bundle from bin on upgrade"
+grep -Fq 'rm -rf "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMKit.bundle"' build.sh || \
+  fail "build.sh does not remove the legacy evaluation bundle from libexec on upgrade"
+grep -Fq 'MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMEvaluationHost.bundle' Scripts/uninstall.sh || \
+  fail "uninstall.sh does not remove both legacy and current evaluation bundles"
 
 for workflow in .github/workflows/nightly.yml .github/workflows/release.yml; do
   grep -Fq 'AFMKit_AFMKitMLX.bundle' "$workflow" || \

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -241,6 +241,7 @@ if grep -ERn \
 fi
 
 evaluation_bundle_consumers=(
+  build.sh
   .github/workflows/nightly.yml
   .github/workflows/release.yml
   Scripts/build-native-wheel.sh
@@ -251,17 +252,24 @@ evaluation_bundle_consumers=(
   Scripts/publish-stable.sh
   Scripts/verify-native-wheel.sh
   Scripts/verify-release-archive.sh
+  Scripts/uninstall.sh
 )
-if grep -En 'MacLocalAPI_AFMKit\.bundle' "${evaluation_bundle_consumers[@]}" >/dev/null; then
+evaluation_bundle_no_legacy_consumers=(
+  .github/workflows/nightly.yml
+  .github/workflows/release.yml
+  Scripts/build-native-wheel.sh
+  Scripts/build-nightly-wheel.sh
+  Scripts/create-tarball.sh
+  Scripts/generate-tap-versioned.sh
+  Scripts/verify-native-wheel.sh
+  Scripts/verify-release-archive.sh
+)
+if grep -En 'MacLocalAPI_AFMKit\.bundle' "${evaluation_bundle_no_legacy_consumers[@]}" >/dev/null; then
   fail "release packaging still references the pre-extraction evaluation bundle"
 fi
 for consumer in "${evaluation_bundle_consumers[@]}"; do
   grep -Fq 'MacLocalAPI_AFMEvaluationHost.bundle' "$consumer" || \
     fail "$consumer does not package the AFMEvaluationHost resource bundle"
-done
-for consumer in build.sh Scripts/uninstall.sh; do
-  grep -Fq 'MacLocalAPI_AFMEvaluationHost.bundle' "$consumer" || \
-    fail "$consumer does not manage the AFMEvaluationHost resource bundle"
 done
 grep -Fq 'rm -rf "$INSTALL_PREFIX/bin/MacLocalAPI_AFMKit.bundle"' build.sh || \
   fail "build.sh does not remove the legacy evaluation bundle from bin on upgrade"
@@ -269,6 +277,10 @@ grep -Fq 'rm -rf "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMKit.bundle"' build.
   fail "build.sh does not remove the legacy evaluation bundle from libexec on upgrade"
 grep -Fq 'MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMEvaluationHost.bundle' Scripts/uninstall.sh || \
   fail "uninstall.sh does not remove both legacy and current evaluation bundles"
+for publisher in Scripts/publish-next.sh Scripts/publish-stable.sh; do
+  grep -Fq "s/libexec\\.install \"MacLocalAPI_AFMKit\\.bundle\"/libexec.install \"MacLocalAPI_AFMEvaluationHost.bundle\"/" "$publisher" || \
+    fail "$publisher does not migrate an existing Homebrew formula to the current evaluation bundle"
+done
 
 for workflow in .github/workflows/nightly.yml .github/workflows/release.yml; do
   grep -Fq 'AFMKit_AFMKitMLX.bundle' "$workflow" || \

--- a/Scripts/create-tarball.sh
+++ b/Scripts/create-tarball.sh
@@ -97,7 +97,7 @@ fi
 DIRNAME="afm-${VERSION}-${ARCH}"
 mkdir -p "$STAGING/$DIRNAME/Resources/webui"
 cp "$BIN" "$STAGING/$DIRNAME/"
-for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
+for BUNDLE_NAME in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
   BUNDLE_DIR="$(dirname "$BIN")/$BUNDLE_NAME"
   if [ ! -d "$BUNDLE_DIR" ]; then
     log_error "Required runtime bundle missing: $BUNDLE_DIR"

--- a/Scripts/generate-tap-versioned.sh
+++ b/Scripts/generate-tap-versioned.sh
@@ -106,7 +106,7 @@ class ${class} < Formula
 
   def install
     bin.install "afm"
-    ["MacLocalAPI_AFMKit.bundle", "AFMKit_AFMKitMLX.bundle", "AFMKit_AFMKitDwarfStar.bundle"].each do |bundle_name|
+    ["MacLocalAPI_AFMEvaluationHost.bundle", "AFMKit_AFMKitMLX.bundle", "AFMKit_AFMKitDwarfStar.bundle"].each do |bundle_name|
       if File.directory?(bundle_name)
         (libexec/bundle_name).install Dir["#{bundle_name}/*"]
       end
@@ -117,7 +117,7 @@ class ${class} < Formula
   end
 
   def post_install
-    ["MacLocalAPI_AFMKit.bundle", "AFMKit_AFMKitMLX.bundle", "AFMKit_AFMKitDwarfStar.bundle"].each do |bundle_name|
+    ["MacLocalAPI_AFMEvaluationHost.bundle", "AFMKit_AFMKitMLX.bundle", "AFMKit_AFMKitDwarfStar.bundle"].each do |bundle_name|
       bundle_src = libexec/bundle_name
       bundle_dst = HOMEBREW_PREFIX/"bin"/bundle_name
       bundle_dst.unlink if bundle_dst.symlink? || bundle_dst.exist?
@@ -165,7 +165,7 @@ class ${class} < Formula
 
   def install
     libexec.install "afm"
-    libexec.install "MacLocalAPI_AFMKit.bundle"
+    libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"
     libexec.install "AFMKit_AFMKitMLX.bundle"
     libexec.install "AFMKit_AFMKitDwarfStar.bundle"
     (bin/"afm").write_env_script libexec/"afm", AFM_BUILD_VERSION: "v#{version}"

--- a/Scripts/publish-next.sh
+++ b/Scripts/publish-next.sh
@@ -323,6 +323,9 @@ if ! grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm-
   log_error "Homebrew nightly formula does not install the required WebUI"
   exit 1
 fi
+if grep -Fq 'libexec.install "MacLocalAPI_AFMKit.bundle"' afm-next.rb; then
+  sed -i '' 's/libexec\.install "MacLocalAPI_AFMKit\.bundle"/libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"/' afm-next.rb
+fi
 if ! grep -Fq 'libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"' afm-next.rb; then
   sed -i '' '/libexec.install "afm"/a\
     libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"

--- a/Scripts/publish-next.sh
+++ b/Scripts/publish-next.sh
@@ -162,9 +162,9 @@ fi
 
 cp "$BIN" "$STAGING/"
 
-# Runtime resource bundles must remain beside the relocated executable: AFMKit
-# supplies evaluation suites, MLX supplies its metallib, and DwarfStar supplies Metal sources.
-for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
+# Runtime resource bundles must remain beside the relocated executable: the AFM
+# host supplies evaluation suites, MLX its metallib, and DwarfStar Metal sources.
+for BUNDLE_NAME in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
   BUNDLE_DIR="$(dirname "$BIN")/$BUNDLE_NAME"
   if [ ! -d "$BUNDLE_DIR" ]; then
     log_error "Required runtime bundle missing: $BUNDLE_DIR"
@@ -323,12 +323,12 @@ if ! grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm-
   log_error "Homebrew nightly formula does not install the required WebUI"
   exit 1
 fi
-if ! grep -Fq 'libexec.install "MacLocalAPI_AFMKit.bundle"' afm-next.rb; then
+if ! grep -Fq 'libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"' afm-next.rb; then
   sed -i '' '/libexec.install "afm"/a\
-    libexec.install "MacLocalAPI_AFMKit.bundle"
+    libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"
 ' afm-next.rb
 fi
-if ! grep -Fq 'libexec.install "MacLocalAPI_AFMKit.bundle"' afm-next.rb; then
+if ! grep -Fq 'libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"' afm-next.rb; then
   log_error "Homebrew nightly formula does not install the bundled evaluation suites"
   exit 1
 fi

--- a/Scripts/publish-stable.sh
+++ b/Scripts/publish-stable.sh
@@ -254,6 +254,9 @@ if ! grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm.
   log_error "Homebrew stable formula does not install the required WebUI"
   exit 1
 fi
+if grep -Fq 'libexec.install "MacLocalAPI_AFMKit.bundle"' afm.rb; then
+  sed -i '' 's/libexec\.install "MacLocalAPI_AFMKit\.bundle"/libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"/' afm.rb
+fi
 if ! grep -Fq 'libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"' afm.rb; then
   sed -i '' '/libexec.install "afm"/a\
     libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"

--- a/Scripts/publish-stable.sh
+++ b/Scripts/publish-stable.sh
@@ -141,7 +141,7 @@ mkdir -p "$STAGING"
 cp "$BIN" "$STAGING/"
 
 # Runtime resource bundles must remain beside the relocated executable.
-for BUNDLE_NAME in MacLocalAPI_AFMKit.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
+for BUNDLE_NAME in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
   BUNDLE_DIR="$(dirname "$BIN")/$BUNDLE_NAME"
   if [ ! -d "$BUNDLE_DIR" ]; then
     log_error "Required runtime bundle missing: $BUNDLE_DIR"
@@ -254,12 +254,12 @@ if ! grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm.
   log_error "Homebrew stable formula does not install the required WebUI"
   exit 1
 fi
-if ! grep -Fq 'libexec.install "MacLocalAPI_AFMKit.bundle"' afm.rb; then
+if ! grep -Fq 'libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"' afm.rb; then
   sed -i '' '/libexec.install "afm"/a\
-    libexec.install "MacLocalAPI_AFMKit.bundle"
+    libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"
 ' afm.rb
 fi
-if ! grep -Fq 'libexec.install "MacLocalAPI_AFMKit.bundle"' afm.rb; then
+if ! grep -Fq 'libexec.install "MacLocalAPI_AFMEvaluationHost.bundle"' afm.rb; then
   log_error "Homebrew stable formula does not install the bundled evaluation suites"
   exit 1
 fi

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -60,22 +60,16 @@ if grep -Fq 'public-gate-secret' "$public_gate_log"; then
   fail "public-release gate leaked a development token"
 fi
 
-private_gate_log="$WORK_ROOT/private-version-error.log"
-if (
-  export AFMKIT_READ_TOKEN="public-gate-secret"
+release_source="$(
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
-  read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.1'
-  }
-  probe_public_source() {
-    return 1
-  }
-  check_public_release_eligibility
-) >"$private_gate_log" 2>&1; then
-  fail "production public-release gate accepted a private exact dependency"
-fi
-grep -Fq 'is not anonymously fetchable' "$private_gate_log" || \
-  fail "public-release failure does not distinguish development authentication"
+  read_public_release_sources
+)"
+IFS=$'\t' read -r release_identity release_url release_revision release_version <<<"$release_source"
+[[ "$release_identity" == "afmkit" ]] || fail "release source identity is not AFMKit"
+[[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
+  fail "release source is not the canonical public HTTPS repository"
+[[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
+[[ "$release_version" == "0.1.1" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.1"
 
 if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
@@ -93,9 +87,11 @@ fi
 
 prefix="$WORK_ROOT/custom-prefix"
 mkdir -p \
+  "$prefix/bin/MacLocalAPI_AFMKit.bundle" \
   "$prefix/bin/MacLocalAPI_AFMEvaluationHost.bundle" \
   "$prefix/bin/AFMKit_AFMKitMLX.bundle" \
   "$prefix/bin/AFMKit_AFMKitDwarfStar.bundle" \
+  "$prefix/libexec/afm/MacLocalAPI_AFMKit.bundle/Evals" \
   "$prefix/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle/Evals" \
   "$prefix/libexec/afm/AFMKit_AFMKitMLX.bundle/Contents/Resources" \
   "$prefix/libexec/afm/AFMKit_AFMKitDwarfStar.bundle/metal" \
@@ -107,6 +103,8 @@ printf 'unrelated' > "$prefix/share/afm/webui/keep-me"
 printf 'resource' > "$prefix/share/afm/webui/index.html.gz"
 INSTALL_PREFIX="$prefix" "$ROOT_DIR/Scripts/uninstall.sh"
 [[ ! -e "$prefix/bin/afm" ]] || fail "custom-prefix binary was not removed"
+[[ ! -e "$prefix/bin/MacLocalAPI_AFMKit.bundle" ]] || fail "legacy evaluation bundle was not removed"
+[[ ! -e "$prefix/libexec/afm/MacLocalAPI_AFMKit.bundle" ]] || fail "legacy libexec evaluation bundle was not removed"
 [[ ! -e "$prefix/bin/MacLocalAPI_AFMEvaluationHost.bundle" ]] || fail "evaluation bundle was not removed"
 [[ ! -e "$prefix/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle" ]] || fail "libexec evaluation bundle was not removed"
 [[ ! -e "$prefix/bin/AFMKit_AFMKitMLX.bundle" ]] || fail "custom-prefix bundle was not removed"

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -71,6 +71,26 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
 [[ "$release_version" == "0.1.1" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.1"
 
+private_gate_log="$WORK_ROOT/private-version-error.log"
+if (
+  export AFMKIT_READ_TOKEN="private-gate-secret"
+  source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
+  read_public_release_sources() {
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.1'
+  }
+  probe_public_source() {
+    [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
+  }
+  check_public_release_eligibility
+) >"$private_gate_log" 2>&1; then
+  fail "production public-release gate accepted an authenticated-only exact dependency"
+fi
+grep -Fq 'is not anonymously fetchable' "$private_gate_log" || \
+  fail "public-release gate did not reject the authenticated-only exact dependency"
+if grep -Fq 'private-gate-secret' "$private_gate_log"; then
+  fail "public-release gate leaked a development token"
+fi
+
 if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -32,7 +32,7 @@ if AFMKIT_GIT_COMMAND="$fake_git" \
    >"$auth_log" 2>&1; then
   fail "unauthenticated AFMKit access unexpectedly succeeded"
 fi
-grep -Fq 'Cannot read the private AFMKit dependency' "$auth_log" || \
+grep -Fq 'Cannot read the private provider dependency' "$auth_log" || \
   fail "private AFMKit error is not actionable"
 grep -Fq 'AFMKIT_READ_TOKEN' "$auth_log" || \
   fail "private AFMKit error does not name the CI secret"
@@ -44,19 +44,18 @@ public_gate_log="$WORK_ROOT/public-release-error.log"
 if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
-  probe_public_afmkit_source() {
-    return 0
+  read_public_release_sources() {
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.1'
+  }
+  probe_public_source() {
+    return 1
   }
   check_public_release_eligibility
 ) >"$public_gate_log" 2>&1; then
-  fail "production public-release gate accepted a revision-pinned dependency"
+  fail "production public-release gate accepted a private dependency"
 fi
-grep -Fq 'Production publishing is blocked' "$public_gate_log" || \
+grep -Fq 'is not anonymously fetchable' "$public_gate_log" || \
   fail "public-release failure is not actionable"
-grep -Fq 'source-package surface' "$public_gate_log" || \
-  fail "public-release failure does not explain the exposed package surface"
-grep -Fq 'exact public semantic version' "$public_gate_log" || \
-  fail "public-release failure does not require a versioned AFMKit contract"
 if grep -Fq 'public-gate-secret' "$public_gate_log"; then
   fail "public-release gate leaked a development token"
 fi
@@ -65,28 +64,27 @@ private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
-  read_afmkit_release_source() {
-    echo "https://github.com/scouzi1966/AFMKit.git 1111111111111111111111111111111111111111 exact 1.2.3 1.2.3"
+  read_public_release_sources() {
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.1'
   }
-  probe_public_afmkit_source() {
-    [[ -z "${AFMKIT_READ_TOKEN:-}" ]] || return 9
+  probe_public_source() {
     return 1
   }
   check_public_release_eligibility
 ) >"$private_gate_log" 2>&1; then
   fail "production public-release gate accepted a private exact dependency"
 fi
-grep -Fq 'cannot satisfy the public distribution requirement' "$private_gate_log" || \
+grep -Fq 'is not anonymously fetchable' "$private_gate_log" || \
   fail "public-release failure does not distinguish development authentication"
 
 if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
-  read_afmkit_release_source() {
-    echo "https://github.com/scouzi1966/AFMKit.git 1111111111111111111111111111111111111111 exact 1.2.3 1.2.3"
+  read_public_release_sources() {
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.1'
   }
-  probe_public_afmkit_source() {
-    [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
+  probe_public_source() {
+    return 0
   }
   check_public_release_eligibility
 ) >"$WORK_ROOT/public-release-success.log" 2>&1; then
@@ -95,8 +93,10 @@ fi
 
 prefix="$WORK_ROOT/custom-prefix"
 mkdir -p \
+  "$prefix/bin/MacLocalAPI_AFMEvaluationHost.bundle" \
   "$prefix/bin/AFMKit_AFMKitMLX.bundle" \
   "$prefix/bin/AFMKit_AFMKitDwarfStar.bundle" \
+  "$prefix/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle/Evals" \
   "$prefix/libexec/afm/AFMKit_AFMKitMLX.bundle/Contents/Resources" \
   "$prefix/libexec/afm/AFMKit_AFMKitDwarfStar.bundle/metal" \
   "$prefix/share/afm/webui"
@@ -107,6 +107,8 @@ printf 'unrelated' > "$prefix/share/afm/webui/keep-me"
 printf 'resource' > "$prefix/share/afm/webui/index.html.gz"
 INSTALL_PREFIX="$prefix" "$ROOT_DIR/Scripts/uninstall.sh"
 [[ ! -e "$prefix/bin/afm" ]] || fail "custom-prefix binary was not removed"
+[[ ! -e "$prefix/bin/MacLocalAPI_AFMEvaluationHost.bundle" ]] || fail "evaluation bundle was not removed"
+[[ ! -e "$prefix/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle" ]] || fail "libexec evaluation bundle was not removed"
 [[ ! -e "$prefix/bin/AFMKit_AFMKitMLX.bundle" ]] || fail "custom-prefix bundle was not removed"
 [[ ! -e "$prefix/libexec/afm/AFMKit_AFMKitDwarfStar.bundle" ]] || fail "libexec bundle was not removed"
 [[ ! -e "$prefix/share/afm/webui/index.html.gz" ]] || fail "WebUI was not removed"

--- a/Scripts/tests/test-xcode27-wheel-layout.sh
+++ b/Scripts/tests/test-xcode27-wheel-layout.sh
@@ -8,9 +8,12 @@ SOURCE_DIR="$(dirname "$SOURCE_BIN")"
 
 rm -rf "$WORK_ROOT"
 mkdir -p \
+  "$WORK_ROOT/MacLocalAPI_AFMEvaluationHost.bundle/Contents/Resources/Evals" \
   "$WORK_ROOT/AFMKit_AFMKitMLX.bundle/Contents/Resources"
 cp "$SOURCE_BIN" "$WORK_ROOT/afm"
 cp -R "$SOURCE_DIR/AFMKit_AFMKitDwarfStar.bundle" "$WORK_ROOT/"
+cp "$ROOT_DIR/Sources/AFMEvaluationHost/Resources/Evals/comprehensive.json" \
+  "$WORK_ROOT/MacLocalAPI_AFMEvaluationHost.bundle/Contents/Resources/Evals/"
 
 SOURCE_METALLIB="$($ROOT_DIR/Scripts/resolve-afmkit-resource.sh --metallib "$SOURCE_DIR")"
 cp "$SOURCE_METALLIB" \
@@ -20,5 +23,7 @@ AFM_RELEASE_BIN="$WORK_ROOT/afm" "$ROOT_DIR/Scripts/build-stable-wheel.sh"
 WHEEL="$(ls -t "$ROOT_DIR"/dist/macafm-*.whl | head -1)"
 unzip -Z1 "$WHEEL" | grep -Fqx \
   'macafm/bin/AFMKit_AFMKitMLX.bundle/Contents/Resources/default.metallib'
+unzip -Z1 "$WHEEL" | grep -Fqx \
+  'macafm/bin/MacLocalAPI_AFMEvaluationHost.bundle/Contents/Resources/Evals/comprehensive.json'
 
 echo "[xcode27-wheel-test] nested bundle archive and installed launch verified"

--- a/Scripts/uninstall.sh
+++ b/Scripts/uninstall.sh
@@ -59,7 +59,7 @@ remove_owned_path() {
 }
 
 remove_owned_path "$INSTALL_PREFIX/bin/afm"
-for bundle in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
+for bundle in MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
   remove_owned_path "$INSTALL_PREFIX/bin/$bundle"
   remove_owned_path "$INSTALL_PREFIX/libexec/afm/$bundle"
 done

--- a/Scripts/uninstall.sh
+++ b/Scripts/uninstall.sh
@@ -59,7 +59,7 @@ remove_owned_path() {
 }
 
 remove_owned_path "$INSTALL_PREFIX/bin/afm"
-for bundle in AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
+for bundle in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
   remove_owned_path "$INSTALL_PREFIX/bin/$bundle"
   remove_owned_path "$INSTALL_PREFIX/libexec/afm/$bundle"
 done

--- a/Scripts/verify-native-wheel.sh
+++ b/Scripts/verify-native-wheel.sh
@@ -56,8 +56,8 @@ for required in \
   }
 done
 
-FLAT_EVAL="$PACKAGE_ROOT/bin/MacLocalAPI_AFMKit.bundle/Evals/comprehensive.json"
-NESTED_EVAL="$PACKAGE_ROOT/bin/MacLocalAPI_AFMKit.bundle/Contents/Resources/Evals/comprehensive.json"
+FLAT_EVAL="$PACKAGE_ROOT/bin/MacLocalAPI_AFMEvaluationHost.bundle/Evals/comprehensive.json"
+NESTED_EVAL="$PACKAGE_ROOT/bin/MacLocalAPI_AFMEvaluationHost.bundle/Contents/Resources/Evals/comprehensive.json"
 if ! grep -Fqx "$FLAT_EVAL" <<<"$CONTENTS" && \
    ! grep -Fqx "$NESTED_EVAL" <<<"$CONTENTS"; then
   echo "[wheel] missing bundled comprehensive evaluation suite" >&2

--- a/Scripts/verify-release-archive.sh
+++ b/Scripts/verify-release-archive.sh
@@ -28,6 +28,13 @@ for required in "${ROOT_ENTRY}Resources/webui/index.html.gz"; do
   }
 done
 
+FLAT_EVAL="${ROOT_ENTRY}MacLocalAPI_AFMEvaluationHost.bundle/Evals/comprehensive.json"
+NESTED_EVAL="${ROOT_ENTRY}MacLocalAPI_AFMEvaluationHost.bundle/Contents/Resources/Evals/comprehensive.json"
+if ! grep -Fqx "$FLAT_EVAL" <<<"$CONTENTS" && \
+   ! grep -Fqx "$NESTED_EVAL" <<<"$CONTENTS"; then
+  echo "[archive] missing bundled comprehensive evaluation suite" >&2
+  exit 1
+fi
 
 FLAT_DWARF_METAL="${ROOT_ENTRY}AFMKit_AFMKitDwarfStar.bundle/metal/moe.metal"
 NESTED_DWARF_METAL="${ROOT_ENTRY}AFMKit_AFMKitDwarfStar.bundle/Contents/Resources/metal/moe.metal"

--- a/build.sh
+++ b/build.sh
@@ -345,9 +345,9 @@ trap - EXIT
 
 FINAL_DIR="$(dirname "$FINAL_BIN")"
 
-# AFMKit owns the bundled, no-judge evaluation suites. Keep its SwiftPM
-# resource bundle beside the executable in every install layout.
-EVAL_BUNDLE_DIR="$FINAL_DIR/MacLocalAPI_AFMKit.bundle"
+# The AFM evaluation host owns the bundled, no-judge evaluation suites. Keep
+# its SwiftPM resource bundle beside the executable in every install layout.
+EVAL_BUNDLE_DIR="$FINAL_DIR/MacLocalAPI_AFMEvaluationHost.bundle"
 if [ -f "$EVAL_BUNDLE_DIR/Evals/comprehensive.json" ]; then
   EVAL_SUITE="$EVAL_BUNDLE_DIR/Evals/comprehensive.json"
 elif [ -f "$EVAL_BUNDLE_DIR/Contents/Resources/Evals/comprehensive.json" ]; then
@@ -458,10 +458,10 @@ if $DO_INSTALL; then
       "$INSTALL_PREFIX/bin/$BUNDLE_NAME"
   done
 
-  run_install_command rm -rf "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMKit.bundle"
-  run_install_command cp -R "$EVAL_BUNDLE_SRC" "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMKit.bundle"
-  run_install_command ln -sfn "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMKit.bundle" \
-    "$INSTALL_PREFIX/bin/MacLocalAPI_AFMKit.bundle"
+  run_install_command rm -rf "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle"
+  run_install_command cp -R "$EVAL_BUNDLE_SRC" "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle"
+  run_install_command ln -sfn "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle" \
+    "$INSTALL_PREFIX/bin/MacLocalAPI_AFMEvaluationHost.bundle"
 
   if [ -f "$WEBUI_SRC" ]; then
     run_install_command install -m 644 "$WEBUI_SRC" "$INSTALL_PREFIX/share/afm/webui/index.html.gz"

--- a/build.sh
+++ b/build.sh
@@ -458,6 +458,11 @@ if $DO_INSTALL; then
       "$INSTALL_PREFIX/bin/$BUNDLE_NAME"
   done
 
+  # Remove the pre-extraction evaluation bundle when upgrading an existing
+  # installation. It is no longer used, but older releases installed it in
+  # both locations.
+  run_install_command rm -rf "$INSTALL_PREFIX/bin/MacLocalAPI_AFMKit.bundle"
+  run_install_command rm -rf "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMKit.bundle"
   run_install_command rm -rf "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle"
   run_install_command cp -R "$EVAL_BUNDLE_SRC" "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle"
   run_install_command ln -sfn "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle" \


### PR DESCRIPTION
## Problem

The AFMEvalKit extraction moved `comprehensive.json` from `MacLocalAPI_AFMKit.bundle` to `MacLocalAPI_AFMEvaluationHost.bundle`, but release, Homebrew, wheel, install, and uninstall tooling still expected the old bundle. A clean v0.9.18 build compiled successfully and then failed its required-resource check.

## Changes

- Package and install the AFMEvaluationHost resource bundle in every distribution path.
- Verify the comprehensive suite in flat and Xcode 27 nested archive/wheel layouts.
- Add a boundary gate preventing the stale bundle name from returning.
- Update uninstall and release-tooling regression coverage.

## Validation

- Clean release build: passed; v0.9.18 binary, Tree-sitter integrity, macOS 26 compatibility, embedded privacy plist, MLX metallib, and comprehensive resource verified.
- Swift suite: 231 XCTest + 138 Swift Testing, 0 failures.
- Release tooling tests: passed.
- Xcode 27 nested wheel build/install/launch: passed.
- Relocated release tarball verification/launch: passed.
- `make test`: binary and portability checks passed.
- Qwen 3.8 27B 4-bit + matching MTP head, `--no-think`: full assertions 108/108 passed (2 capability skips).
- Bundled comprehensive no-AI-judge eval: 91 cases, 0 infrastructure errors, 5 quality misses.

## Summary by Sourcery

Package the AFMEvaluationHost resource bundle consistently across distributions and guard against regressions from the previous bundle name.

Bug Fixes:
- Update all release, installation, Homebrew, wheel, and archive paths to package and verify the AFMEvaluationHost resource bundle containing the comprehensive evaluation suite.
- Remove obsolete evaluation bundles during upgrades and uninstalls to support migration from older installations.

Enhancements:
- Add boundary checks that prevent stale bundle references and enforce consistent evaluation-bundle consumers.
- Expand release-tooling and Xcode 27 wheel regression coverage, including public dependency eligibility and flat or nested bundle layouts.

Tests:
- Extend release tooling tests to validate bundle cleanup, dependency-source checks, and comprehensive-suite presence in nested wheel archives.