### PR TITLE
Fix slow model assertion timeouts

### DIFF
--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -4295,7 +4295,7 @@ if should_run_section 16 && min_tier standard; then
   # Test 16.1: batch + top_k + streaming (was crashing: #72)
   t0=$(now_ms)
   R=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"top_k":50,"stream":true}' 2>&1 || echo 'ERROR')
+    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"top_k":50,"stream":true}' 2>&1) || R=""
   dur=$(($(now_ms) - t0))
   if echo "$R" | grep -q '"content"'; then
     run_test "PairwiseSmoke" "batch + top_k + streaming" "content present" "PASS" "$dur"
@@ -4306,7 +4306,7 @@ if should_run_section 16 && min_tier standard; then
   # Test 16.2: batch + presence_penalty + non-streaming (was crashing: #72)
   t0=$(now_ms)
   R=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"presence_penalty":1.0}' 2>&1 || echo 'ERROR')
+    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"presence_penalty":1.0}' 2>&1) || R=""
   dur=$(($(now_ms) - t0))
   if echo "$R" | grep -q '"finish_reason"'; then
     run_test "PairwiseSmoke" "batch + presence_penalty + non-streaming" "finish_reason present" "PASS" "$dur"
@@ -4317,7 +4317,7 @@ if should_run_section 16 && min_tier standard; then
   # Test 16.3: batch + repetition_penalty + logprobs (was crashing: #72)
   t0=$(now_ms)
   R=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"repetition_penalty":1.5,"logprobs":true,"top_logprobs":3}' 2>&1 || echo 'ERROR')
+    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"repetition_penalty":1.5,"logprobs":true,"top_logprobs":3}' 2>&1) || R=""
   dur=$(($(now_ms) - t0))
   if echo "$R" | grep -q '"finish_reason"'; then
     run_test "PairwiseSmoke" "batch + repetition_penalty + logprobs" "response valid" "PASS" "$dur"
@@ -4328,7 +4328,7 @@ if should_run_section 16 && min_tier standard; then
   # Test 16.4: batch + all sampling params combined
   t0=$(now_ms)
   R=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"top_k":40,"min_p":0.05,"presence_penalty":0.5,"repetition_penalty":1.2,"temperature":0.7}' 2>&1 || echo 'ERROR')
+    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"top_k":40,"min_p":0.05,"presence_penalty":0.5,"repetition_penalty":1.2,"temperature":0.7}' 2>&1) || R=""
   dur=$(($(now_ms) - t0))
   if echo "$R" | grep -q '"finish_reason"'; then
     run_test "PairwiseSmoke" "batch + all sampling params combined" "response valid" "PASS" "$dur"
@@ -4342,11 +4342,11 @@ if should_run_section 16 && min_tier standard; then
     run_test "PairwiseSmoke" "streaming parity (same seed → same output)" "model supports deterministic no-thinking exact output" "SKIP" "$(( $(now_ms) - t0 ))"
   else
     NS=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly yes in lowercase and nothing else.\"}],\"max_tokens\":3,\"temperature\":0,\"seed\":42,\"stream\":false${THINKING_OFF_JSON_FRAGMENT}}" 2>&1 || echo 'ERROR')
+      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly yes in lowercase and nothing else.\"}],\"max_tokens\":3,\"temperature\":0,\"seed\":42,\"stream\":false${THINKING_OFF_JSON_FRAGMENT}}" 2>&1) || NS=""
     S=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly yes in lowercase and nothing else.\"}],\"max_tokens\":3,\"temperature\":0,\"seed\":42,\"stream\":true${THINKING_OFF_JSON_FRAGMENT}}" 2>&1 || echo 'ERROR')
+      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly yes in lowercase and nothing else.\"}],\"max_tokens\":3,\"temperature\":0,\"seed\":42,\"stream\":true${THINKING_OFF_JSON_FRAGMENT}}" 2>&1) || S=""
     dur=$(($(now_ms) - t0))
