### PR TITLE
Fix Qwen tool-call evaluation and model reports

### DIFF
--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.2"
+        exact: "0.1.3"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "33f4c7f47ed11fff2aad06c32b2938af4dea521a",
-        "version" : "0.1.2"
+        "revision" : "c84e26317e4c0b14c7da9756809bf5e9cceb207c",
+        "version" : "0.1.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.2"
+        exact: "0.1.3"
     )
 }
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -145,8 +145,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.2":
-        fail(f"{identity} must resolve the exact 0.1.2 release")
+    if pin["state"].get("version") != "0.1.3":
+        fail(f"{identity} must resolve the exact 0.1.3 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -233,7 +233,7 @@ fi
 
 if grep -ERn \
   'MacLocalAPI_AFMKit(MLX|DwarfStar)\.bundle' \
-  .github/workflows Scripts/build-native-wheel.sh Scripts/build-nightly-wheel.sh \
+  Scripts/build-native-wheel.sh Scripts/build-nightly-wheel.sh \
   Scripts/build-stable-wheel.sh Scripts/create-tarball.sh \
   Scripts/generate-tap-versioned.sh Scripts/publish-next.sh Scripts/publish-stable.sh \
   Scripts/verify-native-wheel.sh Scripts/verify-release-archive.sh >/dev/null; then
@@ -242,8 +242,6 @@ fi
 
 evaluation_bundle_consumers=(
   build.sh
-  .github/workflows/nightly.yml
-  .github/workflows/release.yml
   Scripts/build-native-wheel.sh
   Scripts/build-nightly-wheel.sh
   Scripts/create-tarball.sh
@@ -255,8 +253,6 @@ evaluation_bundle_consumers=(
   Scripts/uninstall.sh
 )
 evaluation_bundle_no_legacy_consumers=(
-  .github/workflows/nightly.yml
-  .github/workflows/release.yml
   Scripts/build-native-wheel.sh
   Scripts/build-nightly-wheel.sh
   Scripts/create-tarball.sh
@@ -282,33 +278,10 @@ for publisher in Scripts/publish-next.sh Scripts/publish-stable.sh; do
     fail "$publisher does not migrate an existing Homebrew formula to the current evaluation bundle"
 done
 
-for workflow in .github/workflows/nightly.yml .github/workflows/release.yml; do
-  grep -Fq 'AFMKit_AFMKitMLX.bundle' "$workflow" || \
-    fail "$workflow does not package the AFMKit MLX resource bundle"
-  grep -Fq 'AFMKit_AFMKitDwarfStar.bundle' "$workflow" || \
-    fail "$workflow does not package the AFMKit DwarfStar resource bundle"
-  grep -Fq 'Scripts/validate-release.sh' "$workflow" || \
-    fail "$workflow does not run the complete local release gate"
-  grep -Fq 'AFMKIT_READ_TOKEN' "$workflow" || \
-    fail "$workflow does not declare authenticated private AFMKit access"
-  grep -Fq 'Scripts/check-public-release-eligibility.sh' "$workflow" || \
-    fail "$workflow can publish without proving anonymous dependency access"
-done
-
 for publisher in Scripts/publish-next.sh Scripts/publish-stable.sh; do
   grep -Fq 'check-public-release-eligibility.sh' "$publisher" || \
     fail "$publisher can publish without proving anonymous dependency access"
 done
-
-grep -Fq 'Scripts/resolve-release-dependencies.sh' .github/workflows/codeql-analysis.yml || \
-  fail "CodeQL does not use the authenticated transition resolver"
-grep -Fq 'AFMKIT_READ_TOKEN' .github/workflows/codeql-analysis.yml || \
-  fail "CodeQL does not declare private AFMKit authentication"
-grep -Fq 'head.repo.fork' .github/workflows/codeql-analysis.yml || \
-  fail "CodeQL does not isolate private credentials from fork pull requests"
-if grep -Eq '^[[:space:]]*swift package resolve[[:space:]]*$' .github/workflows/codeql-analysis.yml; then
-  fail "CodeQL still performs a bare unauthenticated dependency resolve"
-fi
 
 example_manifest=Examples/AFMKitCoreOnlyConsumer/Package.swift
 grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" || \
@@ -316,7 +289,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.2"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.3"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.2",
+    "afmkit": "0.1.3",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/generate-report.py
+++ b/Scripts/generate-report.py
@@ -199,12 +199,16 @@ def config_panel(r):
         ("frequency_penalty", "freq_pen", "#f0883e"),
         ("logprobs", "logprobs", "#a371f7"),
         ("top_logprobs", "top_logprobs", "#a371f7"),
-        ("stop", "stop", "#d29922"),
+        ("stop", "stop (raw JSON)", "#d29922"),
         ("response_format", "resp_fmt", "#d29922"),
     ]:
         val = r.get(key)
         if val is not None:
-            if isinstance(val, list):
+            if key == "stop":
+                # Preserve exact request semantics, including list boundaries,
+                # quotes, escapes, control characters, and Unicode values.
+                val = json.dumps(val, ensure_ascii=False)
+            elif isinstance(val, list):
                 val = ", ".join(str(v) for v in val)
             api_badges.append(config_badge(label_text, val, color))
 

--- a/Scripts/generate-report.py
+++ b/Scripts/generate-report.py
@@ -1,6 +1,34 @@
 #!/usr/bin/env python3
 import json, html, datetime, re, os, sys, shutil, subprocess
 
+
+def extract_ai_scores(content):
+    """Decode the final AI_SCORES array while tolerating harmless marker drift."""
+    marker = "AI_SCORES"
+    marker_pos = content.rfind(marker)
+    if marker_pos < 0:
+        return []
+    array_pos = content.find("[", marker_pos + len(marker))
+    if array_pos < 0:
+        return []
+    try:
+        scores, _ = json.JSONDecoder().raw_decode(content[array_pos:])
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return []
+    if not isinstance(scores, list):
+        return []
+    return scores
+
+
+def strip_ai_scores(content):
+    """Remove the machine-readable score trailer from displayed analysis."""
+    marker_pos = content.rfind("AI_SCORES")
+    if marker_pos < 0:
+        return content.strip()
+    comment_pos = content.rfind("<!--", 0, marker_pos)
+    trailer_pos = comment_pos if comment_pos >= 0 else marker_pos
+    return content[:trailer_pos].strip()
+
 # Read JSONL path from env (set by mlx-model-test.sh) or fall back to hardcoded path
 RESULTS_FILE = os.environ.get("RESULTS_FILE", "/tmp/mlx-test-results.jsonl")
 
@@ -69,10 +97,13 @@ if os.path.isdir(report_dir):
                     with open(os.path.join(report_dir, fname)) as sf:
                         content = sf.read()
                     scores = {}
-                    m_scores = re.search(r'<!-- AI_SCORES (\[.*?\]) -->', content)
-                    if m_scores:
-                        for entry in json.loads(m_scores.group(1)):
-                            scores[entry["i"]] = entry["s"]
+                    for entry in extract_ai_scores(content):
+                        if not isinstance(entry, dict):
+                            continue
+                        idx = entry.get("i")
+                        score = entry.get("s")
+                        if isinstance(idx, int) and isinstance(score, int) and 1 <= score <= 5:
+                            scores[idx] = score
                     smart_analyses.append({"tool": tool_name, "content": content, "scores": scores})
                 except:
                     pass
@@ -248,9 +279,15 @@ def config_panel(r):
 
 # Build per-model response sections
 model_responses = ""
-for i, r in enumerate(ok_sorted):
+response_results = results
+response_index_by_jsonl_idx = {
+    r["_jsonl_idx"]: i for i, r in enumerate(response_results)
+}
+for i, r in enumerate(response_results):
     content = r.get("content", "") or r.get("content_preview", "")
     reasoning = r.get("reasoning_content", "")
+    completion_tokens = r.get("completion_tokens", 0)
+    tokens_per_sec = r.get("tokens_per_sec", 0)
     # Show reasoning if content is empty, or prepend it if both exist
     if not content and reasoning:
         content = f"<details open><summary><strong>🧠 Reasoning</strong> <em>(model used all tokens thinking — no response emitted)</em></summary>\n\n{reasoning}\n\n</details>"
@@ -286,14 +323,16 @@ for i, r in enumerate(ok_sorted):
     # ── Build AI Smart Scores section ──
     smart_html = ""
     jsonl_idx = r.get("_jsonl_idx")
-    if has_per_test_smart and jsonl_idx is not None:
+    if has_ai_scores and jsonl_idx is not None:
         smart_items = []
-        for tool, scores_map in smart_per_test.items():
-            if jsonl_idx in scores_map:
-                entry = scores_map[jsonl_idx]
-                s = entry["score"]
+        for sa in smart_analyses:
+            tool = sa["tool"]
+            detail = smart_per_test.get(tool, {}).get(jsonl_idx)
+            s = detail["score"] if detail else sa["scores"].get(jsonl_idx)
+            if s is not None:
                 emoji = {5: "✅", 4: "👍", 3: "⚠️", 2: "❌", 1: "💥"}.get(s, "❓")
-                reason_esc = html.escape(entry["reason"]) if entry["reason"] else ""
+                reason = detail["reason"] if detail else ""
+                reason_esc = html.escape(reason) if reason else ""
                 score_color = {5: "#3fb950", 4: "#58a6ff", 3: "#d29922", 2: "#f0883e", 1: "#f85149"}.get(s, "#8b949e")
                 line_html = f'<span style="color:{score_color};font-weight:700">{s}/5 {emoji}</span> <strong>{html.escape(tool)}</strong>'
                 if reason_esc:
@@ -313,7 +352,7 @@ for i, r in enumerate(ok_sorted):
     <span class="toggle-icon" id="icon-{i}">&#9654;</span>
     <span class="test-num" style="min-width:2rem;text-align:center">#{resp_test_num}</span>
     <span class="mono">{html.escape(r["model"])}</span>
-    <span class="response-meta">{r["completion_tokens"]} tokens &middot; {r["tokens_per_sec"]:.1f} tok/s</span>
+    <span class="response-meta">{completion_tokens} tokens &middot; {tokens_per_sec:.1f} tok/s</span>
   </h3>
   <div class="response-body" id="body-{i}" style="display:none">
     <div class="config-panel">{panel}</div>{intent_html}{smart_html}
@@ -400,7 +439,8 @@ for i, r in enumerate(ok_sorted):
             score_tds += ai_score_cell(s)
 
     test_num = r.get("_jsonl_idx", i) + 1
-    perf_rows += f"""<tr onclick="scrollToResponse({i})" style="cursor:pointer" title="Click to view full response">
+    response_idx = response_index_by_jsonl_idx[r["_jsonl_idx"]]
+    perf_rows += f"""<tr onclick="scrollToResponse({response_idx})" style="cursor:pointer" title="Click to view full response">
   <td class="rank">{i+1}</td>
   <td class="test-num">{test_num}</td>
   <td class="mono">{html.escape(r["model"])}{label_html}{afm_html}</td>
@@ -433,8 +473,9 @@ if smart_analyses:
     smart_section += '<h2>AI Analysis (--smart)</h2>\n'
     for si, sa in enumerate(smart_analyses):
         tool = html.escape(sa["tool"])
-        # Strip the AI_SCORES line from displayed content
-        display_content = re.sub(r'<!-- AI_SCORES \[.*?\] -->\s*$', '', sa["content"]).strip()
+        # Strip the AI_SCORES trailer from displayed content, including minor
+        # formatting drift from CLI judges (missing/multiline comment close).
+        display_content = strip_ai_scores(sa["content"])
         content_js = json.dumps(display_content)
         num_tools = len(smart_analyses)
         tool_label = f"{tool} Analysis" if num_tools > 1 else "Quality, Anomalies &amp; Recommendations"
@@ -709,20 +750,22 @@ function renderContent(idx) {{
 
 os.makedirs(report_dir, exist_ok=True)
 
-timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+timestamp = os.environ.get("REPORT_TIMESTAMP") or datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
 html_path = os.path.join(report_dir, f"mlx-model-report-{timestamp}.html")
 jsonl_path = os.path.join(report_dir, f"mlx-model-report-{timestamp}.jsonl")
 
 with open(html_path, "w") as f:
     f.write(report)
 
-# Copy results JSONL alongside the HTML report with matching timestamp
-shutil.copy2(RESULTS_FILE, jsonl_path)
+# Copy results JSONL alongside the HTML report with matching timestamp. A
+# deterministic regeneration may already be reading that exact destination.
+if os.path.abspath(RESULTS_FILE) != os.path.abspath(jsonl_path):
+    shutil.copy2(RESULTS_FILE, jsonl_path)
 
 print(f"Report: {html_path}")
 print(f"  Data: {jsonl_path}")
 print(f"  {len(ok)} passed, {len(fail)} failed out of {len(results)} models")
 
 # Auto-open the HTML report on macOS
-if sys.platform == "darwin":
+if sys.platform == "darwin" and os.environ.get("AFM_REPORT_NO_OPEN") != "1":
     subprocess.run(["open", html_path])

--- a/Scripts/generate-report.py
+++ b/Scripts/generate-report.py
@@ -20,8 +20,13 @@ with open(RESULTS_FILE) as f:
 for idx, r in enumerate(results):
     r["_jsonl_idx"] = idx
 
-ok = [r for r in results if r["status"] == "OK"]
-fail = [r for r in results if r["status"] == "FAIL"]
+def result_passed(result):
+    if "overall_status" in result:
+        return result["overall_status"] == "pass"
+    return result.get("status") == "OK"
+
+ok = [r for r in results if result_passed(r)]
+fail = [r for r in results if not result_passed(r)]
 ok_sorted = sorted(ok, key=lambda r: r.get("tokens_per_sec", 0), reverse=True)
 
 now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
@@ -127,7 +132,7 @@ if prompts_file and os.path.isfile(prompts_file):
                                        'seed:', 'top_p:', 'top_k:', 'min_p:', 'response_format:',
                                        'tools:', 'developer:', 'max_completion_tokens:', 'logprobs:',
                                        'top_logprobs:', 'presence_penalty:', 'repetition_penalty:',
-                                       'frequency_penalty:', 'media:')):
+                                       'frequency_penalty:', 'media:', 'expect:')):
                 comment_buf = []
 
 # ── Parse per-test reasons from smart analysis .md files ─────────────────────
@@ -216,6 +221,11 @@ def config_panel(r):
         perf_badges.append(config_badge("json", "valid", "#3fb950"))
     elif vjson is False:
         perf_badges.append(config_badge("json", "INVALID", "#f85149"))
+    assertion = r.get("assertion_status")
+    if assertion == "pass":
+        perf_badges.append(config_badge("assert", "pass", "#3fb950"))
+    elif assertion == "fail":
+        perf_badges.append(config_badge("assert", "FAIL", "#f85149"))
     perf_badges.append(config_badge("load", f'{r.get("load_time_s", "?")}s', "#8b949e"))
     perf_badges.append(config_badge("gen", f'{r.get("gen_time_s", "?")}s', "#8b949e"))
     perf_badges.append(config_badge("prompt_tok", r.get("prompt_tokens", "?"), "#8b949e"))
@@ -250,7 +260,18 @@ for i, r in enumerate(ok_sorted):
     # ── Build AI Intent section ──
     intent_html = ""
     label = r.get("label", "")
