### PR TITLE
Fix repeated assertion harness runs

### DIFF
--- a/Scripts/migrate-xctest-metallib-layout.sh
+++ b/Scripts/migrate-xctest-metallib-layout.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <swiftpm-scratch-path> <state-directory>" >&2
+    exit 2
+fi
+
+SCRATCH_PATH="$1"
+STATE_DIR="$2"
+
+if [[ -z "$SCRATCH_PATH" || "$SCRATCH_PATH" == "/" ]]; then
+    echo "Refusing unsafe SwiftPM scratch path: '$SCRATCH_PATH'" >&2
+    exit 2
+fi
+
+mkdir -p "$STATE_DIR"
+SCRATCH_KEY="$(printf '%s\n' "$SCRATCH_PATH" | shasum -a 256 | awk '{print $1}')"
+MIGRATION_STAMP="$STATE_DIR/xctest-metallib-layout-v2-$SCRATCH_KEY"
+
+if [[ -f "$MIGRATION_STAMP" ]]; then
+    exit 0
+fi
+
+# Older wrapper versions copied mlx.metallib into already-signed native-driver
+# XCTest bundles. Xcode cannot incrementally re-sign those bundles. Remove only
+# the derived native-driver product tree when that stale layout is detected;
+# dependency checkouts, downloaded artifacts, and sources remain untouched.
+if [[ -d "$SCRATCH_PATH/out" ]] &&
+   find "$SCRATCH_PATH/out" -type f -path '*.xctest/Contents/MacOS/mlx.metallib' -print -quit | grep -q .; then
+    echo "[swiftpm-reliable] Removing stale signed XCTest products from the previous metallib layout." >&2
+    rm -rf "$SCRATCH_PATH/out"
+fi
+
+touch "$MIGRATION_STAMP"

--- a/Scripts/swiftpm-reliable.sh
+++ b/Scripts/swiftpm-reliable.sh
@@ -124,8 +124,10 @@ stage_xctest_metallib() {
 
     # MLX's C++ runtime searches for mlx.metallib beside the loaded test
     # executable. SwiftPM 6.3 does not always emit mlx-swift_Cmlx.bundle for
-    # XCTest, so create the colocated resource before linking/running tests.
-    # The linker preserves sibling resources in the .xctest bundle.
+    # XCTest, so create the colocated resource in SwiftPM's package-test layout
+    # before linking/running tests. Do not mutate existing Xcode native-driver
+    # .xctest bundles: adding an unsigned file after their previous CodeSign
+    # makes the next incremental CodeSign fail before tests can run.
     local architecture
     architecture="$(uname -m)"
     local predicted_dir="$scratch_path/${architecture}-apple-macosx/$configuration/MacLocalAPIPackageTests.xctest/Contents/MacOS"
@@ -140,12 +142,6 @@ stage_xctest_metallib() {
     }
 
     stage_metallib "$predicted_dir" || return $?
-
-    local executable_dir
-    while IFS= read -r executable_dir; do
-        [[ "$executable_dir" == "$predicted_dir" ]] && continue
-        stage_metallib "$executable_dir" || return $?
-    done < <(find "$scratch_path" -type d -path '*.xctest/Contents/MacOS' -print 2>/dev/null)
 
     echo "[swiftpm-reliable] Staged MLX metallib for XCTest: $predicted_dir/mlx.metallib" >&2
 }