-    NS_C=$(echo "$NS" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'].strip())" 2>/dev/null)
+    NS_C=$(echo "$NS" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'].strip())" 2>/dev/null) || NS_C=""
     S_C=$(echo "$S" | python3 -c "
 import sys
 content=''
@@ -4360,7 +4360,7 @@ for line in sys.stdin:
             content+=c
         except: pass
 print(content.strip())
-" 2>/dev/null)
+" 2>/dev/null) || S_C=""
     if [ -n "$NS_C" ] && [ "$NS_C" = "$S_C" ]; then
       run_test "PairwiseSmoke" "streaming parity (same seed → same output)" "match" "PASS" "$dur"
     else
@@ -4375,12 +4375,12 @@ print(content.strip())
   else
     pairwise_cache_token="PAIRWISE-CACHE-CERULEAN"
     R1=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly $pairwise_cache_token and nothing else.\"}],\"max_tokens\":20,\"temperature\":0,\"seed\":99${THINKING_OFF_JSON_FRAGMENT}}" 2>&1 || echo 'ERROR')
+      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly $pairwise_cache_token and nothing else.\"}],\"max_tokens\":20,\"temperature\":0,\"seed\":99${THINKING_OFF_JSON_FRAGMENT}}" 2>&1) || R1=""
     R2=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly $pairwise_cache_token and nothing else.\"}],\"max_tokens\":20,\"temperature\":0,\"seed\":99${THINKING_OFF_JSON_FRAGMENT}}" 2>&1 || echo 'ERROR')
+      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly $pairwise_cache_token and nothing else.\"}],\"max_tokens\":20,\"temperature\":0,\"seed\":99${THINKING_OFF_JSON_FRAGMENT}}" 2>&1) || R2=""
     dur=$(($(now_ms) - t0))
