### PR TITLE
Integrate AFMKit vision and media serving

### DIFF
--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.4"
+        exact: "0.1.5"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "54ad34dd6caaa913519e613d529d20ccbd83bdb2",
-        "version" : "0.1.4"
+        "revision" : "114fe6feebe861b3b5626ad09cdb4c297e260b29",
+        "version" : "0.1.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.4"
+        exact: "0.1.5"
     )
 }
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -145,8 +145,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.4":
-        fail(f"{identity} must resolve the exact 0.1.4 release")
+    if pin["state"].get("version") != "0.1.5":
+        fail(f"{identity} must resolve the exact 0.1.5 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -289,7 +289,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.4"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.5"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.4",
+    "afmkit": "0.1.5",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -54,13 +54,13 @@ cat > "$fake_public_git" <<'SH'
 #!/usr/bin/env bash
 arguments=" $* "
 for ref in \
-  refs/tags/0.1.4 \
-  'refs/tags/0.1.4^{}' \
-  refs/tags/v0.1.4 \
-  'refs/tags/v0.1.4^{}'; do
+  refs/tags/0.1.5 \
+  'refs/tags/0.1.5^{}' \
+  refs/tags/v0.1.5 \
+  'refs/tags/v0.1.5^{}'; do
   [[ "$arguments" == *" $ref "* ]] || exit 2
 done
-printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.4^{}'
+printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.5^{}'
 SH
 chmod 700 "$fake_public_git"
 if ! EXPECTED_AFMKIT_REVISION="$expected_afmkit_revision" \
@@ -80,7 +80,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.4'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.5'
   }
   probe_public_source() {
     return 1
@@ -104,14 +104,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.4" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.4"
+[[ "$release_version" == "0.1.5" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.5"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.4'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.5'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -130,7 +130,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.4'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.5'
   }
   probe_public_source() {
     return 0

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -1,6 +1,7 @@
 import AFMKit
 import AFMKitCore
 import AFMKitDwarfStar
+import AFMKitMLX
 import AFMServer
 import AFMTerminalUI
 import ArgumentParser
@@ -1449,7 +1450,14 @@ struct MlxCommand: ParsableCommand {
                     var parts: [ContentPart] = [ContentPart(type: "text", text: prompt, image_url: nil)]
                     for path in mediaPaths {
                         let fileURL = URL(fileURLWithPath: path)
-                        parts.append(ContentPart(type: "image_url", text: nil, image_url: ImageURL(url: fileURL.absoluteString, detail: nil)))
+                        parts.append(ContentPart(
+                            type: "image_url",
+                            text: nil,
+                            image_url: ImageURL(
+                                url: try AFMMLXMediaSecurityPolicy.trustedLocalMediaDataURL(fileURL),
+                                detail: nil
+                            )
+                        ))
                     }
                     messages.append(Message(role: "user", content: .parts(parts)))
                 }

--- a/Sources/AFMServer/AFMMLXCapabilityPresentation.swift
+++ b/Sources/AFMServer/AFMMLXCapabilityPresentation.swift
@@ -1,0 +1,28 @@
+import AFMKitCore
+
+enum AFMMLXCapabilityPresentation {
+    static func modelCapabilityLabels(descriptor: AFMModelDescriptor?) -> [String] {
+        guard let capabilities = descriptor?.capabilities else {
+            return ["chat", "completion"]
+        }
+
+        var labels = ["chat", "completion"]
+        let optionalLabels: [(AFMModelCapabilities, String)] = [
+            (.vision, "vision"),
+            (.reasoning, "reasoning"),
+            (.toolCalling, "tools"),
+            (.structuredOutput, "structured"),
+            (.streaming, "streaming"),
+            (.prefixCaching, "prefix_cache"),
+            (.speculativeDecoding, "speculative_decoding"),
+        ]
+        labels.append(contentsOf: optionalLabels.compactMap { capability, label in
+            capabilities.contains(capability) ? label : nil
+        })
+        return labels
+    }
+
+    static func supportsVision(descriptor: AFMModelDescriptor?) -> Bool {
+        descriptor?.capabilities.contains(.vision) == true
+    }
+}

--- a/Sources/AFMServer/Controllers/AFMChatServing.swift
+++ b/Sources/AFMServer/Controllers/AFMChatServing.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AFMKitCore
 import AFMOpenAICompat
 
 /// Server-owned response channel modes used while rendering OpenAI responses.
@@ -138,6 +139,7 @@ protocol AFMChatServing: Sendable {
     var defaultGuidedJsonSchema: ResponseFormat? { get }
 
     func normalizeModel(_ raw: String) -> String
+    func loadedModelDescriptor(model: String) -> AFMModelDescriptor?
     func resolvedToolCallParser(logBypass: Bool) -> String?
 
     func tryReserveSlot() -> Bool
@@ -264,6 +266,8 @@ extension AFMChatServing {
     var fixToolArgs: Bool { servingConfiguration.fixToolArguments }
     var enableGrammarConstraints: Bool { servingConfiguration.grammarConstraintsEnabled }
     var defaultGuidedJsonSchema: ResponseFormat? { nil }
+
+    func loadedModelDescriptor(model: String) -> AFMModelDescriptor? { nil }
 
     func resetRequestPeakMemory() {}
     func currentRequestPeakMemoryGib() -> Double? { nil }

--- a/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
+++ b/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
@@ -50,7 +50,7 @@ private final class GenericAFMAdmissionGate: @unchecked Sendable {
 /// Bridges the OpenAI-compatible HTTP controllers onto AFMKit's neutral model
 /// and event contracts. Provider scheduler and parser internals stay inside
 /// AFMKitMLX.
-final class AFMKitMLXChatServingAdapter: AFMChatServing, AFMTextTokenizing, @unchecked Sendable {
+final class AFMKitMLXChatServingAdapter: AFMChatServing, AFMTextTokenizing, AFMMLXMediaRequestServing, @unchecked Sendable {
     private let fixedModel: AnyAFMModel
     private let fixedModelID: String
     private let fixedServingConfiguration: AFMChatServingConfiguration
@@ -59,6 +59,7 @@ final class AFMKitMLXChatServingAdapter: AFMChatServing, AFMTextTokenizing, @unc
     private let forceDisableThinking: Bool
     private let fixedMaxConcurrent: Int
     private let mlxServing: (any AFMMLXOpenAIChatServing)?
+    private let mlxMediaServing: (any AFMMLXMediaRequestServing)?
     private let genericAdmission: GenericAFMAdmissionGate?
 
     init(
@@ -75,6 +76,7 @@ final class AFMKitMLXChatServingAdapter: AFMChatServing, AFMTextTokenizing, @unc
         self.forceDisableThinking = forceDisableThinking
         fixedMaxConcurrent = model.maxConcurrent
         mlxServing = model
+        mlxMediaServing = model
         genericAdmission = nil
     }
 
@@ -94,6 +96,7 @@ final class AFMKitMLXChatServingAdapter: AFMChatServing, AFMTextTokenizing, @unc
         let maxConcurrent = Self.maximumConcurrency(for: model.descriptor)
         fixedMaxConcurrent = maxConcurrent
         mlxServing = nil
+        mlxMediaServing = nil
         genericAdmission = GenericAFMAdmissionGate(limit: maxConcurrent)
     }
 
@@ -111,6 +114,44 @@ final class AFMKitMLXChatServingAdapter: AFMChatServing, AFMTextTokenizing, @unc
 
     func normalizeModel(_ raw: String) -> String {
         fixedModelID
+    }
+
+    func loadedModelDescriptor(model: String) -> AFMModelDescriptor? {
+        guard normalizeModel(model) == fixedModelID else { return nil }
+        if let mlxMediaServing {
+            return mlxMediaServing.loadedModelDescriptor(model: model)
+        }
+        return fixedModel.descriptor
+    }
+
+    func validateMediaRequestCapabilities(model: String, messages: [Message]) throws {
+        guard let mlxMediaServing else {
+            throw MLXServiceError.unsupportedMediaInput(model: fixedModelID, kind: "media")
+        }
+        try mlxMediaServing.validateMediaRequestCapabilities(model: model, messages: messages)
+    }
+
+    func preflightMediaRequest(
+        model: String,
+        messages: [Message]
+    ) async throws -> AFMMLXResolvedMediaRequest {
+        guard let mlxMediaServing else {
+            throw MLXServiceError.unsupportedMediaInput(model: fixedModelID, kind: "media")
+        }
+        return try await mlxMediaServing.preflightMediaRequest(model: model, messages: messages)
+    }
+
+    func withPreflightedMediaRequest<Result: Sendable>(
+        _ request: AFMMLXResolvedMediaRequest,
+        operation: ([Message]) async throws -> Result
+    ) async throws -> Result {
+        guard let mlxMediaServing else {
+            throw MLXServiceError.unsupportedMediaInput(model: fixedModelID, kind: "media")
+        }
+        return try await mlxMediaServing.withPreflightedMediaRequest(
+            request,
+            operation: operation
+        )
     }
 
     func resolvedToolCallParser(logBypass: Bool) -> String? {

--- a/Sources/AFMServer/Controllers/ChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/ChatCompletionsController.swift
@@ -357,8 +357,14 @@ struct ChatCompletionsController: RouteCollection {
         // Register the cancel hook BEFORE the asyncStream closure spawns the
         // body Task — closes the cancel-arrives-too-early race. (T1.4/T1.5 fix)
         let cancelHandle = CancellableTaskHandle()
+        let requestRegistration: InflightRequestRegistry.Registration?
         if !streamReqId.isEmpty {
-            await inflightRegistry.register(id: streamReqId, cancel: { cancelHandle.cancel() })
+            requestRegistration = await inflightRegistry.register(
+                id: streamReqId,
+                cancel: { cancelHandle.cancel() }
+            )
+        } else {
+            requestRegistration = nil
         }
 
         httpResponse.body = .init(asyncStream: { writer in
@@ -567,7 +573,10 @@ struct ChatCompletionsController: RouteCollection {
             cancelHandle.assign(bodyTask)
             _ = await bodyTask.value
             if !streamReqId.isEmpty {
-                await inflightRegistry.release(id: streamReqId)
+                await inflightRegistry.release(
+                    id: streamReqId,
+                    registration: requestRegistration
+                )
             }
         })
 

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -11,6 +11,13 @@ struct FinalizedAssistantTurn {
     let toolCalls: [ResponseToolCall]?
 }
 
+/// Swift 6 does not infer Sendable conformance for the transport tuple used by
+/// AFMChatServing, even though every stored component is immutable and
+/// Sendable. Keep that compatibility tuple local to this explicit task box.
+private struct CancellableGenerationResult: @unchecked Sendable {
+    let value: AFMChatGenerationResult
+}
+
 /// Prevents API stop sequences from reaching an SSE client, including when a
 /// delimiter is split across provider chunks. The provider may report that it
 /// stopped only after yielding the token that completed the delimiter, so the
@@ -164,14 +171,82 @@ struct MLXChatCompletionsController: RouteCollection {
 
     private static let debugPipeline = ProcessInfo.processInfo.environment["AFM_DEBUG"] == "1"
 
+    static func containsDeclaredMedia(_ messages: [Message]) -> Bool {
+        messages.contains { message in
+            guard let content = message.content, case .parts(let parts) = content else {
+                return false
+            }
+            return parts.contains { part in
+                part.type == "image_url" || part.type == "input_audio"
+            }
+        }
+    }
+
+    static func redactedRequestJSON(_ request: ChatCompletionRequest) -> String {
+        guard
+            let encoded = try? JSONEncoder().encode(request),
+            var object = try? JSONSerialization.jsonObject(with: encoded) as? [String: Any],
+            var messages = object["messages"] as? [[String: Any]]
+        else {
+            return "<request unavailable>"
+        }
+
+        for messageIndex in messages.indices {
+            guard var parts = messages[messageIndex]["content"] as? [[String: Any]] else {
+                continue
+            }
+            for partIndex in parts.indices {
+                switch parts[partIndex]["type"] as? String {
+                case "image_url":
+                    if var imageURL = parts[partIndex]["image_url"] as? [String: Any] {
+                        imageURL["url"] = "<redacted-media-reference>"
+                        parts[partIndex]["image_url"] = imageURL
+                    }
+                case "input_audio":
+                    if var inputAudio = parts[partIndex]["input_audio"] as? [String: Any] {
+                        inputAudio["data"] = "<redacted-audio-data>"
+                        parts[partIndex]["input_audio"] = inputAudio
+                    }
+                default:
+                    break
+                }
+            }
+            messages[messageIndex]["content"] = parts
+        }
+        object["messages"] = messages
+
+        guard
+            let redacted = try? JSONSerialization.data(
+                withJSONObject: object,
+                options: [.prettyPrinted, .sortedKeys]
+            ),
+            let json = String(data: redacted, encoding: .utf8)
+        else {
+            return "<request unavailable>"
+        }
+        return json
+    }
+
     func chatCompletions(req: Request) async throws -> Response {
         // RequestIDMiddleware sets this; controller piggybacks for log correlation. (T1.1)
         let reqId = req.afmRequestID
+        let inflightRegistry = req.application.inflightRegistry
+        let cancelHandle = CancellableTaskHandle()
+        let requestRegistration: InflightRequestRegistry.Registration?
+        if !reqId.isEmpty {
+            requestRegistration = await inflightRegistry.register(
+                id: reqId,
+                cancel: { cancelHandle.cancel() }
+            )
+        } else {
+            requestRegistration = nil
+        }
+        var requestRegistered = requestRegistration != nil
         do {
             let httpArrival = Self.debugPipeline ? Date() : Date.distantPast
             let chatRequest = try req.content.decode(ChatCompletionRequest.self)
             if veryVerbose {
-                print("\(Self.pink)[\(Self.timestamp())] RECV MLX full request:\n\(encodeJSON(chatRequest))\(Self.reset)"); fflush(stdout)
+                print("\(Self.pink)[\(Self.timestamp())] RECV MLX full request:\n\(Self.redactedRequestJSON(chatRequest))\(Self.reset)"); fflush(stdout)
                 if let lastUser = chatRequest.messages.last(where: { $0.role == "user" }) {
                     let prompt = lastUser.textContent
                     let truncated = prompt.count > 500 ? String(prompt.prefix(500)) + "..." : prompt
@@ -238,10 +313,52 @@ struct MLXChatCompletionsController: RouteCollection {
 
             let tJsonParse = Self.debugPipeline ? Date() : Date.distantPast
 
-            // Reserve a concurrent slot — waits up to 4 minutes for a slot to free up.
-            // RotatingKVCache models (Gemma 4) fall back to serial execution, so
-            // queued requests can wait a long time when all slots are occupied.
-            guard await service.waitForSlot(timeout: Self.slotQueueTimeout) else {
+            let containsMedia = Self.containsDeclaredMedia(chatRequest.messages)
+            let mediaServing = containsMedia
+                ? service as? any AFMMLXMediaRequestServing
+                : nil
+            if containsMedia {
+                guard let mediaServing else {
+                    throw MLXServiceError.unsupportedMediaInput(
+                        model: modelID,
+                        kind: "media"
+                    )
+                }
+                try mediaServing.validateMediaRequestCapabilities(
+                    model: modelID,
+                    messages: chatRequest.messages
+                )
+            }
+
+            let admissionTask = Task<(reserved: Bool, media: AFMMLXResolvedMediaRequest?), Error> {
+                guard await service.waitForSlot(timeout: Self.slotQueueTimeout) else {
+                    try Task.checkCancellation()
+                    return (false, nil)
+                }
+                do {
+                    let preflighted = try await mediaServing?.preflightMediaRequest(
+                        model: modelID,
+                        messages: chatRequest.messages
+                    )
+                    try Task.checkCancellation()
+                    return (true, preflighted)
+                } catch {
+                    service.releaseSlot()
+                    throw error
+                }
+            }
+            cancelHandle.assign(admissionTask)
+            let admission = try await withTaskCancellationHandler {
+                try await admissionTask.value
+            } onCancel: {
+                cancelHandle.cancel()
+            }
+
+            guard admission.reserved else {
+                if requestRegistered {
+                    await inflightRegistry.release(id: reqId, registration: requestRegistration)
+                    requestRegistered = false
+                }
                 let peer = req.peerAddress?.description ?? "unknown"
                 let ua = req.headers.first(name: .userAgent) ?? "unknown"
                 req.logger.warning("Connection refused: at capacity after \(Int(Self.slotQueueTimeout))s wait (\(service.maxConcurrent)/\(service.maxConcurrent)) — client=\(peer) ua=\(ua)")
@@ -255,6 +372,7 @@ struct MLXChatCompletionsController: RouteCollection {
                 ))
                 return response
             }
+            let preflightedMedia = admission.media
 
             // Reset peak memory before each request so usage.peak_memory_gib
             // reflects this request only (matches mlx_lm's mx.reset_peak_memory())
@@ -264,7 +382,17 @@ struct MLXChatCompletionsController: RouteCollection {
             let extractThinking = !rawOutput || isWebUI
 
             if chatRequest.stream == true && streamingEnabled {
-                return try await createStreamingResponse(req: req, chatRequest: chatRequest, extractThinking: extractThinking, effectiveResponseFormat: effectiveResponseFormat, grammarDowngraded: grammarDowngraded, requestId: reqId)
+                return try await createStreamingResponse(
+                    req: req,
+                    chatRequest: chatRequest,
+                    preflightedMedia: preflightedMedia,
+                    cancelHandle: cancelHandle,
+                    extractThinking: extractThinking,
+                    effectiveResponseFormat: effectiveResponseFormat,
+                    grammarDowngraded: grammarDowngraded,
+                    requestId: reqId,
+                    requestRegistration: requestRegistration
+                )
             }
 
             // The controller owns the reservation until generation either uses
@@ -292,7 +420,6 @@ struct MLXChatCompletionsController: RouteCollection {
             let effectivePresencePenalty = chatRequest.presencePenalty ?? presencePenalty
             let effectiveSeed = chatRequest.seed ?? seed
             let effectiveStop = mergeStopSequences(cliStop: stop, apiStop: chatRequest.stop)
-            let started = Date()
             if veryVerbose {
                 let promptChars = chatRequest.messages.map { $0.textContent.count }.reduce(0, +)
                 let stopDesc = effectiveStop.map { $0.map { $0.debugDescription }.joined(separator: ", ") }
@@ -310,30 +437,45 @@ struct MLXChatCompletionsController: RouteCollection {
 
             let result: AFMChatGenerationResult
             if service.maxConcurrent >= 2 {
-                // Batch mode: route through scheduler for batched decode
-                let streamResult: AFMChatStreamingResult = try await service.generateStreaming(
-                    model: modelID,
-                    messages: chatRequest.messages,
-                    temperature: effectiveTemp,
-                    maxTokens: effectiveMaxTokens,
-                    topP: effectiveTopP,
-                    repetitionPenalty: effectiveRepetitionPenalty,
-                    topK: effectiveTopK,
-                    minP: effectiveMinP,
-                    presencePenalty: effectivePresencePenalty,
-                    seed: effectiveSeed,
-                    logprobs: chatRequest.logprobs,
-                    topLogprobs: chatRequest.topLogprobs,
-                    tools: effectiveTools,
-                    toolChoice: chatRequest.toolChoice,
-                    parallelToolCalls: chatRequest.parallelToolCalls,
-                    stop: effectiveStop,
-                    responseFormat: effectiveResponseFormat,
-                    chatTemplateKwargs: chatRequest.effectiveChatTemplateKwargs,
-                    preserveStructuralTags: !extractThinking,
-                    requestId: reqId
-                )
+                // Keep batch generation and stream collection under the same
+                // cancellable task so the registry owns GPU work, not merely
+                // the already-completed admission phase.
                 reservationTransferredToStream = true
+                let generationTask = Task<CancellableGenerationResult, Error> {
+                    var streamOwnsReservation = false
+                    defer {
+                        if !streamOwnsReservation {
+                            service.releaseSlot()
+                        }
+                    }
+                    let streamResult: AFMChatStreamingResult = try await withPreflightedMedia(
+                        preflightedMedia,
+                        messages: chatRequest.messages
+                    ) { trustedMessages in
+                        try await service.generateStreaming(
+                        model: modelID,
+                        messages: trustedMessages,
+                        temperature: effectiveTemp,
+                        maxTokens: effectiveMaxTokens,
+                        topP: effectiveTopP,
+                        repetitionPenalty: effectiveRepetitionPenalty,
+                        topK: effectiveTopK,
+                        minP: effectiveMinP,
+                        presencePenalty: effectivePresencePenalty,
+                        seed: effectiveSeed,
+                        logprobs: chatRequest.logprobs,
+                        topLogprobs: chatRequest.topLogprobs,
+                        tools: effectiveTools,
+                        toolChoice: chatRequest.toolChoice,
+                        parallelToolCalls: chatRequest.parallelToolCalls,
+                        stop: effectiveStop,
+                        responseFormat: effectiveResponseFormat,
+                        chatTemplateKwargs: chatRequest.effectiveChatTemplateKwargs,
+                        preserveStructuralTags: !extractThinking,
+                        requestId: reqId
+                        )
+                    }
+                    streamOwnsReservation = true
 
                 // Collect stream into complete response
                 var fullText = ""
@@ -377,40 +519,62 @@ struct MLXChatCompletionsController: RouteCollection {
 
                 // AFMKit owns model-specific parsing. The HTTP layer only serializes
                 // the typed tool calls emitted by the provider.
-                result = (
-                    modelID: streamResult.modelID,
-                    content: fullText,
-                    promptTokens: promptTokens,
-                    completionTokens: completionTokens,
-                    tokenLogprobs: allLogprobs.isEmpty ? nil : allLogprobs,
-                    toolCalls: finalToolCalls,
-                    cachedTokens: cachedTokens,
-                    promptTime: promptTime,
-                    generateTime: generateTime,
-                    stoppedBySequence: stoppedBySequence
-                )
+                    return CancellableGenerationResult(
+                        value: (
+                            modelID: streamResult.modelID,
+                            content: fullText,
+                            promptTokens: promptTokens,
+                            completionTokens: completionTokens,
+                            tokenLogprobs: allLogprobs.isEmpty ? nil : allLogprobs,
+                            toolCalls: finalToolCalls,
+                            cachedTokens: cachedTokens,
+                            promptTime: promptTime,
+                            generateTime: generateTime,
+                            stoppedBySequence: stoppedBySequence
+                        )
+                    )
+                }
+                cancelHandle.assign(generationTask)
+                result = try await withTaskCancellationHandler {
+                    try await generationTask.value.value
+                } onCancel: {
+                    cancelHandle.cancel()
+                }
             } else {
                 // Serial mode: use existing generate() path
-                result = try await service.generate(
-                    model: modelID,
-                    messages: chatRequest.messages,
-                    temperature: effectiveTemp,
-                    maxTokens: effectiveMaxTokens,
-                    topP: effectiveTopP,
-                    repetitionPenalty: effectiveRepetitionPenalty,
-                    topK: effectiveTopK,
-                    minP: effectiveMinP,
-                    presencePenalty: effectivePresencePenalty,
-                    seed: effectiveSeed,
-                    logprobs: chatRequest.logprobs,
-                    topLogprobs: chatRequest.topLogprobs,
-                    tools: effectiveTools,
-                    toolChoice: chatRequest.toolChoice,
-                    parallelToolCalls: chatRequest.parallelToolCalls,
-                    stop: effectiveStop,
-                    responseFormat: effectiveResponseFormat,
-                    chatTemplateKwargs: chatRequest.effectiveChatTemplateKwargs
-                )
+                let generationTask = Task<AFMChatGenerationResult, Error> {
+                    try await withPreflightedMedia(
+                        preflightedMedia,
+                        messages: chatRequest.messages
+                    ) { trustedMessages in
+                        try await service.generate(
+                            model: modelID,
+                            messages: trustedMessages,
+                            temperature: effectiveTemp,
+                            maxTokens: effectiveMaxTokens,
+                            topP: effectiveTopP,
+                            repetitionPenalty: effectiveRepetitionPenalty,
+                            topK: effectiveTopK,
+                            minP: effectiveMinP,
+                            presencePenalty: effectivePresencePenalty,
+                            seed: effectiveSeed,
+                            logprobs: chatRequest.logprobs,
+                            topLogprobs: chatRequest.topLogprobs,
+                            tools: effectiveTools,
+                            toolChoice: chatRequest.toolChoice,
+                            parallelToolCalls: chatRequest.parallelToolCalls,
+                            stop: effectiveStop,
+                            responseFormat: effectiveResponseFormat,
+                            chatTemplateKwargs: chatRequest.effectiveChatTemplateKwargs
+                        )
+                    }
+                }
+                cancelHandle.assign(generationTask)
+                result = try await withTaskCancellationHandler {
+                    try await generationTask.value
+                } onCancel: {
+                    cancelHandle.cancel()
+                }
             }
             let completionTok = result.completionTokens
             let promptTime = result.promptTime
@@ -443,7 +607,6 @@ struct MLXChatCompletionsController: RouteCollection {
             // If we got tool calls, return a tool_calls response
             if let toolCalls = finalizedTurn.toolCalls, !toolCalls.isEmpty {
                 if veryVerbose {
-                    let toolNames = toolCalls.map { $0.function.name }.joined(separator: ", ")
                     print("\(Self.orange)[\(Self.timestamp())] MLX done: stream=false\n  prompt_tokens=\(result.promptTokens) completion_tokens=\(completionTok)\n  prompt=\(String(format: "%.2f", promptTime))s gen=\(String(format: "%.2f", generateTime))s tok/s=\(String(format: "%.1f", tokPerSec))\n  finish_reason=tool_calls\(Self.reset)"); fflush(stdout)
                     for tc in toolCalls {
                         print("\(Self.gold)[\(Self.timestamp())] SEND tool_call: \(tc.function.name)\n  id=\(tc.id)\n  args=\(tc.function.arguments)\(Self.reset)")
@@ -487,6 +650,10 @@ struct MLXChatCompletionsController: RouteCollection {
                     }
                     fflush(stdout)
                 }
+                if requestRegistered {
+                    await inflightRegistry.release(id: reqId, registration: requestRegistration)
+                    requestRegistered = false
+                }
                 return try await createSuccessResponse(req: req, response: response, grammarDowngraded: grammarDowngraded)
             }
 
@@ -524,8 +691,41 @@ struct MLXChatCompletionsController: RouteCollection {
             if veryVerbose {
                 print("\(Self.teal)[\(Self.timestamp())] SEND full response:\n\(encodeJSON(response))\(Self.reset)"); fflush(stdout)
             }
+            if requestRegistered {
+                await inflightRegistry.release(id: reqId, registration: requestRegistration)
+                requestRegistered = false
+            }
             return try await createSuccessResponse(req: req, response: response, grammarDowngraded: grammarDowngraded)
+        } catch let serviceError as MLXServiceError {
+            if requestRegistered {
+                await inflightRegistry.release(id: reqId, registration: requestRegistration)
+            }
+            let code: String
+            switch serviceError {
+            case .visionAssetsUnavailable:
+                code = "vision_assets_unavailable"
+            case .unsupportedMediaInput:
+                code = "unsupported_media_input"
+            case .invalidMediaInput:
+                code = "invalid_media_input"
+            default:
+                code = "mlx_error"
+            }
+            req.logger.error("[\(Self.timestamp())] MLX request error: \(serviceError.localizedDescription)")
+            return try await createErrorResponse(
+                req: req,
+                error: OpenAIError(
+                    message: serviceError.localizedDescription,
+                    type: code == "mlx_error" ? "mlx_error" : "invalid_request_error",
+                    code: code,
+                    requestId: reqId.isEmpty ? nil : reqId
+                ),
+                status: .badRequest
+            )
         } catch let abort as Abort {
+            if requestRegistered {
+                await inflightRegistry.release(id: reqId, registration: requestRegistration)
+            }
             req.logger.error("[\(Self.timestamp())] MLX completions error: \(abort)")
             return try await createErrorResponse(
                 req: req,
@@ -536,12 +736,42 @@ struct MLXChatCompletionsController: RouteCollection {
                 status: abort.status
             )
         } catch {
+            if requestRegistered {
+                await inflightRegistry.release(id: reqId, registration: requestRegistration)
+            }
             req.logger.error("[\(Self.timestamp())] MLX completions error: \(error)")
             return try await createErrorResponse(req: req, error: OpenAIError(message: error.localizedDescription, type: "mlx_error"), status: .badRequest)
         }
     }
 
-    private func createStreamingResponse(req: Request, chatRequest: ChatCompletionRequest, extractThinking: Bool, effectiveResponseFormat: ResponseFormat?, grammarDowngraded: Bool = false, requestId: String = "") async throws -> Response {
+    private func withPreflightedMedia<Result: Sendable>(
+        _ request: AFMMLXResolvedMediaRequest?,
+        messages: [Message],
+        operation: ([Message]) async throws -> Result
+    ) async throws -> Result {
+        guard let request else {
+            return try await operation(messages)
+        }
+        guard let mediaServing = service as? any AFMMLXMediaRequestServing else {
+            throw MLXServiceError.unsupportedMediaInput(model: modelID, kind: "media")
+        }
+        return try await mediaServing.withPreflightedMediaRequest(
+            request,
+            operation: operation
+        )
+    }
+
+    private func createStreamingResponse(
+        req: Request,
+        chatRequest: ChatCompletionRequest,
+        preflightedMedia: AFMMLXResolvedMediaRequest?,
+        cancelHandle: CancellableTaskHandle,
+        extractThinking: Bool,
+        effectiveResponseFormat: ResponseFormat?,
+        grammarDowngraded: Bool = false,
+        requestId: String = "",
+        requestRegistration: InflightRequestRegistry.Registration? = nil
+    ) async throws -> Response {
         let httpResponse = Response(status: .ok)
         httpResponse.headers.add(name: .contentType, value: "text/event-stream")
         httpResponse.headers.add(name: .cacheControl, value: "no-cache")
@@ -568,10 +798,6 @@ struct MLXChatCompletionsController: RouteCollection {
         // Register the cancel hook BEFORE the asyncStream closure spawns the
         // body Task. Eliminates the race where a cancel arrives between the
         // Response being returned and the closure firing. (T1.4/T1.5 fix)
-        let cancelHandle = CancellableTaskHandle()
-        if !streamReqId.isEmpty {
-            await inflightRegistry.register(id: streamReqId, cancel: { cancelHandle.cancel() })
-        }
         httpResponse.body = .init(asyncStream: { writer in
             // T1.4/T1.5: Wrap the streaming body in an explicit Task so we can
             // cancel it from outside (cancel endpoint, client disconnect detection).
@@ -626,28 +852,33 @@ struct MLXChatCompletionsController: RouteCollection {
                         "\(Self.orange)[\(Self.timestamp())] MLX start: stream=true\n  prompt_chars=\(promptChars) max_tokens=\(effectiveMaxTokens)\n  temperature=\(effectiveTemp?.description ?? "default") top_p=\(effectiveTopP?.description ?? "default") rep_penalty=\(effectiveRepetitionPenalty?.description ?? "none")\n  top_k=\(effectiveTopK?.description ?? "none") min_p=\(effectiveMinP?.description ?? "none") presence_penalty=\(effectivePresencePenalty?.description ?? "none")\n  seed=\(effectiveSeed?.description ?? "none") stop=\(stopDesc ?? "none")\(Self.reset)"
                     ); fflush(stdout)
                 }
-                let res = try await service.generateStreaming(
-                    model: modelID,
-                    messages: chatRequest.messages,
-                    temperature: effectiveTemp,
-                    maxTokens: effectiveMaxTokens,
-                    topP: effectiveTopP,
-                    repetitionPenalty: effectiveRepetitionPenalty,
-                    topK: effectiveTopK,
-                    minP: effectiveMinP,
-                    presencePenalty: effectivePresencePenalty,
-                    seed: effectiveSeed,
-                    logprobs: chatRequest.logprobs,
-                    topLogprobs: chatRequest.topLogprobs,
-                    tools: effectiveTools,
-                    toolChoice: chatRequest.toolChoice,
-                    parallelToolCalls: chatRequest.parallelToolCalls,
-                    stop: effectiveStop,
-                    responseFormat: effectiveResponseFormat,
-                    chatTemplateKwargs: chatRequest.effectiveChatTemplateKwargs,
-                    preserveStructuralTags: !extractThinking,
-                    requestId: streamReqId
-                )
+                let res = try await self.withPreflightedMedia(
+                    preflightedMedia,
+                    messages: chatRequest.messages
+                ) { trustedMessages in
+                    try await service.generateStreaming(
+                        model: modelID,
+                        messages: trustedMessages,
+                        temperature: effectiveTemp,
+                        maxTokens: effectiveMaxTokens,
+                        topP: effectiveTopP,
+                        repetitionPenalty: effectiveRepetitionPenalty,
+                        topK: effectiveTopK,
+                        minP: effectiveMinP,
+                        presencePenalty: effectivePresencePenalty,
+                        seed: effectiveSeed,
+                        logprobs: chatRequest.logprobs,
+                        topLogprobs: chatRequest.topLogprobs,
+                        tools: effectiveTools,
+                        toolChoice: chatRequest.toolChoice,
+                        parallelToolCalls: chatRequest.parallelToolCalls,
+                        stop: effectiveStop,
+                        responseFormat: effectiveResponseFormat,
+                        chatTemplateKwargs: chatRequest.effectiveChatTemplateKwargs,
+                        preserveStructuralTags: !extractThinking,
+                        requestId: streamReqId
+                    )
+                }
                 reservationTransferredToStream = true
                 // Emit an initial assistant delta so clients always open a response container.
                 let initialChunk = ChatCompletionStreamResponse(
@@ -1379,13 +1610,34 @@ struct MLXChatCompletionsController: RouteCollection {
                         fflush(stdout)
                     }
                     req.logger.error("[\(Self.timestamp())] MLX stream error: \(error)")
-                    let errorChunk = ChatCompletionStreamResponse(
-                        id: streamId,
-                        model: self.modelID,
-                        content: "⚠️ **Error**\n\n\(error.localizedDescription)",
-                        isFirst: true
-                    )
-                    if let data = try? encoder.encode(errorChunk), let json = String(data: data, encoding: .utf8) {
+                    let streamError: OpenAIError
+                    if let serviceError = error as? MLXServiceError {
+                        let code: String
+                        switch serviceError {
+                        case .visionAssetsUnavailable:
+                            code = "vision_assets_unavailable"
+                        case .unsupportedMediaInput:
+                            code = "unsupported_media_input"
+                        case .invalidMediaInput:
+                            code = "invalid_media_input"
+                        default:
+                            code = "mlx_error"
+                        }
+                        streamError = OpenAIError(
+                            message: serviceError.localizedDescription,
+                            type: code == "mlx_error" ? "mlx_error" : "invalid_request_error",
+                            code: code,
+                            requestId: streamReqId.isEmpty ? nil : streamReqId
+                        )
+                    } else {
+                        streamError = OpenAIError(
+                            message: error.localizedDescription,
+                            type: "mlx_error",
+                            code: "stream_error",
+                            requestId: streamReqId.isEmpty ? nil : streamReqId
+                        )
+                    }
+                    if let data = try? encoder.encode(streamError), let json = String(data: data, encoding: .utf8) {
                         try? await writer.write(.buffer(.init(string: "data: \(json)\n\n")))
                     }
                 }
@@ -1399,7 +1651,10 @@ struct MLXChatCompletionsController: RouteCollection {
             cancelHandle.assign(bodyTask)
             _ = await bodyTask.value
             if !streamReqId.isEmpty {
-                await inflightRegistry.release(id: streamReqId)
+                await inflightRegistry.release(
+                    id: streamReqId,
+                    registration: requestRegistration
+                )
             }
         })
 

--- a/Sources/AFMServer/Models/InflightRequestRegistry.swift
+++ b/Sources/AFMServer/Models/InflightRequestRegistry.swift
@@ -15,33 +15,48 @@ import Vapor
 /// itself so callers can compose multiple cancellation effects (e.g. cancel
 /// the asyncStream task plus the underlying model generator) under one id.
 actor InflightRequestRegistry {
-    private var inflight: [String: @Sendable () -> Void] = [:]
+    typealias Registration = UUID
+
+    private var inflight: [String: [Registration: @Sendable () -> Void]] = [:]
 
     /// Number of currently-tracked requests. Useful for tests / metrics.
-    var count: Int { inflight.count }
+    var count: Int { inflight.values.reduce(0) { $0 + $1.count } }
 
-    /// Register a cancel closure for `id`. Replaces any prior registration
-    /// with the same id (e.g. when a controller re-registers after slot wait).
+    /// Register a cancel closure for `id` and return its ownership token.
+    /// Multiple requests may share a client-provided id without overwriting
+    /// each other's cancellation state.
     /// No-op for empty ids — callers that don't run behind RequestIDMiddleware
     /// won't have one.
-    func register(id: String, cancel: @escaping @Sendable () -> Void) {
-        guard !id.isEmpty else { return }
-        inflight[id] = cancel
+    @discardableResult
+    func register(
+        id: String,
+        cancel: @escaping @Sendable () -> Void
+    ) -> Registration? {
+        guard !id.isEmpty else { return nil }
+        let registration = Registration()
+        inflight[id, default: [:]][registration] = cancel
+        return registration
     }
 
     /// Remove `id` from the registry without firing the cancel closure.
     /// Called from `defer` in the request handler when work completes normally.
-    func release(id: String) {
+    func release(id: String, registration: Registration?) {
         guard !id.isEmpty else { return }
-        inflight.removeValue(forKey: id)
+        guard let registration else { return }
+        inflight[id]?.removeValue(forKey: registration)
+        if inflight[id]?.isEmpty == true {
+            inflight.removeValue(forKey: id)
+        }
     }
 
     /// Cancel `id` and return whether it was found. Removes the entry as a
     /// side effect so subsequent cancels are no-ops.
     @discardableResult
     func cancel(id: String) -> Bool {
-        guard let cancel = inflight.removeValue(forKey: id) else { return false }
-        cancel()
+        guard let cancellations = inflight.removeValue(forKey: id) else { return false }
+        for cancel in cancellations.values {
+            cancel()
+        }
         return true
     }
 }
@@ -58,16 +73,17 @@ actor InflightRequestRegistry {
 /// body Task — a cancel arriving in that window would 404 silently.
 final class CancellableTaskHandle: @unchecked Sendable {
     private let lock = NSLock()
-    private var task: Task<Void, Never>?
+    private var cancelCurrentTask: (@Sendable () -> Void)?
     private var cancelledEarly: Bool = false
 
-    /// Called from the asyncStream closure once the body Task is created.
-    func assign(_ t: Task<Void, Never>) {
+    /// Assign the current request phase. Admission, media preflight, ordinary
+    /// generation, and streaming body tasks can have different result types.
+    func assign<Success: Sendable, Failure: Error>(_ task: Task<Success, Failure>) {
         lock.lock(); defer { lock.unlock() }
         if cancelledEarly {
-            t.cancel()
+            task.cancel()
         }
-        task = t
+        cancelCurrentTask = { task.cancel() }
     }
 
     /// Called from the registry's cancel closure (typically from another HTTP
@@ -75,7 +91,7 @@ final class CancellableTaskHandle: @unchecked Sendable {
     func cancel() {
         lock.lock(); defer { lock.unlock() }
         cancelledEarly = true
-        task?.cancel()
+        cancelCurrentTask?()
     }
 }
 

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -771,6 +771,7 @@ public class Server: @unchecked Sendable {
             }
 
             if let mlxModelID = self.mlxModelID {
+                let loadedDescriptor = mlxChatService?.loadedModelDescriptor(model: mlxModelID)
                 return ModelsResponse(
                     object: "list",
                     data: [
@@ -787,7 +788,9 @@ public class Server: @unchecked Sendable {
                         ModelDetails(
                             name: mlxModelID,
                             model: mlxModelID,
-                            capabilities: ["chat", "completion", "vision"]
+                            capabilities: AFMMLXCapabilityPresentation.modelCapabilityLabels(
+                                descriptor: loadedDescriptor
+                            )
                         )
                     ] + embeddingDetails
                 )
@@ -979,6 +982,7 @@ public class Server: @unchecked Sendable {
         // Props endpoint for llama.cpp webui compatibility (per-model capabilities)
         app.get("props") { [self] req async -> PropsResponse in
             if let mlxModelID = self.mlxModelID {
+                let loadedDescriptor = mlxChatService?.loadedModelDescriptor(model: mlxModelID)
                 return PropsResponse(
                     default_generation_settings: DefaultGenerationSettings(
                         n_ctx: 8192,
@@ -995,7 +999,12 @@ public class Server: @unchecked Sendable {
                     total_slots: 1,
                     model_path: mlxModelID,
                     role: "mlx",
-                    modalities: Modalities(vision: true, audio: Self.audioAvailable),
+                    modalities: Modalities(
+                        vision: AFMMLXCapabilityPresentation.supportsVision(
+                            descriptor: loadedDescriptor
+                        ),
+                        audio: Self.audioAvailable
+                    ),
                     chat_template: "",
                     bos_token: "",
                     eos_token: "",

--- a/Sources/AFMServer/Services/AFMLocalClient.swift
+++ b/Sources/AFMServer/Services/AFMLocalClient.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AFMKit
+import AFMKitMLX
 
 final class AFMLocalClient {
     private let baseURL: URL
@@ -21,7 +22,14 @@ final class AFMLocalClient {
         } else {
             var parts = [ContentPart(type: "text", text: prompt, image_url: nil)]
             for imageURL in imageURLs {
-                parts.append(ContentPart(type: "image_url", text: nil, image_url: ImageURL(url: imageURL.absoluteString, detail: nil)))
+                parts.append(ContentPart(
+                    type: "image_url",
+                    text: nil,
+                    image_url: ImageURL(
+                        url: try AFMMLXMediaSecurityPolicy.trustedLocalMediaDataURL(imageURL),
+                        detail: nil
+                    )
+                ))
             }
             userMessage = Message(role: "user", content: .parts(parts))
         }

--- a/Sources/AFMServer/Services/TelegramBridge.swift
+++ b/Sources/AFMServer/Services/TelegramBridge.swift
@@ -1,4 +1,5 @@
 import AFMKit
+import AFMKitMLX
 import CryptoKit
 import Foundation
 
@@ -668,7 +669,14 @@ final class TelegramBridge: @unchecked Sendable {
             } else {
                 var parts = [ContentPart(type: "text", text: effectivePrompt, image_url: nil)]
                 for imageURL in imageURLs {
-                    parts.append(ContentPart(type: "image_url", text: nil, image_url: ImageURL(url: imageURL.absoluteString, detail: nil)))
+                    parts.append(ContentPart(
+                        type: "image_url",
+                        text: nil,
+                        image_url: ImageURL(
+                            url: try AFMMLXMediaSecurityPolicy.trustedLocalMediaDataURL(imageURL),
+                            detail: nil
+                        )
+                    ))
                 }
                 currentUserMessage = Message(role: "user", content: .parts(parts))
             }

--- a/Tests/MacLocalAPITests/InflightCancelTests.swift
+++ b/Tests/MacLocalAPITests/InflightCancelTests.swift
@@ -35,8 +35,8 @@ struct InflightCancelTests {
         let registry = InflightRequestRegistry()
         let fired = TestFlag()
 
-        await registry.register(id: "req_xyz", cancel: { fired.set() })
-        await registry.release(id: "req_xyz")
+        let registration = await registry.register(id: "req_xyz", cancel: { fired.set() })
+        await registry.release(id: "req_xyz", registration: registration)
 
         #expect(fired.value == false)
         let cancelled = await registry.cancel(id: "req_xyz")
@@ -50,16 +50,37 @@ struct InflightCancelTests {
         #expect(cancelled == false)
     }
 
-    @Test("re-registering same id replaces prior cancel closure")
-    func reregisterReplaces() async {
+    @Test("duplicate ids retain both cancellation owners")
+    func duplicateIDsRetainBothOwners() async {
         let registry = InflightRequestRegistry()
         let firedOld = TestFlag()
         let firedNew = TestFlag()
 
-        await registry.register(id: "req_dup", cancel: { firedOld.set() })
-        await registry.register(id: "req_dup", cancel: { firedNew.set() })
+        let oldRegistration = await registry.register(id: "req_dup", cancel: { firedOld.set() })
+        let newRegistration = await registry.register(id: "req_dup", cancel: { firedNew.set() })
+
+        #expect(oldRegistration != nil)
+        #expect(newRegistration != nil)
+        #expect(oldRegistration != newRegistration)
+        #expect(await registry.count == 2)
 
         _ = await registry.cancel(id: "req_dup")
+        #expect(firedOld.value == true)
+        #expect(firedNew.value == true)
+    }
+
+    @Test("one duplicate owner cannot release another")
+    func duplicateReleaseIsOwnershipScoped() async {
+        let registry = InflightRequestRegistry()
+        let firedOld = TestFlag()
+        let firedNew = TestFlag()
+
+        let oldRegistration = await registry.register(id: "req_shared", cancel: { firedOld.set() })
+        _ = await registry.register(id: "req_shared", cancel: { firedNew.set() })
+        await registry.release(id: "req_shared", registration: oldRegistration)
+
+        #expect(await registry.count == 1)
+        #expect(await registry.cancel(id: "req_shared"))
         #expect(firedOld.value == false)
         #expect(firedNew.value == true)
     }
@@ -71,7 +92,7 @@ struct InflightCancelTests {
         await registry.register(id: "", cancel: { fired.set() })
         let count = await registry.count
         #expect(count == 0)
-        await registry.release(id: "")
+        await registry.release(id: "", registration: nil)
         let cancelled = await registry.cancel(id: "")
         #expect(cancelled == false)
         #expect(fired.value == false)

--- a/Tests/MacLocalAPITests/MLXCapabilityPresentationTests.swift
+++ b/Tests/MacLocalAPITests/MLXCapabilityPresentationTests.swift
@@ -1,0 +1,102 @@
+import AFMKitCore
+import AFMOpenAICompat
+@testable import AFMServer
+import XCTest
+
+final class MLXCapabilityPresentationTests: XCTestCase {
+    func testLoadedDescriptorPublishesOnlyProvenCapabilities() {
+        let descriptor = AFMModelDescriptor(
+            providerID: "mlx",
+            modelID: "qualified-model",
+            displayName: "qualified-model",
+            capabilities: [
+                .text,
+                .vision,
+                .reasoning,
+                .toolCalling,
+                .structuredOutput,
+                .streaming,
+                .prefixCaching,
+                .speculativeDecoding,
+            ],
+            privacyBoundary: .device
+        )
+
+        XCTAssertTrue(AFMMLXCapabilityPresentation.supportsVision(descriptor: descriptor))
+        XCTAssertEqual(
+            Set(AFMMLXCapabilityPresentation.modelCapabilityLabels(descriptor: descriptor)),
+            [
+                "chat",
+                "completion",
+                "vision",
+                "reasoning",
+                "tools",
+                "structured",
+                "streaming",
+                "prefix_cache",
+                "speculative_decoding",
+            ]
+        )
+    }
+
+    func testMissingDescriptorFailsClosedForOptionalCapabilities() {
+        XCTAssertFalse(AFMMLXCapabilityPresentation.supportsVision(descriptor: nil))
+        XCTAssertEqual(
+            AFMMLXCapabilityPresentation.modelCapabilityLabels(descriptor: nil),
+            ["chat", "completion"]
+        )
+    }
+
+    func testTextDescriptorDoesNotInventVisionOrSpeculation() {
+        let descriptor = AFMModelDescriptor(
+            providerID: "mlx",
+            modelID: "text-model",
+            displayName: "text-model",
+            capabilities: [.text, .streaming],
+            privacyBoundary: .device
+        )
+
+        XCTAssertFalse(AFMMLXCapabilityPresentation.supportsVision(descriptor: descriptor))
+        XCTAssertEqual(
+            Set(AFMMLXCapabilityPresentation.modelCapabilityLabels(descriptor: descriptor)),
+            ["chat", "completion", "streaming"]
+        )
+    }
+
+    func testDeclaredMediaDetectionDoesNotRequirePayloadField() {
+        let messages = [
+            Message(
+                role: "user",
+                content: .parts([ContentPart(type: "image_url")])
+            )
+        ]
+
+        XCTAssertTrue(MLXChatCompletionsController.containsDeclaredMedia(messages))
+    }
+
+    func testVerboseRequestRenderingRedactsMediaSecrets() throws {
+        let json = #"""
+        {
+          "model": "test-model",
+          "messages": [{
+            "role": "user",
+            "content": [
+              {"type":"image_url","image_url":{"url":"https://example.com/a.png?token=signed-secret"}},
+              {"type":"input_audio","input_audio":{"data":"private-base64-audio","format":"wav"}}
+            ]
+          }]
+        }
+        """#
+        let request = try JSONDecoder().decode(
+            ChatCompletionRequest.self,
+            from: Data(json.utf8)
+        )
+
+        let rendered = MLXChatCompletionsController.redactedRequestJSON(request)
+
+        XCTAssertFalse(rendered.contains("signed-secret"))
+        XCTAssertFalse(rendered.contains("private-base64-audio"))
+        XCTAssertTrue(rendered.contains("<redacted-media-reference>"))
+        XCTAssertTrue(rendered.contains("<redacted-audio-data>"))
+    }
+}

--- a/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
+++ b/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
@@ -3,6 +3,7 @@ import Vapor
 import XCTVapor
 
 @testable import AFMKit
+import AFMKitMLX
 @testable import AFMServer
 
 final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
@@ -1021,6 +1022,298 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
         }
     }
 
+    func testDeclaredMediaWithoutMediaCapabilityReturnsTypedError() async throws {
+        let service = FakeMLXChatService(
+            mediaValidationError: .unsupportedMediaInput(model: "test-model", kind: "image"),
+            streamingResult: makeStreamingResult(chunks: [])
+        )
+        try MLXChatCompletionsController(
+            modelID: "test-model", service: service, temperature: nil, repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let body = mediaRequestBody(stream: false, imageURLJSON: #"{"url":"data:image/png;base64,AA=="}"#)
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/chat/completions", headers: requestHeaders(for: body), body: body
+        ) { res async in
+            XCTAssertEqual(res.status, .badRequest)
+            XCTAssertContains(res.body.string, #""code":"unsupported_media_input""#)
+            XCTAssertContains(res.body.string, #""type":"invalid_request_error""#)
+            XCTAssertEqual(service.mediaPreflightCount, 0)
+        }
+    }
+
+    func testMalformedDeclaredMediaReturnsTypedErrorBeforePreflight() async throws {
+        let service = FakeMLXChatService(streamingResult: makeStreamingResult(chunks: []))
+        try MLXChatCompletionsController(
+            modelID: "test-model", service: service, temperature: nil, repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let body = mediaRequestBody(stream: false, imageURLJSON: "null")
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/chat/completions", headers: requestHeaders(for: body), body: body
+        ) { res async in
+            XCTAssertEqual(res.status, .badRequest)
+            XCTAssertContains(res.body.string, #""code":"invalid_media_input""#)
+            XCTAssertEqual(service.mediaPreflightCount, 0)
+        }
+    }
+
+    func testMediaRequestPreflightsExactlyOnceAndUsesResolvedMessages() async throws {
+        let service = FakeMLXChatService(streamingResult: makeStreamingResult(chunks: []))
+        try MLXChatCompletionsController(
+            modelID: "test-model", service: service, temperature: nil, repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLJ4QAAAABJRU5ErkJggg=="
+        let body = mediaRequestBody(
+            stream: false,
+            imageURLJSON: #"{"url":"data:image/png;base64,\#(png)"}"#
+        )
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/chat/completions", headers: requestHeaders(for: body), body: body
+        ) { res async in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(service.mediaPreflightCount, 1)
+            XCTAssertEqual(service.withPreflightedMediaCount, 1)
+            XCTAssertEqual(service.recordedGenerateMediaPartCounts, [1])
+        }
+    }
+
+    func testMediaPreflightFailureReleasesReservedSlot() async throws {
+        let service = FakeMLXChatService(
+            mediaPreflightError: .invalidMediaInput("preflight rejected"),
+            streamingResult: makeStreamingResult(chunks: [])
+        )
+        try MLXChatCompletionsController(
+            modelID: "test-model", service: service, temperature: nil, repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLJ4QAAAABJRU5ErkJggg=="
+        let body = mediaRequestBody(
+            stream: false,
+            imageURLJSON: #"{"url":"data:image/png;base64,\#(png)"}"#
+        )
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/chat/completions", headers: requestHeaders(for: body), body: body
+        ) { res async in
+            XCTAssertEqual(res.status, .badRequest)
+            XCTAssertContains(res.body.string, #""code":"invalid_media_input""#)
+            XCTAssertEqual(service.mediaPreflightCount, 1)
+            XCTAssertEqual(service.releaseSlotCount, 1)
+        }
+    }
+
+    func testCancellationDuringMediaPreflightReleasesSlotAndRegistry() async throws {
+        let probe = CancellationProbe()
+        let service = FakeMLXChatService(
+            mediaPreflightProbe: probe,
+            streamingResult: makeStreamingResult(chunks: [])
+        )
+        app.middleware.use(RequestIDMiddleware())
+        try CancelController().boot(routes: app)
+        try MLXChatCompletionsController(
+            modelID: "test-model", service: service, temperature: nil, repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let requestID = "req_cancel_preflight"
+        let png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLJ4QAAAABJRU5ErkJggg=="
+        let body = mediaRequestBody(
+            stream: false,
+            imageURLJSON: #"{"url":"data:image/png;base64,\#(png)"}"#
+        )
+        let headers = requestHeaders(for: body, requestID: requestID)
+        let tester = try app.testable()
+        async let completion = tester.sendRequest(
+            .POST, "/v1/chat/completions", headers: headers, body: body
+        )
+
+        let registry = app.inflightRegistry
+        let didStart = await probe.waitUntilStarted()
+        XCTAssertTrue(didStart)
+        let registeredCount = await registry.count
+        XCTAssertEqual(registeredCount, 1)
+        let didCancel = await registry.cancel(id: requestID)
+        XCTAssertTrue(didCancel)
+        _ = try? await completion
+
+        let providerObservedCancellation = await probe.waitUntilCancelled()
+        XCTAssertTrue(providerObservedCancellation)
+        let released = await waitUntil { service.releaseSlotCount == 1 }
+        XCTAssertTrue(released)
+        XCTAssertEqual(service.releaseSlotCount, 1)
+        let registryCleaned = await waitUntil { await registry.count == 0 }
+        XCTAssertTrue(registryCleaned)
+    }
+
+    func testCancellationDuringSerialGenerationReleasesSlotAndRegistry() async throws {
+        let probe = CancellationProbe()
+        let service = FakeMLXChatService(
+            maxConcurrent: 1,
+            generateProbe: probe,
+            streamingResult: makeStreamingResult(chunks: [])
+        )
+        app.middleware.use(RequestIDMiddleware())
+        try CancelController().boot(routes: app)
+        try MLXChatCompletionsController(
+            modelID: "test-model", service: service, temperature: nil, repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let requestID = "req_cancel_serial"
+        let body = try requestBody(stream: false)
+        let headers = requestHeaders(for: body, requestID: requestID)
+        let tester = try app.testable()
+        async let completion = tester.sendRequest(
+            .POST, "/v1/chat/completions", headers: headers, body: body
+        )
+
+        let registry = app.inflightRegistry
+        let didStart = await probe.waitUntilStarted()
+        XCTAssertTrue(didStart)
+        let registeredCount = await registry.count
+        XCTAssertEqual(registeredCount, 1)
+        let didCancel = await registry.cancel(id: requestID)
+        XCTAssertTrue(didCancel)
+        _ = try? await completion
+
+        let providerObservedCancellation = await probe.waitUntilCancelled()
+        XCTAssertTrue(providerObservedCancellation)
+        let released = await waitUntil { service.releaseSlotCount == 1 }
+        XCTAssertTrue(released)
+        XCTAssertEqual(service.releaseSlotCount, 1)
+        let registryCleaned = await waitUntil { await registry.count == 0 }
+        XCTAssertTrue(registryCleaned)
+    }
+
+    func testCancellationDuringConcurrentCollectionReleasesSlotAndRegistry() async throws {
+        let probe = CancellationProbe()
+        let service = FakeMLXChatService(
+            maxConcurrent: 2,
+            streamCollectionProbe: probe,
+            streamingResult: makeStreamingResult(chunks: [])
+        )
+        app.middleware.use(RequestIDMiddleware())
+        try CancelController().boot(routes: app)
+        try MLXChatCompletionsController(
+            modelID: "test-model", service: service, temperature: nil, repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let requestID = "req_cancel_concurrent"
+        let body = try requestBody(stream: false)
+        let headers = requestHeaders(for: body, requestID: requestID)
+        let tester = try app.testable()
+        async let completion = tester.sendRequest(
+            .POST, "/v1/chat/completions", headers: headers, body: body
+        )
+
+        let registry = app.inflightRegistry
+        let didStart = await probe.waitUntilStarted()
+        XCTAssertTrue(didStart)
+        let registeredCount = await registry.count
+        XCTAssertEqual(registeredCount, 1)
+        let didCancel = await registry.cancel(id: requestID)
+        XCTAssertTrue(didCancel)
+        _ = try? await completion
+
+        let providerObservedCancellation = await probe.waitUntilCancelled()
+        XCTAssertTrue(providerObservedCancellation)
+        let released = await waitUntil { service.releaseSlotCount == 1 }
+        XCTAssertTrue(released)
+        XCTAssertEqual(service.releaseSlotCount, 1)
+        let registryCleaned = await waitUntil { await registry.count == 0 }
+        XCTAssertTrue(registryCleaned)
+    }
+
+    func testStreamingMediaPreflightFailureOccursBeforeSSEHeaders() async throws {
+        let service = FakeMLXChatService(
+            mediaPreflightError: .invalidMediaInput("preflight rejected"),
+            streamingResult: makeStreamingResult(chunks: [])
+        )
+        try MLXChatCompletionsController(
+            modelID: "test-model", service: service, temperature: nil, repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLJ4QAAAABJRU5ErkJggg=="
+        let body = mediaRequestBody(
+            stream: true,
+            imageURLJSON: #"{"url":"data:image/png;base64,\#(png)"}"#
+        )
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/chat/completions", headers: requestHeaders(for: body), body: body
+        ) { res async in
+            XCTAssertEqual(res.status, .badRequest)
+            XCTAssertEqual(res.headers.contentType, .json)
+            XCTAssertFalse(res.body.string.contains("data: [DONE]"))
+            XCTAssertEqual(service.releaseSlotCount, 1)
+        }
+    }
+
+    func testStreamingMediaPreflightsOnceAndHandsOffResolvedMessages() async throws {
+        let service = FakeMLXChatService(
+            streamingHandler: { messages in
+                XCTAssertEqual(
+                    AFMMLXMediaSecurityPolicy.declaredMediaKinds(in: messages).count,
+                    1
+                )
+                return self.makeStreamingResult(chunks: [
+                    AFMServerStreamChunk(
+                        text: "seen",
+                        promptTokens: 4,
+                        completionTokens: 1,
+                        promptTime: 0.01,
+                        generateTime: 0.01
+                    )
+                ])
+            }
+        )
+        try MLXChatCompletionsController(
+            modelID: "test-model", service: service, temperature: nil, repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLJ4QAAAABJRU5ErkJggg=="
+        let body = mediaRequestBody(
+            stream: true,
+            imageURLJSON: #"{"url":"data:image/png;base64,\#(png)"}"#
+        )
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/chat/completions", headers: requestHeaders(for: body), body: body
+        ) { res async in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.headers.contentType, .init(type: "text", subType: "event-stream"))
+            XCTAssertContains(res.body.string, #""content":"seen""#)
+            XCTAssertEqual(service.mediaPreflightCount, 1)
+            XCTAssertEqual(service.withPreflightedMediaCount, 1)
+        }
+    }
+
+    func testLateStreamingFailureUsesOpenAIErrorEventWithoutAssistantWarning() async throws {
+        let stream = AsyncThrowingStream<AFMServerStreamChunk, Error> { continuation in
+            continuation.yield(AFMServerStreamChunk(text: "partial"))
+            continuation.finish(throwing: MLXServiceError.invalidMediaInput("late media failure"))
+        }
+        let service = FakeMLXChatService(streamingResult: (
+            modelID: "test-model",
+            stream: stream,
+            promptTokens: 2,
+            toolCallStartTag: "<tool_call>",
+            toolCallEndTag: "</tool_call>",
+            thinkStartTag: nil,
+            thinkEndTag: nil
+        ))
+        try MLXChatCompletionsController(
+            modelID: "test-model", service: service, temperature: nil, repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let body = try requestBody(stream: true)
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/chat/completions", headers: requestHeaders(for: body), body: body
+        ) { res async in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertContains(res.body.string, #""code":"invalid_media_input""#)
+            XCTAssertContains(res.body.string, "data: [DONE]")
+            XCTAssertFalse(res.body.string.contains("⚠️"))
+        }
+    }
+
     private func requestBody(
         stream: Bool = true,
         prompt: String = "What is the weather in Berlin?",
@@ -1047,11 +1340,46 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
         return buffer
     }
 
-    private func requestHeaders(for body: ByteBuffer) -> HTTPHeaders {
+    private func requestHeaders(for body: ByteBuffer, requestID: String? = nil) -> HTTPHeaders {
         var headers = HTTPHeaders()
         headers.contentType = .json
         headers.replaceOrAdd(name: .contentLength, value: body.readableBytes.description)
+        if let requestID {
+            headers.replaceOrAdd(name: "X-Request-ID", value: requestID)
+        }
         return headers
+    }
+
+    private func waitUntil(
+        timeoutIterations: Int = 200,
+        condition: @escaping @Sendable () async -> Bool
+    ) async -> Bool {
+        for _ in 0..<timeoutIterations {
+            if await condition() { return true }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return false
+    }
+
+    private func mediaRequestBody(stream: Bool, imageURLJSON: String) -> ByteBuffer {
+        let json = """
+        {
+          "model": "test-model",
+          "stream": \(stream ? "true" : "false"),
+          "messages": [
+            {
+              "role": "user",
+              "content": [
+                { "type": "text", "text": "Describe this image." },
+                { "type": "image_url", "image_url": \(imageURLJSON) }
+              ]
+            }
+          ]
+        }
+        """
+        var buffer = ByteBufferAllocator().buffer(capacity: json.utf8.count)
+        buffer.writeString(json)
+        return buffer
     }
 
     private func makeStreamingResult(chunks: [AFMServerStreamChunk]) -> AFMChatStreamingResult {
@@ -1223,7 +1551,7 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
     """
 }
 
-private final class FakeMLXChatService: AFMChatServing, @unchecked Sendable {
+private final class FakeMLXChatService: AFMChatServing, AFMMLXMediaRequestServing, @unchecked Sendable {
     let maxConcurrent: Int
     let toolCallParser: String?
     let supportsStrictToolGrammar: Bool
@@ -1246,12 +1574,24 @@ private final class FakeMLXChatService: AFMChatServing, @unchecked Sendable {
     private let generateResult: AFMChatGenerationResult
     private let streamingResult: AFMChatStreamingResult
     private let streamingHandler: (([Message]) -> AFMChatStreamingResult)?
+    private let mediaValidationError: MLXServiceError?
+    private let mediaPreflightError: MLXServiceError?
+    private let mediaPreflightProbe: CancellationProbe?
+    private let generateProbe: CancellationProbe?
+    private let streamCollectionProbe: CancellationProbe?
     private let stateLock = NSLock()
     private(set) var recordedGenerateToolNames: [[String]] = []
     private(set) var recordedStreamingToolNames: [[String]] = []
     private(set) var recordedGenerateToolChoices: [String] = []
     private(set) var recordedStreamingToolChoices: [String] = []
     private(set) var recordedPreserveStructuralTags: [Bool] = []
+    private var _mediaPreflightCount = 0
+    private var _withPreflightedMediaCount = 0
+    private var _releaseSlotCount = 0
+    private(set) var recordedGenerateMediaPartCounts: [Int] = []
+    var mediaPreflightCount: Int { stateLock.withLock { _mediaPreflightCount } }
+    var withPreflightedMediaCount: Int { stateLock.withLock { _withPreflightedMediaCount } }
+    var releaseSlotCount: Int { stateLock.withLock { _releaseSlotCount } }
 
     init(
         maxConcurrent: Int = 1,
@@ -1261,6 +1601,11 @@ private final class FakeMLXChatService: AFMChatServing, @unchecked Sendable {
         thinkEndTag: String? = nil,
         responseChannelFormat: AFMResponseChannelFormat = .none,
         fixToolArgs: Bool = false,
+        mediaValidationError: MLXServiceError? = nil,
+        mediaPreflightError: MLXServiceError? = nil,
+        mediaPreflightProbe: CancellationProbe? = nil,
+        generateProbe: CancellationProbe? = nil,
+        streamCollectionProbe: CancellationProbe? = nil,
         generateResult: AFMChatGenerationResult? = nil,
         streamingResult: AFMChatStreamingResult
     ) {
@@ -1271,6 +1616,11 @@ private final class FakeMLXChatService: AFMChatServing, @unchecked Sendable {
         self.thinkEndTag = thinkEndTag
         self.responseChannelFormat = responseChannelFormat
         self.fixToolArgs = fixToolArgs
+        self.mediaValidationError = mediaValidationError
+        self.mediaPreflightError = mediaPreflightError
+        self.mediaPreflightProbe = mediaPreflightProbe
+        self.generateProbe = generateProbe
+        self.streamCollectionProbe = streamCollectionProbe
         self.generateResult = generateResult ?? (
             modelID: "test-model",
             content: "",
@@ -1295,6 +1645,11 @@ private final class FakeMLXChatService: AFMChatServing, @unchecked Sendable {
         thinkEndTag: String? = nil,
         responseChannelFormat: AFMResponseChannelFormat = .none,
         fixToolArgs: Bool = false,
+        mediaValidationError: MLXServiceError? = nil,
+        mediaPreflightError: MLXServiceError? = nil,
+        mediaPreflightProbe: CancellationProbe? = nil,
+        generateProbe: CancellationProbe? = nil,
+        streamCollectionProbe: CancellationProbe? = nil,
         streamingHandler: @escaping ([Message]) -> AFMChatStreamingResult
     ) {
         self.maxConcurrent = maxConcurrent
@@ -1304,6 +1659,11 @@ private final class FakeMLXChatService: AFMChatServing, @unchecked Sendable {
         self.thinkEndTag = thinkEndTag
         self.responseChannelFormat = responseChannelFormat
         self.fixToolArgs = fixToolArgs
+        self.mediaValidationError = mediaValidationError
+        self.mediaPreflightError = mediaPreflightError
+        self.mediaPreflightProbe = mediaPreflightProbe
+        self.generateProbe = generateProbe
+        self.streamCollectionProbe = streamCollectionProbe
         self.generateResult = (
             modelID: "test-model",
             content: "",
@@ -1323,7 +1683,7 @@ private final class FakeMLXChatService: AFMChatServing, @unchecked Sendable {
     func normalizeModel(_ raw: String) -> String { raw }
     func resolvedToolCallParser(logBypass: Bool) -> String? { toolCallParser }
     func tryReserveSlot() -> Bool { true }
-    func releaseSlot() {}
+    func releaseSlot() { stateLock.withLock { _releaseSlotCount += 1 } }
     func ensureBatchMode(concurrency: Int) async throws {}
     func releaseBatchReference() {}
     func cancelBatchSlots(ids: Set<UUID>) async {}
@@ -1333,6 +1693,41 @@ private final class FakeMLXChatService: AFMChatServing, @unchecked Sendable {
     }
     func stopAPIProfileExtended(promptTokens: Int, completionTokens: Int, promptTime: Double, generateTime: Double) -> AFMProfileExtended {
         AFMProfileExtended(summary: stopAPIProfile(promptTokens: promptTokens, completionTokens: completionTokens, promptTime: promptTime, generateTime: generateTime), samples: [])
+    }
+
+    func loadedModelDescriptor(model: String) -> AFMModelDescriptor? { nil }
+
+    func validateMediaRequestCapabilities(model: String, messages: [Message]) throws {
+        if let mediaValidationError { throw mediaValidationError }
+        do {
+            try AFMMLXMediaSecurityPolicy.validateReferences(in: messages)
+        } catch {
+            throw MLXServiceError.invalidMediaInput(error.localizedDescription)
+        }
+    }
+
+    func preflightMediaRequest(
+        model: String,
+        messages: [Message]
+    ) async throws -> AFMMLXResolvedMediaRequest {
+        stateLock.withLock { _mediaPreflightCount += 1 }
+        if let mediaPreflightProbe {
+            try await mediaPreflightProbe.suspendUntilCancelled()
+        }
+        if let mediaPreflightError { throw mediaPreflightError }
+        do {
+            return try await AFMMLXMediaSecurityPolicy.resolveRequest(in: messages)
+        } catch {
+            throw MLXServiceError.invalidMediaInput(error.localizedDescription)
+        }
+    }
+
+    func withPreflightedMediaRequest<Result: Sendable>(
+        _ request: AFMMLXResolvedMediaRequest,
+        operation: ([Message]) async throws -> Result
+    ) async throws -> Result {
+        stateLock.withLock { _withPreflightedMediaCount += 1 }
+        return try await operation(request.messages)
     }
 
     func generate(
@@ -1355,6 +1750,14 @@ private final class FakeMLXChatService: AFMChatServing, @unchecked Sendable {
         chatTemplateKwargs: [String: AnyCodable]?
     ) async throws -> AFMChatGenerationResult {
         recordGenerateTools(tools)
+        if let generateProbe {
+            try await generateProbe.suspendUntilCancelled()
+        }
+        stateLock.withLock {
+            recordedGenerateMediaPartCounts.append(
+                AFMMLXMediaSecurityPolicy.declaredMediaKinds(in: messages).count
+            )
+        }
         return generateResult
     }
 
@@ -1420,6 +1823,31 @@ private final class FakeMLXChatService: AFMChatServing, @unchecked Sendable {
         chatTemplateKwargs: [String: AnyCodable]?
     ) async throws -> AFMChatStreamingResult {
         recordStreamingTools(tools)
+        if let streamCollectionProbe {
+            let stream = AsyncThrowingStream<AFMServerStreamChunk, Error> { continuation in
+                let task = Task {
+                    do {
+                        try await streamCollectionProbe.suspendUntilCancelled()
+                        continuation.finish()
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+                continuation.onTermination = { [weak self] _ in
+                    task.cancel()
+                    self?.releaseSlot()
+                }
+            }
+            return (
+                modelID: "test-model",
+                stream: stream,
+                promptTokens: 0,
+                toolCallStartTag: "<tool_call>",
+                toolCallEndTag: "</tool_call>",
+                thinkStartTag: nil,
+                thinkEndTag: nil
+            )
+        }
         return streamingHandler?(messages) ?? streamingResult
     }
 
@@ -1561,4 +1989,36 @@ private final class FakeMLXChatService: AFMChatServing, @unchecked Sendable {
         thinkStartTag: nil,
         thinkEndTag: nil
     )
+}
+
+private final class CancellationProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _started = false
+    private var _cancelled = false
+
+    func suspendUntilCancelled() async throws {
+        lock.withLock { _started = true }
+        do {
+            try await Task.sleep(nanoseconds: 60_000_000_000)
+        } catch {
+            lock.withLock { _cancelled = true }
+            throw error
+        }
+    }
+
+    func waitUntilStarted() async -> Bool {
+        await waitUntil { self.lock.withLock { self._started } }
+    }
+
+    func waitUntilCancelled() async -> Bool {
+        await waitUntil { self.lock.withLock { self._cancelled } }
+    }
+
+    private func waitUntil(_ condition: @escaping @Sendable () -> Bool) async -> Bool {
+        for _ in 0..<200 {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return false
+    }
 }

--- a/docs/afmkit-url-consumption.md
+++ b/docs/afmkit-url-consumption.md
@@ -6,7 +6,7 @@ one exact release and selects every provider product from it:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.4"
+    exact: "0.1.5"
 )
 ```
 
@@ -14,7 +14,7 @@ Do not use a branch or revision requirement for release builds.
 
 ## Production Blocker
 
-AFMKit is public and exposes `0.1.4`. AFM release publication remains
+AFMKit is public and exposes `0.1.5`. AFM release publication remains
 fail-closed unless AFMKit and every dependency in its root graph are
 anonymously readable and the tracked lock resolves that exact tag.
 
@@ -38,7 +38,7 @@ surface publishable.
 
 ## Dependency Resolution
 
-AFMKit 0.1.4 is public, so normal resolution requires no GitHub credential:
+AFMKit 0.1.5 is public, so normal resolution requires no GitHub credential:
 
 ```bash
 Scripts/resolve-release-dependencies.sh
@@ -55,7 +55,7 @@ The normal graph is independent of maclocal-api's dirty vendor worktrees:
 
 | Dependency | Requirement | Purpose |
 | --- | --- | --- |
-| `AFMKit` | exact `0.1.4` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
+| `AFMKit` | exact `0.1.5` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
 
 The MLX, mlx-c, Swift bindings, and mlx-swift-lm sources are snapshots inside
 AFMKit's `vendor/MLX` tree. They are not separate SwiftPM dependencies of


### PR DESCRIPTION
## Summary

- pin the public AFMKit v0.1.5 release that owns Qwen 3.8 vision/provider implementation
- keep maclocal-api focused on CLI, Vapor/OpenAI HTTP adaptation, capability presentation, and trusted local media conversion
- delegate media validation, bounded preflight, and resolved-message handoff to AFMKit without model-specific rewriting
- expose loaded runtime capabilities through `/v1/models` and `/props`, preserving fail-closed `nil` descriptors
- make inflight cancellation ownership-safe for duplicate client request IDs and cancellable across admission, media preflight, serial generation, and concurrent stream collection
- return typed media errors before SSE headers and structured error events for late streaming failures

Closes #191.

Supersedes #194, whose provider implementation predates the standalone AFMKit package boundary. The provider work is now released by AFMKit v0.1.5; this PR is the exact-version consumer integration.

## Validation

- `AFM_SWIFTPM_DRIVER=native Scripts/swiftpm-reliable.sh test -c release --filter MLXChatCompletionsControllerStreamingTests`: 36 passed, 0 failed
- `AFM_SWIFTPM_DRIVER=native Scripts/swiftpm-reliable.sh test -c release`: passed; Swift Testing reported 139 tests across 17 suites, 0 failed
- `Scripts/check-afmkit-consumer-boundary.sh`: passed
- `Scripts/check-public-release-eligibility.sh`: passed; AFMKit v0.1.5 is exact and anonymously fetchable
- `Scripts/tests/test-release-tooling.sh`: passed
- `git diff --check`: passed

An independent sub-agent review returned MERGE with no concrete defects after the cancellation regression coverage was added.

No GitHub Actions dependency is introduced or required.

## Summary by Sourcery

Integrate AFMKit 0.1.5 as the provider boundary for trusted media requests, runtime capability reporting, and robust cancellable chat serving.

New Features:
- Integrate AFMKit v0.1.5 as the exact public dependency for vision and media-serving support.
- Expose loaded model capabilities through the models and properties endpoints.
- Add trusted local media handling for CLI and local integrations.

Bug Fixes:
- Return typed media validation errors before streaming begins and structured errors for failures during streaming.
- Make request cancellation ownership-safe for duplicate request IDs and effective across admission, media preflight, generation, and stream collection.
- Redact media references and audio payloads from verbose request logging.

Enhancements:
- Delegate media validation, preflight resolution, and resolved-message handoff to AFMKit without model-specific rewriting.
- Fail closed when model capability descriptors are unavailable instead of inventing optional capabilities.

Build:
- Pin the main package, example consumer, lockfile checks, release eligibility checks, and release tooling to AFMKit 0.1.5.

Documentation:
- Update AFMKit dependency consumption documentation for the exact public 0.1.5 release.

Tests:
- Add coverage for capability presentation, media preflight and error handling, cancellation across request phases, duplicate request ID ownership, redacted logging, and late streaming failures.