### PR TITLE
Update AFMKit to 0.1.2

### DIFF
--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.1"
+        exact: "0.1.2"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "0811fdcf71f1ffe5a990a32d5d7d144dfc37fb23064e2e286fd57d0c961f3f53",
+  "originHash" : "318ae5f9fe3eb3c04e51a78e569247db81a285c9f97aab26d6b7b61489662dc1",
   "pins" : [
     {
       "identity" : "afmkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "fc38b8fa646ee8a23d5cdfce483cd123c29acdfa",
-        "version" : "0.1.1"
+        "revision" : "33f4c7f47ed11fff2aad06c32b2938af4dea521a",
+        "version" : "0.1.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.1"
+        exact: "0.1.2"
     )
 }
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -145,8 +145,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.1":
-        fail(f"{identity} must resolve the exact 0.1.1 release")
+    if pin["state"].get("version") != "0.1.2":
+        fail(f"{identity} must resolve the exact 0.1.2 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -316,7 +316,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.1"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.2"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.1",
+    "afmkit": "0.1.2",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -45,7 +45,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.1'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.2'
   }
   probe_public_source() {
     return 1
@@ -69,14 +69,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.1" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.1"
+[[ "$release_version" == "0.1.2" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.2"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.1'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.2'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -95,7 +95,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.1'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.2'
   }
   probe_public_source() {
     return 0

--- a/docs/afmkit-url-consumption.md
+++ b/docs/afmkit-url-consumption.md
@@ -6,7 +6,7 @@ one exact release and selects every provider product from it:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.1"
+    exact: "0.1.2"
 )
 ```
 
@@ -16,7 +16,7 @@ Do not use a branch or revision requirement for release builds.
 
 This branch deliberately stops before making repositories public or publishing
 tags. AFM release publication remains fail-closed until AFMKit and every
-dependency in its root graph are anonymously readable, AFMKit exposes `0.1.1`,
+dependency in its root graph are anonymously readable, AFMKit exposes `0.1.2`,
 and the tracked lock resolves that exact tag. Making a repository public is an explicit human checkpoint,
 not part of the reversible code cutover.
 
@@ -67,7 +67,7 @@ The normal graph is independent of maclocal-api's dirty vendor worktrees:
 
 | Dependency | Requirement | Purpose |
 | --- | --- | --- |
-| `AFMKit` | exact `0.1.1` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, and the vendored MLX runtime |
+| `AFMKit` | exact `0.1.2` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, and the vendored MLX runtime |
 
 The MLX, mlx-c, Swift bindings, and mlx-swift-lm sources are snapshots inside
 AFMKit's `vendor/MLX` tree. They are not separate SwiftPM dependencies of


### PR DESCRIPTION
## Summary

Pin AFM to AFMKit 0.1.2 so packaged builds include the MLX stop-sequence shutdown fix. Update the immutable lock, boundary checks, public-release gate, example consumer, release-tooling fixtures, and dependency documentation together.

## Validation

- remote exact AFMKit 0.1.2 Release build: passed
- full AFM suite: 231 XCTest + 138 Swift Testing, 0 failures
- release-tooling regression: passed
- AFMKit consumer-boundary gate: passed
- Qwen 3.8 27B MLX MTP stop reproducer: 3/3, exit 0, `finish_reason=stop`, no duplicate tail
- `git diff --check`: passed
- no AI judge used

Public-source eligibility remains intentionally fail-closed while AFMKit is private; prebuilt staging archives remain testable.

## Summary by Sourcery

Pin all AFM consumers and release safeguards to AFMKit 0.1.2.

Bug Fixes:
- Update AFMKit to 0.1.2 so packaged builds receive the MLX stop-sequence shutdown fix.

Enhancements:
- Align the AFMKit consumer boundary, release eligibility checks, and dependency documentation with the new exact release pin.

Documentation:
- Update AFMKit dependency guidance and release-readiness documentation to reference version 0.1.2 while preserving fail-closed publication checks.

Tests:
- Update release-tooling fixtures and boundary validation to verify the exact AFMKit 0.1.2 dependency.

Chores:
- Refresh the immutable Swift package lockfile for AFMKit 0.1.2.