### PR TITLE
Cap comprehensive eval output at 20000 tokens

### DIFF
--- a/Scripts/test-llm-comprehensive.txt
+++ b/Scripts/test-llm-comprehensive.txt
@@ -962,7 +962,7 @@ Translate "Hello, how are you?" into French, Spanish, Japanese, and Arabic. Form
 # AI: valid Python, use correct algorithm, and handle edge cases (n < 2).
 [@ code-python]
 temperature: 0.0
-max_tokens: 32768
+max_tokens: 20000
 system: You are a Python expert. Write clean code with no explanation.
 Write a function that finds all prime numbers up to n using the Sieve of Eratosthenes.
 
@@ -971,7 +971,7 @@ Write a function that finds all prime numbers up to n using the Sieve of Eratost
 # AI: and Result type for error handling. Relevant to this project (afm is written in Swift).
 [@ code-swift]
 temperature: 0.0
-max_tokens: 32768
+max_tokens: 20000
 system: You are a Swift expert. Write clean code with no explanation.
 Write a Swift async function that fetches JSON from a URL using URLSession, decodes it into a Codable struct, and handles errors with Result type.
 
@@ -981,7 +981,7 @@ Write a Swift async function that fetches JSON from a URL using URLSession, deco
 # AI: discount, subtotal, and tax steps correctly. Tests reasoning without <think> support.
 [@ math]
 temperature: 0.0
-max_tokens: 32768
+max_tokens: 20000
 A store sells notebooks for $3.50 each. If you buy 5 or more, you get a 20% discount. Sales tax is 8.5%. How much do 7 notebooks cost after tax? Show your work.
 
 # AI: Tests long-form coherent writing. Feature: model quality — extended generation.


### PR DESCRIPTION
## Problem

Three comprehensive evaluation variants overrode the suite-wide 20,000-token ceiling with 32,768, making the qualifying run internally inconsistent.

## Approach

Cap the Python, Swift, and math variants at 20,000 tokens. Short-output variants retain their intentionally lower limits.

## Validation

- Parsed all 80 explicit max_tokens declarations; maximum is 20,000
- Confirmed 91 variants
- Confirmed global --no-think
- Confirmed there is no global baseline record
- git diff --check

The interrupted DeepSeek result is retained only as a partial diagnostic; the qualifying four-model run will restart from the merged fix.