### PR TITLE
Add no-think mode to Promptfoo profiles

### DIFF
--- a/Scripts/feature-promptfoo-agentic/README.md
+++ b/Scripts/feature-promptfoo-agentic/README.md
@@ -81,14 +81,16 @@ The configs expect these environment variables:
   Base URL for AFM started with:
   `--tool-call-parser afm_adaptive_xml --enable-grammar-constraints`.
 
-Optional for CLI structured-output checks:
+Optional runner and CLI structured-output settings:
 
 - `AFM_BINARY`
   Path to the `afm` binary. Defaults to `.build/arm64-apple-macosx/release/afm`.
 - `MACAFM_MLX_MODEL_CACHE`
   Local model cache root.
 - `AFM_NO_THINK`
-  Set to `1` to add `--no-think` in CLI guided-json mode.
+  Set to `1` to add `--no-think` to every server started by
+  `run-promptfoo-agentic.sh` and to CLI guided-json checks. The runner accepts
+  only `0` or `1`; unset and `0` preserve the model's default reasoning mode.
 
 ## Suggested server matrix
 

--- a/Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh
+++ b/Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh
@@ -11,8 +11,14 @@ afm_binary="${AFM_BINARY:-.build/arm64-apple-macosx/release/afm}"
 out_dir="${AFM_PROMPTFOO_OUT_DIR:-/Volumes/edata/promptfoo/data/maclocal-api/current}"
 mode="${1:-all}"
 port="${AFM_PROMPTFOO_PORT:-9999}"
+no_think="${AFM_NO_THINK:-0}"
 server_pid=""
 overall_status=0
+
+if [[ "$no_think" != "0" && "$no_think" != "1" ]]; then
+  echo "AFM_NO_THINK must be 0 or 1" >&2
+  exit 1
+fi
 
 mkdir -p "$out_dir"
 
@@ -123,6 +129,12 @@ start_server() {
   # MTP path without accepting an arbitrary string of shell arguments.
   if [[ "${AFM_MTP:-0}" == "1" ]]; then
     extra_args+=(--mtp)
+  fi
+
+  # Keep reasoning-mode qualification explicit and shell-safe across every
+  # Promptfoo profile without accepting an arbitrary string of CLI arguments.
+  if [[ "$no_think" == "1" ]]; then
+    extra_args+=(--no-think)
   fi
 
   cleanup

--- a/Scripts/tests/test-promptfoo-runner-args.sh
+++ b/Scripts/tests/test-promptfoo-runner-args.sh
@@ -1,0 +1,57 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+script_dir="${0:A:h}"
+repo_root="${script_dir:h:h}"
+runner="$repo_root/Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh"
+work_root="$(mktemp -d "${TMPDIR:-/tmp}/afm-promptfoo-args.XXXXXX")"
+
+cleanup() {
+  rm -rf "$work_root"
+}
+trap cleanup EXIT INT TERM
+
+trace_launch() {
+  local profile="$1"
+  shift
+  env \
+    "$@" \
+    AFM_BINARY=/usr/bin/false \
+    AFM_PROMPTFOO_OUT_DIR="$work_root" \
+    zsh -x "$runner" "$profile" 2>&1 || true
+}
+
+server_argv() {
+  grep '/usr/bin/false mlx' | tail -1
+}
+
+occurrences() {
+  local pattern="$1"
+  awk -v pattern="$pattern" '{ total += gsub(pattern, "") } END { print total + 0 }'
+}
+
+unset_line="$(trace_launch default -u AFM_NO_THINK -u AFM_MTP | server_argv)"
+[[ -n "$unset_line" ]]
+[[ "$(print -r -- "$unset_line" | occurrences --no-think)" == "0" ]]
+[[ "$(print -r -- "$unset_line" | occurrences --mtp)" == "0" ]]
+
+zero_line="$(trace_launch adaptive-xml-grammar AFM_NO_THINK=0 AFM_MTP=0 | server_argv)"
+[[ "$(print -r -- "$zero_line" | occurrences --no-think)" == "0" ]]
+[[ "$(print -r -- "$zero_line" | occurrences --mtp)" == "0" ]]
+[[ "$(print -r -- "$zero_line" | occurrences afm_adaptive_xml)" == "1" ]]
+[[ "$(print -r -- "$zero_line" | occurrences --enable-grammar-constraints)" == "1" ]]
+
+enabled_line="$(trace_launch adaptive-xml AFM_NO_THINK=1 AFM_MTP=1 | server_argv)"
+[[ "$(print -r -- "$enabled_line" | occurrences --no-think)" == "1" ]]
+[[ "$(print -r -- "$enabled_line" | occurrences --mtp)" == "1" ]]
+[[ "$(print -r -- "$enabled_line" | occurrences afm_adaptive_xml)" == "1" ]]
+
+set +e
+invalid_output="$(AFM_NO_THINK=invalid "$runner" all 2>&1)"
+invalid_status=$?
+set -e
+[[ "$invalid_status" == "1" ]]
+[[ "$invalid_output" == "AFM_NO_THINK must be 0 or 1" ]]
+
+echo "Promptfoo runner argument tests passed."


### PR DESCRIPTION
Closes #217.

## Problem

The Promptfoo agentic runner had no shell-safe way to apply no-think mode to every AFM server profile, so it could not match the qualifying assertion and comprehensive configurations.

## Approach

Add an AFM_NO_THINK boolean environment switch, reject values other than 0 or 1, and append --no-think centrally in start_server so every profile receives it. No arbitrary shell argument string is accepted.

## Validation

- zsh syntax check
- invalid-value rejection test
- git diff --check
- central start_server inspection covers every profile

## Summary by Sourcery

Enable shell-safe no-think mode configuration across Promptfoo agentic runner profiles.

New Features:
- Add an AFM_NO_THINK environment switch that applies no-think mode to all Promptfoo runner server profiles and CLI guided-JSON checks.

Enhancements:
- Validate AFM_NO_THINK as a shell-safe 0-or-1 setting while preserving the default reasoning behavior when unset or disabled.

Documentation:
- Document the expanded AFM_NO_THINK behavior and accepted values.

Tests:
- Add runner argument coverage for enabled, disabled, unset, and invalid AFM_NO_THINK values across server profiles.