-    C1=$(echo "$R1" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'].strip())" 2>/dev/null)
-    C2=$(echo "$R2" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'].strip())" 2>/dev/null)
+    C1=$(echo "$R1" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'].strip())" 2>/dev/null) || C1=""
+    C2=$(echo "$R2" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'].strip())" 2>/dev/null) || C2=""
     if [ -n "$C1" ] && [ "$C1" = "$C2" ]; then
       run_test "PairwiseSmoke" "cache idempotency (same seed → same output)" "match" "PASS" "$dur"
     else

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -30,6 +30,7 @@ MODEL_SUPPORTS_THINKING_TOGGLE=true
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 REPORT_DIR="${AFM_ASSERTIONS_REPORT_DIR:-$PROJECT_ROOT/test-reports}"
+REQUEST_TIMEOUT="${AFM_ASSERTIONS_REQUEST_TIMEOUT:-60}"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -45,6 +46,10 @@ done
 
 if [[ ! "$TIER" =~ ^(unit|smoke|standard|full)$ ]]; then
   echo "ERROR: --tier must be unit, smoke, standard, or full"
+  exit 1
+fi
+if [[ ! "$REQUEST_TIMEOUT" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: AFM_ASSERTIONS_REQUEST_TIMEOUT must be a positive integer" >&2
   exit 1
 fi
 
@@ -110,7 +115,7 @@ print(json.dumps({
 # Helper: call API and return full JSON response
 api_call() {
   local body="$1"
-  curl -sf --max-time 60 "$BASE_URL/v1/chat/completions" \
+  curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" \
     -H 'Content-Type: application/json' \
     -d "$body" 2>/dev/null || echo '{"error":"curl_failed"}'
 }
@@ -118,7 +123,7 @@ api_call() {
 # Helper: call API and return response headers (one per line)
 api_call_headers() {
   local body="$1"
-  curl -sf --max-time 60 -D - -o /dev/null "$BASE_URL/v1/chat/completions" \
+  curl -sf --max-time "$REQUEST_TIMEOUT" -D - -o /dev/null "$BASE_URL/v1/chat/completions" \
     -H 'Content-Type: application/json' \
     -d "$body" 2>/dev/null || echo 'ERROR'
 }
@@ -126,7 +131,7 @@ api_call_headers() {
 # Helper: call API streaming and return raw SSE
 api_stream() {
   local body="$1"
-  curl -sf --max-time 60 -N "$BASE_URL/v1/chat/completions" \
+  curl -sf --max-time "$REQUEST_TIMEOUT" -N "$BASE_URL/v1/chat/completions" \
     -H 'Content-Type: application/json' \
     -d "$body" 2>/dev/null || echo 'ERROR'
 }
@@ -4181,7 +4186,7 @@ except Exception as e:
 
   # ── Test 15.8: SSE multiplex non-streaming ─────────────────────────────
   t0=$(now_ms)
-  sse_resp=$(curl -sf --max-time 30 -N "$BASE_URL/v1/batch/completions" \
+  sse_resp=$(curl -sf --max-time "$REQUEST_TIMEOUT" -N "$BASE_URL/v1/batch/completions" \
     -H 'Content-Type: application/json' \
     -d '{"requests":[{"custom_id":"sse-a","body":{"model":"'"$MODEL"'","messages":[{"role":"user","content":"Say hi"}],"max_tokens":10}},{"custom_id":"sse-b","body":{"model":"'"$MODEL"'","messages":[{"role":"user","content":"Say bye"}],"max_tokens":10}}]}' 2>/dev/null || echo 'ERROR')
   dur=$(( $(now_ms) - t0 ))
@@ -4210,7 +4215,7 @@ else:
 
   # ── Test 15.9: SSE multiplex streaming interleaved ─────────────────────
   t0=$(now_ms)
-  sse_stream_resp=$(curl -sf --max-time 30 -N "$BASE_URL/v1/batch/completions" \
+  sse_stream_resp=$(curl -sf --max-time "$REQUEST_TIMEOUT" -N "$BASE_URL/v1/batch/completions" \
     -H 'Content-Type: application/json' \
     -d '{"requests":[{"custom_id":"str-x","body":{"model":"'"$MODEL"'","stream":true,"messages":[{"role":"user","content":"Count to 3"}],"max_tokens":15}},{"custom_id":"str-y","body":{"model":"'"$MODEL"'","stream":true,"messages":[{"role":"user","content":"Say ok"}],"max_tokens":10}}]}' 2>/dev/null || echo 'ERROR')
   dur=$(( $(now_ms) - t0 ))
@@ -4289,8 +4294,8 @@ if should_run_section 16 && min_tier standard; then
 
   # Test 16.1: batch + top_k + streaming (was crashing: #72)
   t0=$(now_ms)
-  R=$(curl -sf --max-time 20 "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"top_k":50,"stream":true}' 2>&1)
+  R=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
+    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"top_k":50,"stream":true}' 2>&1 || echo 'ERROR')
   dur=$(($(now_ms) - t0))
   if echo "$R" | grep -q '"content"'; then
     run_test "PairwiseSmoke" "batch + top_k + streaming" "content present" "PASS" "$dur"
@@ -4300,8 +4305,8 @@ if should_run_section 16 && min_tier standard; then
 
   # Test 16.2: batch + presence_penalty + non-streaming (was crashing: #72)
   t0=$(now_ms)
-  R=$(curl -sf --max-time 20 "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"presence_penalty":1.0}' 2>&1)
+  R=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
+    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"presence_penalty":1.0}' 2>&1 || echo 'ERROR')
   dur=$(($(now_ms) - t0))
   if echo "$R" | grep -q '"finish_reason"'; then
     run_test "PairwiseSmoke" "batch + presence_penalty + non-streaming" "finish_reason present" "PASS" "$dur"
@@ -4311,8 +4316,8 @@ if should_run_section 16 && min_tier standard; then
 
   # Test 16.3: batch + repetition_penalty + logprobs (was crashing: #72)
   t0=$(now_ms)
-  R=$(curl -sf --max-time 20 "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"repetition_penalty":1.5,"logprobs":true,"top_logprobs":3}' 2>&1)
+  R=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
+    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"repetition_penalty":1.5,"logprobs":true,"top_logprobs":3}' 2>&1 || echo 'ERROR')
   dur=$(($(now_ms) - t0))
   if echo "$R" | grep -q '"finish_reason"'; then
     run_test "PairwiseSmoke" "batch + repetition_penalty + logprobs" "response valid" "PASS" "$dur"
@@ -4322,8 +4327,8 @@ if should_run_section 16 && min_tier standard; then
 
   # Test 16.4: batch + all sampling params combined
   t0=$(now_ms)
-  R=$(curl -sf --max-time 20 "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"top_k":40,"min_p":0.05,"presence_penalty":0.5,"repetition_penalty":1.2,"temperature":0.7}' 2>&1)
+  R=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
+    -d '{"model":"m","messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"top_k":40,"min_p":0.05,"presence_penalty":0.5,"repetition_penalty":1.2,"temperature":0.7}' 2>&1 || echo 'ERROR')
   dur=$(($(now_ms) - t0))
   if echo "$R" | grep -q '"finish_reason"'; then
     run_test "PairwiseSmoke" "batch + all sampling params combined" "response valid" "PASS" "$dur"
@@ -4336,10 +4341,10 @@ if should_run_section 16 && min_tier standard; then
   if [ "$MODEL_SUPPORTS_THINKING_TOGGLE" != "true" ]; then
     run_test "PairwiseSmoke" "streaming parity (same seed → same output)" "model supports deterministic no-thinking exact output" "SKIP" "$(( $(now_ms) - t0 ))"
   else
-    NS=$(curl -sf --max-time 20 "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly yes in lowercase and nothing else.\"}],\"max_tokens\":3,\"temperature\":0,\"seed\":42,\"stream\":false${THINKING_OFF_JSON_FRAGMENT}}" 2>&1)
-    S=$(curl -sf --max-time 20 "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly yes in lowercase and nothing else.\"}],\"max_tokens\":3,\"temperature\":0,\"seed\":42,\"stream\":true${THINKING_OFF_JSON_FRAGMENT}}" 2>&1)
+    NS=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
+      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly yes in lowercase and nothing else.\"}],\"max_tokens\":3,\"temperature\":0,\"seed\":42,\"stream\":false${THINKING_OFF_JSON_FRAGMENT}}" 2>&1 || echo 'ERROR')
+    S=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
+      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly yes in lowercase and nothing else.\"}],\"max_tokens\":3,\"temperature\":0,\"seed\":42,\"stream\":true${THINKING_OFF_JSON_FRAGMENT}}" 2>&1 || echo 'ERROR')
     dur=$(($(now_ms) - t0))
     NS_C=$(echo "$NS" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'].strip())" 2>/dev/null)
     S_C=$(echo "$S" | python3 -c "
@@ -4369,10 +4374,10 @@ print(content.strip())
     run_test "PairwiseSmoke" "cache idempotency (same seed → same output)" "model supports deterministic no-thinking exact output" "SKIP" "$(( $(now_ms) - t0 ))"
   else
     pairwise_cache_token="PAIRWISE-CACHE-CERULEAN"
-    R1=$(curl -sf --max-time 20 "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly $pairwise_cache_token and nothing else.\"}],\"max_tokens\":20,\"temperature\":0,\"seed\":99${THINKING_OFF_JSON_FRAGMENT}}" 2>&1)
-    R2=$(curl -sf --max-time 20 "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
-      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly $pairwise_cache_token and nothing else.\"}],\"max_tokens\":20,\"temperature\":0,\"seed\":99${THINKING_OFF_JSON_FRAGMENT}}" 2>&1)
+    R1=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
+      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly $pairwise_cache_token and nothing else.\"}],\"max_tokens\":20,\"temperature\":0,\"seed\":99${THINKING_OFF_JSON_FRAGMENT}}" 2>&1 || echo 'ERROR')
+    R2=$(curl -sf --max-time "$REQUEST_TIMEOUT" "$BASE_URL/v1/chat/completions" -H "Content-Type: application/json" \
+      -d "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly $pairwise_cache_token and nothing else.\"}],\"max_tokens\":20,\"temperature\":0,\"seed\":99${THINKING_OFF_JSON_FRAGMENT}}" 2>&1 || echo 'ERROR')
     dur=$(($(now_ms) - t0))
     C1=$(echo "$R1" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'].strip())" 2>/dev/null)
     C2=$(echo "$R2" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'].strip())" 2>/dev/null)

--- a/Scripts/tests/fixtures/slow-openai-server.py
+++ b/Scripts/tests/fixtures/slow-openai-server.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+"""Minimal OpenAI-compatible server that stalls completion responses."""
+
+import json
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_args):
+        pass
+
+    def do_GET(self):
+        if self.path != "/v1/models":
+            self.send_error(404)
+            return
+        body = json.dumps({"data": [{"id": "fixture/slow-model"}]}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        if self.path != "/v1/chat/completions":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        request_body = self.rfile.read(length)
+        if b'"stream":true' in request_body:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(
+                b'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n'
+            )
+            self.wfile.flush()
+        time.sleep(2)
+
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    handle.write(str(server.server_port))
+server.serve_forever()

--- a/Scripts/tests/test-assertion-harness-fixtures.sh
+++ b/Scripts/tests/test-assertion-harness-fixtures.sh
@@ -28,6 +28,12 @@ if request.get("stop") != ["\n"]:
     raise SystemExit(
         f"newline stop fixture sent {request.get('stop')!r}, expected an actual newline"
     )
+
+pairwise = source.split("# Section 16: Pairwise Smoke", 1)[1]
+if pairwise.count("2>&1 || echo 'ERROR')") < 8:
+    raise SystemExit("pairwise curl failures are not fully converted into assertion results")
+if "--max-time \"$REQUEST_TIMEOUT\"" not in pairwise:
+    raise SystemExit("pairwise requests do not use the configurable assertion timeout")
 PY
 
 if rg -q "find .*\\.xctest/Contents/MacOS" "$ROOT_DIR/Scripts/swiftpm-reliable.sh"; then
@@ -58,6 +64,16 @@ touch "$stale_bundle/mlx.metallib"
 "$ROOT_DIR/Scripts/migrate-xctest-metallib-layout.sh" "$scratch_path" "$state_path"
 [[ -f "$stale_bundle/mlx.metallib" ]] || {
     echo "completed migration ran more than once" >&2
+    exit 1
+}
+
+if AFM_ASSERTIONS_REQUEST_TIMEOUT=invalid \
+    "$ROOT_DIR/Scripts/test-assertions.sh" --tier unit >/dev/null 2>"$WORK_ROOT/timeout-error"; then
+    echo "invalid assertion timeout was accepted" >&2
+    exit 1
+fi
+grep -q "AFM_ASSERTIONS_REQUEST_TIMEOUT must be a positive integer" "$WORK_ROOT/timeout-error" || {
+    echo "invalid assertion timeout did not produce the expected diagnostic" >&2
     exit 1
 }
 

--- a/Scripts/tests/test-assertion-harness-fixtures.sh
+++ b/Scripts/tests/test-assertion-harness-fixtures.sh
@@ -4,7 +4,15 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORK_ROOT="$(mktemp -d)"
-trap 'rm -rf "$WORK_ROOT"' EXIT
+timeout_server_pid=""
+cleanup() {
+    if [[ -n "$timeout_server_pid" ]]; then
+        kill "$timeout_server_pid" 2>/dev/null || true
+        wait "$timeout_server_pid" 2>/dev/null || true
+    fi
+    rm -rf "$WORK_ROOT"
+}
+trap cleanup EXIT
 
 python3 - "$ROOT_DIR/Scripts/test-assertions.sh" <<'PY'
 import json
@@ -30,8 +38,12 @@ if request.get("stop") != ["\n"]:
     )
 
 pairwise = source.split("# Section 16: Pairwise Smoke", 1)[1]
-if pairwise.count("2>&1 || echo 'ERROR')") < 8:
-    raise SystemExit("pairwise curl failures are not fully converted into assertion results")
+for result_var in ("R", "NS", "S", "R1", "R2"):
+    if f') || {result_var}=""' not in pairwise:
+        raise SystemExit(f"pairwise curl failures do not clear partial {result_var} output")
+for parsed_var in ("NS_C", "S_C", "C1", "C2"):
+    if f') || {parsed_var}=""' not in pairwise:
+        raise SystemExit(f"pairwise JSON parsing does not tolerate empty {parsed_var} input")
 if "--max-time \"$REQUEST_TIMEOUT\"" not in pairwise:
     raise SystemExit("pairwise requests do not use the configurable assertion timeout")
 PY
@@ -76,5 +88,52 @@ grep -q "AFM_ASSERTIONS_REQUEST_TIMEOUT must be a positive integer" "$WORK_ROOT/
     echo "invalid assertion timeout did not produce the expected diagnostic" >&2
     exit 1
 }
+
+# A server that accepts each request and then stalls exercises curl's timeout
+# path, including the partial-output hazard of a streaming response. The
+# assertion harness must record every pairwise failure and still write reports.
+timeout_port_file="$WORK_ROOT/timeout-server-port"
+/usr/bin/python3 "$ROOT_DIR/Scripts/tests/fixtures/slow-openai-server.py" "$timeout_port_file" &
+timeout_server_pid=$!
+for _ in $(seq 1 50); do
+    [[ -s "$timeout_port_file" ]] && break
+    sleep 0.1
+done
+[[ -s "$timeout_port_file" ]] || {
+    echo "timeout fixture server did not start" >&2
+    kill "$timeout_server_pid" 2>/dev/null || true
+    exit 1
+}
+timeout_report_dir="$WORK_ROOT/timeout-reports"
+timeout_status=0
+AFM_ASSERTIONS_REQUEST_TIMEOUT=1 \
+AFM_ASSERTIONS_REPORT_DIR="$timeout_report_dir" \
+    "$ROOT_DIR/Scripts/test-assertions.sh" \
+    --tier standard --section 16 --model fixture/slow-model \
+    --port "$(<"$timeout_port_file")" --bin /usr/bin/true \
+    >"$WORK_ROOT/timeout-run-output" 2>&1 || timeout_status=$?
+kill "$timeout_server_pid" 2>/dev/null || true
+wait "$timeout_server_pid" 2>/dev/null || true
+timeout_server_pid=""
+[[ "$timeout_status" -eq 6 ]] || {
+    echo "timeout fixture expected six recorded failures, got status $timeout_status" >&2
+    cat "$WORK_ROOT/timeout-run-output" >&2
+    exit 1
+}
+timeout_jsonl=$(find "$timeout_report_dir" -maxdepth 1 -name 'assertions-report-*.jsonl' -print -quit)
+timeout_html=$(find "$timeout_report_dir" -maxdepth 1 -name 'assertions-report-*.html' -print -quit)
+[[ -n "$timeout_jsonl" && -n "$timeout_html" ]] || {
+    echo "timeout fixture did not produce both JSONL and HTML reports" >&2
+    exit 1
+}
+python3 - "$timeout_jsonl" <<'PY'
+import json
+import sys
+
+records = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8")]
+pairwise = [record for record in records if record["group"] == "PairwiseSmoke"]
+if len(pairwise) != 6 or any(record["status"] != "FAIL" for record in pairwise):
+    raise SystemExit(f"expected six recorded pairwise failures, got {pairwise!r}")
+PY
 
 echo "assertion harness fixture checks passed"


### PR DESCRIPTION
Closes #221.

## Problem

Hard-coded 20/30-second curl limits caused the full assertion harness to terminate under `set -e` on slow reasoning models, preventing its final report.

## Approach

- Add validated `AFM_ASSERTIONS_REQUEST_TIMEOUT` with a 60-second default.
- Use it for completion helpers, batch SSE, and pairwise smoke calls.
- Convert pairwise curl failures into individual assertion failures so the suite always reaches its report.
- Extend harness regression coverage for validation and non-aborting curl paths.

## Validation

- `Scripts/tests/test-assertion-harness-fixtures.sh`
- shell syntax and `git diff --check`
- Muse focused Section 16: 6/6 passed, 2 capability skips
- Muse focused Section 15 completed and reported its three genuine batch-capacity failures instead of aborting

## Summary by Sourcery

Make assertion harness timeouts configurable and ensure slow request failures produce complete test reports instead of terminating the run.

Bug Fixes:
- Prevent assertion runs from aborting on slow or failed pairwise requests, ensuring all checks are recorded and final reports are generated.

Enhancements:
- Make assertion request timeouts configurable through AFM_ASSERTIONS_REQUEST_TIMEOUT with validation and a 60-second default.

Tests:
- Add regression coverage for timeout validation, stalled responses, recorded pairwise failures, and report generation.