### PR TITLE
Update AFMKit to 0.1.8

### DIFF
--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.7"
+        exact: "0.1.8"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "2f8eafdce4ddcecc578e2203ad80f3e5df8e7910",
-        "version" : "0.1.7"
+        "revision" : "740c6f83f1f386b8b0ce194c54d25e762e355be4",
+        "version" : "0.1.8"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.7"
+        exact: "0.1.8"
     )
 }
 

--- a/README.md
+++ b/README.md
@@ -352,13 +352,11 @@ This maclocal-api consumer package separately defines its application adapters:
 - `AFMServer` — Vapor HTTP layer
 - `afm` — CLI executable
 
-AFMKit is revision-pinned while its API is under development. That checkpoint
-is valid for authenticated development, but it is not a versioned SwiftPM
-publication contract even if the revision is anonymously fetchable. See
+AFMKit is pinned to one exact public SwiftPM release so provider source,
+runtime resources, and the consumer contract advance together. See
 [AFMKit URL consumption](docs/afmkit-url-consumption.md) for the dependency and
-publication policy. Release workflows fail closed until AFMKit is required by
-an exact public semantic version, or the source-package release surface is
-explicitly excluded.
+publication policy. Release tooling fails closed unless the manifest, lock,
+public tag, and anonymously fetchable revision all agree.
 
 `AFMKitFoundationModels27DwarfStar` remains as a source-compatible re-export;
 the implementation and runtime lifetime management now live in AFMKit's
@@ -373,17 +371,14 @@ Start with the [AFMKit public API guide](docs/afmkit-public-api.md) and the
 ```bash
 git clone https://github.com/scouzi1966/maclocal-api.git
 cd maclocal-api
-gh auth login
-gh auth setup-git
 ./build.sh
 ```
 
-The authenticated build resolves only the revisions in the tracked
-`Package.resolved`, initializes pinned submodules, builds the locked WebUI, and
-packages AFMKit-owned runtime resources without mutating dependency sources. CI
-uses a masked `AFMKIT_READ_TOKEN` with read access to the private AFMKit
-repository. Add `--install` to install under `INSTALL_PREFIX` (default
-`/usr/local`).
+The build resolves only the revisions in the tracked `Package.resolved`,
+initializes pinned submodules, builds the locked WebUI, and packages AFMKit-owned
+runtime resources without mutating dependency sources. AFMKit is public, so the
+normal build needs no repository token. Add `--install` to install under
+`INSTALL_PREFIX` (default `/usr/local`).
 
 ## Requirements
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -145,8 +145,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.7":
-        fail(f"{identity} must resolve the exact 0.1.7 release")
+    if pin["state"].get("version") != "0.1.8":
+        fail(f"{identity} must resolve the exact 0.1.8 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -289,7 +289,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.7"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.8"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.7",
+    "afmkit": "0.1.8",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -54,13 +54,13 @@ cat > "$fake_public_git" <<'SH'
 #!/usr/bin/env bash
 arguments=" $* "
 for ref in \
-  refs/tags/0.1.7 \
-  'refs/tags/0.1.7^{}' \
-  refs/tags/v0.1.7 \
-  'refs/tags/v0.1.7^{}'; do
+  refs/tags/0.1.8 \
+  'refs/tags/0.1.8^{}' \
+  refs/tags/v0.1.8 \
+  'refs/tags/v0.1.8^{}'; do
   [[ "$arguments" == *" $ref "* ]] || exit 2
 done
-printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.7^{}'
+printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.8^{}'
 SH
 chmod 700 "$fake_public_git"
 if ! EXPECTED_AFMKIT_REVISION="$expected_afmkit_revision" \
@@ -80,7 +80,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.7'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.8'
   }
   probe_public_source() {
     return 1
@@ -104,14 +104,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.7" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.7"
+[[ "$release_version" == "0.1.8" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.8"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.7'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.8'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -130,7 +130,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.7'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.8'
   }
   probe_public_source() {
     return 0

--- a/docs/afmkit-url-consumption.md
+++ b/docs/afmkit-url-consumption.md
@@ -6,7 +6,7 @@ one exact release and selects every provider product from it:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.7"
+    exact: "0.1.8"
 )
 ```
 
@@ -14,7 +14,7 @@ Do not use a branch or revision requirement for release builds.
 
 ## Production Blocker
 
-AFMKit is public and exposes `0.1.7`. AFM release publication remains
+AFMKit is public and exposes `0.1.8`. AFM release publication remains
 fail-closed unless AFMKit and every dependency in its root graph are
 anonymously readable and the tracked lock resolves that exact tag.
 
@@ -38,7 +38,7 @@ surface publishable.
 
 ## Dependency Resolution
 
-AFMKit 0.1.7 is public, so normal resolution requires no GitHub credential:
+AFMKit 0.1.8 is public, so normal resolution requires no GitHub credential:
 
 ```bash
 Scripts/resolve-release-dependencies.sh
@@ -55,7 +55,7 @@ The normal graph is independent of maclocal-api's dirty vendor worktrees:
 
 | Dependency | Requirement | Purpose |
 | --- | --- | --- |
-| `AFMKit` | exact `0.1.7` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
+| `AFMKit` | exact `0.1.8` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
 
 The MLX, mlx-c, Swift bindings, and mlx-swift-lm sources are snapshots inside
 AFMKit's `vendor/MLX` tree. They are not separate SwiftPM dependencies of


### PR DESCRIPTION
Closes #209.

## Problem

maclocal-api still pins AFMKit 0.1.7, so it cannot consume the qualified MLX 0.32.2 and self-contained Qwen4/MLXSwift updates published in AFMKit 0.1.8.

## Approach

- Pin the single AFMKit dependency and lock to exact public release 0.1.8 (`740c6f83f1f3`).
- Advance the independent consumer example and fail-closed release/boundary tests to the same exact release.
- Correct README/dependency guidance now that AFMKit is public and requires no token for normal builds.
- Keep all provider implementation, Qwen, parser, Metal, and stream behavior inside AFMKit/MLXSwift.

## Validation

- `Scripts/check-afmkit-consumer-boundary.sh`
- `Scripts/resolve-release-dependencies.sh`
- `Scripts/tests/test-release-tooling.sh`
- `make build` (Xcode 27 beta 4 reliability wrapper; native retry passed)
- `Scripts/swiftpm-reliable.sh test -c release` (139 tests in 17 suites passed)

No GitHub Actions dependency is introduced. DFlash and TurboQuant are out of scope.

## Summary by Sourcery

Adopt AFMKit 0.1.8 as the exact public dependency release and align consumers, release checks, tests, and guidance accordingly.

Enhancements:
- Update the application and independent consumer to the exact public AFMKit 0.1.8 release.
- Align release eligibility, dependency boundary checks, and documentation with AFMKit’s public, token-free consumption model.

Documentation:
- Update AFMKit dependency and release guidance to reflect the public 0.1.8 release and anonymous normal builds.

Tests:
- Advance release and consumer boundary tests to validate the exact AFMKit 0.1.8 release.