-    if label and label in ai_intents:
+    if r.get("is_baseline"):
+        intent_lines = (
+            "Global [all] baseline: judge this ordinary prompt on its own response quality. "
+            "The enclosing variant's settings remain active, but its variant-specific test "
+            "intent and expectations do not apply to this record."
+        )
+        intent_html = f"""
+    <details class="ai-detail">
+      <summary class="ai-detail-summary">🎯 Baseline Intent</summary>
+      <div class="ai-detail-body">{html.escape(intent_lines)}</div>
+    </details>"""
+    elif label and label in ai_intents:
         intent_lines = "<br>".join(html.escape(line) for line in ai_intents[label])
         intent_html = f"""
     <details class="ai-detail">
@@ -312,7 +333,7 @@ def ai_score_cell(score):
 fail_rows = ""
 if fail:
     for r in fail:
-        error = r.get("error", "Unknown error")
+        error = r.get("error") or "; ".join(r.get("assertion_failures", [])) or "Unknown error"
         error_clean = error.replace("\\n", " ").replace('\\"', '"').strip()
         if "loadFailed" in error_clean:
             m = re.search(r'loadFailed\("([^"]+)"\)', error_clean)

--- a/Scripts/generate-report.py
+++ b/Scripts/generate-report.py
@@ -295,7 +295,7 @@ for i, r in enumerate(response_results):
         content = f"<details><summary><strong>🧠 Reasoning</strong></summary>\n\n{reasoning}\n\n</details>\n\n{content}"
     content_js = json.dumps(content)
     prompt_text = r.get("prompt", "")
-    prompt_html = html.escape(prompt_text[:500]) + ("..." if len(prompt_text) > 500 else "")
+    prompt_html = html.escape(prompt_text)
     panel = config_panel(r)
 
     # ── Build AI Intent section ──

--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -39,6 +39,11 @@
 #   system:              System prompt text
 #   developer:           OpenAI developer-role message text
 #   tools:               OpenAI tools array as JSON
+#   expect:              Executable result oracle as JSON, e.g.:
+#                         {"valid_json":true,"finish_reason":"stop"}
+#                         {"tool_calls":[{"name":"get_weather","arguments":{"city":"Paris"}}]}
+#                         {"logprobs_min":1}
+#                         {"content_equals":"prefix","content_not_contains":["STOP","suffix"]}
 #   afm:                 CLI flags passed to the afm server process, e.g.:
 #                          --verbose / --very-verbose
 #                          --no-streaming
@@ -119,6 +124,7 @@ set -uo pipefail
 # Unset CLAUDECODE so that `claude` CLI can be invoked from within a Claude Code session
 # (e.g. when this script is launched via --smart from an active Claude Code terminal)
 unset CLAUDECODE 2>/dev/null || true
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Prefer local build over PATH (Homebrew install may be stale)
 if [ -z "${AFM_BIN:-}" ] && [ -x ".build/arm64-apple-macosx/release/afm" ]; then
@@ -595,6 +601,8 @@ with open(filepath) as f:
                 config['defaults']['developer'] = line.split(':', 1)[1].strip()
             elif line.startswith('tools:'):
                 config['defaults']['tools'] = json.loads(line.split(':', 1)[1].strip())
+            elif line.startswith('expect:'):
+                config['defaults']['expect'] = json.loads(line.split(':', 1)[1].strip())
             elif line.startswith('afm:'):
                 config['defaults']['afm'] = line.split(':', 1)[1].strip()
             elif line.startswith('media:'):
@@ -653,6 +661,8 @@ with open(filepath) as f:
             sec['params']['developer'] = line.split(':', 1)[1].strip()
         elif line.startswith('tools:'):
             sec['params']['tools'] = json.loads(line.split(':', 1)[1].strip())
+        elif line.startswith('expect:'):
+            sec['params']['expect'] = json.loads(line.split(':', 1)[1].strip())
         elif line.startswith('afm:'):
             sec['afm'] = line.split(':', 1)[1].strip()
         elif line.startswith('media:'):
@@ -876,6 +886,7 @@ result = {
     'system': system,
     'developer': merge_param('developer'),
     'tools': merge_param('tools'),
+    'expect': merge_param('expect'),
     'afm_args': afm_args,
     'top_p': merge_param('top_p'),
     'top_k': merge_param('top_k'),
@@ -998,8 +1009,9 @@ print(json.dumps(c))
 " "$display_name" "$prompt_text" "$pidx")
 
   # Single python3 block: builds OpenAI SDK call, sends request, outputs JSONL result
-  METRICS=$(_SEND_CONFIG="$send_config" python3 - "$PORT" "$load_time" "$TIMEOUT_GENERATE" <<'SEND_PYEOF'
+  METRICS=$(_SEND_CONFIG="$send_config" PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 - "$PORT" "$load_time" "$TIMEOUT_GENERATE" <<'SEND_PYEOF'
 import json, sys, time, os
+from mlx_model_test_oracle import evaluate_expectations, expectation_for_prompt
 
 # Read config from env var (stdin used by heredoc)
 config = json.loads(os.environ['_SEND_CONFIG'])
@@ -1101,6 +1113,9 @@ if config.get('repetition_penalty') is not None:
 if extra_body:
     kwargs['extra_body'] = extra_body
 
+is_baseline = config.get('prompt_idx', 0) < config.get('num_baseline', 0)
+expectation = expectation_for_prompt(config)
+
 try:
     gen_start = time.time()
     response = client.chat.completions.create(**kwargs)
@@ -1151,24 +1166,40 @@ try:
     if logprobs_data and hasattr(logprobs_data, 'content') and logprobs_data.content:
         logprobs_count = len(logprobs_data.content)
 
-    # JSON validation: check if content is valid JSON
+    # JSON validation is explicit. Natural-language mentions of "JSON" are not
+    # an oracle (for example, a prompt can ask for Swift code that parses JSON).
     is_valid_json = None  # None = not tested
     response_format = config.get('response_format')
     response_format_type = response_format.get('type') if isinstance(response_format, dict) else response_format
-    if response_format_type in ('json_object', 'json_schema') or \
-       any(kw in prompt_text.lower() for kw in ('json', 'valid json')):
+    if response_format_type in ('json_object', 'json_schema') or expectation.get('valid_json') is not None:
         try:
             json.loads(msg)
             is_valid_json = True
         except (json.JSONDecodeError, ValueError):
             is_valid_json = False
 
+    oracle_valid_json, assertion_failures = evaluate_expectations(
+        expectation,
+        content=msg,
+        finish_reason=finish_reason,
+        logprobs_count=logprobs_count,
+        tool_calls=tool_calls,
+    )
+    if is_valid_json is None:
+        is_valid_json = oracle_valid_json
+
+    assertion_status = 'not_configured' if not expectation else ('fail' if assertion_failures else 'pass')
+
     result = {
-        'model': display_name,
+        'model': model,
         'label': label,
         'prompt': prompt_text,
-        'is_baseline': config.get('prompt_idx', 0) < config.get('num_baseline', 0),
+        'is_baseline': is_baseline,
         'status': 'OK',
+        'transport_status': 'pass',
+        'assertion_status': assertion_status,
+        'overall_status': 'fail' if assertion_failures else 'pass',
+        'assertion_failures': assertion_failures,
         'load_time_s': load_time,
         'gen_time_s': round(gen_time, 2),
         'prompt_tokens': prompt_tokens,
@@ -1201,6 +1232,8 @@ try:
                 'stop', 'response_format', 'media', 'tools'):
         if config.get(key) is not None:
             result[key] = config[key]
+    if expectation:
+        result['expect'] = expectation
 
     print(json.dumps(result))
 
@@ -1208,10 +1241,13 @@ except Exception as e:
     gen_end = time.time()
     error_msg = str(e)[:500]
     result = {
-        'model': display_name,
+        'model': model,
         'label': label,
         'prompt': prompt_text,
         'status': 'FAIL',
+        'transport_status': 'fail',
+        'assertion_status': 'not_run',
+        'overall_status': 'fail',
         'error': error_msg,
         'load_time_s': load_time,
         'temperature': temperature,
@@ -1226,6 +1262,8 @@ except Exception as e:
                 'stop', 'response_format', 'media', 'tools'):
         if config.get(key) is not None:
             result[key] = config[key]
+    if expectation:
+        result['expect'] = expectation
     print(json.dumps(result))
 SEND_PYEOF
   )
@@ -1236,7 +1274,7 @@ SEND_PYEOF
 import json, os
 config = json.loads(os.environ['_SEND_CONFIG'])
 print(json.dumps({
-    'model': config.get('display_name', config.get('model', '')),
+    'model': config.get('model', ''),
     'label': config.get('label', ''),
     'prompt': config.get('prompt_text', ''),
     'status': 'FAIL',
@@ -1248,14 +1286,14 @@ PYEOF
   printf '%s\n' "$METRICS" >> "$RESULTS_FILE"
 
   # Extract status for display
-  local status=$(echo "$METRICS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('status','?'))")
-  if [ "$status" = "OK" ]; then
+  local status=$(echo "$METRICS" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('overall_status', 'pass' if d.get('status') == 'OK' else 'fail'))")
+  if [ "$status" = "pass" ]; then
     local tps=$(echo "$METRICS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tokens_per_sec',0))")
     local ctok=$(echo "$METRICS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('completion_tokens',0))")
     local gtime=$(echo "$METRICS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('gen_time_s',0))")
     echo "    OK: ${ctok} tokens in ${gtime}s (${tps} tok/s)"
   else
-    local error_msg=$(echo "$METRICS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('error','unknown')[:200])")
+    local error_msg=$(echo "$METRICS" | python3 -c "import json,sys; d=json.load(sys.stdin); print((d.get('error') or '; '.join(d.get('assertion_failures', [])) or 'unknown')[:200])")
     echo "    FAIL: $error_msg"
     OVERALL_STATUS=1
   fi
@@ -1359,7 +1397,7 @@ print(f'API: {api}' if api else 'API: (none)')
       fi
     fi
     echo "  FAIL: $error_msg"
-    echo "{\"model\":$(escape_json "$display_name"),\"label\":$(escape_json "$label"),\"status\":\"FAIL\",\"error\":$(escape_json "$error_msg"),\"load_time_s\":$load_time,\"temperature\":$temperature,\"max_tokens\":$max_tokens,\"system_prompt\":$(escape_json "$sys_prompt"),\"afm_args\":$(escape_json "$afm_args")}" >> "$RESULTS_FILE"
+    echo "{\"model\":$(escape_json "$model"),\"label\":$(escape_json "$label"),\"status\":\"FAIL\",\"error\":$(escape_json "$error_msg"),\"load_time_s\":$load_time,\"temperature\":$temperature,\"max_tokens\":$max_tokens,\"system_prompt\":$(escape_json "$sys_prompt"),\"afm_args\":$(escape_json "$afm_args")}" >> "$RESULTS_FILE"
     OVERALL_STATUS=1
     kill_server $SERVER_PID
     SERVER_PID=0
@@ -1533,7 +1571,7 @@ result = {
 for key in ('top_p', 'top_k', 'min_p', 'seed', 'logprobs', 'top_logprobs',
             'presence_penalty', 'repetition_penalty', 'frequency_penalty',
             'stop', 'response_format', 'media', 'max_completion_tokens',
-            'developer', 'tools'):
+            'developer', 'tools', 'expect'):
     if key in defaults:
         result[key] = defaults[key]
 print(json.dumps(result))
@@ -1650,8 +1688,11 @@ IMPORTANT scoring notes:
 - Reserve score 1 strictly for: status=FAIL, server crashes, load failures.
 - FORMAT COMPLIANCE: For tests with response_format=json_object or guided-json (afm: --guided-json),
   the variant-specific prompt output MUST be valid JSON. Plain text output = score 2.
-  The [all] baseline prompt may produce unconstrained text under these variants — that is expected,
-  score it normally on text quality. Only apply format checks to variant-specific prompts.
+- BASELINE ROUTING: A result with "is_baseline": true is the global [all] prompt executed
+  under a variant's active settings. Judge that result only against its own prompt and general
+  response quality. Do NOT apply the enclosing label's variant-specific # AI intent, executable
+  expectations, expected tool names/arguments, formatting requirements, or stop behavior.
+  For example, a primary-colors baseline labeled tool-call-auto is not expected to call weather.
 - STOP COMPLIANCE: For stop sequence tests, output must NOT contain the stop string past the
   expected truncation point. If it does, score 2.
 
@@ -1678,7 +1719,7 @@ $(cat "$PROMPTS_FILE")"
   fi
 
   # Build combined prompt+data for tools that need it in one stream
-  SMART_INPUT="$(mktemp /tmp/smart-input-XXXXXX.txt)"
+  SMART_INPUT="$(mktemp /tmp/smart-input-XXXXXX)"
   { echo "$ANALYSIS_PROMPT"; echo "$SMART_TEST_FILE_SECTION"; echo ""; echo "--- JSONL DATA ---"; cat "$RESULTS_FILE"; } > "$SMART_INPUT"
 
   # ── Per-test prompt (used in SMART_BATCH=1 mode) ─────────────────────────
@@ -1707,9 +1748,10 @@ Scoring rules:
 - For tool call tests: verify finish_reason="tool_calls" and valid function/args.
 - For response_format=json_object tests: output MUST be valid JSON. Plain text = score 2.
 - For guided-json tests (afm: --guided-json): output MUST be valid JSON matching the schema. Plain text = score 2.
-- For [all] baseline prompts running under a guided-json or response_format variant:
-  the baseline may produce unconstrained text — this is expected. Score the text quality
-  normally but note that format constraints only apply to variant-specific prompts.
+- If "is_baseline" is true, ignore the enclosing label's TEST SPEC and all variant-specific
+  expectations. Judge only whether the response handles its own prompt coherently. Variant
+  settings remain active, but a primary-colors baseline under tool-call-auto is not a Tokyo
+  weather test and must not be scored as one.
 
 Respond with EXACTLY one line of JSON, nothing else:
 {"score": N, "reason": "brief explanation referencing expected outcome"}
@@ -1724,10 +1766,12 @@ PER_TEST_PROMPT_END
 
     # ── SMART_BATCH=1: per-test mode ──────────────────────────────────────
     if [ "$SMART_BATCH" = "1" ]; then
-      echo "  Per-test scoring with $tool ($( wc -l < "$RESULTS_FILE" | tr -d ' ') results)..."
-
       PERTEST_SCORES_DIR="$(mktemp -d /tmp/smart-pertest-XXXXXX)"
-      total_lines=$(wc -l < "$RESULTS_FILE" | tr -d ' ')
+      total_lines=$(python3 -c "
+import json, sys
+print(sum(1 for line in open(sys.argv[1]) if line.strip() and not json.loads(line).get('_meta')))
+" "$RESULTS_FILE")
+      echo "  Per-test scoring with $tool ($total_lines results)..."
 
       # Extract test spec blocks from the test file (label → comment block mapping)
       PERTEST_SPECS=""
@@ -1781,13 +1825,18 @@ print(json.dumps(specs))
         model_label=$(echo "$jsonl_line" | python3 -c "import json,sys; d=json.load(sys.stdin); print((d.get('label','') or d.get('model','?'))[:40])")
         echo -n "$model_label... "
 
-        # Look up test spec for this label
+        # Look up the variant spec only for the variant-specific prompt. Every
+        # section also runs the global [all] prompt, which shares the label but
+        # must not inherit that section's semantic expectations.
         test_spec=""
         if [ -n "$PERTEST_SPECS" ]; then
           test_spec=$(echo "$jsonl_line" | python3 -c "
 import json, sys
 specs = json.loads(sys.argv[1])
 d = json.load(sys.stdin)
+if d.get('is_baseline'):
+    print('Global [all] baseline. Judge only the actual prompt and response quality; ignore the enclosing variant-specific intent and expectations.')
+    raise SystemExit
 label = d.get('label', '')
 print(specs.get(label, ''))
 " "$PERTEST_SPECS" 2>/dev/null)
@@ -1811,9 +1860,9 @@ $jsonl_line"
             PERTEST_SCORE=$(echo "$PERTEST_INPUT" | "$tool" -p - 2>/tmp/smart-${tool}-stderr-$$.log)
             ;;
           codex)
-            CODEX_TMP="$(mktemp /tmp/smart-codex-pertest-XXXXXX.txt)"
+            CODEX_TMP="$(mktemp /tmp/smart-codex-pertest-XXXXXX)"
             echo "$PERTEST_INPUT" > "$CODEX_TMP"
-            PERTEST_SCORE=$("$tool" exec --skip-git-repo-check "Read and score the test result in $CODEX_TMP. Output exactly one JSON line: {\"score\": N, \"reason\": \"...\"}" 2>/tmp/smart-${tool}-stderr-$$.log)
+            PERTEST_SCORE=$("$tool" exec --skip-git-repo-check "Read and score the test result in $CODEX_TMP. Output exactly one JSON line: {\"score\": N, \"reason\": \"...\"}" </dev/null 2>/tmp/smart-${tool}-stderr-$$.log)
             rm -f "$CODEX_TMP"
             ;;
           afm)
@@ -1825,12 +1874,12 @@ $jsonl_line"
         esac
 
         echo "$PERTEST_SCORE" > "$PERTEST_SCORES_DIR/score_${line_idx}.txt"
-        score_val=$(echo "$PERTEST_SCORE" | python3 -c "
-import json, sys, re
+        score_val=$(echo "$PERTEST_SCORE" | PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c "
+import sys
+from mlx_model_test_oracle import extract_score_payload
 text = sys.stdin.read().strip()
-m = re.search(r'\{[^}]*\"score\"\s*:\s*(\d+)[^}]*\}', text)
-if m: print(m.group(1))
-else: print('?')
+payload = extract_score_payload(text)
+print(payload['score'] if payload else '?')
 " 2>/dev/null)
         echo "score=$score_val"
         line_idx=$((line_idx + 1))
@@ -1839,55 +1888,52 @@ else: print('?')
       echo "  Assembling per-test report..."
 
       # Build scores JSON + per-test markdown report
-      python3 -c "
-import json, sys, os, re
+      PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c "
+import json, sys, os
+from mlx_model_test_oracle import extract_score_payload
 
 scores_dir = sys.argv[1]
 results_file = sys.argv[2]
 
 scores = []
 report_lines = ['# Per-Test AI Analysis', '']
+result_idx = 0
 with open(results_file) as f:
-    for idx, line in enumerate(f):
+    for line in f:
         line = line.strip()
         if not line: continue
         r = json.loads(line)
+        if r.get('_meta'):
+            continue
 
-        score_file = os.path.join(scores_dir, f'score_{idx}.txt')
+        score_file = os.path.join(scores_dir, f'score_{result_idx}.txt')
         score_text = ''
         score_val = 3
         reason = ''
         if os.path.exists(score_file):
             with open(score_file) as sf:
                 score_text = sf.read().strip()
-            m = re.search(r'\{[^}]*\"score\"\s*:\s*(\d+)[^}]*\"reason\"\s*:\s*\"([^\"]*?)\"[^}]*\}', score_text)
-            if not m:
-                m = re.search(r'\{[^}]*\"reason\"\s*:\s*\"([^\"]*?)\"[^}]*\"score\"\s*:\s*(\d+)[^}]*\}', score_text)
-                if m:
-                    score_val = int(m.group(2))
-                    reason = m.group(1)
-            else:
-                score_val = int(m.group(1))
-                reason = m.group(2)
-            if not reason:
-                sm = re.search(r'\"score\"\s*:\s*(\d+)', score_text)
-                if sm:
-                    score_val = int(sm.group(1))
+            payload = extract_score_payload(score_text)
+            if payload:
+                score_val = payload['score']
+                reason = str(payload.get('reason', ''))
 
-        scores.append({'i': idx, 's': score_val})
+        scores.append({'i': result_idx, 's': score_val})
 
         model = r.get('model', '')
         label = r.get('label', '')
-        name = f'{model} @ {label}' if label else model
+        label_suffix = f' @ {label}' if label else ''
+        name = model if not label_suffix or model.endswith(label_suffix) else model + label_suffix
         tps = r.get('tokens_per_sec', 0)
         status = r.get('status', '')
         emoji = {5:'✅', 4:'👍', 3:'⚠️', 2:'❌', 1:'💥'}.get(score_val, '❓')
 
-        report_lines.append(f'### {idx}. {name}')
+        report_lines.append(f'### {result_idx}. {name}')
         report_lines.append(f'**Score: {score_val}/5** {emoji} | Status: {status} | {tps:.1f} tok/s')
         if reason:
             report_lines.append(f'> {reason}')
         report_lines.append('')
+        result_idx += 1
 
 # Summary
 total = len(scores)
@@ -1917,7 +1963,7 @@ $SMART_TEST_FILE_SECTION
         codex)
           # codex exec: use temp file to avoid ARG_MAX limit on command line
           # (91+ test results with full responses easily exceed OS argument length)
-          "$tool" exec --skip-git-repo-check "Read and follow the analysis instructions in $SMART_INPUT. Score every JSONL entry and output the AI_SCORES block as specified." > "$SMART_REPORT" 2>/tmp/smart-${tool}-stderr-$$.log
+          "$tool" exec --skip-git-repo-check "Read and follow the analysis instructions in $SMART_INPUT. Score every JSONL entry and output the AI_SCORES block as specified." </dev/null > "$SMART_REPORT" 2>/tmp/smart-${tool}-stderr-$$.log
           ;;
         afm)
           # afm uses Apple Foundation Models — context window is limited (~4K tokens).
@@ -2049,7 +2095,8 @@ with open(results_file) as f:
 
         model = r.get('model', '')
         label = r.get('label', '')
-        name = f'{model} @ {label}' if label else model
+        label_suffix = f' @ {label}' if label else ''
+        name = model if not label_suffix or model.endswith(label_suffix) else model + label_suffix
         tps = r.get('tokens_per_sec', 0)
         status = r.get('status', '')
         compact_lines.append(f'{idx}: {name} | {status} score={score_val} tps={tps}')

--- a/Scripts/mlx_model_test_oracle.py
+++ b/Scripts/mlx_model_test_oracle.py
@@ -108,13 +108,24 @@ def evaluate_expectations(
         expected_calls = expectation["tool_calls"]
         if len(tool_calls) != len(expected_calls):
             failures.append(f"tool_calls count expected {len(expected_calls)}, got {len(tool_calls)}")
-        for index, expected_call in enumerate(expected_calls[: len(tool_calls)]):
-            actual_call = tool_calls[index]
-            actual_name = actual_call["function"]["name"]
-            if actual_name != expected_call.get("name"):
+        unmatched_calls = list(enumerate(tool_calls))
+        for expected_call in expected_calls:
+            expected_name = expected_call.get("name")
+            match_offset = next(
+                (
+                    offset
+                    for offset, (_, call) in enumerate(unmatched_calls)
+                    if call.get("function", {}).get("name") == expected_name
+                ),
+                None,
+            )
+            if match_offset is None:
                 failures.append(
-                    f"tool_calls[{index}].name expected {expected_call.get('name')!r}, got {actual_name!r}"
+                    f"tool_calls missing expected function {expected_name!r}"
                 )
+                continue
+            actual_index, actual_call = unmatched_calls.pop(match_offset)
+            actual_name = actual_call["function"]["name"]
             try:
                 actual_arguments = json.loads(actual_call["function"]["arguments"])
             except (json.JSONDecodeError, TypeError, ValueError):
@@ -123,7 +134,8 @@ def evaluate_expectations(
                 actual_value = actual_arguments.get(key) if isinstance(actual_arguments, dict) else None
                 if actual_value != expected_value:
                     failures.append(
-                        f"tool_calls[{index}].arguments.{key} expected {expected_value!r}, got {actual_value!r}"
+                        f"tool_calls[{actual_index}] ({actual_name}).arguments.{key} "
+                        f"expected {expected_value!r}, got {actual_value!r}"
                     )
 
     return valid_json, failures

--- a/Scripts/mlx_model_test_oracle.py
+++ b/Scripts/mlx_model_test_oracle.py
@@ -1,0 +1,129 @@
+"""Deterministic response assertions for mlx-model-test.sh."""
+
+import json
+
+
+def extract_score_payload(text):
+    """Extract the last valid {score, reason} object from CLI output."""
+    decoder = json.JSONDecoder()
+    payload = None
+    for offset, character in enumerate(text):
+        if character != "{":
+            continue
+        try:
+            candidate, _ = decoder.raw_decode(text[offset:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(candidate, dict) and isinstance(candidate.get("score"), int):
+            payload = candidate
+    return payload
+
+
+def expectation_for_prompt(config):
+    """Give synthetic baselines their own oracle, not the variant oracle."""
+    if config.get("prompt_idx", 0) < config.get("num_baseline", 0):
+        # The global baseline is deliberately unrelated to every supplied tool.
+        # A tool-enabled variant must therefore answer normally, not guess a call.
+        return {"tool_calls": []} if config.get("tools") else {}
+    return config.get("expect") or {}
+
+
+def _validate_schema(value, schema, path="$"):
+    failures = []
+    schema_type = schema.get("type")
+    type_matches = {
+        "object": isinstance(value, dict),
+        "array": isinstance(value, list),
+        "string": isinstance(value, str),
+        "integer": isinstance(value, int) and not isinstance(value, bool),
+        "number": isinstance(value, (int, float)) and not isinstance(value, bool),
+        "boolean": isinstance(value, bool),
+        "null": value is None,
+    }
+    if schema_type and not type_matches.get(schema_type, True):
+        return [f"{path} expected type {schema_type}"]
+    if isinstance(value, dict):
+        for key in schema.get("required", []):
+            if key not in value:
+                failures.append(f"{path}.{key} is required")
+        for key, child_schema in schema.get("properties", {}).items():
+            if key in value:
+                failures.extend(_validate_schema(value[key], child_schema, f"{path}.{key}"))
+    if isinstance(value, list) and isinstance(schema.get("items"), dict):
+        for index, item in enumerate(value):
+            failures.extend(_validate_schema(item, schema["items"], f"{path}[{index}]"))
+    return failures
+
+
+def evaluate_expectations(
+    expectation,
+    *,
+    content,
+    finish_reason,
+    logprobs_count,
+    tool_calls,
+):
+    """Return (valid_json, failures) for a response and declarative expectation."""
+    parsed_json = None
+    valid_json = None
+    if expectation.get("valid_json") is not None or expectation.get("json_schema") is not None:
+        try:
+            parsed_json = json.loads(content)
+            valid_json = True
+        except (json.JSONDecodeError, TypeError, ValueError):
+            valid_json = False
+
+    failures = []
+    if expectation.get("valid_json") is not None and valid_json != expectation["valid_json"]:
+        failures.append(f"valid_json expected {expectation['valid_json']}, got {valid_json}")
+    if expectation.get("finish_reason") is not None and finish_reason != expectation["finish_reason"]:
+        failures.append(
+            f"finish_reason expected {expectation['finish_reason']!r}, got {finish_reason!r}"
+        )
+    if expectation.get("logprobs_min") is not None and logprobs_count < int(expectation["logprobs_min"]):
+        failures.append(
+            f"logprobs_count expected >= {expectation['logprobs_min']}, got {logprobs_count}"
+        )
+
+    if expectation.get("content_equals") is not None and content != expectation["content_equals"]:
+        failures.append(
+            f"content expected exactly {expectation['content_equals']!r}, got {content!r}"
+        )
+    if expectation.get("content_contains") is not None:
+        required = expectation["content_contains"]
+        required = required if isinstance(required, list) else [required]
+        for value in required:
+            if value not in content:
+                failures.append(f"content expected to contain {value!r}")
+    if expectation.get("content_not_contains") is not None:
+        forbidden = expectation["content_not_contains"]
+        forbidden = forbidden if isinstance(forbidden, list) else [forbidden]
+        for value in forbidden:
+            if value in content:
+                failures.append(f"content must not contain {value!r}")
+    if expectation.get("json_schema") is not None:
+        failures.extend(_validate_schema(parsed_json, expectation["json_schema"]))
+
+    if expectation.get("tool_calls") is not None:
+        expected_calls = expectation["tool_calls"]
+        if len(tool_calls) != len(expected_calls):
+            failures.append(f"tool_calls count expected {len(expected_calls)}, got {len(tool_calls)}")
+        for index, expected_call in enumerate(expected_calls[: len(tool_calls)]):
+            actual_call = tool_calls[index]
+            actual_name = actual_call["function"]["name"]
+            if actual_name != expected_call.get("name"):
+                failures.append(
+                    f"tool_calls[{index}].name expected {expected_call.get('name')!r}, got {actual_name!r}"
+                )
+            try:
+                actual_arguments = json.loads(actual_call["function"]["arguments"])
+            except (json.JSONDecodeError, TypeError, ValueError):
+                actual_arguments = None
+            for key, expected_value in expected_call.get("arguments", {}).items():
+                actual_value = actual_arguments.get(key) if isinstance(actual_arguments, dict) else None
+                if actual_value != expected_value:
+                    failures.append(
+                        f"tool_calls[{index}].arguments.{key} expected {expected_value!r}, got {actual_value!r}"
+                    )
+
+    return valid_json, failures

--- a/Scripts/resolve-release-dependencies.sh
+++ b/Scripts/resolve-release-dependencies.sh
@@ -98,20 +98,25 @@ run_authenticated() {
 
 for source in "${AFMKIT_RELEASE_SOURCES[@]}"; do
   IFS=$'\t' read -r AFMKIT_IDENTITY AFMKIT_URL AFMKIT_REVISION AFMKIT_VERSION <<< "$source"
-  AFMKIT_REMOTE_REFS="$(run_authenticated "$GIT_COMMAND" ls-remote --tags "$AFMKIT_URL" "refs/tags/$AFMKIT_VERSION*" 2>/dev/null || true)"
+  AFMKIT_REMOTE_REFS="$(
+    run_authenticated "$GIT_COMMAND" ls-remote --tags "$AFMKIT_URL" \
+      "refs/tags/$AFMKIT_VERSION" \
+      "refs/tags/$AFMKIT_VERSION^{}" \
+      "refs/tags/v$AFMKIT_VERSION" \
+      "refs/tags/v$AFMKIT_VERSION^{}" \
+      2>/dev/null || true
+  )"
   if grep -Fq "$AFMKIT_REVISION" <<<"$AFMKIT_REMOTE_REFS"; then
     echo "[afmkit-auth] Access verified for $AFMKIT_IDENTITY ${AFMKIT_REVISION:0:12}."
     continue
   fi
   cat >&2 <<EOF
-[afmkit-auth] Cannot read the private provider dependency at $AFMKIT_URL.
-[afmkit-auth] Local builds: authenticate a GitHub account with repository read access
-[afmkit-auth] using 'gh auth login' followed by 'gh auth setup-git'.
-[afmkit-auth] CI/releases: provide a masked AFMKIT_READ_TOKEN secret with read access
-[afmkit-auth] to the AFMKit repository. The default cross-repository GITHUB_TOKEN is
-[afmkit-auth] not sufficient. No production release is permitted until AFMKit and
-[afmkit-auth] every dependency in its root graph are public or an approved
-[afmkit-auth] public immutable artifact replaces this private dependency.
+[afmkit-auth] Cannot read the exact provider dependency at $AFMKIT_URL.
+[afmkit-auth] Confirm network access and that tag $AFMKIT_VERSION resolves to
+[afmkit-auth] ${AFMKIT_REVISION:0:12}. For an explicitly private development source,
+[afmkit-auth] authenticate with 'gh auth login' and 'gh auth setup-git', or provide a
+[afmkit-auth] masked AFMKIT_READ_TOKEN with repository read access. Production release
+[afmkit-auth] eligibility always requires anonymous access and never relies on a token.
 EOF
   exit 1
 done

--- a/Scripts/test-Qwen3.5-35B-A3B-4bit.txt
+++ b/Scripts/test-Qwen3.5-35B-A3B-4bit.txt
@@ -401,110 +401,120 @@ Think step by step: what is 17 * 23?
 # --- Basic API-level stop ---
 
 # AI: Tests single stop sequence via API. Feature: stop parameter in OpenAI request.
-# AI: Expected: output lists items 1-2 only, stops before "3." appears.
-# AI: finish_reason must be "stop". Output must NOT contain "3." or any items after it.
+# AI: The prompt forces a literal marker and suffix. The response must equal the prefix,
+# AI: proving truncation instead of treating a natural EOS finish_reason as sufficient.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-single]
 temperature: 0.0
 max_tokens: 4096
-stop: ["3."]
-List 10 fruits, numbered 1-10, one per line.
+stop: ["<AFM_STOP>"]
+expect: {"finish_reason":"stop","content_equals":"AFM_PREFIX","content_not_contains":["<AFM_STOP>","AFM_SUFFIX"]}
+Output exactly the following text, with no quotes, markdown, explanation, or extra whitespace: AFM_PREFIX<AFM_STOP>AFM_SUFFIX
 
 # AI: Tests multiple stop sequences via API. Feature: stop parameter with array of 2 strings.
-# AI: Expected: output should stop at whichever of "```" or "END" appears first in the
-# AI: generated text. Likely stops at the closing ``` of the code block. finish_reason="stop".
+# AI: The exact-output instruction guarantees both stop candidates would be generated;
+# AI: the first candidate must win and its suffix must not leak.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-multi]
 temperature: 0.0
 max_tokens: 4096
-stop: ["```", "END"]
-Write a Python hello world program in a code block, then write END after it.
+stop: ["<AFM_FIRST_STOP>", "<AFM_SECOND_STOP>"]
+expect: {"finish_reason":"stop","content_equals":"AFM_MULTI_PREFIX","content_not_contains":["<AFM_FIRST_STOP>","AFM_BETWEEN","<AFM_SECOND_STOP>","AFM_MULTI_SUFFIX"]}
+Output exactly the following text, with no quotes, markdown, explanation, or extra whitespace: AFM_MULTI_PREFIX<AFM_FIRST_STOP>AFM_BETWEEN<AFM_SECOND_STOP>AFM_MULTI_SUFFIX
 
 # AI: Tests stop on newline character. Feature: stop parameter with "\n".
-# AI: Expected: exactly one line of output (the answer), no newline in content.
+# AI: Expected: exactly AFM_LINE_ONE; the newline and second forced line are withheld.
 # AI: finish_reason="stop". Tests that escape sequences in stop are handled correctly.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-newline]
 temperature: 0.0
 max_tokens: 4096
 stop: ["\n"]
-What is the capital of France? Answer in one sentence.
+expect: {"finish_reason":"stop","content_equals":"AFM_LINE_ONE","content_not_contains":"AFM_LINE_TWO"}
+Output exactly two lines. The first line must be AFM_LINE_ONE and the second line must be AFM_LINE_TWO. Output nothing else.
 
 # AI: Tests stop on double newline. Feature: stop parameter with "\n\n".
-# AI: Expected: exactly one paragraph (about the ocean). The second paragraph about
-# AI: mountains should NOT appear. finish_reason="stop".
+# AI: Expected: exactly AFM_PARAGRAPH_ONE; the blank-line delimiter and forced second
+# AI: paragraph are withheld. finish_reason="stop".
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-double-newline]
 temperature: 0.0
 max_tokens: 4096
 stop: ["\n\n"]
-Write a short paragraph about the ocean. Then write a second paragraph about mountains.
+expect: {"finish_reason":"stop","content_equals":"AFM_PARAGRAPH_ONE","content_not_contains":"AFM_PARAGRAPH_TWO"}
+Output exactly AFM_PARAGRAPH_ONE, then one blank line, then AFM_PARAGRAPH_TWO. Output nothing else.
 
 # AI: Tests stop on a word boundary. Feature: stop parameter with a common word.
-# AI: Expected: output stops just before "Python" appears. The list should include
-# AI: some languages but cut off at or before the Python entry. finish_reason="stop".
+# AI: Expected: exactly AFM_WORD_PREFIX; the forced word delimiter and suffix are withheld.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-word]
 temperature: 0.0
 max_tokens: 4096
 stop: ["Python"]
-Name 5 programming languages and briefly describe each one.
+expect: {"finish_reason":"stop","content_equals":"AFM_WORD_PREFIX","content_not_contains":["Python","AFM_WORD_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_WORD_PREFIXPythonAFM_WORD_SUFFIX
 
 # AI: Tests stop on punctuation (period). Feature: stop parameter with ".".
-# AI: Expected: only the beginning of the first sentence, cut off before the first period.
-# AI: finish_reason="stop". Very aggressive stop — output may be just a few words.
+# AI: Expected: exactly AFM_PERIOD_PREFIX, cut off before the forced period.
+# AI: finish_reason="stop". Tests an aggressive one-character delimiter.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-period]
 temperature: 0.0
 max_tokens: 4096
 stop: ["."]
-Tell me about the sun in three sentences.
+expect: {"finish_reason":"stop","content_equals":"AFM_PERIOD_PREFIX","content_not_contains":"AFM_PERIOD_SUFFIX"}
+Output exactly the following text, with no quotes or extra whitespace: AFM_PERIOD_PREFIX.AFM_PERIOD_SUFFIX
 
 # --- CLI-level stop (`--stop` flag) ---
 
 # AI: Tests CLI-level stop (--stop flag). Feature: afm --stop (server-side stop sequences).
-# AI: Expected: same behavior as API stop — output lists items 1-2, stops before "3.".
+# AI: Expected: exactly AFM_CLI_PREFIX; the forced CLI delimiter and suffix are withheld.
 # AI: This tests the CLI flag path rather than the API request body path.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-cli-only]
 temperature: 0.0
 max_tokens: 4096
-afm: --stop "3."
-List 10 types of cheese, numbered 1 through 10, one per line.
+afm: --stop "<AFM_CLI_STOP>"
+expect: {"finish_reason":"stop","content_equals":"AFM_CLI_PREFIX","content_not_contains":["<AFM_CLI_STOP>","AFM_CLI_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_CLI_PREFIX<AFM_CLI_STOP>AFM_CLI_SUFFIX
 
 # AI: Tests CLI stop with multiple comma-separated sequences. Feature: --stop with commas.
-# AI: Expected: output stops at first occurrence of either "```" or "DONE".
-# AI: Tests that comma parsing in --stop works correctly for multiple sequences.
+# AI: Expected: exactly AFM_CLI_MULTI_PREFIX at the first forced delimiter.
+# AI: Tests comma parsing in --stop with two deterministic sequences.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-cli-multi]
 temperature: 0.0
 max_tokens: 4096
-afm: --stop "```,DONE"
-Write a bash script that prints the current date inside a code block, then write DONE.
+afm: --stop "<AFM_CLI_FIRST>,<AFM_CLI_SECOND>"
+expect: {"finish_reason":"stop","content_equals":"AFM_CLI_MULTI_PREFIX","content_not_contains":["<AFM_CLI_FIRST>","AFM_CLI_BETWEEN","<AFM_CLI_SECOND>","AFM_CLI_MULTI_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_CLI_MULTI_PREFIX<AFM_CLI_FIRST>AFM_CLI_BETWEEN<AFM_CLI_SECOND>AFM_CLI_MULTI_SUFFIX
 
 # AI: Tests CLI + API stop merge. Feature: stop sequences from both sources are combined.
-# AI: CLI provides "5.", API provides "3." — should stop at "3." since it comes first
-# AI: in the numbered list. Verifies both sources are active simultaneously.
+# AI: The API delimiter is forced before the CLI delimiter, so output must equal
+# AI: AFM_MERGE_PREFIX. Verifies both sources are active simultaneously.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-cli-api-merge]
 temperature: 0.0
 max_tokens: 4096
-stop: ["3."]
-afm: --stop "5."
-List 10 countries, numbered 1 through 10, one per line.
+stop: ["<AFM_API_STOP>"]
+afm: --stop "<AFM_CLI_STOP>"
+expect: {"finish_reason":"stop","content_equals":"AFM_MERGE_PREFIX","content_not_contains":["<AFM_API_STOP>","AFM_MERGE_BETWEEN","<AFM_CLI_STOP>","AFM_MERGE_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_MERGE_PREFIX<AFM_API_STOP>AFM_MERGE_BETWEEN<AFM_CLI_STOP>AFM_MERGE_SUFFIX
 
 # AI: Tests CLI + API stop deduplication. Feature: duplicate stop sequences from both sources.
-# AI: Both CLI and API provide "3." — server should deduplicate and work normally.
-# AI: Expected: stops at "3.", no errors or double-triggering.
+# AI: CLI and API provide the same forced delimiter. Expected: exactly
+# AI: AFM_DEDUP_PREFIX, with no error or double-triggering.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-cli-api-dedup]
 temperature: 0.0
 max_tokens: 4096
-stop: ["3."]
-afm: --stop "3."
-List 10 cities, numbered 1 through 10, one per line.
+stop: ["<AFM_DEDUP_STOP>"]
+afm: --stop "<AFM_DEDUP_STOP>"
+expect: {"finish_reason":"stop","content_equals":"AFM_DEDUP_PREFIX","content_not_contains":["<AFM_DEDUP_STOP>","AFM_DEDUP_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_DEDUP_PREFIX<AFM_DEDUP_STOP>AFM_DEDUP_SUFFIX
 
 # --- Non-streaming ---
 
 # AI: Tests stop sequences in non-streaming mode. Feature: stop + --no-streaming combined.
-# AI: Expected: output lists items 1-2, stops before "3.". Same truncation point as
-# AI: streaming mode (stop-single). Verifies stop works without SSE chunking.
+# AI: Expected: exactly AFM_NONSTREAM_PREFIX. Verifies deterministic truncation
+# AI: works without SSE chunking.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-non-streaming]
 temperature: 0.0
 max_tokens: 4096
 afm: --no-streaming
-stop: ["3."]
-List 10 planets or celestial objects, numbered 1 through 10, one per line.
+stop: ["<AFM_NONSTREAM_STOP>"]
+expect: {"finish_reason":"stop","content_equals":"AFM_NONSTREAM_PREFIX","content_not_contains":["<AFM_NONSTREAM_STOP>","AFM_NONSTREAM_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_NONSTREAM_PREFIX<AFM_NONSTREAM_STOP>AFM_NONSTREAM_SUFFIX
 
 # --- Stop + guided JSON ---
 
@@ -516,6 +526,7 @@ temperature: 0.0
 max_tokens: 4096
 stop: ["Tokyo"]
 afm: --guided-json '{"type":"object","properties":{"cities":{"type":"array","items":{"type":"string"}}},"required":["cities"]}'
+expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":"Tokyo"}
 List 5 major world cities as a JSON array. Include Tokyo.
 
 # AI: Tests stop on JSON structural token inside guided JSON. Feature: stop + --guided-json.
@@ -526,6 +537,7 @@ temperature: 0.0
 max_tokens: 4096
 stop: [","]
 afm: --guided-json '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"},"city":{"type":"string"}},"required":["name","age","city"]}'
+expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":","}
 Generate a person profile for someone named Alice who is 30 and lives in Paris.
 
 # AI: Tests stop on closing brace inside guided JSON. Feature: stop + --guided-json.
@@ -536,6 +548,7 @@ temperature: 0.0
 max_tokens: 4096
 stop: ["}"]
 afm: --guided-json '{"type":"object","properties":{"color":{"type":"string"},"hex":{"type":"string"}},"required":["color","hex"]}'
+expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":"}"}
 Describe the color blue with its hex code.
 
 # --- Stop + response format (json_object mode) ---
@@ -548,26 +561,29 @@ temperature: 0.0
 max_tokens: 4096
 response_format: json_object
 stop: ["age"]
+expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":"age"}
 Generate a JSON object with keys "name", "age", and "city" for a person named Carol.
 
 # --- Multi-token and long stop strings ---
 
 # AI: Tests stop on a long multi-word phrase. Feature: stop with multi-token string.
-# AI: Expected: essay contains paragraphs 1-2 about renewable energy, stops before
-# AI: "In conclusion" appears. Tests buffer-based stop detection across token boundaries.
+# AI: Expected: exactly AFM_LONG_PREFIX, stopping before the forced multi-token phrase.
+# AI: Tests buffer-based stop detection across token boundaries.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-long-phrase]
 temperature: 0.0
 max_tokens: 4096
 stop: ["In conclusion"]
-Write a 3-paragraph essay about renewable energy. Start the last paragraph with "In conclusion".
+expect: {"finish_reason":"stop","content_equals":"AFM_LONG_PREFIX","content_not_contains":["In conclusion","AFM_LONG_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_LONG_PREFIXIn conclusionAFM_LONG_SUFFIX
 
 # AI: Tests stop on a multi-word string. Feature: stop with "Step 3" (spans 2+ tokens).
-# AI: Expected: recipe shows Steps 1-2 only, stops before "Step 3". finish_reason="stop".
+# AI: Expected: exactly AFM_MULTI_WORD_PREFIX, stopping before "Step 3".
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-multi-word]
 temperature: 0.0
 max_tokens: 4096
 stop: ["Step 3"]
-Write a 5-step recipe for making tea. Label each step as "Step 1", "Step 2", etc.
+expect: {"finish_reason":"stop","content_equals":"AFM_MULTI_WORD_PREFIX","content_not_contains":["Step 3","AFM_MULTI_WORD_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_MULTI_WORD_PREFIXStep 3AFM_MULTI_WORD_SUFFIX
 
 # --- Edge cases ---
 
@@ -579,52 +595,56 @@ Write a 5-step recipe for making tea. Label each step as "Step 1", "Step 2", etc
 temperature: 0.0
 max_tokens: 256
 stop: ["XYZZY_NEVER_MATCH"]
+expect: {"content_contains":["TCP","UDP"],"content_not_contains":"XYZZY_NEVER_MATCH"}
 Explain the difference between TCP and UDP in a few sentences.
 
-# AI: Tests immediate stop (first token matches). Feature: stop on common first tokens.
-# AI: Expected: empty or near-empty output. The model's first token is likely "The", "I",
-# AI: or "A" — all are in the stop list. finish_reason="stop", completion_tokens near 0.
+# AI: Tests immediate stop with a forced first character sequence.
+# AI: Expected: exactly empty output with finish_reason="stop".
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-immediate]
 temperature: 0.0
 max_tokens: 4096
-stop: ["The", "I", "A"]
-Explain what gravity is.
+stop: ["AFM_IMMEDIATE_STOP"]
+expect: {"finish_reason":"stop","content_equals":"","content_not_contains":"AFM_IMMEDIATE_SUFFIX"}
+Output exactly the following text, with no quotes or leading whitespace: AFM_IMMEDIATE_STOPAFM_IMMEDIATE_SUFFIX
 
 # AI: Tests stop on markdown special characters. Feature: stop with "**".
-# AI: Expected: output stops at first "**" bold marker. Only partial text before the first
-# AI: bold-formatted word. Tests that special regex characters in stop are handled correctly.
+# AI: Expected: exactly AFM_MARKDOWN_PREFIX before the forced "**" marker.
+# AI: Tests that special regex characters in stop are handled correctly.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-special-chars]
 temperature: 0.0
 max_tokens: 4096
 stop: ["**"]
-List 3 facts about the moon. Use **bold** markdown for emphasis.
+expect: {"finish_reason":"stop","content_equals":"AFM_MARKDOWN_PREFIX","content_not_contains":["**","AFM_MARKDOWN_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_MARKDOWN_PREFIX**AFM_MARKDOWN_SUFFIX
 
 # AI: Tests stop on HTML closing tag. Feature: stop with "</li>" (multi-char tag).
-# AI: Expected: output contains <ul>, first <li> content, stops at first </li>.
+# AI: Expected: exactly <ul><li>AFM_HTML_PREFIX, stopping at the forced </li>.
 # AI: Tests stop detection on angle-bracket sequences common in structured output.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-html-tag]
 temperature: 0.0
 max_tokens: 4096
 stop: ["</li>"]
-Write an HTML unordered list of 5 fruits using <ul> and <li> tags.
+expect: {"finish_reason":"stop","content_equals":"<ul><li>AFM_HTML_PREFIX","content_not_contains":["</li>","AFM_HTML_SUFFIX"]}
+Output exactly the following text, with no quotes, markdown fence, or extra whitespace: <ul><li>AFM_HTML_PREFIX</li>AFM_HTML_SUFFIX
 
 # AI: Tests stop on unicode character (bullet point •). Feature: stop with unicode.
-# AI: Expected: output stops at first bullet point character. Tests that the stop
+# AI: Expected: exactly AFM_UNICODE_PREFIX before the forced bullet. Tests that the
 # AI: sequence matcher handles multi-byte UTF-8 characters correctly.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-unicode]
 temperature: 0.0
 max_tokens: 4096
 stop: ["\u2022"]
-List 5 items about space using bullet points (•).
+expect: {"finish_reason":"stop","content_equals":"AFM_UNICODE_PREFIX","content_not_contains":["\u2022","AFM_UNICODE_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_UNICODE_PREFIX•AFM_UNICODE_SUFFIX
 
 # AI: Tests maximum 4 stop sequences (OpenAI spec limit). Feature: stop with 4 entries.
-# AI: Expected: output stops at whichever of "3.", "three", "Third", "III" appears first.
-# AI: Prompt asks for mixed digit/word numbering to give multiple stop strings a chance.
+# AI: Expected: exactly AFM_FOUR_PREFIX at the first forced candidate.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ stop-four-max]
 temperature: 0.0
 max_tokens: 4096
 stop: ["3.", "three", "Third", "III"]
-List 10 facts about numbers, alternating between digit format (1., 2.) and word format (three, four). One per line.
+expect: {"finish_reason":"stop","content_equals":"AFM_FOUR_PREFIX","content_not_contains":["3.","three","Third","III","AFM_FOUR_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_FOUR_PREFIX3.AFM_FOUR_SUFFIXthreeThirdIII
 
 # --- Stop + system prompt interaction ---
 
@@ -636,6 +656,7 @@ temperature: 0.0
 max_tokens: 4096
 system: You are a pirate. Speak like a pirate in all responses.
 stop: ["Arrr"]
+expect: {"finish_reason":"stop","content_not_contains":"Arrr"}
 Tell me about treasure hunting on the high seas.
 
 # AI: Tests stop with instruction system prompt. Feature: stop + system message combined.
@@ -646,6 +667,7 @@ temperature: 0.0
 max_tokens: 4096
 system: Always respond with numbered lists. Never use bullet points.
 stop: ["4."]
+expect: {"finish_reason":"stop","content_not_contains":"4."}
 What are the main benefits of exercise?
 
 # --- Stop + sampling parameters ---
@@ -657,6 +679,7 @@ What are the main benefits of exercise?
 temperature: 1.0
 max_tokens: 4096
 stop: ["3."]
+expect: {"finish_reason":"stop","content_not_contains":"3."}
 List 10 random words, numbered 1 through 10, one per line.
 
 # AI: Tests stop + seed determinism (run 1 of 2). Feature: stop + seed combined.
@@ -667,6 +690,7 @@ temperature: 0.7
 max_tokens: 4096
 seed: 42
 stop: ["3."]
+expect: {"finish_reason":"stop","content_not_contains":"3."}
 List 10 flowers, numbered 1 through 10, one per line.
 
 # AI: Tests stop + seed determinism (run 2 of 2). Feature: stop + seed combined.
@@ -677,6 +701,7 @@ temperature: 0.7
 max_tokens: 4096
 seed: 42
 stop: ["3."]
+expect: {"finish_reason":"stop","content_not_contains":"3."}
 List 10 flowers, numbered 1 through 10, one per line.
 
 # AI: Tests stop vs max_tokens race. Feature: stop + low max_tokens combined.
@@ -686,6 +711,7 @@ List 10 flowers, numbered 1 through 10, one per line.
 temperature: 0.0
 max_tokens: 100
 stop: ["2."]
+expect: {"finish_reason":"stop","content_not_contains":"2."}
 List 10 mountains, numbered 1 through 10, one per line.
 
 # ══════════════════════════════════════════════════════════════════════
@@ -928,7 +954,8 @@ system: You are a Swift expert. Write clean code with no explanation.
 Write a Swift async function that fetches JSON from a URL using URLSession, decodes it into a Codable struct, and handles errors with Result type.
 
 # AI: Tests mathematical reasoning. Feature: model quality — multi-step arithmetic.
-# AI: Expected: correct answer $21.252 (7 × $3.50 × 0.80 × 1.085). The model must chain
+# AI: Expected: correct answer $21.266, conventionally rounded to $21.27
+# AI: (7 × $3.50 × 0.80 × 1.085). The model must chain
 # AI: discount, subtotal, and tax steps correctly. Tests reasoning without <think> support.
 [mlx-community/Qwen3.5-35B-A3B-4bit @ math]
 temperature: 0.0

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -520,54 +520,42 @@ if should_run_section 2; then
 echo ""
 echo "🛑 Section 2: Stop Sequences"
 
-# Test: stop string absent from output
+# Test: deterministic stop prefix. A natural EOS cannot satisfy this oracle unless
+# the model ignores an explicit exact-output instruction at precisely the marker.
 t0=$(now_ms)
-resp=$(api_call '{"messages":[{"role":"user","content":"Count from 1 to 20, one number per line."}],"max_tokens":200,"stream":false,"temperature":0,"stop":["5"]}')
+resp=$(api_call '{"messages":[{"role":"user","content":"Output exactly this text with no quotes or extra whitespace: AFM_PREFIX<AFM_STOP>AFM_SUFFIX"}],"max_tokens":200,"stream":false,"temperature":0,"stop":["<AFM_STOP>"]}')
 content=$(echo "$resp" | extract_visible_content)
 finish=$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0].get('finish_reason',''))" 2>/dev/null || echo "error")
 dur=$(( $(now_ms) - t0 ))
-if ! echo "$content" | grep -q "5"; then
-  run_test "Stop" "Stop string '5' absent from output" "no '5' in content" "PASS" "$dur"
+if [ "$content" = "AFM_PREFIX" ]; then
+  run_test "Stop" "Deterministic stop returns exact prefix" "AFM_PREFIX only" "PASS" "$dur"
 else
-  run_test "Stop" "Stop string '5' absent from output" "no '5' in content" "FAIL: found '5' in: $content" "$dur"
+  run_test "Stop" "Deterministic stop returns exact prefix" "AFM_PREFIX only" "FAIL: got '$content'" "$dur"
 fi
 
 t0=$(now_ms)
-# finish_reason should be "stop" when the stop sequence fired, or "length" if the model
-# exhausted max_tokens on thinking without producing visible content (model behavior, not a bug).
-content_empty=$(echo "$resp" | python3 -c "
-import sys, json
-try:
-    d = json.load(sys.stdin)
-    c = d['choices'][0]['message'].get('content') or ''
-    print('yes' if not c.strip() else 'no')
-except: print('no')
-" 2>/dev/null || echo "no")
+# The deterministic prefix oracle above proves the stop marker was reached, while
+# this checks OpenAI-compatible public response mapping.
 if [ "$finish" = "stop" ]; then
-  run_test "Stop" "finish_reason is 'stop' with stop sequence" "stop" "PASS" "$(( $(now_ms) - t0 ))"
-elif [ "$finish" = "length" ] && [ "$content_empty" = "yes" ]; then
-  # Model spent entire budget on thinking — stop never fired on visible content. Correct behavior.
   run_test "Stop" "finish_reason is 'stop' with stop sequence" "stop" "PASS" "$(( $(now_ms) - t0 ))"
 else
   run_test "Stop" "finish_reason is 'stop' with stop sequence" "stop" "FAIL: got '$finish'" "$(( $(now_ms) - t0 ))"
 fi
 
-# Test: multi-word stop
+# Test: multi-character stop
 t0=$(now_ms)
-resp=$(api_call '{"messages":[{"role":"user","content":"Write a short paragraph about cats."}],"max_tokens":200,"stream":false,"temperature":0,"stop":["and"]}')
+resp=$(api_call '{"messages":[{"role":"user","content":"Output exactly this text with no quotes or extra whitespace: AFM_MULTI_PREFIX<AFM_MULTI_STOP>AFM_MULTI_SUFFIX"}],"max_tokens":200,"stream":false,"temperature":0,"stop":["<AFM_MULTI_STOP>"]}')
 content=$(echo "$resp" | extract_visible_content)
 dur=$(( $(now_ms) - t0 ))
-# "and" should not appear in output (case sensitive)
-if ! echo "$content" | grep -qw "and"; then
-  run_test "Stop" "Multi-word stop 'and' truncates correctly" "no 'and' in output" "PASS" "$dur"
+if [ "$content" = "AFM_MULTI_PREFIX" ]; then
+  run_test "Stop" "Multi-character stop truncates exactly" "AFM_MULTI_PREFIX only" "PASS" "$dur"
 else
-  # Check if it's just in a word like "understand" — that's fine, we check word boundary
-  run_test "Stop" "Multi-word stop 'and' truncates correctly" "no 'and' in output" "FAIL: found in: $(echo "$content" | head -1)" "$dur"
+  run_test "Stop" "Multi-character stop truncates exactly" "AFM_MULTI_PREFIX only" "FAIL: got '$content'" "$dur"
 fi
 
 # Test: stop with newline
 t0=$(now_ms)
-resp=$(api_call '{"messages":[{"role":"user","content":"Say hello world"}],"max_tokens":500,"stream":false,"temperature":0,"stop":["\\n"]}')
+resp=$(api_call '{"messages":[{"role":"user","content":"Output exactly two lines: AFM_LINE_ONE on the first line and AFM_LINE_TWO on the second. Output nothing else."}],"max_tokens":500,"stream":false,"temperature":0,"stop":["\\n"]}')
 dur=$(( $(now_ms) - t0 ))
 stop_nl_ok=$(echo "$resp" | python3 -c "
 import sys, json
@@ -575,14 +563,10 @@ try:
     d = json.load(sys.stdin)
     msg = d['choices'][0]['message']
     c = msg.get('content') or ''
-    # Visible content should have no newlines (stop fired before any newline)
-    if '\n' not in c:
-        print('PASS')
-    elif not c.strip():
-        # Empty content is OK — thinking model used all tokens on reasoning
+    if c == 'AFM_LINE_ONE':
         print('PASS')
     else:
-        print(f'FAIL: multi-line: {repr(c[:80])}')
+        print(f'FAIL: expected exact prefix, got {repr(c[:80])}')
 except Exception as e:
     print(f'FAIL: {e}')
 " 2>/dev/null || echo "FAIL: parse error")
@@ -594,13 +578,13 @@ fi
 
 # Test: multiple stop sequences
 t0=$(now_ms)
-resp=$(api_call '{"messages":[{"role":"user","content":"Count from 1 to 20."}],"max_tokens":200,"stream":false,"temperature":0,"stop":["7","12"]}')
+resp=$(api_call '{"messages":[{"role":"user","content":"Output exactly this text with no quotes or extra whitespace: AFM_FIRST<AFM_STOP_ONE>AFM_MIDDLE<AFM_STOP_TWO>AFM_LAST"}],"max_tokens":200,"stream":false,"temperature":0,"stop":["<AFM_STOP_ONE>","<AFM_STOP_TWO>"]}')
 content=$(echo "$resp" | extract_visible_content)
 dur=$(( $(now_ms) - t0 ))
-if ! echo "$content" | grep -q "7" && ! echo "$content" | grep -q "12"; then
-  run_test "Stop" "Multiple stop sequences [7, 12]" "neither found" "PASS" "$dur"
+if [ "$content" = "AFM_FIRST" ]; then
+  run_test "Stop" "Multiple stop sequences choose first marker" "AFM_FIRST only" "PASS" "$dur"
 else
-  run_test "Stop" "Multiple stop sequences [7, 12]" "neither found" "FAIL: content=$content" "$dur"
+  run_test "Stop" "Multiple stop sequences choose first marker" "AFM_FIRST only" "FAIL: content=$content" "$dur"
 fi
 
 # Test: empty stop array is no-op
@@ -616,7 +600,7 @@ fi
 
 # Test: streaming stop sequence parity
 t0=$(now_ms)
-stream_resp=$(api_stream '{"messages":[{"role":"user","content":"Count from 1 to 20, one number per line."}],"max_tokens":200,"stream":true,"temperature":0,"stop":["5"]}')
+stream_resp=$(api_stream '{"messages":[{"role":"user","content":"Output exactly this text with no quotes or extra whitespace: AFM_STREAM_PREFIX<AFM_STREAM_STOP>AFM_STREAM_SUFFIX"}],"max_tokens":200,"stream":true,"temperature":0,"stop":["<AFM_STREAM_STOP>"]}')
 stream_content=$(echo "$stream_resp" | grep "^data: {" | grep -v '"[DONE]"' | python3 -c "
 import sys, json
 content = ''
@@ -636,11 +620,11 @@ for line in sys.stdin:
 print(content)
 " 2>/dev/null || echo "__ERROR__")
 dur=$(( $(now_ms) - t0 ))
-if ! echo "$stream_content" | grep -q "5"; then
-  run_test "Stop" "Streaming: stop string '5' absent" "no '5' in stream" "PASS" "$dur"
+if [ "$stream_content" = "AFM_STREAM_PREFIX" ]; then
+  run_test "Stop" "Streaming: deterministic exact stop prefix" "AFM_STREAM_PREFIX only" "PASS" "$dur"
 else
   stream_preview=$(printf '%s' "$stream_content" | head -c 240)
-  run_test "Stop" "Streaming: stop string '5' absent" "no '5' in stream" "FAIL: found '5' in: $stream_preview" "$dur"
+  run_test "Stop" "Streaming: deterministic exact stop prefix" "AFM_STREAM_PREFIX only" "FAIL: got '$stream_preview'" "$dur"
 fi
 
 if min_tier standard; then
@@ -648,13 +632,13 @@ if min_tier standard; then
   # Additional stop tests for standard+ tiers
   # Test: stop sequence with JSON array format
   t0=$(now_ms)
-  resp=$(api_call '{"messages":[{"role":"user","content":"List 5 fruits, one per line."}],"max_tokens":100,"stream":false,"temperature":0,"stop":["3."]}')
+  resp=$(api_call '{"messages":[{"role":"user","content":"Output exactly this text with no quotes or extra whitespace: AFM_ARRAY_PREFIX<AFM_ARRAY_STOP>AFM_ARRAY_SUFFIX"}],"max_tokens":100,"stream":false,"temperature":0,"stop":["<AFM_ARRAY_STOP>"]}')
   content=$(echo "$resp" | extract_visible_content)
   dur=$(( $(now_ms) - t0 ))
-  if ! echo "$content" | grep -q "3\."; then
-    run_test "Stop" "Stop sequence '3.' truncates list" "no '3.' in output" "PASS" "$dur"
+  if [ "$content" = "AFM_ARRAY_PREFIX" ]; then
+    run_test "Stop" "Stop array format truncates exactly" "AFM_ARRAY_PREFIX only" "PASS" "$dur"
   else
-    run_test "Stop" "Stop sequence '3.' truncates list" "no '3.' in output" "FAIL" "$dur"
+    run_test "Stop" "Stop array format truncates exactly" "AFM_ARRAY_PREFIX only" "FAIL: got '$content'" "$dur"
   fi
 
   # Test: stop doesn't fire on partial match

--- a/Scripts/test-llm-comprehensive.txt
+++ b/Scripts/test-llm-comprehensive.txt
@@ -33,8 +33,9 @@
 # - For model-specific tests, see test-<ModelName>.txt files
 # ══════════════════════════════════════════════════════════════════════
 
-max_tokens: 4096
+max_tokens: 20000
 temperature: 0.7
+afm: --no-think
 
 [all]
 Name three primary colors and explain why they matter in design. Answer concisely.
@@ -49,7 +50,7 @@ Name three primary colors and explain why they matter in design. Answer concisel
 # AI: Compare with default/high-temp — this should be the least creative but most precise.
 [@ greedy]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 Explain why the sky is blue in exactly 3 bullet points.
 
 # AI: Tests default sampling (temperature=0.7). Feature: balanced randomness.
@@ -70,21 +71,21 @@ Explain why the sky is blue in exactly 3 bullet points.
 # AI: Expected: coherent 3-bullet response, quality between greedy and high-temp.
 [@ top-p]
 temperature: 0.8
-afm: --top-p 0.9
+afm: --no-think --top-p 0.9
 Explain why the sky is blue in exactly 3 bullet points.
 
 # AI: Tests top-k sampling (top_k=30). Feature: --top-k CLI flag.
 # AI: Expected: coherent response. Top-k restricts to 30 most likely tokens per step.
 [@ top-k]
 temperature: 0.8
-afm: --top-k 30
+afm: --no-think --top-k 30
 Explain why the sky is blue in exactly 3 bullet points.
 
 # AI: Tests min-p filtering (min_p=0.05). Feature: --min-p CLI flag.
 # AI: Expected: coherent response. Min-p filters tokens below 5% of max probability.
 [@ min-p]
 temperature: 0.8
-afm: --min-p 0.05
+afm: --no-think --min-p 0.05
 Explain why the sky is blue in exactly 3 bullet points.
 
 # AI: Tests combined sampler chain: top-k → min-p → temperature (llama.cpp order).
@@ -92,7 +93,7 @@ Explain why the sky is blue in exactly 3 bullet points.
 # AI: Verifies the sampler chain doesn't conflict or crash when all are combined.
 [@ combined-samplers]
 temperature: 0.8
-afm: --top-k 50 --min-p 0.03 --top-p 0.95
+afm: --no-think --top-k 50 --min-p 0.03 --top-p 0.95
 Explain why the sky is blue in exactly 3 bullet points.
 
 # AI: Tests seed-based determinism (seed=42, run 1 of 2). Feature: --seed CLI flag.
@@ -100,14 +101,14 @@ Explain why the sky is blue in exactly 3 bullet points.
 # AI: character-for-character identical since same seed + same temperature.
 [@ seed-42-run1]
 temperature: 0.7
-afm: --seed 42
+afm: --no-think --seed 42
 Write a limerick about a cat.
 
 # AI: Tests seed-based determinism (seed=42, run 2 of 2). Feature: --seed CLI flag.
 # AI: Expected: output MUST be identical to seed-42-run1. Any difference = seed bug.
 [@ seed-42-run2]
 temperature: 0.7
-afm: --seed 42
+afm: --no-think --seed 42
 Write a limerick about a cat.
 
 # ══════════════════════════════════════════════════════════════════════
@@ -119,8 +120,8 @@ Write a limerick about a cat.
 # AI: "civilization", etc. Compare with with-penalty — this is the control.
 [@ no-penalty]
 temperature: 0.8
-max_tokens: 4096
-afm: --presence-penalty 0.0
+max_tokens: 20000
+afm: --no-think --presence-penalty 0.0
 Write a long essay about the history of bread making across civilizations.
 
 # AI: Tests strong presence penalty (1.5). Feature: --presence-penalty flag.
@@ -128,8 +129,8 @@ Write a long essay about the history of bread making across civilizations.
 # AI: If output becomes incoherent or too short, penalty may be too aggressive.
 [@ with-penalty]
 temperature: 0.8
-max_tokens: 4096
-afm: --presence-penalty 1.5
+max_tokens: 20000
+afm: --no-think --presence-penalty 1.5
 Write a long essay about the history of bread making across civilizations.
 
 # AI: Tests repetition penalty (1.2). Feature: --repetition-penalty flag.
@@ -137,8 +138,8 @@ Write a long essay about the history of bread making across civilizations.
 # AI: than presence penalty (multiplicative vs additive). Output should stay coherent.
 [@ repetition-penalty]
 temperature: 0.8
-max_tokens: 4096
-afm: --repetition-penalty 1.2
+max_tokens: 20000
+afm: --no-think --repetition-penalty 1.2
 Write a long essay about the history of bread making across civilizations.
 
 # ══════════════════════════════════════════════════════════════════════
@@ -178,7 +179,7 @@ Tell me about quantum computing.
 # AI: Verify is_valid_json=true in JSONL. Any preamble or explanation = format failure.
 [@ json-output]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 expect: {"valid_json":true,"json_schema":{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"},"city":{"type":"string"}},"required":["name","age","city"]}}
 Respond with a valid JSON object containing keys "name", "age", and "city". Nothing else.
 
@@ -186,7 +187,7 @@ Respond with a valid JSON object containing keys "name", "age", and "city". Noth
 # AI: Expected: exactly 5 lines, each "N. animal_name", no other text.
 [@ numbered-list]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 List exactly 5 animals, one per line, numbered 1-5. No other text.
 
 # AI: Tests guided JSON with simple schema. Feature: --guided-json (constrained decoding).
@@ -194,8 +195,8 @@ List exactly 5 animals, one per line, numbered 1-5. No other text.
 # AI: be valid JSON that conforms to the schema — verify is_valid_json=true.
 [@ guided-json-simple]
 temperature: 0.0
-max_tokens: 4096
-afm: --guided-json '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}'
+max_tokens: 20000
+afm: --no-think --guided-json '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}'
 expect: {"valid_json":true,"json_schema":{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}}
 Return a person record for Ada, age 37.
 
@@ -204,8 +205,8 @@ Return a person record for Ada, age 37.
 # AI: 3+ strings). Verify schema conformance and is_valid_json=true.
 [@ guided-json-nested]
 temperature: 0.0
-max_tokens: 4096
-afm: --guided-json '{"type":"object","properties":{"city":{"type":"string"},"population":{"type":"integer"},"landmarks":{"type":"array","items":{"type":"string"}}},"required":["city","population","landmarks"]}'
+max_tokens: 20000
+afm: --no-think --guided-json '{"type":"object","properties":{"city":{"type":"string"},"population":{"type":"integer"},"landmarks":{"type":"array","items":{"type":"string"}}},"required":["city","population","landmarks"]}'
 Describe Tokyo as a structured record with at least 3 landmarks.
 
 # ══════════════════════════════════════════════════════════════════════
@@ -221,7 +222,7 @@ Describe Tokyo as a structured record with at least 3 landmarks.
 # AI: Compare TTFT with agent-cached-turn1 to see if caching speeds up prefill.
 [@ agent-no-cache-turn1]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
 Read the file Sources/MacLocalAPI/main.swift and explain what it does.
 
@@ -230,7 +231,7 @@ Read the file Sources/MacLocalAPI/main.swift and explain what it does.
 # AI: no caching — the system prompt is re-processed from scratch each time.
 [@ agent-no-cache-turn2]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
 Now add a --timeout flag to the CLI that sets a request timeout in seconds.
 
@@ -238,7 +239,7 @@ Now add a --timeout flag to the CLI that sets a request timeout in seconds.
 # AI: Expected: unit test code. TTFT should be similar to turns 1-2.
 [@ agent-no-cache-turn3]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
 Write a unit test for the timeout feature you just described.
 
@@ -247,8 +248,8 @@ Write a unit test for the timeout feature you just described.
 # AI: system prompt, so TTFT may be similar (cache miss). The cache gets populated here.
 [@ agent-cached-turn1]
 temperature: 0.0
-max_tokens: 4096
-afm: --enable-prefix-caching
+max_tokens: 20000
+afm: --no-think --enable-prefix-caching
 system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
 Read the file Sources/MacLocalAPI/main.swift and explain what it does.
 
@@ -257,8 +258,8 @@ Read the file Sources/MacLocalAPI/main.swift and explain what it does.
 # AI: faster because the system prompt KV cache is reused from turn 1 (cache hit).
 [@ agent-cached-turn2]
 temperature: 0.0
-max_tokens: 4096
-afm: --enable-prefix-caching
+max_tokens: 20000
+afm: --no-think --enable-prefix-caching
 system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
 Now add a --timeout flag to the CLI that sets a request timeout in seconds.
 
@@ -267,8 +268,8 @@ Now add a --timeout flag to the CLI that sets a request timeout in seconds.
 # AI: Compare gen_time_s across all 3 cached turns vs all 3 no-cache turns.
 [@ agent-cached-turn3]
 temperature: 0.0
-max_tokens: 4096
-afm: --enable-prefix-caching
+max_tokens: 20000
+afm: --no-think --enable-prefix-caching
 system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
 Write a unit test for the timeout feature you just described.
 
@@ -300,11 +301,11 @@ Write a detailed recipe for chocolate chip cookies with ingredients, steps, tips
 # AI: include top-5 token probabilities per generated token. Trivial prompt for easy verification.
 [@ logprobs]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 logprobs: true
 top_logprobs: 5
 expect: {"logprobs_min":1}
-afm: --max-logprobs 5
+afm: --no-think --max-logprobs 5
 What is 1+1?
 
 # ══════════════════════════════════════════════════════════════════════
@@ -316,8 +317,8 @@ What is 1+1?
 # AI: but this prompt is short enough to fit. Verify no truncation or crash.
 [@ small-kv]
 temperature: 0.7
-max_tokens: 4096
-afm: --max-kv-size 2048
+max_tokens: 20000
+afm: --no-think --max-kv-size 2048
 Summarize the key ideas of machine learning in a few paragraphs.
 
 # AI: Tests KV cache quantization. Feature: --kv-bits 4 (4-bit quantized KV cache).
@@ -325,8 +326,8 @@ Summarize the key ideas of machine learning in a few paragraphs.
 # AI: but may slightly degrade quality. Compare output quality with small-kv.
 [@ kv-quantized]
 temperature: 0.7
-max_tokens: 4096
-afm: --kv-bits 4
+max_tokens: 20000
+afm: --no-think --kv-bits 4
 Summarize the key ideas of machine learning in a few paragraphs.
 
 # AI: Tests default prefill step size. Feature: --prefill-step-size (GPU batch size for prompt).
@@ -334,7 +335,7 @@ Summarize the key ideas of machine learning in a few paragraphs.
 # AI: TTFT with prefill-large-4096 and prefill-small-256 (same prompt, different step sizes).
 [@ prefill-default]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 system: You are an expert software architect reviewing a large codebase. The project is a Swift macOS application that serves LLM inference through an OpenAI-compatible API. It uses Vapor for HTTP, MLX for GPU compute, and supports streaming SSE responses. The architecture includes model services, controllers, request/response types, prompt caching, tool call parsing, logprobs computation, and a built-in WebUI. The codebase has vendor dependencies managed through a patch system. There are multiple model formats supported including Qwen, Gemma, Llama, DeepSeek, GLM, and others. Each model may have different tool call formats, chat templates, and tokenizer configurations. The server must handle concurrent requests safely using async/await and serial access containers.
 Given this architecture, what are the top 3 performance bottlenecks you would investigate first?
 
@@ -343,8 +344,8 @@ Given this architecture, what are the top 3 performance bottlenecks you would in
 # AI: process more tokens per GPU pass (faster prefill but more memory per pass).
 [@ prefill-large-4096]
 temperature: 0.0
-max_tokens: 4096
-afm: --prefill-step-size 4096
+max_tokens: 20000
+afm: --no-think --prefill-step-size 4096
 system: You are an expert software architect reviewing a large codebase. The project is a Swift macOS application that serves LLM inference through an OpenAI-compatible API. It uses Vapor for HTTP, MLX for GPU compute, and supports streaming SSE responses. The architecture includes model services, controllers, request/response types, prompt caching, tool call parsing, logprobs computation, and a built-in WebUI. The codebase has vendor dependencies managed through a patch system. There are multiple model formats supported including Qwen, Gemma, Llama, DeepSeek, GLM, and others. Each model may have different tool call formats, chat templates, and tokenizer configurations. The server must handle concurrent requests safely using async/await and serial access containers.
 Given this architecture, what are the top 3 performance bottlenecks you would investigate first?
 
@@ -353,8 +354,8 @@ Given this architecture, what are the top 3 performance bottlenecks you would in
 # AI: GPU passes to process the long system prompt but use less memory per pass.
 [@ prefill-small-256]
 temperature: 0.0
-max_tokens: 4096
-afm: --prefill-step-size 256
+max_tokens: 20000
+afm: --no-think --prefill-step-size 256
 system: You are an expert software architect reviewing a large codebase. The project is a Swift macOS application that serves LLM inference through an OpenAI-compatible API. It uses Vapor for HTTP, MLX for GPU compute, and supports streaming SSE responses. The architecture includes model services, controllers, request/response types, prompt caching, tool call parsing, logprobs computation, and a built-in WebUI. The codebase has vendor dependencies managed through a patch system. There are multiple model formats supported including Qwen, Gemma, Llama, DeepSeek, GLM, and others. Each model may have different tool call formats, chat templates, and tokenizer configurations. The server must handle concurrent requests safely using async/await and serial access containers.
 Given this architecture, what are the top 3 performance bottlenecks you would investigate first?
 
@@ -367,8 +368,8 @@ Given this architecture, what are the top 3 performance bottlenecks you would in
 # AI: Verify output is complete and coherent — same quality as streaming mode.
 [@ no-streaming]
 temperature: 0.7
-max_tokens: 4096
-afm: --no-streaming
+max_tokens: 20000
+afm: --no-think --no-streaming
 Write a short poem about the moon.
 
 # AI: Tests raw mode. Feature: --raw (disables <think> tag extraction).
@@ -377,8 +378,8 @@ Write a short poem about the moon.
 # AI: as literal text in content (not extracted to reasoning_content).
 [@ raw-mode]
 temperature: 0.7
-max_tokens: 4096
-afm: --raw
+max_tokens: 20000
+afm: --no-think --raw
 Think step by step: what is 17 * 23?
 
 # ══════════════════════════════════════════════════════════════════════
@@ -403,7 +404,7 @@ Think step by step: what is 17 * 23?
 # AI: proving truncation instead of treating a natural EOS finish_reason as sufficient.
 [@ stop-single]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["<AFM_STOP>"]
 expect: {"finish_reason":"stop","content_equals":"AFM_PREFIX","content_not_contains":["<AFM_STOP>","AFM_SUFFIX"]}
 Output exactly the following text, with no quotes, markdown, explanation, or extra whitespace: AFM_PREFIX<AFM_STOP>AFM_SUFFIX
@@ -413,7 +414,7 @@ Output exactly the following text, with no quotes, markdown, explanation, or ext
 # AI: the first candidate must win and its suffix must not leak.
 [@ stop-multi]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["<AFM_FIRST_STOP>", "<AFM_SECOND_STOP>"]
 expect: {"finish_reason":"stop","content_equals":"AFM_MULTI_PREFIX","content_not_contains":["<AFM_FIRST_STOP>","AFM_BETWEEN","<AFM_SECOND_STOP>","AFM_MULTI_SUFFIX"]}
 Output exactly the following text, with no quotes, markdown, explanation, or extra whitespace: AFM_MULTI_PREFIX<AFM_FIRST_STOP>AFM_BETWEEN<AFM_SECOND_STOP>AFM_MULTI_SUFFIX
@@ -423,7 +424,7 @@ Output exactly the following text, with no quotes, markdown, explanation, or ext
 # AI: finish_reason="stop". Tests that escape sequences in stop are handled correctly.
 [@ stop-newline]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["\n"]
 expect: {"finish_reason":"stop","content_equals":"AFM_LINE_ONE","content_not_contains":"AFM_LINE_TWO"}
 Output exactly two lines. The first line must be AFM_LINE_ONE and the second line must be AFM_LINE_TWO. Output nothing else.
@@ -433,7 +434,7 @@ Output exactly two lines. The first line must be AFM_LINE_ONE and the second lin
 # AI: paragraph are withheld. finish_reason="stop".
 [@ stop-double-newline]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["\n\n"]
 expect: {"finish_reason":"stop","content_equals":"AFM_PARAGRAPH_ONE","content_not_contains":"AFM_PARAGRAPH_TWO"}
 Output exactly AFM_PARAGRAPH_ONE, then one blank line, then AFM_PARAGRAPH_TWO. Output nothing else.
@@ -442,7 +443,7 @@ Output exactly AFM_PARAGRAPH_ONE, then one blank line, then AFM_PARAGRAPH_TWO. O
 # AI: Expected: exactly AFM_WORD_PREFIX; the forced word delimiter and suffix are withheld.
 [@ stop-word]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["Python"]
 expect: {"finish_reason":"stop","content_equals":"AFM_WORD_PREFIX","content_not_contains":["Python","AFM_WORD_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_WORD_PREFIXPythonAFM_WORD_SUFFIX
@@ -452,7 +453,7 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_WORD_
 # AI: finish_reason="stop". Tests an aggressive one-character delimiter.
 [@ stop-period]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["."]
 expect: {"finish_reason":"stop","content_equals":"AFM_PERIOD_PREFIX","content_not_contains":"AFM_PERIOD_SUFFIX"}
 Output exactly the following text, with no quotes or extra whitespace: AFM_PERIOD_PREFIX.AFM_PERIOD_SUFFIX
@@ -464,8 +465,8 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_PERIO
 # AI: This tests the CLI flag path rather than the API request body path.
 [@ stop-cli-only]
 temperature: 0.0
-max_tokens: 4096
-afm: --stop "<AFM_CLI_STOP>"
+max_tokens: 20000
+afm: --no-think --stop "<AFM_CLI_STOP>"
 expect: {"finish_reason":"stop","content_equals":"AFM_CLI_PREFIX","content_not_contains":["<AFM_CLI_STOP>","AFM_CLI_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_CLI_PREFIX<AFM_CLI_STOP>AFM_CLI_SUFFIX
 
@@ -474,8 +475,8 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_CLI_P
 # AI: Tests comma parsing in --stop with two deterministic sequences.
 [@ stop-cli-multi]
 temperature: 0.0
-max_tokens: 4096
-afm: --stop "<AFM_CLI_FIRST>,<AFM_CLI_SECOND>"
+max_tokens: 20000
+afm: --no-think --stop "<AFM_CLI_FIRST>,<AFM_CLI_SECOND>"
 expect: {"finish_reason":"stop","content_equals":"AFM_CLI_MULTI_PREFIX","content_not_contains":["<AFM_CLI_FIRST>","AFM_CLI_BETWEEN","<AFM_CLI_SECOND>","AFM_CLI_MULTI_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_CLI_MULTI_PREFIX<AFM_CLI_FIRST>AFM_CLI_BETWEEN<AFM_CLI_SECOND>AFM_CLI_MULTI_SUFFIX
 
@@ -484,9 +485,9 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_CLI_M
 # AI: AFM_MERGE_PREFIX. Verifies both sources are active simultaneously.
 [@ stop-cli-api-merge]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["<AFM_API_STOP>"]
-afm: --stop "<AFM_CLI_STOP>"
+afm: --no-think --stop "<AFM_CLI_STOP>"
 expect: {"finish_reason":"stop","content_equals":"AFM_MERGE_PREFIX","content_not_contains":["<AFM_API_STOP>","AFM_MERGE_BETWEEN","<AFM_CLI_STOP>","AFM_MERGE_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_MERGE_PREFIX<AFM_API_STOP>AFM_MERGE_BETWEEN<AFM_CLI_STOP>AFM_MERGE_SUFFIX
 
@@ -495,9 +496,9 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_MERGE
 # AI: AFM_DEDUP_PREFIX, with no error or double-triggering.
 [@ stop-cli-api-dedup]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["<AFM_DEDUP_STOP>"]
-afm: --stop "<AFM_DEDUP_STOP>"
+afm: --no-think --stop "<AFM_DEDUP_STOP>"
 expect: {"finish_reason":"stop","content_equals":"AFM_DEDUP_PREFIX","content_not_contains":["<AFM_DEDUP_STOP>","AFM_DEDUP_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_DEDUP_PREFIX<AFM_DEDUP_STOP>AFM_DEDUP_SUFFIX
 
@@ -508,8 +509,8 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_DEDUP
 # AI: works without SSE chunking.
 [@ stop-non-streaming]
 temperature: 0.0
-max_tokens: 4096
-afm: --no-streaming
+max_tokens: 20000
+afm: --no-think --no-streaming
 stop: ["<AFM_NONSTREAM_STOP>"]
 expect: {"finish_reason":"stop","content_equals":"AFM_NONSTREAM_PREFIX","content_not_contains":["<AFM_NONSTREAM_STOP>","AFM_NONSTREAM_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_NONSTREAM_PREFIX<AFM_NONSTREAM_STOP>AFM_NONSTREAM_SUFFIX
@@ -521,9 +522,9 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_NONST
 # AI: Output will be truncated JSON (not valid). finish_reason="stop".
 [@ stop-guided-json-value]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["Tokyo"]
-afm: --guided-json '{"type":"object","properties":{"cities":{"type":"array","items":{"type":"string"}}},"required":["cities"]}'
+afm: --no-think --guided-json '{"type":"object","properties":{"cities":{"type":"array","items":{"type":"string"}}},"required":["cities"]}'
 expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":"Tokyo"}
 List 5 major world cities as a JSON array. Include Tokyo.
 
@@ -532,9 +533,9 @@ List 5 major world cities as a JSON array. Include Tokyo.
 # AI: (truncated before the comma). Tests stop on syntax characters within constrained output.
 [@ stop-guided-json-comma]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: [","]
-afm: --guided-json '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"},"city":{"type":"string"}},"required":["name","age","city"]}'
+afm: --no-think --guided-json '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"},"city":{"type":"string"}},"required":["name","age","city"]}'
 expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":","}
 Generate a person profile for someone named Alice who is 30 and lives in Paris.
 
@@ -543,9 +544,9 @@ Generate a person profile for someone named Alice who is 30 and lives in Paris.
 # AI: Tests that stop applies even to schema-constrained structural tokens.
 [@ stop-guided-json-brace]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["}"]
-afm: --guided-json '{"type":"object","properties":{"color":{"type":"string"},"hex":{"type":"string"}},"required":["color","hex"]}'
+afm: --no-think --guided-json '{"type":"object","properties":{"color":{"type":"string"},"hex":{"type":"string"}},"required":["color","hex"]}'
 expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":"}"}
 Describe the color blue with its hex code.
 
@@ -556,7 +557,7 @@ Describe the color blue with its hex code.
 # AI: Unlike guided-json, json_object uses prompt injection — stop still applies to raw output.
 [@ stop-json-object-key]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 response_format: json_object
 stop: ["age"]
 expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":"age"}
@@ -569,7 +570,7 @@ Generate a JSON object with keys "name", "age", and "city" for a person named Ca
 # AI: Tests buffer-based stop detection across token boundaries.
 [@ stop-long-phrase]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["In conclusion"]
 expect: {"finish_reason":"stop","content_equals":"AFM_LONG_PREFIX","content_not_contains":["In conclusion","AFM_LONG_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_LONG_PREFIXIn conclusionAFM_LONG_SUFFIX
@@ -578,7 +579,7 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_LONG_
 # AI: Expected: exactly AFM_MULTI_WORD_PREFIX, stopping before "Step 3".
 [@ stop-multi-word]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["Step 3"]
 expect: {"finish_reason":"stop","content_equals":"AFM_MULTI_WORD_PREFIX","content_not_contains":["Step 3","AFM_MULTI_WORD_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_MULTI_WORD_PREFIXStep 3AFM_MULTI_WORD_SUFFIX
@@ -600,7 +601,7 @@ Explain the difference between TCP and UDP in a few sentences.
 # AI: Expected: exactly empty output with finish_reason="stop".
 [@ stop-immediate]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["AFM_IMMEDIATE_STOP"]
 expect: {"finish_reason":"stop","content_equals":"","content_not_contains":"AFM_IMMEDIATE_SUFFIX"}
 Output exactly the following text, with no quotes or leading whitespace: AFM_IMMEDIATE_STOPAFM_IMMEDIATE_SUFFIX
@@ -610,7 +611,7 @@ Output exactly the following text, with no quotes or leading whitespace: AFM_IMM
 # AI: Tests that special regex characters in stop are handled correctly.
 [@ stop-special-chars]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["**"]
 expect: {"finish_reason":"stop","content_equals":"AFM_MARKDOWN_PREFIX","content_not_contains":["**","AFM_MARKDOWN_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_MARKDOWN_PREFIX**AFM_MARKDOWN_SUFFIX
@@ -620,7 +621,7 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_MARKD
 # AI: Tests stop detection on angle-bracket sequences common in structured output.
 [@ stop-html-tag]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["</li>"]
 expect: {"finish_reason":"stop","content_equals":"<ul><li>AFM_HTML_PREFIX","content_not_contains":["</li>","AFM_HTML_SUFFIX"]}
 Output exactly the following text, with no quotes, markdown fence, or extra whitespace: <ul><li>AFM_HTML_PREFIX</li>AFM_HTML_SUFFIX
@@ -630,7 +631,7 @@ Output exactly the following text, with no quotes, markdown fence, or extra whit
 # AI: sequence matcher handles multi-byte UTF-8 characters correctly.
 [@ stop-unicode]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["\u2022"]
 expect: {"finish_reason":"stop","content_equals":"AFM_UNICODE_PREFIX","content_not_contains":["\u2022","AFM_UNICODE_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_UNICODE_PREFIX•AFM_UNICODE_SUFFIX
@@ -639,7 +640,7 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_UNICO
 # AI: Expected: exactly AFM_FOUR_PREFIX at the first forced candidate.
 [@ stop-four-max]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["3.", "three", "Third", "III"]
 expect: {"finish_reason":"stop","content_equals":"AFM_FOUR_PREFIX","content_not_contains":["3.","three","Third","III","AFM_FOUR_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_FOUR_PREFIX3.AFM_FOUR_SUFFIXthreeThirdIII
@@ -651,7 +652,7 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_FOUR_
 # AI: Verifies stop sequences work correctly when system prompt modifies output style.
 [@ stop-system-pirate]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 system: You are a pirate. Speak like a pirate in all responses.
 stop: ["Arrr"]
 expect: {"finish_reason":"stop","content_not_contains":"Arrr"}
@@ -662,7 +663,7 @@ Tell me about treasure hunting on the high seas.
 # AI: System prompt forces numbered format, stop triggers on that format.
 [@ stop-system-numbered]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 system: Always respond with numbered lists. Never use bullet points.
 stop: ["4."]
 expect: {"finish_reason":"stop","content_not_contains":"4."}
@@ -675,7 +676,7 @@ What are the main benefits of exercise?
 # AI: be deterministic regardless of sampling temperature. finish_reason="stop".
 [@ stop-high-temp]
 temperature: 1.0
-max_tokens: 4096
+max_tokens: 20000
 stop: ["3."]
 expect: {"finish_reason":"stop","content_not_contains":"3."}
 List 10 random words, numbered 1 through 10, one per line.
@@ -685,7 +686,7 @@ List 10 random words, numbered 1 through 10, one per line.
 # AI: both outputs MUST be identical (same seed, same temp, same stop).
 [@ stop-seed-run1]
 temperature: 0.7
-max_tokens: 4096
+max_tokens: 20000
 seed: 42
 stop: ["3."]
 expect: {"finish_reason":"stop","content_not_contains":"3."}
@@ -696,7 +697,7 @@ List 10 flowers, numbered 1 through 10, one per line.
 # AI: in either seed handling or stop sequence interaction with cached state.
 [@ stop-seed-run2]
 temperature: 0.7
-max_tokens: 4096
+max_tokens: 20000
 seed: 42
 stop: ["3."]
 expect: {"finish_reason":"stop","content_not_contains":"3."}
@@ -723,7 +724,7 @@ List 10 mountains, numbered 1 through 10, one per line.
 # AI: (not constrained decoding) — output may include markdown fences around JSON.
 [@ response-format-json]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 response_format: {"type":"json_object"}
 Return a JSON object with keys "language", "year_created", and "creator" for Python.
 
@@ -732,7 +733,7 @@ Return a JSON object with keys "language", "year_created", and "creator" for Pyt
 # AI: "hobbies" (array of strings). Verify is_valid_json=true and schema conformance.
 [@ response-format-schema]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 response_format: {"type":"json_schema","json_schema":{"name":"person","schema":{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"},"hobbies":{"type":"array","items":{"type":"string"}}},"required":["name","age","hobbies"]}}}
 Generate a fictional person profile.
 
@@ -741,7 +742,7 @@ Generate a fictional person profile.
 # AI: response-format-json — same info but in natural language instead of JSON.
 [@ response-format-text]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 Tell me the language Python, what year it was created, and who created it. Be brief.
 
 # ══════════════════════════════════════════════════════════════════════
@@ -757,7 +758,7 @@ Tell me the language Python, what year it was created, and who created it. Be br
 # AI: the model is unexpectedly emitting <think> tags (possible chat template issue).
 [@ think-normal]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 Solve step by step: If a train travels at 60 mph for 2.5 hours, how far does it go?
 
 # AI: Tests raw mode on non-thinking model. Feature: --raw (skip think extraction).
@@ -766,8 +767,8 @@ Solve step by step: If a train travels at 60 mph for 2.5 hours, how far does it 
 # AI: Verify no crash when --raw is used with a model that doesn't emit <think>.
 [@ think-raw]
 temperature: 0.0
-max_tokens: 4096
-afm: --raw
+max_tokens: 20000
+afm: --no-think --raw
 Solve step by step: If a train travels at 60 mph for 2.5 hours, how far does it go?
 
 # ══════════════════════════════════════════════════════════════════════
@@ -781,8 +782,8 @@ Solve step by step: If a train travels at 60 mph for 2.5 hours, how far does it 
 # AI: both MUST produce identical output (same seed=123, same temperature).
 [@ streaming-seeded]
 temperature: 0.7
-max_tokens: 4096
-afm: --seed 123
+max_tokens: 20000
+afm: --no-think --seed 123
 Write a 4-line poem about the ocean.
 
 # AI: Tests non-streaming output with seed. Feature: --no-streaming + seed determinism.
@@ -790,8 +791,8 @@ Write a 4-line poem about the ocean.
 # AI: a bug in streaming vs non-streaming code paths (chunking affecting output).
 [@ non-streaming-seeded]
 temperature: 0.7
-max_tokens: 4096
-afm: --no-streaming --seed 123
+max_tokens: 20000
+afm: --no-think --no-streaming --seed 123
 Write a 4-line poem about the ocean.
 
 # ══════════════════════════════════════════════════════════════════════
@@ -813,7 +814,7 @@ Explain the causes and consequences of the French Revolution.
 # AI: The "developer" role is an OpenAI convention — afm maps it to "system" role.
 [@ developer-role]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 developer: You are a helpful coding assistant. Only respond with code, no explanations.
 Write a Python function that reverses a string.
 
@@ -826,8 +827,8 @@ Write a Python function that reverses a string.
 # AI: logging — response content and format should be identical to a non-verbose request.
 [@ verbose]
 temperature: 0.7
-max_tokens: 4096
-afm: --verbose
+max_tokens: 20000
+afm: --no-think --verbose
 Hello, how are you?
 
 # AI: Tests very-verbose logging mode. Feature: --very-verbose flag (full request/response logging).
@@ -835,8 +836,8 @@ Hello, how are you?
 # AI: Very-verbose logs full HTTP request/response bodies — verify no performance regression.
 [@ very-verbose]
 temperature: 0.7
-max_tokens: 4096
-afm: --very-verbose
+max_tokens: 20000
+afm: --no-think --very-verbose
 Hello, how are you?
 
 # ══════════════════════════════════════════════════════════════════════
@@ -851,7 +852,7 @@ Hello, how are you?
 # AI: Verify tool_calls array in response contains valid function name and arguments.
 [@ tool-call-auto]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"get_weather","arguments":{"city":"Tokyo"}}]}
 tools: [{"type":"function","function":{"name":"get_weather","description":"Get current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string","description":"City name"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["city"]}}}]
 Call get_weather exactly once for Tokyo. Call no other tools.
@@ -861,8 +862,8 @@ Call get_weather exactly once for Tokyo. Call no other tools.
 # AI: Same as tool-call-auto but explicitly sets the parser — verifies the flag works.
 [@ tool-call-xml]
 temperature: 0.0
-max_tokens: 4096
-afm: --tool-call-parser qwen3_xml
+max_tokens: 20000
+afm: --no-think --tool-call-parser qwen3_xml
 expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"get_weather","arguments":{"city":"Paris","unit":"celsius"}}]}
 tools: [{"type":"function","function":{"name":"get_weather","description":"Get current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string","description":"City name"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["city"]}}}]
 Call get_weather exactly once for Paris with unit celsius. Call no other tools.
@@ -872,7 +873,7 @@ Call get_weather exactly once for Paris with unit celsius. Call no other tools.
 # AI: finish_reason="tool_calls". Tests that the parser handles multiple <tool_call> blocks.
 [@ tool-call-multi]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"get_weather","arguments":{"city":"London"}},{"name":"get_time","arguments":{"timezone":"Asia/Tokyo"}}]}
 tools: [{"type":"function","function":{"name":"get_weather","description":"Get current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["city"]}}},{"type":"function","function":{"name":"get_time","description":"Get current time in a timezone","parameters":{"type":"object","properties":{"timezone":{"type":"string","description":"IANA timezone"}},"required":["timezone"]}}}]
 Call get_weather exactly once for London and get_time exactly once for Asia/Tokyo. Call no other tools.
@@ -882,7 +883,7 @@ Call get_weather exactly once for London and get_time exactly once for Asia/Toky
 # AI: options={recursive: true, max_results: 50}. Tests nested JSON in tool arguments.
 [@ tool-call-complex]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"search_files","arguments":{"path":"Sources/","pattern":"*.swift","options":{"recursive":true,"max_results":50}}}]}
 tools: [{"type":"function","function":{"name":"search_files","description":"Search for files matching criteria","parameters":{"type":"object","properties":{"path":{"type":"string","description":"Directory to search"},"pattern":{"type":"string","description":"Glob pattern"},"options":{"type":"object","properties":{"recursive":{"type":"boolean"},"max_results":{"type":"integer"}}}},"required":["path","pattern"]}}}]
 Call search_files exactly once with path Sources/, pattern *.swift, recursive true, and max_results 50.
@@ -892,7 +893,7 @@ Call search_files exactly once with path Sources/, pattern *.swift, recursive tr
 # AI: NOT a serialized string. finish_reason="tool_calls". Validates array params survive serialization.
 [@ tool-call-array-param]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"todowrite","arguments":{"todos":["Buy milk","Call dentist","Fix bug #42"]}}]}
 tools: [{"type":"function","function":{"name":"todowrite","description":"Write a list of todo items","parameters":{"type":"object","properties":{"todos":{"type":"array","items":{"type":"string"},"description":"List of todo items to create"}},"required":["todos"]}}}]
 Call todowrite exactly once with these three items in order: Buy milk, Call dentist, Fix bug #42.
@@ -903,7 +904,7 @@ Call todowrite exactly once with these three items in order: Buy milk, Call dent
 # AI: finish_reason="tool_calls". Validates nullable schemas don't cause server errors.
 [@ tool-call-nullable-param]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"get_weather","arguments":{"location":"Chicago"}}]}
 tools: [{"type":"function","function":{"name":"get_weather","description":"Get weather for a location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"City name"},"units":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Temperature units","default":null}},"required":["location"]}}}]
 Call get_weather exactly once for Chicago. Call no other tools.
@@ -914,7 +915,7 @@ Call get_weather exactly once for Chicago. Call no other tools.
 # AI: This is a weather question that would trigger tool calls if tools were available.
 [@ tool-call-none]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 expect: {"finish_reason":"stop","tool_calls":[]}
 What is the current temperature in Berlin?
 
@@ -926,7 +927,7 @@ What is the current temperature in Berlin?
 # AI: Expected: a friendly conversational response. Must not crash, hang, or produce empty output.
 [@ minimal-prompt]
 temperature: 0.7
-max_tokens: 4096
+max_tokens: 20000
 Hi
 
 # AI: Tests long repetitive prompt. Feature: prefill performance + context handling.
@@ -934,7 +935,7 @@ Hi
 # AI: prompts don't cause OOM, truncation, or garbled output during prefill.
 [@ long-prompt]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 Repeat after me exactly: The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. Now say DONE.
 
 # AI: Tests special character and unicode handling. Feature: tokenizer + detokenizer fidelity.
@@ -942,7 +943,7 @@ Repeat after me exactly: The quick brown fox jumps over the lazy dog. The quick 
 # AI: emoji (🎉🚀), CJK (你好), and Arabic (مرحبا). Tests multi-byte UTF-8 roundtrip.
 [@ special-chars]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 Repeat these characters exactly: <tag> "quotes" 'apostrophes' & ampersand \n newline \t tab emoji: 🎉🚀 CJK: 你好 Arabic: مرحبا
 
 # ══════════════════════════════════════════════════════════════════════
@@ -956,7 +957,7 @@ Repeat these characters exactly: <tag> "quotes" 'apostrophes' & ampersand \n new
 # AI: and Arabic (مرحبا). Tests that tokenizer handles non-Latin scripts without garbling.
 [@ multilingual]
 temperature: 0.3
-max_tokens: 4096
+max_tokens: 20000
 Translate "Hello, how are you?" into French, Spanish, Japanese, and Arabic. Format as a numbered list.
 
 # AI: Tests Python code generation. Feature: model quality — code output.
@@ -992,7 +993,7 @@ A store sells notebooks for $3.50 each. If you buy 5 or more, you get a 20% disc
 # AI: over 1000+ tokens — watch for repetition loops or topic drift.
 [@ long-form]
 temperature: 0.7
-max_tokens: 4096
+max_tokens: 20000
 Write a detailed technical blog post explaining how Mixture-of-Experts (MoE) models work, why they are efficient, and how they compare to dense models of similar total parameter count. Include concrete examples.
 
 # AI: Tests strict format compliance. Feature: model quality — exact instruction following.
@@ -1000,5 +1001,5 @@ Write a detailed technical blog post explaining how Mixture-of-Experts (MoE) mod
 # AI: No numbering, no punctuation, no extra text. Any deviation = instruction following failure.
 [@ strict-format]
 temperature: 0.0
-max_tokens: 4096
+max_tokens: 20000
 Output EXACTLY 3 lines. Each line must contain exactly one word. The words must be: apple, banana, cherry. No other text, no numbering, no punctuation.

--- a/Scripts/test-llm-comprehensive.txt
+++ b/Scripts/test-llm-comprehensive.txt
@@ -179,6 +179,7 @@ Tell me about quantum computing.
 [@ json-output]
 temperature: 0.0
 max_tokens: 4096
+expect: {"valid_json":true,"json_schema":{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"},"city":{"type":"string"}},"required":["name","age","city"]}}
 Respond with a valid JSON object containing keys "name", "age", and "city". Nothing else.
 
 # AI: Tests strict numbered list format. Feature: instruction following.
@@ -195,7 +196,8 @@ List exactly 5 animals, one per line, numbered 1-5. No other text.
 temperature: 0.0
 max_tokens: 4096
 afm: --guided-json '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}'
-Generate a person record.
+expect: {"valid_json":true,"json_schema":{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}}
+Return a person record for Ada, age 37.
 
 # AI: Tests guided JSON with nested schema (object with array). Feature: --guided-json.
 # AI: Expected: valid JSON with "city", "population" (integer), and "landmarks" (array of
@@ -299,6 +301,9 @@ Write a detailed recipe for chocolate chip cookies with ingredients, steps, tips
 [@ logprobs]
 temperature: 0.0
 max_tokens: 4096
+logprobs: true
+top_logprobs: 5
+expect: {"logprobs_min":1}
 afm: --max-logprobs 5
 What is 1+1?
 
@@ -394,110 +399,120 @@ Think step by step: what is 17 * 23?
 # --- Basic API-level stop ---
 
 # AI: Tests single stop sequence via API. Feature: stop parameter in OpenAI request.
-# AI: Expected: output lists items 1-2 only, stops before "3." appears.
-# AI: finish_reason must be "stop". Output must NOT contain "3." or any items after it.
+# AI: The prompt forces a literal marker and suffix. The response must equal the prefix,
+# AI: proving truncation instead of treating a natural EOS finish_reason as sufficient.
 [@ stop-single]
 temperature: 0.0
 max_tokens: 4096
-stop: ["3."]
-List 10 fruits, numbered 1-10, one per line.
+stop: ["<AFM_STOP>"]
+expect: {"finish_reason":"stop","content_equals":"AFM_PREFIX","content_not_contains":["<AFM_STOP>","AFM_SUFFIX"]}
+Output exactly the following text, with no quotes, markdown, explanation, or extra whitespace: AFM_PREFIX<AFM_STOP>AFM_SUFFIX
 
 # AI: Tests multiple stop sequences via API. Feature: stop parameter with array of 2 strings.
-# AI: Expected: output should stop at whichever of "```" or "END" appears first in the
-# AI: generated text. Likely stops at the closing ``` of the code block. finish_reason="stop".
+# AI: The exact-output instruction guarantees both stop candidates would be generated;
+# AI: the first candidate must win and its suffix must not leak.
 [@ stop-multi]
 temperature: 0.0
 max_tokens: 4096
-stop: ["```", "END"]
-Write a Python hello world program in a code block, then write END after it.
+stop: ["<AFM_FIRST_STOP>", "<AFM_SECOND_STOP>"]
+expect: {"finish_reason":"stop","content_equals":"AFM_MULTI_PREFIX","content_not_contains":["<AFM_FIRST_STOP>","AFM_BETWEEN","<AFM_SECOND_STOP>","AFM_MULTI_SUFFIX"]}
+Output exactly the following text, with no quotes, markdown, explanation, or extra whitespace: AFM_MULTI_PREFIX<AFM_FIRST_STOP>AFM_BETWEEN<AFM_SECOND_STOP>AFM_MULTI_SUFFIX
 
 # AI: Tests stop on newline character. Feature: stop parameter with "\n".
-# AI: Expected: exactly one line of output (the answer), no newline in content.
+# AI: Expected: exactly AFM_LINE_ONE; the newline and second forced line are withheld.
 # AI: finish_reason="stop". Tests that escape sequences in stop are handled correctly.
 [@ stop-newline]
 temperature: 0.0
 max_tokens: 4096
 stop: ["\n"]
-What is the capital of France? Answer in one sentence.
+expect: {"finish_reason":"stop","content_equals":"AFM_LINE_ONE","content_not_contains":"AFM_LINE_TWO"}
+Output exactly two lines. The first line must be AFM_LINE_ONE and the second line must be AFM_LINE_TWO. Output nothing else.
 
 # AI: Tests stop on double newline. Feature: stop parameter with "\n\n".
-# AI: Expected: exactly one paragraph (about the ocean). The second paragraph about
-# AI: mountains should NOT appear. finish_reason="stop".
+# AI: Expected: exactly AFM_PARAGRAPH_ONE; the blank-line delimiter and forced second
+# AI: paragraph are withheld. finish_reason="stop".
 [@ stop-double-newline]
 temperature: 0.0
 max_tokens: 4096
 stop: ["\n\n"]
-Write a short paragraph about the ocean. Then write a second paragraph about mountains.
+expect: {"finish_reason":"stop","content_equals":"AFM_PARAGRAPH_ONE","content_not_contains":"AFM_PARAGRAPH_TWO"}
+Output exactly AFM_PARAGRAPH_ONE, then one blank line, then AFM_PARAGRAPH_TWO. Output nothing else.
 
 # AI: Tests stop on a word boundary. Feature: stop parameter with a common word.
-# AI: Expected: output stops just before "Python" appears. The list should include
-# AI: some languages but cut off at or before the Python entry. finish_reason="stop".
+# AI: Expected: exactly AFM_WORD_PREFIX; the forced word delimiter and suffix are withheld.
 [@ stop-word]
 temperature: 0.0
 max_tokens: 4096
 stop: ["Python"]
-Name 5 programming languages and briefly describe each one.
+expect: {"finish_reason":"stop","content_equals":"AFM_WORD_PREFIX","content_not_contains":["Python","AFM_WORD_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_WORD_PREFIXPythonAFM_WORD_SUFFIX
 
 # AI: Tests stop on punctuation (period). Feature: stop parameter with ".".
-# AI: Expected: only the beginning of the first sentence, cut off before the first period.
-# AI: finish_reason="stop". Very aggressive stop — output may be just a few words.
+# AI: Expected: exactly AFM_PERIOD_PREFIX, cut off before the forced period.
+# AI: finish_reason="stop". Tests an aggressive one-character delimiter.
 [@ stop-period]
 temperature: 0.0
 max_tokens: 4096
 stop: ["."]
-Tell me about the sun in three sentences.
+expect: {"finish_reason":"stop","content_equals":"AFM_PERIOD_PREFIX","content_not_contains":"AFM_PERIOD_SUFFIX"}
+Output exactly the following text, with no quotes or extra whitespace: AFM_PERIOD_PREFIX.AFM_PERIOD_SUFFIX
 
 # --- CLI-level stop (`--stop` flag) ---
 
 # AI: Tests CLI-level stop (--stop flag). Feature: afm --stop (server-side stop sequences).
-# AI: Expected: same behavior as API stop — output lists items 1-2, stops before "3.".
+# AI: Expected: exactly AFM_CLI_PREFIX; the forced CLI delimiter and suffix are withheld.
 # AI: This tests the CLI flag path rather than the API request body path.
 [@ stop-cli-only]
 temperature: 0.0
 max_tokens: 4096
-afm: --stop "3."
-List 10 types of cheese, numbered 1 through 10, one per line.
+afm: --stop "<AFM_CLI_STOP>"
+expect: {"finish_reason":"stop","content_equals":"AFM_CLI_PREFIX","content_not_contains":["<AFM_CLI_STOP>","AFM_CLI_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_CLI_PREFIX<AFM_CLI_STOP>AFM_CLI_SUFFIX
 
 # AI: Tests CLI stop with multiple comma-separated sequences. Feature: --stop with commas.
-# AI: Expected: output stops at first occurrence of either "```" or "DONE".
-# AI: Tests that comma parsing in --stop works correctly for multiple sequences.
+# AI: Expected: exactly AFM_CLI_MULTI_PREFIX at the first forced delimiter.
+# AI: Tests comma parsing in --stop with two deterministic sequences.
 [@ stop-cli-multi]
 temperature: 0.0
 max_tokens: 4096
-afm: --stop "```,DONE"
-Write a bash script that prints the current date inside a code block, then write DONE.
+afm: --stop "<AFM_CLI_FIRST>,<AFM_CLI_SECOND>"
+expect: {"finish_reason":"stop","content_equals":"AFM_CLI_MULTI_PREFIX","content_not_contains":["<AFM_CLI_FIRST>","AFM_CLI_BETWEEN","<AFM_CLI_SECOND>","AFM_CLI_MULTI_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_CLI_MULTI_PREFIX<AFM_CLI_FIRST>AFM_CLI_BETWEEN<AFM_CLI_SECOND>AFM_CLI_MULTI_SUFFIX
 
 # AI: Tests CLI + API stop merge. Feature: stop sequences from both sources are combined.
-# AI: CLI provides "5.", API provides "3." — should stop at "3." since it comes first
-# AI: in the numbered list. Verifies both sources are active simultaneously.
+# AI: The API delimiter is forced before the CLI delimiter, so output must equal
+# AI: AFM_MERGE_PREFIX. Verifies both sources are active simultaneously.
 [@ stop-cli-api-merge]
 temperature: 0.0
 max_tokens: 4096
-stop: ["3."]
-afm: --stop "5."
-List 10 countries, numbered 1 through 10, one per line.
+stop: ["<AFM_API_STOP>"]
+afm: --stop "<AFM_CLI_STOP>"
+expect: {"finish_reason":"stop","content_equals":"AFM_MERGE_PREFIX","content_not_contains":["<AFM_API_STOP>","AFM_MERGE_BETWEEN","<AFM_CLI_STOP>","AFM_MERGE_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_MERGE_PREFIX<AFM_API_STOP>AFM_MERGE_BETWEEN<AFM_CLI_STOP>AFM_MERGE_SUFFIX
 
 # AI: Tests CLI + API stop deduplication. Feature: duplicate stop sequences from both sources.
-# AI: Both CLI and API provide "3." — server should deduplicate and work normally.
-# AI: Expected: stops at "3.", no errors or double-triggering.
+# AI: CLI and API provide the same forced delimiter. Expected: exactly
+# AI: AFM_DEDUP_PREFIX, with no error or double-triggering.
 [@ stop-cli-api-dedup]
 temperature: 0.0
 max_tokens: 4096
-stop: ["3."]
-afm: --stop "3."
-List 10 cities, numbered 1 through 10, one per line.
+stop: ["<AFM_DEDUP_STOP>"]
+afm: --stop "<AFM_DEDUP_STOP>"
+expect: {"finish_reason":"stop","content_equals":"AFM_DEDUP_PREFIX","content_not_contains":["<AFM_DEDUP_STOP>","AFM_DEDUP_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_DEDUP_PREFIX<AFM_DEDUP_STOP>AFM_DEDUP_SUFFIX
 
 # --- Non-streaming ---
 
 # AI: Tests stop sequences in non-streaming mode. Feature: stop + --no-streaming combined.
-# AI: Expected: output lists items 1-2, stops before "3.". Same truncation point as
-# AI: streaming mode (stop-single). Verifies stop works without SSE chunking.
+# AI: Expected: exactly AFM_NONSTREAM_PREFIX. Verifies deterministic truncation
+# AI: works without SSE chunking.
 [@ stop-non-streaming]
 temperature: 0.0
 max_tokens: 4096
 afm: --no-streaming
-stop: ["3."]
-List 10 planets or celestial objects, numbered 1 through 10, one per line.
+stop: ["<AFM_NONSTREAM_STOP>"]
+expect: {"finish_reason":"stop","content_equals":"AFM_NONSTREAM_PREFIX","content_not_contains":["<AFM_NONSTREAM_STOP>","AFM_NONSTREAM_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_NONSTREAM_PREFIX<AFM_NONSTREAM_STOP>AFM_NONSTREAM_SUFFIX
 
 # --- Stop + guided JSON ---
 
@@ -509,6 +524,7 @@ temperature: 0.0
 max_tokens: 4096
 stop: ["Tokyo"]
 afm: --guided-json '{"type":"object","properties":{"cities":{"type":"array","items":{"type":"string"}}},"required":["cities"]}'
+expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":"Tokyo"}
 List 5 major world cities as a JSON array. Include Tokyo.
 
 # AI: Tests stop on JSON structural token inside guided JSON. Feature: stop + --guided-json.
@@ -519,6 +535,7 @@ temperature: 0.0
 max_tokens: 4096
 stop: [","]
 afm: --guided-json '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"},"city":{"type":"string"}},"required":["name","age","city"]}'
+expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":","}
 Generate a person profile for someone named Alice who is 30 and lives in Paris.
 
 # AI: Tests stop on closing brace inside guided JSON. Feature: stop + --guided-json.
@@ -529,6 +546,7 @@ temperature: 0.0
 max_tokens: 4096
 stop: ["}"]
 afm: --guided-json '{"type":"object","properties":{"color":{"type":"string"},"hex":{"type":"string"}},"required":["color","hex"]}'
+expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":"}"}
 Describe the color blue with its hex code.
 
 # --- Stop + response format (json_object mode) ---
@@ -541,26 +559,29 @@ temperature: 0.0
 max_tokens: 4096
 response_format: json_object
 stop: ["age"]
+expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":"age"}
 Generate a JSON object with keys "name", "age", and "city" for a person named Carol.
 
 # --- Multi-token and long stop strings ---
 
 # AI: Tests stop on a long multi-word phrase. Feature: stop with multi-token string.
-# AI: Expected: essay contains paragraphs 1-2 about renewable energy, stops before
-# AI: "In conclusion" appears. Tests buffer-based stop detection across token boundaries.
+# AI: Expected: exactly AFM_LONG_PREFIX, stopping before the forced multi-token phrase.
+# AI: Tests buffer-based stop detection across token boundaries.
 [@ stop-long-phrase]
 temperature: 0.0
 max_tokens: 4096
 stop: ["In conclusion"]
-Write a 3-paragraph essay about renewable energy. Start the last paragraph with "In conclusion".
+expect: {"finish_reason":"stop","content_equals":"AFM_LONG_PREFIX","content_not_contains":["In conclusion","AFM_LONG_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_LONG_PREFIXIn conclusionAFM_LONG_SUFFIX
 
 # AI: Tests stop on a multi-word string. Feature: stop with "Step 3" (spans 2+ tokens).
-# AI: Expected: recipe shows Steps 1-2 only, stops before "Step 3". finish_reason="stop".
+# AI: Expected: exactly AFM_MULTI_WORD_PREFIX, stopping before "Step 3".
 [@ stop-multi-word]
 temperature: 0.0
 max_tokens: 4096
 stop: ["Step 3"]
-Write a 5-step recipe for making tea. Label each step as "Step 1", "Step 2", etc.
+expect: {"finish_reason":"stop","content_equals":"AFM_MULTI_WORD_PREFIX","content_not_contains":["Step 3","AFM_MULTI_WORD_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_MULTI_WORD_PREFIXStep 3AFM_MULTI_WORD_SUFFIX
 
 # --- Edge cases ---
 
@@ -572,52 +593,56 @@ Write a 5-step recipe for making tea. Label each step as "Step 1", "Step 2", etc
 temperature: 0.0
 max_tokens: 256
 stop: ["XYZZY_NEVER_MATCH"]
+expect: {"content_contains":["TCP","UDP"],"content_not_contains":"XYZZY_NEVER_MATCH"}
 Explain the difference between TCP and UDP in a few sentences.
 
-# AI: Tests immediate stop (first token matches). Feature: stop on common first tokens.
-# AI: Expected: empty or near-empty output. The model's first token is likely "The", "I",
-# AI: or "A" — all are in the stop list. finish_reason="stop", completion_tokens near 0.
+# AI: Tests immediate stop with a forced first character sequence.
+# AI: Expected: exactly empty output with finish_reason="stop".
 [@ stop-immediate]
 temperature: 0.0
 max_tokens: 4096
-stop: ["The", "I", "A"]
-Explain what gravity is.
+stop: ["AFM_IMMEDIATE_STOP"]
+expect: {"finish_reason":"stop","content_equals":"","content_not_contains":"AFM_IMMEDIATE_SUFFIX"}
+Output exactly the following text, with no quotes or leading whitespace: AFM_IMMEDIATE_STOPAFM_IMMEDIATE_SUFFIX
 
 # AI: Tests stop on markdown special characters. Feature: stop with "**".
-# AI: Expected: output stops at first "**" bold marker. Only partial text before the first
-# AI: bold-formatted word. Tests that special regex characters in stop are handled correctly.
+# AI: Expected: exactly AFM_MARKDOWN_PREFIX before the forced "**" marker.
+# AI: Tests that special regex characters in stop are handled correctly.
 [@ stop-special-chars]
 temperature: 0.0
 max_tokens: 4096
 stop: ["**"]
-List 3 facts about the moon. Use **bold** markdown for emphasis.
+expect: {"finish_reason":"stop","content_equals":"AFM_MARKDOWN_PREFIX","content_not_contains":["**","AFM_MARKDOWN_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_MARKDOWN_PREFIX**AFM_MARKDOWN_SUFFIX
 
 # AI: Tests stop on HTML closing tag. Feature: stop with "</li>" (multi-char tag).
-# AI: Expected: output contains <ul>, first <li> content, stops at first </li>.
+# AI: Expected: exactly <ul><li>AFM_HTML_PREFIX, stopping at the forced </li>.
 # AI: Tests stop detection on angle-bracket sequences common in structured output.
 [@ stop-html-tag]
 temperature: 0.0
 max_tokens: 4096
 stop: ["</li>"]
-Write an HTML unordered list of 5 fruits using <ul> and <li> tags.
+expect: {"finish_reason":"stop","content_equals":"<ul><li>AFM_HTML_PREFIX","content_not_contains":["</li>","AFM_HTML_SUFFIX"]}
+Output exactly the following text, with no quotes, markdown fence, or extra whitespace: <ul><li>AFM_HTML_PREFIX</li>AFM_HTML_SUFFIX
 
 # AI: Tests stop on unicode character (bullet point •). Feature: stop with unicode.
-# AI: Expected: output stops at first bullet point character. Tests that the stop
+# AI: Expected: exactly AFM_UNICODE_PREFIX before the forced bullet. Tests that the
 # AI: sequence matcher handles multi-byte UTF-8 characters correctly.
 [@ stop-unicode]
 temperature: 0.0
 max_tokens: 4096
 stop: ["\u2022"]
-List 5 items about space using bullet points (•).
+expect: {"finish_reason":"stop","content_equals":"AFM_UNICODE_PREFIX","content_not_contains":["\u2022","AFM_UNICODE_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_UNICODE_PREFIX•AFM_UNICODE_SUFFIX
 
 # AI: Tests maximum 4 stop sequences (OpenAI spec limit). Feature: stop with 4 entries.
-# AI: Expected: output stops at whichever of "3.", "three", "Third", "III" appears first.
-# AI: Prompt asks for mixed digit/word numbering to give multiple stop strings a chance.
+# AI: Expected: exactly AFM_FOUR_PREFIX at the first forced candidate.
 [@ stop-four-max]
 temperature: 0.0
 max_tokens: 4096
 stop: ["3.", "three", "Third", "III"]
-List 10 facts about numbers, alternating between digit format (1., 2.) and word format (three, four). One per line.
+expect: {"finish_reason":"stop","content_equals":"AFM_FOUR_PREFIX","content_not_contains":["3.","three","Third","III","AFM_FOUR_SUFFIX"]}
+Output exactly the following text, with no quotes or extra whitespace: AFM_FOUR_PREFIX3.AFM_FOUR_SUFFIXthreeThirdIII
 
 # --- Stop + system prompt interaction ---
 
@@ -629,6 +654,7 @@ temperature: 0.0
 max_tokens: 4096
 system: You are a pirate. Speak like a pirate in all responses.
 stop: ["Arrr"]
+expect: {"finish_reason":"stop","content_not_contains":"Arrr"}
 Tell me about treasure hunting on the high seas.
 
 # AI: Tests stop with instruction system prompt. Feature: stop + system message combined.
@@ -639,6 +665,7 @@ temperature: 0.0
 max_tokens: 4096
 system: Always respond with numbered lists. Never use bullet points.
 stop: ["4."]
+expect: {"finish_reason":"stop","content_not_contains":"4."}
 What are the main benefits of exercise?
 
 # --- Stop + sampling parameters ---
@@ -650,6 +677,7 @@ What are the main benefits of exercise?
 temperature: 1.0
 max_tokens: 4096
 stop: ["3."]
+expect: {"finish_reason":"stop","content_not_contains":"3."}
 List 10 random words, numbered 1 through 10, one per line.
 
 # AI: Tests stop + seed determinism (run 1 of 2). Feature: stop + seed combined.
@@ -660,6 +688,7 @@ temperature: 0.7
 max_tokens: 4096
 seed: 42
 stop: ["3."]
+expect: {"finish_reason":"stop","content_not_contains":"3."}
 List 10 flowers, numbered 1 through 10, one per line.
 
 # AI: Tests stop + seed determinism (run 2 of 2). Feature: stop + seed combined.
@@ -670,6 +699,7 @@ temperature: 0.7
 max_tokens: 4096
 seed: 42
 stop: ["3."]
+expect: {"finish_reason":"stop","content_not_contains":"3."}
 List 10 flowers, numbered 1 through 10, one per line.
 
 # AI: Tests stop vs max_tokens race. Feature: stop + low max_tokens combined.
@@ -679,6 +709,7 @@ List 10 flowers, numbered 1 through 10, one per line.
 temperature: 0.0
 max_tokens: 100
 stop: ["2."]
+expect: {"finish_reason":"stop","content_not_contains":"2."}
 List 10 mountains, numbered 1 through 10, one per line.
 
 # ══════════════════════════════════════════════════════════════════════
@@ -821,18 +852,20 @@ Hello, how are you?
 [@ tool-call-auto]
 temperature: 0.0
 max_tokens: 4096
+expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"get_weather","arguments":{"city":"Tokyo"}}]}
 tools: [{"type":"function","function":{"name":"get_weather","description":"Get current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string","description":"City name"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["city"]}}}]
-What is the weather in Tokyo?
+Call get_weather exactly once for Tokyo. Call no other tools.
 
-# AI: Tests explicit xmlFunction parser. Feature: --tool-call-parser xmlFunction.
+# AI: Tests explicit native Qwen parser. Feature: --tool-call-parser qwen3_xml.
 # AI: Expected: get_weather tool call with city="Paris", unit="celsius".
 # AI: Same as tool-call-auto but explicitly sets the parser — verifies the flag works.
 [@ tool-call-xml]
 temperature: 0.0
 max_tokens: 4096
-afm: --tool-call-parser xmlFunction
+afm: --tool-call-parser qwen3_xml
+expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"get_weather","arguments":{"city":"Paris","unit":"celsius"}}]}
 tools: [{"type":"function","function":{"name":"get_weather","description":"Get current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string","description":"City name"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["city"]}}}]
-What is the weather in Paris in celsius?
+Call get_weather exactly once for Paris with unit celsius. Call no other tools.
 
 # AI: Tests multiple tool calls in one response. Feature: parallel tool calling.
 # AI: Expected: TWO tool calls — get_weather(city="London") AND get_time(timezone="Asia/Tokyo").
@@ -840,8 +873,9 @@ What is the weather in Paris in celsius?
 [@ tool-call-multi]
 temperature: 0.0
 max_tokens: 4096
+expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"get_weather","arguments":{"city":"London"}},{"name":"get_time","arguments":{"timezone":"Asia/Tokyo"}}]}
 tools: [{"type":"function","function":{"name":"get_weather","description":"Get current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["city"]}}},{"type":"function","function":{"name":"get_time","description":"Get current time in a timezone","parameters":{"type":"object","properties":{"timezone":{"type":"string","description":"IANA timezone"}},"required":["timezone"]}}}]
-What is the weather in London and what time is it in Tokyo?
+Call get_weather exactly once for London and get_time exactly once for Asia/Tokyo. Call no other tools.
 
 # AI: Tests tool call with nested object parameters. Feature: complex tool parameter schemas.
 # AI: Expected: search_files tool call with path="Sources/", pattern="*.swift",
@@ -849,8 +883,9 @@ What is the weather in London and what time is it in Tokyo?
 [@ tool-call-complex]
 temperature: 0.0
 max_tokens: 4096
+expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"search_files","arguments":{"path":"Sources/","pattern":"*.swift","options":{"recursive":true,"max_results":50}}}]}
 tools: [{"type":"function","function":{"name":"search_files","description":"Search for files matching criteria","parameters":{"type":"object","properties":{"path":{"type":"string","description":"Directory to search"},"pattern":{"type":"string","description":"Glob pattern"},"options":{"type":"object","properties":{"recursive":{"type":"boolean"},"max_results":{"type":"integer"}}}},"required":["path","pattern"]}}}]
-Search recursively for all Swift files under Sources/ with a max of 50 results.
+Call search_files exactly once with path Sources/, pattern *.swift, recursive true, and max_results 50.
 
 # AI: Tests tool call with array-type parameter (regression: PR #37).
 # AI: Expected: todowrite tool call with todos parameter as a JSON array ["Buy milk", "Call dentist", "Fix bug #42"],
@@ -858,8 +893,9 @@ Search recursively for all Swift files under Sources/ with a max of 50 results.
 [@ tool-call-array-param]
 temperature: 0.0
 max_tokens: 4096
+expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"todowrite","arguments":{"todos":["Buy milk","Call dentist","Fix bug #42"]}}]}
 tools: [{"type":"function","function":{"name":"todowrite","description":"Write a list of todo items","parameters":{"type":"object","properties":{"todos":{"type":"array","items":{"type":"string"},"description":"List of todo items to create"}},"required":["todos"]}}}]
-Create three todo items: Buy milk, Call dentist, Fix bug #42.
+Call todowrite exactly once with these three items in order: Buy milk, Call dentist, Fix bug #42.
 
 # AI: Tests tool call with nullable parameter schema (regression: PR #33).
 # AI: Expected: get_weather tool call with location as a string. The "units" parameter has
@@ -868,8 +904,9 @@ Create three todo items: Buy milk, Call dentist, Fix bug #42.
 [@ tool-call-nullable-param]
 temperature: 0.0
 max_tokens: 4096
+expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"get_weather","arguments":{"location":"Chicago"}}]}
 tools: [{"type":"function","function":{"name":"get_weather","description":"Get weather for a location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"City name"},"units":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Temperature units","default":null}},"required":["location"]}}}]
-What is the weather in Chicago?
+Call get_weather exactly once for Chicago. Call no other tools.
 
 # AI: Tests tool-bait prompt WITHOUT tools provided. Feature: no-tool hallucination check.
 # AI: Expected: model answers naturally ("I don't have real-time data" or general info),
@@ -878,6 +915,7 @@ What is the weather in Chicago?
 [@ tool-call-none]
 temperature: 0.0
 max_tokens: 4096
+expect: {"finish_reason":"stop","tool_calls":[]}
 What is the current temperature in Berlin?
 
 # ══════════════════════════════════════════════════════════════════════
@@ -940,7 +978,8 @@ system: You are a Swift expert. Write clean code with no explanation.
 Write a Swift async function that fetches JSON from a URL using URLSession, decodes it into a Codable struct, and handles errors with Result type.
 
 # AI: Tests mathematical reasoning. Feature: model quality — multi-step arithmetic.
-# AI: Expected: correct answer $21.252 (7 × $3.50 × 0.80 × 1.085). The model must chain
+# AI: Expected: correct answer $21.266, conventionally rounded to $21.27
+# AI: (7 × $3.50 × 0.80 × 1.085). The model must chain
 # AI: discount, subtotal, and tax steps correctly. Tests reasoning without <think> support.
 [@ math]
 temperature: 0.0

--- a/Scripts/test-llm-comprehensive.txt
+++ b/Scripts/test-llm-comprehensive.txt
@@ -29,16 +29,13 @@
 # NOTES
 # -----
 # - Uses [@ label] template mode — supply --model on the command line
-# - The [all] section prompt runs for every test variant as a baseline
+# - Every variant owns its prompt; there is no duplicated global baseline
 # - For model-specific tests, see test-<ModelName>.txt files
 # ══════════════════════════════════════════════════════════════════════
 
 max_tokens: 20000
 temperature: 0.7
 afm: --no-think
-
-[all]
-Name three primary colors and explain why they matter in design. Answer concisely.
 
 
 # ══════════════════════════════════════════════════════════════════════

--- a/Scripts/test-llm-comprehensive.txt
+++ b/Scripts/test-llm-comprehensive.txt
@@ -71,21 +71,21 @@ Explain why the sky is blue in exactly 3 bullet points.
 # AI: Expected: coherent 3-bullet response, quality between greedy and high-temp.
 [@ top-p]
 temperature: 0.8
-afm: --no-think --top-p 0.9
+afm: --top-p 0.9
 Explain why the sky is blue in exactly 3 bullet points.
 
 # AI: Tests top-k sampling (top_k=30). Feature: --top-k CLI flag.
 # AI: Expected: coherent response. Top-k restricts to 30 most likely tokens per step.
 [@ top-k]
 temperature: 0.8
-afm: --no-think --top-k 30
+afm: --top-k 30
 Explain why the sky is blue in exactly 3 bullet points.
 
 # AI: Tests min-p filtering (min_p=0.05). Feature: --min-p CLI flag.
 # AI: Expected: coherent response. Min-p filters tokens below 5% of max probability.
 [@ min-p]
 temperature: 0.8
-afm: --no-think --min-p 0.05
+afm: --min-p 0.05
 Explain why the sky is blue in exactly 3 bullet points.
 
 # AI: Tests combined sampler chain: top-k → min-p → temperature (llama.cpp order).
@@ -93,7 +93,7 @@ Explain why the sky is blue in exactly 3 bullet points.
 # AI: Verifies the sampler chain doesn't conflict or crash when all are combined.
 [@ combined-samplers]
 temperature: 0.8
-afm: --no-think --top-k 50 --min-p 0.03 --top-p 0.95
+afm: --top-k 50 --min-p 0.03 --top-p 0.95
 Explain why the sky is blue in exactly 3 bullet points.
 
 # AI: Tests seed-based determinism (seed=42, run 1 of 2). Feature: --seed CLI flag.
@@ -101,14 +101,14 @@ Explain why the sky is blue in exactly 3 bullet points.
 # AI: character-for-character identical since same seed + same temperature.
 [@ seed-42-run1]
 temperature: 0.7
-afm: --no-think --seed 42
+afm: --seed 42
 Write a limerick about a cat.
 
 # AI: Tests seed-based determinism (seed=42, run 2 of 2). Feature: --seed CLI flag.
 # AI: Expected: output MUST be identical to seed-42-run1. Any difference = seed bug.
 [@ seed-42-run2]
 temperature: 0.7
-afm: --no-think --seed 42
+afm: --seed 42
 Write a limerick about a cat.
 
 # ══════════════════════════════════════════════════════════════════════
@@ -121,7 +121,7 @@ Write a limerick about a cat.
 [@ no-penalty]
 temperature: 0.8
 max_tokens: 20000
-afm: --no-think --presence-penalty 0.0
+afm: --presence-penalty 0.0
 Write a long essay about the history of bread making across civilizations.
 
 # AI: Tests strong presence penalty (1.5). Feature: --presence-penalty flag.
@@ -130,7 +130,7 @@ Write a long essay about the history of bread making across civilizations.
 [@ with-penalty]
 temperature: 0.8
 max_tokens: 20000
-afm: --no-think --presence-penalty 1.5
+afm: --presence-penalty 1.5
 Write a long essay about the history of bread making across civilizations.
 
 # AI: Tests repetition penalty (1.2). Feature: --repetition-penalty flag.
@@ -139,7 +139,7 @@ Write a long essay about the history of bread making across civilizations.
 [@ repetition-penalty]
 temperature: 0.8
 max_tokens: 20000
-afm: --no-think --repetition-penalty 1.2
+afm: --repetition-penalty 1.2
 Write a long essay about the history of bread making across civilizations.
 
 # ══════════════════════════════════════════════════════════════════════
@@ -196,7 +196,7 @@ List exactly 5 animals, one per line, numbered 1-5. No other text.
 [@ guided-json-simple]
 temperature: 0.0
 max_tokens: 20000
-afm: --no-think --guided-json '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}'
+afm: --guided-json '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}'
 expect: {"valid_json":true,"json_schema":{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}}
 Return a person record for Ada, age 37.
 
@@ -206,7 +206,7 @@ Return a person record for Ada, age 37.
 [@ guided-json-nested]
 temperature: 0.0
 max_tokens: 20000
-afm: --no-think --guided-json '{"type":"object","properties":{"city":{"type":"string"},"population":{"type":"integer"},"landmarks":{"type":"array","items":{"type":"string"}}},"required":["city","population","landmarks"]}'
+afm: --guided-json '{"type":"object","properties":{"city":{"type":"string"},"population":{"type":"integer"},"landmarks":{"type":"array","items":{"type":"string"}}},"required":["city","population","landmarks"]}'
 Describe Tokyo as a structured record with at least 3 landmarks.
 
 # ══════════════════════════════════════════════════════════════════════
@@ -249,7 +249,7 @@ Write a unit test for the timeout feature you just described.
 [@ agent-cached-turn1]
 temperature: 0.0
 max_tokens: 20000
-afm: --no-think --enable-prefix-caching
+afm: --enable-prefix-caching
 system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
 Read the file Sources/MacLocalAPI/main.swift and explain what it does.
 
@@ -259,7 +259,7 @@ Read the file Sources/MacLocalAPI/main.swift and explain what it does.
 [@ agent-cached-turn2]
 temperature: 0.0
 max_tokens: 20000
-afm: --no-think --enable-prefix-caching
+afm: --enable-prefix-caching
 system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
 Now add a --timeout flag to the CLI that sets a request timeout in seconds.
 
@@ -269,7 +269,7 @@ Now add a --timeout flag to the CLI that sets a request timeout in seconds.
 [@ agent-cached-turn3]
 temperature: 0.0
 max_tokens: 20000
-afm: --no-think --enable-prefix-caching
+afm: --enable-prefix-caching
 system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
 Write a unit test for the timeout feature you just described.
 
@@ -305,7 +305,7 @@ max_tokens: 20000
 logprobs: true
 top_logprobs: 5
 expect: {"logprobs_min":1}
-afm: --no-think --max-logprobs 5
+afm: --max-logprobs 5
 What is 1+1?
 
 # ══════════════════════════════════════════════════════════════════════
@@ -318,7 +318,7 @@ What is 1+1?
 [@ small-kv]
 temperature: 0.7
 max_tokens: 20000
-afm: --no-think --max-kv-size 2048
+afm: --max-kv-size 2048
 Summarize the key ideas of machine learning in a few paragraphs.
 
 # AI: Tests KV cache quantization. Feature: --kv-bits 4 (4-bit quantized KV cache).
@@ -327,7 +327,7 @@ Summarize the key ideas of machine learning in a few paragraphs.
 [@ kv-quantized]
 temperature: 0.7
 max_tokens: 20000
-afm: --no-think --kv-bits 4
+afm: --kv-bits 4
 Summarize the key ideas of machine learning in a few paragraphs.
 
 # AI: Tests default prefill step size. Feature: --prefill-step-size (GPU batch size for prompt).
@@ -345,7 +345,7 @@ Given this architecture, what are the top 3 performance bottlenecks you would in
 [@ prefill-large-4096]
 temperature: 0.0
 max_tokens: 20000
-afm: --no-think --prefill-step-size 4096
+afm: --prefill-step-size 4096
 system: You are an expert software architect reviewing a large codebase. The project is a Swift macOS application that serves LLM inference through an OpenAI-compatible API. It uses Vapor for HTTP, MLX for GPU compute, and supports streaming SSE responses. The architecture includes model services, controllers, request/response types, prompt caching, tool call parsing, logprobs computation, and a built-in WebUI. The codebase has vendor dependencies managed through a patch system. There are multiple model formats supported including Qwen, Gemma, Llama, DeepSeek, GLM, and others. Each model may have different tool call formats, chat templates, and tokenizer configurations. The server must handle concurrent requests safely using async/await and serial access containers.
 Given this architecture, what are the top 3 performance bottlenecks you would investigate first?
 
@@ -355,7 +355,7 @@ Given this architecture, what are the top 3 performance bottlenecks you would in
 [@ prefill-small-256]
 temperature: 0.0
 max_tokens: 20000
-afm: --no-think --prefill-step-size 256
+afm: --prefill-step-size 256
 system: You are an expert software architect reviewing a large codebase. The project is a Swift macOS application that serves LLM inference through an OpenAI-compatible API. It uses Vapor for HTTP, MLX for GPU compute, and supports streaming SSE responses. The architecture includes model services, controllers, request/response types, prompt caching, tool call parsing, logprobs computation, and a built-in WebUI. The codebase has vendor dependencies managed through a patch system. There are multiple model formats supported including Qwen, Gemma, Llama, DeepSeek, GLM, and others. Each model may have different tool call formats, chat templates, and tokenizer configurations. The server must handle concurrent requests safely using async/await and serial access containers.
 Given this architecture, what are the top 3 performance bottlenecks you would investigate first?
 
@@ -369,7 +369,7 @@ Given this architecture, what are the top 3 performance bottlenecks you would in
 [@ no-streaming]
 temperature: 0.7
 max_tokens: 20000
-afm: --no-think --no-streaming
+afm: --no-streaming
 Write a short poem about the moon.
 
 # AI: Tests raw mode. Feature: --raw (disables <think> tag extraction).
@@ -379,7 +379,7 @@ Write a short poem about the moon.
 [@ raw-mode]
 temperature: 0.7
 max_tokens: 20000
-afm: --no-think --raw
+afm: --raw
 Think step by step: what is 17 * 23?
 
 # ══════════════════════════════════════════════════════════════════════
@@ -466,7 +466,7 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_PERIO
 [@ stop-cli-only]
 temperature: 0.0
 max_tokens: 20000
-afm: --no-think --stop "<AFM_CLI_STOP>"
+afm: --stop "<AFM_CLI_STOP>"
 expect: {"finish_reason":"stop","content_equals":"AFM_CLI_PREFIX","content_not_contains":["<AFM_CLI_STOP>","AFM_CLI_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_CLI_PREFIX<AFM_CLI_STOP>AFM_CLI_SUFFIX
 
@@ -476,7 +476,7 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_CLI_P
 [@ stop-cli-multi]
 temperature: 0.0
 max_tokens: 20000
-afm: --no-think --stop "<AFM_CLI_FIRST>,<AFM_CLI_SECOND>"
+afm: --stop "<AFM_CLI_FIRST>,<AFM_CLI_SECOND>"
 expect: {"finish_reason":"stop","content_equals":"AFM_CLI_MULTI_PREFIX","content_not_contains":["<AFM_CLI_FIRST>","AFM_CLI_BETWEEN","<AFM_CLI_SECOND>","AFM_CLI_MULTI_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_CLI_MULTI_PREFIX<AFM_CLI_FIRST>AFM_CLI_BETWEEN<AFM_CLI_SECOND>AFM_CLI_MULTI_SUFFIX
 
@@ -487,7 +487,7 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_CLI_M
 temperature: 0.0
 max_tokens: 20000
 stop: ["<AFM_API_STOP>"]
-afm: --no-think --stop "<AFM_CLI_STOP>"
+afm: --stop "<AFM_CLI_STOP>"
 expect: {"finish_reason":"stop","content_equals":"AFM_MERGE_PREFIX","content_not_contains":["<AFM_API_STOP>","AFM_MERGE_BETWEEN","<AFM_CLI_STOP>","AFM_MERGE_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_MERGE_PREFIX<AFM_API_STOP>AFM_MERGE_BETWEEN<AFM_CLI_STOP>AFM_MERGE_SUFFIX
 
@@ -498,7 +498,7 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_MERGE
 temperature: 0.0
 max_tokens: 20000
 stop: ["<AFM_DEDUP_STOP>"]
-afm: --no-think --stop "<AFM_DEDUP_STOP>"
+afm: --stop "<AFM_DEDUP_STOP>"
 expect: {"finish_reason":"stop","content_equals":"AFM_DEDUP_PREFIX","content_not_contains":["<AFM_DEDUP_STOP>","AFM_DEDUP_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_DEDUP_PREFIX<AFM_DEDUP_STOP>AFM_DEDUP_SUFFIX
 
@@ -510,7 +510,7 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_DEDUP
 [@ stop-non-streaming]
 temperature: 0.0
 max_tokens: 20000
-afm: --no-think --no-streaming
+afm: --no-streaming
 stop: ["<AFM_NONSTREAM_STOP>"]
 expect: {"finish_reason":"stop","content_equals":"AFM_NONSTREAM_PREFIX","content_not_contains":["<AFM_NONSTREAM_STOP>","AFM_NONSTREAM_SUFFIX"]}
 Output exactly the following text, with no quotes or extra whitespace: AFM_NONSTREAM_PREFIX<AFM_NONSTREAM_STOP>AFM_NONSTREAM_SUFFIX
@@ -524,7 +524,7 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_NONST
 temperature: 0.0
 max_tokens: 20000
 stop: ["Tokyo"]
-afm: --no-think --guided-json '{"type":"object","properties":{"cities":{"type":"array","items":{"type":"string"}}},"required":["cities"]}'
+afm: --guided-json '{"type":"object","properties":{"cities":{"type":"array","items":{"type":"string"}}},"required":["cities"]}'
 expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":"Tokyo"}
 List 5 major world cities as a JSON array. Include Tokyo.
 
@@ -535,7 +535,7 @@ List 5 major world cities as a JSON array. Include Tokyo.
 temperature: 0.0
 max_tokens: 20000
 stop: [","]
-afm: --no-think --guided-json '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"},"city":{"type":"string"}},"required":["name","age","city"]}'
+afm: --guided-json '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"},"city":{"type":"string"}},"required":["name","age","city"]}'
 expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":","}
 Generate a person profile for someone named Alice who is 30 and lives in Paris.
 
@@ -546,7 +546,7 @@ Generate a person profile for someone named Alice who is 30 and lives in Paris.
 temperature: 0.0
 max_tokens: 20000
 stop: ["}"]
-afm: --no-think --guided-json '{"type":"object","properties":{"color":{"type":"string"},"hex":{"type":"string"}},"required":["color","hex"]}'
+afm: --guided-json '{"type":"object","properties":{"color":{"type":"string"},"hex":{"type":"string"}},"required":["color","hex"]}'
 expect: {"finish_reason":"stop","valid_json":false,"content_not_contains":"}"}
 Describe the color blue with its hex code.
 
@@ -768,7 +768,7 @@ Solve step by step: If a train travels at 60 mph for 2.5 hours, how far does it 
 [@ think-raw]
 temperature: 0.0
 max_tokens: 20000
-afm: --no-think --raw
+afm: --raw
 Solve step by step: If a train travels at 60 mph for 2.5 hours, how far does it go?
 
 # ══════════════════════════════════════════════════════════════════════
@@ -783,7 +783,7 @@ Solve step by step: If a train travels at 60 mph for 2.5 hours, how far does it 
 [@ streaming-seeded]
 temperature: 0.7
 max_tokens: 20000
-afm: --no-think --seed 123
+afm: --seed 123
 Write a 4-line poem about the ocean.
 
 # AI: Tests non-streaming output with seed. Feature: --no-streaming + seed determinism.
@@ -792,7 +792,7 @@ Write a 4-line poem about the ocean.
 [@ non-streaming-seeded]
 temperature: 0.7
 max_tokens: 20000
-afm: --no-think --no-streaming --seed 123
+afm: --no-streaming --seed 123
 Write a 4-line poem about the ocean.
 
 # ══════════════════════════════════════════════════════════════════════
@@ -828,7 +828,7 @@ Write a Python function that reverses a string.
 [@ verbose]
 temperature: 0.7
 max_tokens: 20000
-afm: --no-think --verbose
+afm: --verbose
 Hello, how are you?
 
 # AI: Tests very-verbose logging mode. Feature: --very-verbose flag (full request/response logging).
@@ -837,7 +837,7 @@ Hello, how are you?
 [@ very-verbose]
 temperature: 0.7
 max_tokens: 20000
-afm: --no-think --very-verbose
+afm: --very-verbose
 Hello, how are you?
 
 # ══════════════════════════════════════════════════════════════════════
@@ -863,7 +863,7 @@ Call get_weather exactly once for Tokyo. Call no other tools.
 [@ tool-call-xml]
 temperature: 0.0
 max_tokens: 20000
-afm: --no-think --tool-call-parser qwen3_xml
+afm: --tool-call-parser qwen3_xml
 expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"get_weather","arguments":{"city":"Paris","unit":"celsius"}}]}
 tools: [{"type":"function","function":{"name":"get_weather","description":"Get current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string","description":"City name"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}},"required":["city"]}}}]
 Call get_weather exactly once for Paris with unit celsius. Call no other tools.

--- a/Scripts/test_generate_report.py
+++ b/Scripts/test_generate_report.py
@@ -57,6 +57,34 @@ class GenerateReportTests(unittest.TestCase):
             self.assertIn("2/5 ❌", report)
             self.assertEqual(report.count('class="response-section" id="resp-'), 2)
 
+    def test_full_prompt_is_rendered_without_truncation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            report_dir = root / "test-reports"
+            report_dir.mkdir()
+            results_path = root / "results.jsonl"
+            long_prompt = "A" * 600 + " FULL_PROMPT_TAIL"
+            record = self.record("long-prompt", "pass", "OK")
+            record["prompt"] = long_prompt
+            results_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "RESULTS_FILE": str(results_path),
+                    "REPORT_OUTPUT_DIR": str(root),
+                    "REPORT_TIMESTAMP": "20260825_050607",
+                    "AFM_REPORT_NO_OPEN": "1",
+                }
+            )
+            subprocess.run([sys.executable, str(SCRIPT)], env=env, check=True)
+
+            report = (
+                report_dir / "mlx-model-report-20260825_050607.html"
+            ).read_text(encoding="utf-8")
+            self.assertIn(long_prompt, report)
+            self.assertNotIn("A" * 500 + "...", report)
+
     @staticmethod
     def record(label, overall_status, status):
         return {

--- a/Scripts/test_generate_report.py
+++ b/Scripts/test_generate_report.py
@@ -1,0 +1,87 @@
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).with_name("generate-report.py")
+
+
+class GenerateReportTests(unittest.TestCase):
+    def test_batch_scores_render_for_passed_and_failed_records(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            report_dir = root / "test-reports"
+            report_dir.mkdir()
+            results_path = root / "results.jsonl"
+            records = [
+                {"_meta": True, "test_command": "mlx-model-test.sh"},
+                self.record("pass-case", "pass", "OK"),
+                self.record("fail-case", "fail", "FAIL"),
+            ]
+            results_path.write_text(
+                "".join(json.dumps(record) + "\n" for record in records),
+                encoding="utf-8",
+            )
+
+            # Batch judges occasionally place the comment close on the next line.
+            # The JSON array remains valid and should still populate every record.
+            smart_timestamp = "20260825_010203"
+            (report_dir / f"smart-analysis-codex-{smart_timestamp}.md").write_text(
+                "## Analysis\n\n<!-- AI_SCORES "
+                '[{"i":0,"s":5},{"i":1,"s":2}]\n-->\n',
+                encoding="utf-8",
+            )
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "RESULTS_FILE": str(results_path),
+                    "REPORT_OUTPUT_DIR": str(root),
+                    "REPORT_TIMESTAMP": "20260825_040506",
+                    "SMART_TIMESTAMP": smart_timestamp,
+                    "AFM_REPORT_NO_OPEN": "1",
+                }
+            )
+            subprocess.run([sys.executable, str(SCRIPT)], env=env, check=True)
+
+            report = (
+                report_dir / "mlx-model-report-20260825_040506.html"
+            ).read_text(encoding="utf-8")
+            self.assertEqual(report.count("🤖 AI Scores"), 2)
+            self.assertEqual(report.count("<strong>codex</strong>"), 2)
+            self.assertIn("5/5 ✅", report)
+            self.assertIn("2/5 ❌", report)
+            self.assertEqual(report.count('class="response-section" id="resp-'), 2)
+
+    @staticmethod
+    def record(label, overall_status, status):
+        return {
+            "model": "test/model",
+            "label": label,
+            "prompt": f"Prompt for {label}",
+            "content": "response",
+            "content_preview": "response",
+            "reasoning_content": "",
+            "overall_status": overall_status,
+            "status": status,
+            "assertion_status": "pass" if overall_status == "pass" else "fail",
+            "assertion_failures": [] if overall_status == "pass" else ["expected failure"],
+            "completion_tokens": 2,
+            "prompt_tokens": 3,
+            "total_tokens": 5,
+            "tokens_per_sec": 10.0,
+            "load_time_s": 1.0,
+            "gen_time_s": 0.2,
+            "temperature": 0.0,
+            "max_tokens": 20,
+            "finish_reason": "stop",
+            "afm_args": "--no-think",
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/test_mlx_model_test_oracle.py
+++ b/Scripts/test_mlx_model_test_oracle.py
@@ -30,7 +30,7 @@ class ModelTestOracleTests(unittest.TestCase):
         config["prompt_idx"] = 1
         self.assertEqual(expectation_for_prompt(config), config["expect"])
 
-    def test_accepts_exact_ordered_distinct_tool_calls(self):
+    def test_accepts_distinct_tool_calls_in_either_order(self):
         expectation = {
             "finish_reason": "tool_calls",
             "tool_calls": [
@@ -39,8 +39,8 @@ class ModelTestOracleTests(unittest.TestCase):
             ],
         }
         actual = [
-            {"function": {"name": "get_weather", "arguments": '{"city":"London"}'}},
             {"function": {"name": "get_time", "arguments": '{"timezone":"Asia/Tokyo"}'}},
+            {"function": {"name": "get_weather", "arguments": '{"city":"London"}'}},
         ]
 
         _, failures = evaluate_expectations(
@@ -73,8 +73,8 @@ class ModelTestOracleTests(unittest.TestCase):
             tool_calls=actual,
         )
 
-        self.assertTrue(any("tool_calls[0].name" in failure for failure in failures))
-        self.assertTrue(any("arguments.city" in failure for failure in failures))
+        self.assertIn("tool_calls missing expected function 'get_weather'", failures)
+        self.assertTrue(any("arguments.timezone" in failure for failure in failures))
 
     def test_rejects_fenced_or_schema_invalid_json(self):
         expectation = {

--- a/Scripts/test_mlx_model_test_oracle.py
+++ b/Scripts/test_mlx_model_test_oracle.py
@@ -1,0 +1,138 @@
+import unittest
+
+from mlx_model_test_oracle import (
+    evaluate_expectations,
+    expectation_for_prompt,
+    extract_score_payload,
+)
+
+
+class ModelTestOracleTests(unittest.TestCase):
+    def test_extracts_score_reason_with_escaped_quotes_from_cli_output(self):
+        payload = extract_score_payload(
+            'analysis noise\n{"score":5,"reason":"finish_reason=\\"tool_calls\\" is correct"}\n'
+        )
+
+        self.assertEqual(
+            payload,
+            {"score": 5, "reason": 'finish_reason="tool_calls" is correct'},
+        )
+
+    def test_variant_expectation_is_not_applied_to_global_baseline(self):
+        config = {
+            "prompt_idx": 0,
+            "num_baseline": 1,
+            "tools": [{"function": {"name": "get_weather"}}],
+            "expect": {"tool_calls": [{"name": "get_weather"}]},
+        }
+        self.assertEqual(expectation_for_prompt(config), {"tool_calls": []})
+
+        config["prompt_idx"] = 1
+        self.assertEqual(expectation_for_prompt(config), config["expect"])
+
+    def test_accepts_exact_ordered_distinct_tool_calls(self):
+        expectation = {
+            "finish_reason": "tool_calls",
+            "tool_calls": [
+                {"name": "get_weather", "arguments": {"city": "London"}},
+                {"name": "get_time", "arguments": {"timezone": "Asia/Tokyo"}},
+            ],
+        }
+        actual = [
+            {"function": {"name": "get_weather", "arguments": '{"city":"London"}'}},
+            {"function": {"name": "get_time", "arguments": '{"timezone":"Asia/Tokyo"}'}},
+        ]
+
+        _, failures = evaluate_expectations(
+            expectation,
+            content="",
+            finish_reason="tool_calls",
+            logprobs_count=0,
+            tool_calls=actual,
+        )
+
+        self.assertEqual(failures, [])
+
+    def test_rejects_duplicate_substitution_and_wrong_argument(self):
+        expectation = {
+            "tool_calls": [
+                {"name": "get_weather", "arguments": {"city": "London"}},
+                {"name": "get_time", "arguments": {"timezone": "Asia/Tokyo"}},
+            ]
+        }
+        actual = [
+            {"function": {"name": "get_time", "arguments": '{"timezone":"Europe/London"}'}},
+            {"function": {"name": "get_time", "arguments": '{"timezone":"Asia/Tokyo"}'}},
+        ]
+
+        _, failures = evaluate_expectations(
+            expectation,
+            content="",
+            finish_reason="tool_calls",
+            logprobs_count=0,
+            tool_calls=actual,
+        )
+
+        self.assertTrue(any("tool_calls[0].name" in failure for failure in failures))
+        self.assertTrue(any("arguments.city" in failure for failure in failures))
+
+    def test_rejects_fenced_or_schema_invalid_json(self):
+        expectation = {
+            "valid_json": True,
+            "json_schema": {
+                "type": "object",
+                "properties": {"age": {"type": "integer"}},
+                "required": ["age"],
+            },
+        }
+
+        valid_json, failures = evaluate_expectations(
+            expectation,
+            content='```json\n{"age":"37"}\n```',
+            finish_reason="stop",
+            logprobs_count=0,
+            tool_calls=[],
+        )
+
+        self.assertFalse(valid_json)
+        self.assertTrue(failures)
+
+        valid_json, failures = evaluate_expectations(
+            expectation,
+            content='{"age":"37"}',
+            finish_reason="stop",
+            logprobs_count=0,
+            tool_calls=[],
+        )
+        self.assertTrue(valid_json)
+        self.assertIn("$.age expected type integer", failures)
+
+    def test_exact_content_proves_deterministic_stop_prefix(self):
+        expectation = {
+            "finish_reason": "stop",
+            "content_equals": "AFM_PREFIX",
+            "content_not_contains": ["<AFM_STOP>", "AFM_SUFFIX"],
+        }
+
+        _, failures = evaluate_expectations(
+            expectation,
+            content="AFM_PREFIX",
+            finish_reason="stop",
+            logprobs_count=0,
+            tool_calls=[],
+        )
+        self.assertEqual(failures, [])
+
+        _, failures = evaluate_expectations(
+            expectation,
+            content="AFM_PREFIX AFM_SUFFIX",
+            finish_reason="stop",
+            logprobs_count=0,
+            tool_calls=[],
+        )
+        self.assertTrue(any("content expected exactly" in failure for failure in failures))
+        self.assertTrue(any("must not contain 'AFM_SUFFIX'" in failure for failure in failures))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -32,12 +32,47 @@ if AFMKIT_GIT_COMMAND="$fake_git" \
    >"$auth_log" 2>&1; then
   fail "unauthenticated AFMKit access unexpectedly succeeded"
 fi
-grep -Fq 'Cannot read the private provider dependency' "$auth_log" || \
-  fail "private AFMKit error is not actionable"
+grep -Fq 'Cannot read the exact provider dependency' "$auth_log" || \
+  fail "AFMKit access error is not actionable"
 grep -Fq 'AFMKIT_READ_TOKEN' "$auth_log" || \
   fail "private AFMKit error does not name the CI secret"
 if grep -Fq 'must-not-appear' "$auth_log"; then
   fail "private AFMKit token leaked into diagnostics"
+fi
+
+expected_afmkit_revision="$(python3 - "$ROOT_DIR/Package.resolved" <<'PY'
+import json
+import sys
+
+lock = json.load(open(sys.argv[1]))
+pin = next(pin for pin in lock["pins"] if pin["identity"] == "afmkit")
+print(pin["state"]["revision"])
+PY
+)"
+fake_public_git="$WORK_ROOT/git-public"
+cat > "$fake_public_git" <<'SH'
+#!/usr/bin/env bash
+arguments=" $* "
+for ref in \
+  refs/tags/0.1.3 \
+  'refs/tags/0.1.3^{}' \
+  refs/tags/v0.1.3 \
+  'refs/tags/v0.1.3^{}'; do
+  [[ "$arguments" == *" $ref "* ]] || exit 2
+done
+printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.3^{}'
+SH
+chmod 700 "$fake_public_git"
+if ! EXPECTED_AFMKIT_REVISION="$expected_afmkit_revision" \
+   AFMKIT_GIT_COMMAND="$fake_public_git" \
+   "$ROOT_DIR/Scripts/resolve-release-dependencies.sh" --check-access \
+   >"$WORK_ROOT/public-access.log" 2>&1; then
+  fail "v-prefixed public AFMKit release was not recognized"
+fi
+
+if grep -Fq '.github/workflows' "$ROOT_DIR/Scripts/check-afmkit-consumer-boundary.sh" || \
+   grep -Fq 'AFMKIT_READ_TOKEN' "$ROOT_DIR/Scripts/check-afmkit-consumer-boundary.sh"; then
+  fail "local consumer boundary still depends on hosted workflow configuration"
 fi
 
 public_gate_log="$WORK_ROOT/public-release-error.log"
@@ -45,7 +80,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.2'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.3'
   }
   probe_public_source() {
     return 1
@@ -69,14 +104,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.2" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.2"
+[[ "$release_version" == "0.1.3" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.3"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.2'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.3'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -95,7 +130,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.2'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.3'
   }
   probe_public_source() {
     return 0

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -280,7 +280,7 @@ struct MlxCommand: ParsableCommand {
           --dspark-confidence: DSpark confidence-pruning threshold (default: 0.7)
           --dspark-strict: Load DSpark support but use target-only decoding
           --eagle3: EAGLE3 drafter directory for compatible dense Gemma4 models
-          --tool-call-parser: Override tool call format (none, afm_adaptive_xml, hermes, llama3_json, gemma, mistral, qwen3_xml). Omit for default native mode and MLX Python-style parity; use "none" for raw output; use "afm_adaptive_xml" for opt-in repair mode.
+          --tool-call-parser: Override tool call format (none, afm_adaptive_xml, deepseek_dsml, hermes, llama3_json, gemma, mistral, qwen3_xml). Omit for default native mode and MLX Python-style parity; use "none" for raw output; use "afm_adaptive_xml" for opt-in repair mode.
           --fix-tool-args: Opt-in repair-mode helper that post-processes tool call arg names to match original tool schema
           --enable-grammar-constraints: Enable grammar-constrained decoding engine. When active, API requests with strict: true on tools or response_format.json_schema use xgrammar for token-level enforcement. Without this flag, strict: true is silently downgraded to best-effort.
           --no-think: Disable thinking/reasoning when supported; for Muse, requests the lowest reasoning strength
@@ -326,6 +326,7 @@ struct MlxCommand: ParsableCommand {
             hermes: JSON format with Hermes chat template (Llama, Qwen, most models)
             llama3_json: JSON format with Llama-3 chat template
             mistral: JSON format with Mistral chat template
+            deepseek_dsml: Native DeepSeek V4 DSML tool-call format
             qwen3_xml: XML function format with Qwen3-Coder chat template
             gemma: Gemma function call format (uses model's built-in template)
           benchmark_guidance: Use default native mode for MLX Python parity and VulcanBench comparisons. Treat afm_adaptive_xml / --fix-tool-args results as AFM repair-layer results, not plain-vanilla parity.
@@ -495,7 +496,7 @@ struct MlxCommand: ParsableCommand {
     @Option(name: .long, help: "Require a specific prefix for Telegram messages, for example '/afm' (default: no prefix required)")
     var telegramRequirePrefix: String?
 
-    @Option(name: .long, help: "Tool call parser override: none, afm_adaptive_xml, hermes, llama3_json, gemma, mistral, qwen3_xml. Omit for default native mode and MLX Python-style parity; Qwen XML models default to qwen3_xml. Use none for raw output with no AFM extraction. Use afm_adaptive_xml for opt-in repair behavior with JSON-in-XML fallback, type coercion, and optional xgrammar EBNF constrained decoding.")
+    @Option(name: .long, help: "Tool call parser override: none, afm_adaptive_xml, deepseek_dsml, hermes, llama3_json, gemma, mistral, qwen3_xml. Omit for default native mode and MLX Python-style parity; Qwen XML models default to qwen3_xml and DeepSeek V4 models use deepseek_dsml. Use none for raw output with no AFM extraction. Use afm_adaptive_xml for opt-in repair behavior with JSON-in-XML fallback, type coercion, and optional xgrammar EBNF constrained decoding.")
     var toolCallParser: String?
 
     @Option(name: .long, help: "OpenAI-compatible tools array JSON for single-prompt mode")
@@ -637,6 +638,18 @@ struct MlxCommand: ParsableCommand {
         }
         if tui && (raw || json || openclawConfig) {
             throw ValidationError("--tui cannot be combined with --raw, --json, or --openclaw-config")
+        }
+        if let toolCallParser {
+            let normalizedParser = toolCallParser.trimmingCharacters(in: .whitespacesAndNewlines)
+            let supportedParsers: Set<String> = [
+                "none", "afm_adaptive_xml", "deepseek_dsml", "hermes", "llama3_json",
+                "gemma", "mistral", "qwen3_xml",
+            ]
+            guard supportedParsers.contains(normalizedParser) else {
+                throw ValidationError(
+                    "--tool-call-parser must be one of: \(supportedParsers.sorted().joined(separator: ", "))"
+                )
+            }
         }
 
         // GPU capture: set MTL_CAPTURE_ENABLED before Metal device is created

--- a/Tests/MacLocalAPITests/BatchDispatchTests.swift
+++ b/Tests/MacLocalAPITests/BatchDispatchTests.swift
@@ -1765,6 +1765,7 @@ struct StreamCollectorTests {
         ])
 
         let collected = try await StreamCollector.collect(from: result, extractThinking: false)
+        #expect(collected.stoppedBySequence)
         #expect(collected.finishReason == "stop")
     }
 
@@ -1790,6 +1791,7 @@ struct StreamCollectorTests {
         ])
 
         let collected = try await StreamCollector.collect(from: result, extractThinking: false)
+        #expect(!collected.stoppedBySequence)
         #expect(collected.finishReason == "stop")
     }
 

--- a/docs/afmkit-url-consumption.md
+++ b/docs/afmkit-url-consumption.md
@@ -6,7 +6,7 @@ one exact release and selects every provider product from it:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.2"
+    exact: "0.1.3"
 )
 ```
 
@@ -14,23 +14,19 @@ Do not use a branch or revision requirement for release builds.
 
 ## Production Blocker
 
-This branch deliberately stops before making repositories public or publishing
-tags. AFM release publication remains fail-closed until AFMKit and every
-dependency in its root graph are anonymously readable, AFMKit exposes `0.1.2`,
-and the tracked lock resolves that exact tag. Making a repository public is an explicit human checkpoint,
-not part of the reversible code cutover.
+AFMKit is public and exposes `0.1.3`. AFM release publication remains
+fail-closed unless AFMKit and every dependency in its root graph are
+anonymously readable and the tracked lock resolves that exact tag.
 
-Rollback before that checkpoint is a normal branch deletion. After merging but
-before publishing a new AFM version, revert the merge commit. After an AFM
-release, restore the previous AFM version and revert the dependency bump; the
-old implementation remains preserved in the pre-cutover branch and tag.
+Before publishing a new AFM version, rollback means restoring the previous
+exact AFMKit version and its reviewed lock revision. After an AFM release, make
+the same dependency rollback in a new patch release; never move an existing
+version tag.
 
-The current policy chooses the first option and fails closed. Private CI access
-and an anonymously fetchable revision are development mechanisms, not evidence
-of versioned SwiftPM readiness. As observed on 2026-08-20, GitHub Actions are
-also disabled for the maclocal-api repository. The workflow definitions are
-complete, but hosted enforcement requires a repository administrator to
-re-enable Actions.
+The current policy chooses the first option and fails closed. An anonymously
+fetchable revision alone is not evidence of versioned SwiftPM readiness: the
+exact release tag and tracked lock must agree. Local qualification and
+publication do not depend on GitHub Actions; hosted workflows are optional.
 
 Every tag, nightly, and manual publishing entry point runs
 `Scripts/check-public-release-eligibility.sh` before building or uploading. The
@@ -40,26 +36,18 @@ can be fetched anonymously. Authentication can keep development CI working,
 but neither authentication nor a public bare revision makes this source-package
 surface publishable.
 
-## Authenticated Resolution
+## Dependency Resolution
 
-Local developers must authenticate a GitHub identity with read access:
+AFMKit 0.1.3 is public, so normal resolution requires no GitHub credential:
 
 ```bash
-gh auth login
-gh auth setup-git
 Scripts/resolve-release-dependencies.sh
 ```
 
-CI and release jobs provide a masked `AFMKIT_READ_TOKEN` secret with repository
-read access. The resolver uses an ephemeral `GIT_ASKPASS` helper containing no
-credential material, never writes the token to the manifest or lock, and emits
-an actionable error when access is missing. GitHub's default repository token
-does not grant cross-repository access to a separate private dependency.
-
-The Swift CodeQL job uses that same authenticated resolver on trusted branches.
-Fork and Dependabot pull requests never receive the secret: their analysis job
-is skipped with an explicit transition notice, and maintainers must run CodeQL
-from a trusted branch until AFMKit is publicly resolvable.
+The resolver retains optional `AFMKIT_READ_TOKEN` support only for explicitly
+private development sources. Its `GIT_ASKPASS` helper contains no credential
+material, the token is never written to the manifest or lock, and production
+eligibility removes ambient credentials before proving anonymous access.
 
 ## Immutable Release Graph
 
@@ -67,7 +55,7 @@ The normal graph is independent of maclocal-api's dirty vendor worktrees:
 
 | Dependency | Requirement | Purpose |
 | --- | --- | --- |
-| `AFMKit` | exact `0.1.2` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, and the vendored MLX runtime |
+| `AFMKit` | exact `0.1.3` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, and the vendored MLX runtime |
 
 The MLX, mlx-c, Swift bindings, and mlx-swift-lm sources are snapshots inside
 AFMKit's `vendor/MLX` tree. They are not separate SwiftPM dependencies of


### PR DESCRIPTION
## Problem

The comprehensive model harness mixed a global primary-colors baseline into variant-specific records, displayed placeholder-looking stop values without enough context, used positional multi-tool assertions, and dropped Codex batch scores from generated HTML. Those problems obscured real Qwen3.8 tool-call behavior and produced misleading reports.

Relates to #209 and depends on provider-side AFMKit PR scouzi1966/AFMKit#11.

## Approach

- Add strict CLI validation and expose the native DeepSeek DSML parser name.
- Replace weak stop prompts with deterministic prefix/marker/suffix cases and executable expectations.
- Remove the duplicated global baseline so all 91 records use their own test-specific prompt.
- Evaluate tool calls by function name rather than emitted order.
- Preserve native tool argument failures instead of masking them in the oracle.
- Display exact stop arrays as raw JSON.
- Robustly import Codex batch score trailers and render AI scores for every passed or failed record.
- Include failed records and complete, untruncated prompts in Full Responses.
- Set the comprehensive defaults to `--no-think` and 20,000 tokens without duplicating CLI flags.

## Four-model validation

| Model | Deterministic result | Codex average |
|---|---:|---:|
| DeepSeek V4 Flash | 88/91 | 4.70 |
| Nemotron 3.5 Lightning | 89/91 | 4.69 |
| Muse Glimmer | 72/91 | 3.88 |
| Qwen3.8-27B | 88/91 | 4.70 |

Qwen3.8 passed auto-detected tool calling, explicit `qwen3_xml`, nested-object, nullable-argument, and no-tool cases. Its remaining live failures are recorded in #209.

## Focused validation

- Python report/oracle tests: 8/8 passed.
- StreamCollector tests via `Scripts/swiftpm-reliable.sh`: 17/17 passed.
- Shell syntax, Python compilation, and diff checks passed.
- All four HTML reports regenerated with 91 response sections and 91 Codex score panels.
- Independent sub-agent review completed; its report truncation finding was fixed in `8ce57eb`.

## Merge sequencing

maclocal-api currently pins AFMKit 0.1.2. Merge and release AFMKit#11 first, then update this PR with the new exact AFMKit version before merging so normal builds consume the provider fix.

## Summary by Sourcery

Make model tool-call evaluation deterministic and ensure generated reports accurately represent every test result and AI score.

New Features:
- Add declarative, deterministic response expectations for content, JSON, schemas, stop behavior, logprobs, finish reasons, and tool calls.
- Expose and validate the native DeepSeek DSML tool-call parser.
- Generate comprehensive reports with complete response coverage, raw stop configuration, assertion results, and Codex scores for passed and failed records.

Bug Fixes:
- Correct model evaluation so global baseline prompts are not judged against variant-specific expectations.
- Match multiple tool calls by function name and preserve argument-validation failures.
- Improve parsing of batch AI score trailers and prevent report prompt truncation.
- Replace ambiguous stop-sequence checks with deterministic prefix and marker assertions.

Enhancements:
- Separate transport, assertion, and overall result statuses in model-test output.
- Strengthen report and oracle parsing against formatting variation and support deterministic report regeneration.

Build:
- Update AFMKit and release tooling to exact version 0.1.3.

Documentation:
- Update AFMKit dependency and release-resolution documentation for the public 0.1.3 release.

Tests:
- Add oracle and report-generation tests covering baseline isolation, unordered tool calls, JSON/schema validation, deterministic stops, score extraction, failed-record rendering, and full prompts.
- Extend stream collection tests to verify stop-sequence detection.

Chores:
- Refine release dependency access checks and remove obsolete workflow-specific consumer-boundary assumptions.