--- a/Scripts/swiftpm-reliable.sh
+++ b/Scripts/swiftpm-reliable.sh
@@ -283,6 +283,11 @@ SCRATCH_PATH="$(test_scratch_path "$@")"
 if [[ "$SCRATCH_PATH" != /* ]]; then
     SCRATCH_PATH="$ROOT_DIR/$SCRATCH_PATH"
 fi
+if [[ "$SUBCOMMAND" == "test" ]]; then
+    "$ROOT_DIR/Scripts/migrate-xctest-metallib-layout.sh" \
+        "$SCRATCH_PATH" \
+        "$STATE_DIR" || exit $?
+fi
 OPERATION_STAMP="$STATE_DIR/last-operation-${CONFIGURATION}"
 PREVIOUS_OPERATION="$(cat "$OPERATION_STAMP" 2>/dev/null || true)"
 if [[ "$SUBCOMMAND" == "test" && "$PREVIOUS_OPERATION" == "build" ]]; then

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -555,7 +555,7 @@ fi
 
 # Test: stop with newline
 t0=$(now_ms)
-resp=$(api_call '{"messages":[{"role":"user","content":"Output exactly two lines: AFM_LINE_ONE on the first line and AFM_LINE_TWO on the second. Output nothing else."}],"max_tokens":500,"stream":false,"temperature":0,"stop":["\\n"]}')
+resp=$(api_call '{"messages":[{"role":"user","content":"Output exactly two lines: AFM_LINE_ONE on the first line and AFM_LINE_TWO on the second. Output nothing else."}],"max_tokens":500,"stream":false,"temperature":0,"stop":["\n"]}')
 dur=$(( $(now_ms) - t0 ))
 stop_nl_ok=$(echo "$resp" | python3 -c "
 import sys, json

--- a/Scripts/tests/test-assertion-harness-fixtures.sh
+++ b/Scripts/tests/test-assertion-harness-fixtures.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK_ROOT="$(mktemp -d)"
+trap 'rm -rf "$WORK_ROOT"' EXIT
 
 python3 - "$ROOT_DIR/Scripts/test-assertions.sh" <<'PY'
 import json
@@ -32,5 +34,31 @@ if rg -q "find .*\\.xctest/Contents/MacOS" "$ROOT_DIR/Scripts/swiftpm-reliable.s
     echo "swiftpm-reliable must not mutate existing signed XCTest bundles" >&2
     exit 1
 fi
+
+scratch_path="$WORK_ROOT/scratch"
+state_path="$WORK_ROOT/state"
+stale_bundle="$scratch_path/out/Products/Debug/StaleTests.xctest/Contents/MacOS"
+mkdir -p "$stale_bundle" "$scratch_path/checkouts/PreservedDependency"
+touch "$stale_bundle/mlx.metallib" "$scratch_path/checkouts/PreservedDependency/Package.swift"
+
+"$ROOT_DIR/Scripts/migrate-xctest-metallib-layout.sh" "$scratch_path" "$state_path"
+[[ ! -e "$scratch_path/out" ]] || {
+    echo "stale native-driver products were not removed" >&2
+    exit 1
+}
+[[ -f "$scratch_path/checkouts/PreservedDependency/Package.swift" ]] || {
+    echo "migration removed a preserved dependency checkout" >&2
+    exit 1
+}
+
+# The per-scratch stamp makes this migration one-time. A later clean native
+# product tree must remain untouched even if it contains a same-named resource.
+mkdir -p "$stale_bundle"
+touch "$stale_bundle/mlx.metallib"
+"$ROOT_DIR/Scripts/migrate-xctest-metallib-layout.sh" "$scratch_path" "$state_path"
+[[ -f "$stale_bundle/mlx.metallib" ]] || {
+    echo "completed migration ran more than once" >&2
+    exit 1
+}
 
 echo "assertion harness fixture checks passed"

--- a/Scripts/tests/test-assertion-harness-fixtures.sh
+++ b/Scripts/tests/test-assertion-harness-fixtures.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+python3 - "$ROOT_DIR/Scripts/test-assertions.sh" <<'PY'
+import json
+import re
+import sys
+
+source = open(sys.argv[1], encoding="utf-8").read()
+line = next(
+    (line for line in source.splitlines() if "AFM_LINE_ONE" in line and "api_call" in line),
+    None,
+)
+if line is None:
+    raise SystemExit("newline stop assertion request was not found")
+
+match = re.search(r"api_call '(.*)'\)$", line)
+if match is None:
+    raise SystemExit("newline stop assertion request could not be parsed")
+
+request = json.loads(match.group(1))
+if request.get("stop") != ["\n"]:
+    raise SystemExit(
+        f"newline stop fixture sent {request.get('stop')!r}, expected an actual newline"
+    )
+PY
+
+if rg -q "find .*\\.xctest/Contents/MacOS" "$ROOT_DIR/Scripts/swiftpm-reliable.sh"; then
+    echo "swiftpm-reliable must not mutate existing signed XCTest bundles" >&2
+    exit 1
+fi
+
+echo "assertion harness fixture checks passed"


### PR DESCRIPTION
Closes #219.

## Problem

Repeated full assertion runs failed before Swift tests because the reliable wrapper mutated already-signed native XCTest bundles. The newline stop fixture also sent a literal backslash+n while asserting actual newline behavior.

## Approach

- Stage the MLX metallib only in the predictable SwiftPM package-test layout; do not mutate existing signed native-driver bundles.
- Send the actual JSON newline stop string in the assertion fixture.
- Add a regression check for both harness invariants.

## Validation

- `Scripts/tests/test-assertion-harness-fixtures.sh`
- `bash -n Scripts/swiftpm-reliable.sh Scripts/test-assertions.sh Scripts/tests/test-assertion-harness-fixtures.sh`
- `Scripts/swiftpm-reliable.sh test` twice consecutively: 139 tests in 17 suites passed both times
- `git diff --check`

## Summary by Sourcery

Make repeated assertion harness runs reliable by avoiding signed XCTest bundle mutations and correcting newline stop validation.

Bug Fixes:
- Prevent repeated assertion harness test runs from failing due to mutations of already-signed XCTest bundles.
- Correct the newline stop assertion fixture to send an actual newline character.

Enhancements:
- Limit MLX metallib staging to SwiftPM’s predictable package-test layout.
- Add one-time migration handling that removes only stale native-driver products while preserving dependencies and other scratch data.

Tests:
- Add regression checks for newline fixture encoding and safe, one-time XCTest layout migration.