### PR TITLE
Fix evaluation prompts and capability reporting

### DIFF
--- a/Scripts/assemble_smart_report.py
+++ b/Scripts/assemble_smart_report.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Assemble per-result AI scores into the markdown consumed by the HTML report."""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from mlx_model_test_oracle import extract_score_payload
+
+
+def assemble_per_test_report(scores_dir: str | Path, results_file: str | Path) -> str:
+    scores_path = Path(scores_dir)
+    scores = []
+    report_lines = ["# Per-Test AI Analysis", ""]
+    result_idx = 0
+
+    with Path(results_file).open(encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line:
+                continue
+            result = json.loads(line)
+            if result.get("_meta"):
+                continue
+
+            model = result.get("model", "")
+            label = result.get("label", "")
+            label_suffix = f" @ {label}" if label else ""
+            name = (
+                model
+                if not label_suffix or model.endswith(label_suffix)
+                else model + label_suffix
+            )
+
+            if result.get("status") == "SKIP" or result.get("overall_status") == "skip":
+                skip_reason = result.get("skip_reason") or "Required capability unavailable"
+                report_lines.append(f"### {result_idx}. {name}")
+                report_lines.append("**Not scored** ⏭️ | Status: SKIP")
+                report_lines.append(f"> {skip_reason}.")
+                report_lines.append("")
+                result_idx += 1
+                continue
+
+            score_file = scores_path / f"score_{result_idx}.txt"
+            payload = None
+            if score_file.exists():
+                payload = extract_score_payload(score_file.read_text(encoding="utf-8").strip())
+            score_value = payload["score"] if payload else 3
+            reason = str(payload.get("reason", "")) if payload else ""
+            scores.append({"i": result_idx, "s": score_value})
+
+            tokens_per_second = result.get("tokens_per_sec", 0) or 0
+            status = result.get("status", "")
+            emoji = {5: "✅", 4: "👍", 3: "⚠️", 2: "❌", 1: "💥"}.get(
+                score_value, "❓"
+            )
+            report_lines.append(f"### {result_idx}. {name}")
+            report_lines.append(
+                f"**Score: {score_value}/5** {emoji} | Status: {status} | "
+                f"{float(tokens_per_second):.1f} tok/s"
+            )
+            if reason:
+                report_lines.append(f"> {reason}")
+            report_lines.append("")
+            result_idx += 1
+
+    total = len(scores)
+    pass_count = sum(1 for score in scores if score["s"] >= 4)
+    fail_count = sum(1 for score in scores if score["s"] <= 2)
+    report_lines.append("---")
+    report_lines.append(
+        f"**Summary**: {pass_count}/{total} passed (score ≥ 4), "
+        f"{fail_count} failed (score ≤ 2)"
+    )
+    report_lines.append("")
+    report_lines.append("<!-- AI_SCORES " + json.dumps(scores) + " -->")
+    return "\n".join(report_lines)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            "usage: assemble_smart_report.py <scores-dir> <results-jsonl>",
+            file=sys.stderr,
+        )
+        return os.EX_USAGE
+    print(assemble_per_test_report(sys.argv[1], sys.argv[2]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/generate-report.py
+++ b/Scripts/generate-report.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json, html, datetime, re, os, sys, shutil, subprocess
+from mlx_model_test_oracle import evaluation_lane
 
 
 def extract_ai_scores(content):
@@ -47,6 +48,15 @@ with open(RESULTS_FILE) as f:
 # Tag each result with its original JSONL line index
 for idx, r in enumerate(results):
     r["_jsonl_idx"] = idx
+    r.setdefault(
+        "evaluation_lane",
+        evaluation_lane(
+            model=r.get("model", ""),
+            afm_args=r.get("afm_args", ""),
+            is_baseline=bool(r.get("is_baseline")),
+            has_expectation=r.get("assertion_status") not in (None, "not_configured"),
+        ),
+    )
 
 def result_passed(result):
     if "overall_status" in result:
@@ -54,7 +64,11 @@ def result_passed(result):
     return result.get("status") == "OK"
 
 ok = [r for r in results if result_passed(r)]
-fail = [r for r in results if not result_passed(r)]
+skipped = [
+    r for r in results
+    if r.get("overall_status") == "skip" or r.get("status") == "SKIP"
+]
+fail = [r for r in results if not result_passed(r) and r not in skipped]
 ok_sorted = sorted(ok, key=lambda r: r.get("tokens_per_sec", 0), reverse=True)
 
 now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
@@ -124,6 +138,29 @@ if os.path.isdir(report_dir):
 
 has_ai_scores = len(ai_scores) > 0
 
+native_protocol_results = [
+    r for r in results
+    if r.get("evaluation_lane") == "native_protocol" and r not in skipped
+]
+forced_parser_results = [
+    r for r in results
+    if r.get("evaluation_lane") == "forced_parser_compatibility" and r not in skipped
+]
+quality_scores = {
+    idx: score
+    for idx, score in ai_scores.items()
+    if idx < len(results)
+    and results[idx] not in skipped
+    and results[idx].get("evaluation_lane") == "model_agent_behavior"
+}
+native_protocol_passed = sum(result_passed(r) for r in native_protocol_results)
+forced_parser_passed = sum(result_passed(r) for r in forced_parser_results)
+quality_passed = sum(score >= 4 for score in quality_scores.values())
+
+
+def ratio_text(passed, candidates, *, unavailable="N/A"):
+    return f"{passed}/{len(candidates)}" if candidates else unavailable
+
 # ── Parse AI intent comments from test file ──────────────────────────────────
 # Maps label -> list of "# AI:" comment lines from the prompts file
 ai_intents = {}
@@ -160,8 +197,10 @@ if prompts_file and os.path.isfile(prompts_file):
             comment_buf = []
         else:
             if not stripped.startswith(('temperature:', 'max_tokens:', 'stop:', 'afm:', 'system:',
+                                       'system_json:', 'instructions:', 'instructions_json:', 'requires:',
                                        'seed:', 'top_p:', 'top_k:', 'min_p:', 'response_format:',
-                                       'tools:', 'developer:', 'max_completion_tokens:', 'logprobs:',
+                                       'tools:', 'developer:', 'developer_json:', 'expect_by_prompt:',
+                                       'max_completion_tokens:', 'logprobs:',
                                        'top_logprobs:', 'presence_penalty:', 'repetition_penalty:',
                                        'frequency_penalty:', 'media:', 'expect:')):
                 comment_buf = []
@@ -203,17 +242,36 @@ def config_panel(r):
     afm = r.get("afm_args", "")
     if afm:
         cli_badges.append(config_badge("afm", afm, "#f0883e"))
+    instructions = r.get("server_instructions", "")
+    if instructions:
+        short_instructions = instructions[:80] + ("..." if len(instructions) > 80 else "")
+        cli_badges.append(config_badge("instructions", short_instructions, "#f0883e"))
+
+    # --- API params (request-level) ---
     sp = r.get("system_prompt", "")
     if sp:
         short_sp = sp[:80] + ("..." if len(sp) > 80 else "")
-        cli_badges.append(config_badge("system", short_sp, "#3fb950"))
-
-    # --- API params (request-level) ---
+        api_badges.append(config_badge("system", short_sp, "#3fb950"))
+    developer = r.get("developer_prompt", "")
+    if developer:
+        short_developer = developer[:80] + ("..." if len(developer) > 80 else "")
+        api_badges.append(config_badge("developer", short_developer, "#3fb950"))
+    required = r.get("required_capabilities") or []
+    if required:
+        api_badges.append(config_badge("requires", ", ".join(required), "#a371f7"))
     label = r.get("label", "")
     if label:
         api_badges.append(config_badge("variant", label, "#a371f7"))
     if r.get("is_baseline"):
         api_badges.append(config_badge("baseline", "yes", "#8b949e"))
+    lane_labels = {
+        "native_protocol": "native protocol",
+        "model_agent_behavior": "model/agent behavior",
+        "forced_parser_compatibility": "forced-parser experiment",
+    }
+    lane = r.get("evaluation_lane")
+    if lane:
+        api_badges.append(config_badge("evaluation", lane_labels.get(lane, lane), "#58a6ff"))
     temp = r.get("temperature", "")
     if temp != "":
         api_badges.append(config_badge("temp", temp, "#d29922"))
@@ -261,9 +319,17 @@ def config_panel(r):
         perf_badges.append(config_badge("assert", "pass", "#3fb950"))
     elif assertion == "fail":
         perf_badges.append(config_badge("assert", "FAIL", "#f85149"))
+    if r.get("overall_status") == "skip" or r.get("status") == "SKIP":
+        perf_badges.append(config_badge("status", "SKIP", "#d29922"))
+    classification = r.get("failure_classification")
+    if classification and classification != "conformant":
+        perf_badges.append(config_badge("classification", classification, "#f0883e"))
     perf_badges.append(config_badge("load", f'{r.get("load_time_s", "?")}s', "#8b949e"))
     perf_badges.append(config_badge("gen", f'{r.get("gen_time_s", "?")}s', "#8b949e"))
     perf_badges.append(config_badge("prompt_tok", r.get("prompt_tokens", "?"), "#8b949e"))
+    cached_tokens = r.get("cached_input_tokens", 0)
+    if cached_tokens:
+        perf_badges.append(config_badge("cached_tok", cached_tokens, "#58a6ff"))
     perf_badges.append(config_badge("comp_tok", r.get("completion_tokens", "?"), "#8b949e"))
     tps = r.get("tokens_per_sec", 0)
     if tps:
@@ -285,6 +351,8 @@ response_index_by_jsonl_idx = {
 }
 for i, r in enumerate(response_results):
     content = r.get("content", "") or r.get("content_preview", "")
+    if r.get("overall_status") == "skip" or r.get("status") == "SKIP":
+        content = f"**Skipped:** {r.get('skip_reason', 'required capability unavailable')}"
     reasoning = r.get("reasoning_content", "")
     completion_tokens = r.get("completion_tokens", 0)
     tokens_per_sec = r.get("tokens_per_sec", 0)
@@ -323,8 +391,14 @@ for i, r in enumerate(response_results):
     # ── Build AI Smart Scores section ──
     smart_html = ""
     jsonl_idx = r.get("_jsonl_idx")
-    if has_ai_scores and jsonl_idx is not None:
+    if smart_analyses and jsonl_idx is not None:
         smart_items = []
+        if r.get("overall_status") == "skip" or r.get("status") == "SKIP":
+            smart_items.append(
+                "<div style='margin:4px 0;color:#d29922'>"
+                "⏭️ <strong>Not AI-scored</strong>: required capability was unavailable, so no model response was generated."
+                "</div>"
+            )
         for sa in smart_analyses:
             tool = sa["tool"]
             detail = smart_per_test.get(tool, {}).get(jsonl_idx)
@@ -407,6 +481,19 @@ if fail:
   {score_tds}
   <td>{temp_html} {afm_html}</td>
   <td>{r.get("load_time_s", "?")}</td>
+</tr>
+"""
+
+skip_rows = ""
+for r in skipped:
+    label = r.get("label", "")
+    label_html = f' <span class="variant-tag">{html.escape(label)}</span>' if label else ""
+    reason = html.escape(r.get("skip_reason", "capability-aware skip"))
+    test_num = r.get("_jsonl_idx", 0) + 1
+    skip_rows += f"""<tr>
+  <td class="test-num">{test_num}</td>
+  <td class="mono">{html.escape(r.get("model", "").strip())}{label_html}</td>
+  <td style="color:#d29922">{reason}</td>
 </tr>
 """
 
@@ -637,8 +724,19 @@ MathJax = {{
   <div class="card"><div class="label">Test Runs</div><div class="value blue">{len(results)}</div></div>
   <div class="card"><div class="label">Passed</div><div class="value green">{len(ok)}</div></div>
   <div class="card"><div class="label">Failed</div><div class="value red">{len(fail)}</div></div>
+  <div class="card"><div class="label">Skipped</div><div class="value yellow">{len(skipped)}</div></div>
   <div class="card"><div class="label">Best tok/s</div><div class="value yellow">{best_tps}</div></div>
   <div class="card"><div class="label">Fastest</div><div class="value" style="font-size:1rem;color:#d29922">{best_model}</div></div>
+</div>
+
+<h2>Separated Evaluation Totals</h2>
+<p style="color:#8b949e;font-size:0.85rem;margin-bottom:0.5rem">
+  Protocol and parser totals use deterministic assertions. Model/agent quality uses Codex scores of 4–5 only for the model/agent behavior lane.
+</p>
+<div class="summary">
+  <div class="card"><div class="label">Native Protocol Conformance</div><div class="value green">{ratio_text(native_protocol_passed, native_protocol_results)}</div></div>
+  <div class="card"><div class="label">Model / Agent Behavior Quality</div><div class="value blue">{ratio_text(quality_passed, quality_scores)}</div></div>
+  <div class="card"><div class="label">Forced-Parser Compatibility Experiments</div><div class="value yellow">{ratio_text(forced_parser_passed, forced_parser_results)}</div></div>
 </div>
 
 <h2>Performance Ranking (by tokens/sec)</h2>
@@ -661,6 +759,8 @@ MathJax = {{
 </table>
 
 {"<h2>Failed Runs</h2>" + chr(10) + "<table>" + chr(10) + "<tr><th>Test</th><th>Model</th><th>Error</th>" + (ai_score_header) + "<th>Config</th><th>Load (s)</th></tr>" + chr(10) + fail_rows + "</table>" if fail else ""}
+
+{"<h2>Capability-Aware Skips</h2>" + chr(10) + "<table>" + chr(10) + "<tr><th>Test</th><th>Model</th><th>Reason</th></tr>" + chr(10) + skip_rows + "</table>" if skipped else ""}
 
 {smart_section}
 
@@ -764,7 +864,10 @@ if os.path.abspath(RESULTS_FILE) != os.path.abspath(jsonl_path):
 
 print(f"Report: {html_path}")
 print(f"  Data: {jsonl_path}")
-print(f"  {len(ok)} passed, {len(fail)} failed out of {len(results)} models")
+print(
+    f"  {len(ok)} passed, {len(fail)} failed, {len(skipped)} skipped "
+    f"out of {len(results)} tests"
+)
 
 # Auto-open the HTML report on macOS
 if sys.platform == "darwin" and os.environ.get("AFM_REPORT_NO_OPEN") != "1":

--- a/Scripts/generate-report.py
+++ b/Scripts/generate-report.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json, html, datetime, re, os, sys, shutil, subprocess
-from mlx_model_test_oracle import evaluation_lane
+from mlx_model_test_config import ai_intent_for_result, parse_ai_intent_specs
+from mlx_model_test_oracle import classify_result_likelihood, evaluation_lane
 
 
 def extract_ai_scores(content):
@@ -48,13 +49,25 @@ with open(RESULTS_FILE) as f:
 # Tag each result with its original JSONL line index
 for idx, r in enumerate(results):
     r["_jsonl_idx"] = idx
+    transport_failed = r.get("transport_status") == "fail" or r.get("status") == "FAIL"
     r.setdefault(
         "evaluation_lane",
-        evaluation_lane(
+        "native_protocol" if transport_failed else evaluation_lane(
             model=r.get("model", ""),
             afm_args=r.get("afm_args", ""),
             is_baseline=bool(r.get("is_baseline")),
             has_expectation=r.get("assertion_status") not in (None, "not_configured"),
+        ),
+    )
+    r.setdefault(
+        "failure_classification",
+        classify_result_likelihood(
+            model=r.get("model", ""),
+            label=r.get("label", ""),
+            afm_args=r.get("afm_args", ""),
+            is_baseline=bool(r.get("is_baseline")),
+            status="FAIL" if transport_failed else r.get("status", "OK"),
+            failures=r.get("assertion_failures") or [],
         ),
     )
 
@@ -162,7 +175,7 @@ def ratio_text(passed, candidates, *, unavailable="N/A"):
     return f"{passed}/{len(candidates)}" if candidates else unavailable
 
 # ── Parse AI intent comments from test file ──────────────────────────────────
-# Maps label -> list of "# AI:" comment lines from the prompts file
+# Maps model + label to the "# AI:" comment lines from the prompts file.
 ai_intents = {}
 prompts_file = ""
 # Try to find prompts file from run metadata or environment
@@ -173,37 +186,7 @@ if m_prompts:
 if not prompts_file:
     prompts_file = os.environ.get("PROMPTS_FILE", "")
 if prompts_file and os.path.isfile(prompts_file):
-    with open(prompts_file) as pf:
-        pf_lines = pf.readlines()
-    comment_buf = []
-    for pf_line in pf_lines:
-        stripped = pf_line.strip()
-        if stripped.startswith('#'):
-            comment_buf.append(stripped)
-        elif re.match(r'^\[.+\]$', stripped):
-            # Handle both [model @ label] and [@ label] (template) formats
-            m_template = re.match(r'^\[@\s*(.+?)\]$', stripped)
-            m_label = re.match(r'^\[(.+?)(?:\s*@\s*(.+?))?\]$', stripped)
-            if m_template:
-                label = m_template.group(1).strip()
-            elif m_label:
-                label = (m_label.group(2) or '').strip()
-            else:
-                label = ''
-            if label:
-                ai_lines = [c for c in comment_buf if '# AI:' in c]
-                if ai_lines:
-                    ai_intents[label] = [c.replace('# AI:', '').strip() for c in ai_lines]
-            comment_buf = []
-        else:
-            if not stripped.startswith(('temperature:', 'max_tokens:', 'stop:', 'afm:', 'system:',
-                                       'system_json:', 'instructions:', 'instructions_json:', 'requires:',
-                                       'seed:', 'top_p:', 'top_k:', 'min_p:', 'response_format:',
-                                       'tools:', 'developer:', 'developer_json:', 'expect_by_prompt:',
-                                       'max_completion_tokens:', 'logprobs:',
-                                       'top_logprobs:', 'presence_penalty:', 'repetition_penalty:',
-                                       'frequency_penalty:', 'media:', 'expect:')):
-                comment_buf = []
+    ai_intents = parse_ai_intent_specs(prompts_file)
 
 # ── Parse per-test reasons from smart analysis .md files ─────────────────────
 # Maps (tool, jsonl_idx) -> {"score": int, "reason": str}
@@ -380,8 +363,12 @@ for i, r in enumerate(response_results):
       <summary class="ai-detail-summary">🎯 Baseline Intent</summary>
       <div class="ai-detail-body">{html.escape(intent_lines)}</div>
     </details>"""
-    elif label and label in ai_intents:
-        intent_lines = "<br>".join(html.escape(line) for line in ai_intents[label])
+    else:
+        matched_intent = ai_intent_for_result(
+            ai_intents, r.get("model", ""), label
+        )
+        intent_lines = "<br>".join(html.escape(line) for line in matched_intent)
+    if not r.get("is_baseline") and intent_lines:
         intent_html = f"""
     <details class="ai-detail">
       <summary class="ai-detail-summary">🎯 Test Intent</summary>

--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -886,51 +886,11 @@ record_skipped_run() {
   _RUN_CONFIG="$run_config" _SKIP_REASON="$reason" PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 - <<'PYEOF' >> "$RESULTS_FILE"
 import json
 import os
-from mlx_model_test_oracle import (
-    classify_result_likelihood,
-    evaluation_lane,
-    expectation_for_prompt,
-)
+from mlx_model_test_oracle import skipped_run_records
 
 config = json.loads(os.environ["_RUN_CONFIG"])
-prompts = config.get("prompts") or [""]
-for prompt_index, prompt in enumerate(prompts):
-    is_baseline = prompt_index < config.get("num_baseline", 0)
-    prompt_config = dict(config, prompt_idx=prompt_index)
-    expectation = expectation_for_prompt(prompt_config)
-    model = config.get("model", "")
-    afm_args = config.get("afm_args", "")
-    print(json.dumps({
-        "model": model,
-        "label": config.get("label", ""),
-        "prompt": prompt,
-        "is_baseline": is_baseline,
-        "status": "SKIP",
-        "transport_status": "not_run",
-        "assertion_status": "not_run",
-        "overall_status": "skip",
-        "skip_reason": os.environ["_SKIP_REASON"],
-        "evaluation_lane": evaluation_lane(
-            model=model,
-            afm_args=afm_args,
-            is_baseline=is_baseline,
-            has_expectation=bool(expectation),
-        ),
-        "failure_classification": classify_result_likelihood(
-            model=model,
-            label=config.get("label", ""),
-            afm_args=afm_args,
-            is_baseline=is_baseline,
-            status="SKIP",
-        ),
-        "temperature": config.get("temperature"),
-        "max_tokens": config.get("max_tokens"),
-        "system_prompt": config.get("system", ""),
-        "developer_prompt": config.get("developer", ""),
-        "server_instructions": config.get("instructions", ""),
-        "required_capabilities": config.get("requires") or [],
-        "afm_args": afm_args,
-    }))
+for record in skipped_run_records(config, reason=os.environ["_SKIP_REASON"]):
+    print(json.dumps(record))
 PYEOF
 }
 
@@ -987,6 +947,8 @@ from mlx_model_test_oracle import (
     evaluate_expectations,
     evaluation_lane,
     expectation_for_prompt,
+    request_configuration_fields,
+    transport_failure_record,
 )
 
 # Read config from env var (stdin used by heredoc)
@@ -1227,92 +1189,35 @@ try:
         result['is_valid_json'] = is_valid_json
 
     # Record all optional params that were set
-    for key in ('top_p', 'top_k', 'min_p', 'seed', 'logprobs', 'top_logprobs',
-                'presence_penalty', 'repetition_penalty', 'frequency_penalty',
-                'stop', 'response_format', 'media', 'tools'):
-        if config.get(key) is not None:
-            result[key] = config[key]
-    if expectation:
-        result['expect'] = expectation
+    result.update(request_configuration_fields(config, expectation=expectation))
 
     print(json.dumps(result))
 
 except Exception as e:
     gen_end = time.time()
     error_msg = str(e)[:500]
-    result = {
-        'model': model,
-        'label': label,
-        'prompt': prompt_text,
-        'status': 'FAIL',
-        'transport_status': 'fail',
-        'assertion_status': 'not_run',
-        'overall_status': 'fail',
-        'evaluation_lane': evaluation_lane(
-            model=model,
-            afm_args=afm_args,
-            is_baseline=is_baseline,
-            has_expectation=bool(expectation),
-        ),
-        'failure_classification': classify_result_likelihood(
-            model=model,
-            label=label,
-            afm_args=afm_args,
-            is_baseline=is_baseline,
-            status='FAIL',
-        ),
-        'error': error_msg,
-        'load_time_s': load_time,
-        'temperature': temperature,
-        'max_tokens': max_tokens,
-        'max_completion_tokens': max_completion_tokens,
-        'system_prompt': system_prompt,
-        'developer_prompt': developer_prompt,
-        'server_instructions': server_instructions,
-        'required_capabilities': config.get('requires') or [],
-        'afm_args': afm_args,
-    }
-    for key in ('top_p', 'top_k', 'min_p', 'seed', 'logprobs', 'top_logprobs',
-                'presence_penalty', 'repetition_penalty', 'frequency_penalty',
-                'stop', 'response_format', 'media', 'tools'):
-        if config.get(key) is not None:
-            result[key] = config[key]
-    if expectation:
-        result['expect'] = expectation
+    result = transport_failure_record(
+        config,
+        prompt=prompt_text,
+        error=error_msg,
+        load_time_s=load_time,
+    )
     print(json.dumps(result))
 SEND_PYEOF
   )
 
   if ! printf '%s' "$METRICS" | python3 -c 'import json,sys; json.load(sys.stdin)' >/dev/null 2>&1; then
     local raw_metrics="$METRICS"
-    METRICS=$(_RAW_METRICS="$raw_metrics" _SEND_CONFIG="$send_config" PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 - <<'PYEOF'
+    METRICS=$(_RAW_METRICS="$raw_metrics" _SEND_CONFIG="$send_config" _LOAD_TIME="$load_time" PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 - <<'PYEOF'
 import json, os
-from mlx_model_test_oracle import classify_result_likelihood, evaluation_lane
+from mlx_model_test_oracle import transport_failure_record
 config = json.loads(os.environ['_SEND_CONFIG'])
-model = config.get('model', '')
-afm_args = config.get('afm_args', '')
-is_baseline = config.get('prompt_idx', 0) < config.get('num_baseline', 0)
-print(json.dumps({
-    'model': model,
-    'label': config.get('label', ''),
-    'prompt': config.get('prompt_text', ''),
-    'status': 'FAIL',
-    'overall_status': 'fail',
-    'evaluation_lane': evaluation_lane(
-        model=model,
-        afm_args=afm_args,
-        is_baseline=is_baseline,
-        has_expectation=bool(config.get('expect')),
-    ),
-    'failure_classification': classify_result_likelihood(
-        model=model,
-        label=config.get('label', ''),
-        afm_args=afm_args,
-        is_baseline=is_baseline,
-        status='FAIL',
-    ),
-    'error': 'Test client did not return valid JSON: ' + os.environ.get('_RAW_METRICS', '')[:400],
-}))
+print(json.dumps(transport_failure_record(
+    config,
+    prompt=config.get('prompt_text', ''),
+    error='Test client did not return valid JSON: ' + os.environ.get('_RAW_METRICS', '')[:400],
+    load_time_s=float(os.environ['_LOAD_TIME']),
+)))
 PYEOF
     )
   fi

--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -506,11 +506,13 @@ mkdir -p "$CAPABILITY_CACHE_DIR"
 
 # ── Capture test run metadata (version, command) ─────────────────────────────
 AFM_VERSION=$("$AFM" --version 2>/dev/null || echo "unknown")
+AFM_RESOLVED_PATH=$(command -v "$AFM" 2>/dev/null || printf '%s' "$AFM")
+AFM_BINARY_DIGEST=$(shasum -a 256 "$AFM_RESOLVED_PATH" | awk '{print $1}')
 TEST_COMMAND="mlx-model-test.sh $*"
-export AFM_VERSION TEST_COMMAND
+export AFM_VERSION AFM_RESOLVED_PATH AFM_BINARY_DIGEST TEST_COMMAND
 
 # Write metadata record as first JSONL line
-echo "{\"_meta\":true,\"afm_version\":\"$AFM_VERSION\",\"test_command\":\"$TEST_COMMAND\",\"afm_binary\":\"$(which "$AFM" 2>/dev/null || echo "$AFM")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "$RESULTS_FILE"
+echo "{\"_meta\":true,\"afm_version\":\"$AFM_VERSION\",\"test_command\":\"$TEST_COMMAND\",\"afm_binary\":\"$AFM_RESOLVED_PATH\",\"afm_binary_sha256\":\"$AFM_BINARY_DIGEST\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "$RESULTS_FILE"
 
 # ── Parse prompts file into JSON config ───────────────────────────────────────
 
@@ -834,7 +836,7 @@ escape_json() {
 capability_cache_file() {
   local run_config="$1"
   local digest
-  digest=$(printf '%s' "$run_config" | shasum -a 256 | awk '{print $1}')
+  digest=$(printf '%s\0%s\0%s\0%s' "$AFM_RESOLVED_PATH" "$AFM_VERSION" "$AFM_BINARY_DIGEST" "$run_config" | shasum -a 256 | awk '{print $1}')
   printf '%s/%s.json\n' "$CAPABILITY_CACHE_DIR" "$digest"
 }
 
@@ -929,6 +931,25 @@ for prompt_index, prompt in enumerate(prompts):
         "required_capabilities": config.get("requires") or [],
         "afm_args": afm_args,
     }))
+PYEOF
+}
+
+record_failed_run() {
+  local run_config="$1"
+  local error_message="$2"
+  local load_time="$3"
+  _RUN_CONFIG="$run_config" _ERROR_MESSAGE="$error_message" _LOAD_TIME="$load_time" PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 - <<'PYEOF' >> "$RESULTS_FILE"
+import json
+import os
+from mlx_model_test_oracle import failed_run_records
+
+config = json.loads(os.environ["_RUN_CONFIG"])
+for record in failed_run_records(
+    config,
+    error=os.environ["_ERROR_MESSAGE"],
+    load_time_s=int(os.environ["_LOAD_TIME"]),
+):
+    print(json.dumps(record))
 PYEOF
 }
 
@@ -1430,7 +1451,7 @@ print(f'API: {api}' if api else 'API: (none)')
       fi
     fi
     echo "  FAIL: $error_msg"
-    echo "{\"model\":$(escape_json "$model"),\"label\":$(escape_json "$label"),\"status\":\"FAIL\",\"error\":$(escape_json "$error_msg"),\"load_time_s\":$load_time,\"temperature\":$temperature,\"max_tokens\":$max_tokens,\"system_prompt\":$(escape_json "$sys_prompt"),\"server_instructions\":$(escape_json "$server_instructions"),\"afm_args\":$(escape_json "$afm_args")}" >> "$RESULTS_FILE"
+    record_failed_run "$run_config" "$error_msg" "$load_time"
     OVERALL_STATUS=1
     kill_server $SERVER_PID
     SERVER_PID=0
@@ -1757,7 +1778,8 @@ Output the block EXACTLY like this (one line, valid JSON array):
 Rules:
 - Include an entry for every executed result, including failed ones (score 1)
 - Omit status=SKIP records from AI_SCORES; they were not executed and have no model output
-- The "i" field is the 0-based line index in the JSONL
+- The "i" field is the 0-based result index after metadata records are removed
+- SKIP records retain their result index but have no AI_SCORES entry
 - The "s" field is the integer score 1-5
 - This line must be the LAST line of your output
 - Do NOT wrap it in a code block
@@ -1829,46 +1851,13 @@ print(sum(1 for line in open(sys.argv[1]) if line.strip() and not json.loads(lin
 " "$RESULTS_FILE")
       echo "  Per-test scoring with $tool ($total_lines results)..."
 
-      # Extract test spec blocks from the test file (label → comment block mapping)
+      # Extract test specs by model + label, with template sections as fallback.
       PERTEST_SPECS=""
       if [ -n "$PROMPTS_FILE" ] && [ -f "$PROMPTS_FILE" ]; then
-        PERTEST_SPECS=$(python3 -c "
-import sys, re
-
-# Parse test file to extract the # AI: comment block preceding each [section @ label]
-lines = open(sys.argv[1]).readlines()
-specs = {}
-comment_buf = []
-for line in lines:
-    stripped = line.strip()
-    if stripped.startswith('#'):
-        comment_buf.append(stripped)
-    elif re.match(r'^\[.+\]$', stripped):
-        # Extract label from [org/model @ label] OR [@ label] (template mode)
-        m_template = re.match(r'^\[@\s*(.+?)\s*\]$', stripped)
-        m_named = re.match(r'^\[(.+?)\s*@\s*(.+?)\]$', stripped)
-        label = ''
-        if m_template:
-            label = m_template.group(1).strip()
-        elif m_named:
-            label = m_named.group(2).strip()
-        if label:
-            # Keep the AI: comments + section header
-            spec_lines = [c for c in comment_buf if '# AI:' in c or c.startswith('# ---')]
-            specs[label] = '\n'.join(spec_lines) if spec_lines else ''
-        comment_buf = []
-    else:
-        if not stripped.startswith(('temperature:', 'max_tokens:', 'stop:', 'afm:', 'system:',
-                                    'system_json:', 'instructions:', 'instructions_json:', 'requires:',
-                                    'seed:', 'top_p:', 'top_k:', 'min_p:', 'response_format:',
-                                    'tools:', 'developer:', 'developer_json:', 'expect_by_prompt:',
-                                    'max_completion_tokens:', 'logprobs:',
-                                    'top_logprobs:', 'presence_penalty:', 'repetition_penalty:',
-                                    'frequency_penalty:', 'media:')):
-            comment_buf = []  # reset on non-param, non-comment lines
-
-import json
-print(json.dumps(specs))
+        PERTEST_SPECS=$(PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c "
+import json, sys
+from mlx_model_test_config import parse_ai_intent_specs
+print(json.dumps(parse_ai_intent_specs(sys.argv[1])))
 " "$PROMPTS_FILE" 2>/dev/null)
       fi
 
@@ -1893,15 +1882,16 @@ print(json.dumps(specs))
         # must not inherit that section's semantic expectations.
         test_spec=""
         if [ -n "$PERTEST_SPECS" ]; then
-          test_spec=$(echo "$jsonl_line" | python3 -c "
+          test_spec=$(echo "$jsonl_line" | PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c "
 import json, sys
+from mlx_model_test_config import ai_intent_for_result
 specs = json.loads(sys.argv[1])
 d = json.load(sys.stdin)
 if d.get('is_baseline'):
     print('Global [all] baseline. Judge only the actual prompt and response quality; ignore the enclosing variant-specific intent and expectations.')
     raise SystemExit
-label = d.get('label', '')
-print(specs.get(label, ''))
+lines = ai_intent_for_result(specs, d.get('model', ''), d.get('label', ''))
+print('\n'.join('# AI: ' + line for line in lines))
 " "$PERTEST_SPECS" 2>/dev/null)
         fi
 
@@ -2050,31 +2040,10 @@ $SMART_TEST_FILE_SECTION
           # Extract test spec blocks for per-result context
           AFM_SPECS=""
           if [ -n "$PROMPTS_FILE" ] && [ -f "$PROMPTS_FILE" ]; then
-            AFM_SPECS=$(python3 -c "
-import sys, re, json
-lines = open(sys.argv[1]).readlines()
-specs = {}
-comment_buf = []
-for line in lines:
-    stripped = line.strip()
-    if stripped.startswith('#'):
-        comment_buf.append(stripped)
-    elif re.match(r'^\[.+\]$', stripped):
-        m = re.match(r'^\[(.+?)(?:\s*@\s*(.+?))?\]$', stripped)
-        if m:
-            label = (m.group(2) or '').strip()
-            if label:
-                spec_lines = [c for c in comment_buf if '# AI:' in c]
-                specs[label] = ' '.join(spec_lines)[:200] if spec_lines else ''
-        comment_buf = []
-    else:
-        if not stripped.startswith(('temperature:', 'max_tokens:', 'stop:', 'afm:', 'system:',
-                                    'seed:', 'top_p:', 'top_k:', 'min_p:', 'response_format:',
-                                    'tools:', 'developer:', 'max_completion_tokens:', 'logprobs:',
-                                    'top_logprobs:', 'presence_penalty:', 'repetition_penalty:',
-                                    'frequency_penalty:', 'media:')):
-            comment_buf = []
-print(json.dumps(specs))
+            AFM_SPECS=$(PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c "
+import json, sys
+from mlx_model_test_config import parse_ai_intent_specs
+print(json.dumps(parse_ai_intent_specs(sys.argv[1])))
 " "$PROMPTS_FILE" 2>/dev/null)
           fi
 
@@ -2088,12 +2057,13 @@ print(json.dumps(specs))
             # Get test spec for this label (truncated for afm's limited context)
             afm_spec=""
             if [ -n "$AFM_SPECS" ]; then
-              afm_spec=$(echo "$jsonl_line" | python3 -c "
+              afm_spec=$(echo "$jsonl_line" | PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c "
 import json, sys
+from mlx_model_test_config import ai_intent_for_result
 specs = json.loads(sys.argv[1])
 d = json.load(sys.stdin)
-label = d.get('label', '')
-print(specs.get(label, ''))
+lines = ai_intent_for_result(specs, d.get('model', ''), d.get('label', ''))
+print(' '.join(lines)[:200])
 " "$AFM_SPECS" 2>/dev/null)
             fi
 

--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -37,13 +37,18 @@
 #   stop:                Comma-separated stop sequences (e.g. stop: </s>,<|end|>)
 #   response_format:     text | json_object
 #   system:              System prompt text
+#   system_json:         System prompt encoded as a JSON string (decodes \n, \t, etc.)
 #   developer:           OpenAI developer-role message text
+#   developer_json:      Developer message encoded as a JSON string
+#   instructions:        Server-level default instructions (passed to afm -i)
+#   instructions_json:   Server instructions encoded as a JSON string
 #   tools:               OpenAI tools array as JSON
 #   expect:              Executable result oracle as JSON, e.g.:
 #                         {"valid_json":true,"finish_reason":"stop"}
 #                         {"tool_calls":[{"name":"get_weather","arguments":{"city":"Paris"}}]}
 #                         {"logprobs_min":1}
 #                         {"content_equals":"prefix","content_not_contains":["STOP","suffix"]}
+#   expect_by_prompt:    JSON array of executable oracles for prompts in one run
 #   afm:                 CLI flags passed to the afm server process, e.g.:
 #                          --verbose / --very-verbose
 #                          --no-streaming
@@ -52,6 +57,7 @@
 #                          --tool-call-parser <hermes|llama3_json|gemma|mistral|qwen3_xml>
 #                          --fix-tool-args
 #   media:               Comma-separated media paths for VLM (auto-injects --vlm)
+#   requires:            Comma-separated /v1/models capabilities required by this test
 #   skip                 Skip this model entirely
 #
 # ANY OTHER LINE in a section is treated as a prompt.
@@ -336,14 +342,20 @@ PROMPTS FILE FORMAT
     stop:                Comma-separated stop sequences (e.g. stop: </s>,<|end|>)
     response_format:     Response format (e.g. response_format: json_object)
     system:              System prompt (e.g. system: You are a helpful assistant)
+    system_json:         JSON string form for exact escapes and multiline content
     developer:           OpenAI developer-role message
                          (e.g. developer: Return code only)
+    developer_json:      JSON string form of the developer message
+    instructions:        Server-level default instructions passed to afm -i
+    instructions_json:   JSON string form of server-level instructions
     tools:               OpenAI tools array encoded as JSON
     afm:                 Extra CLI flags passed to afm server
                          (e.g. afm: --verbose --enable-prefix-caching)
     media:               Comma-separated media file paths for VLM testing
                          (e.g. media: media/puppy.png)
                          Auto-injects --vlm into afm args.
+    requires:            Comma-separated capability labels required by the test
+                         (e.g. requires: structured, streaming)
     skip                 Skip this model/variant entirely (no value needed)
 
   Everything else in a section is treated as a prompt.
@@ -489,6 +501,8 @@ fi
 
 mkdir -p "$(dirname "$RESULTS_FILE")" "$SERVER_LOG_DIR"
 > "$RESULTS_FILE"
+CAPABILITY_CACHE_DIR="$SERVER_LOG_DIR/capabilities"
+mkdir -p "$CAPABILITY_CACHE_DIR"
 
 # ── Capture test run metadata (version, command) ─────────────────────────────
 AFM_VERSION=$("$AFM" --version 2>/dev/null || echo "unknown")
@@ -502,181 +516,11 @@ echo "{\"_meta\":true,\"afm_version\":\"$AFM_VERSION\",\"test_command\":\"$TEST_
 
 PARSED_CONFIG=""
 if [ -n "$PROMPTS_FILE" ]; then
-  PARSED_CONFIG=$(python3 - "$PROMPTS_FILE" <<'PYEOF'
-import sys, json, re
-
-filepath = sys.argv[1]
-config = {
-    "defaults": {},
-    "all": [],
-    "runs": []   # ordered list of {model, label, prompts, params, skip, afm}
-}
-
-# Track model sections for merging into runs at the end
-model_sections = {}  # key = "model" or "model @ label"
-
-current_section = None  # None = defaults, "all", or section key
-
-with open(filepath) as f:
-    for raw_line in f:
-        line = raw_line.strip()
-
-        # Skip comments and blank lines
-        if not line or line.startswith('#'):
-            continue
-
-        # Section header: [all] or [org/model] or [org/model @ label]
-        m = re.match(r'^\[(.+)\]$', line)
-        if m:
-            section_name = m.group(1).strip()
-            if section_name == 'all':
-                current_section = 'all'
-            else:
-                current_section = section_name
-                if section_name not in model_sections:
-                    # Parse "@ label" (template), "org/model @ label", or "org/model"
-                    if section_name.startswith('@ '):
-                        # Template mode: [@ label] — model injected at runtime
-                        model_id = ""
-                        label = section_name[2:].strip()
-                    elif ' @ ' in section_name:
-                        model_id, label = section_name.split(' @ ', 1)
-                        model_id = model_id.strip()
-                        label = label.strip()
-                    else:
-                        model_id = section_name
-                        label = ""
-                    model_sections[section_name] = {
-                        'model': model_id,
-                        'label': label,
-                        'prompts': [],
-                        'params': {},
-                        'afm': '',
-                        'skip': False
-                    }
-            continue
-
-        # Before any section = defaults
-        if current_section is None:
-            if line.startswith('max_tokens:'):
-                config['defaults']['max_tokens'] = int(line.split(':', 1)[1].strip())
-            elif line.startswith('max_completion_tokens:'):
-                config['defaults']['max_completion_tokens'] = int(line.split(':', 1)[1].strip())
-            elif line.startswith('temperature:'):
-                config['defaults']['temperature'] = float(line.split(':', 1)[1].strip())
-            elif line.startswith('top_p:'):
-                config['defaults']['top_p'] = float(line.split(':', 1)[1].strip())
-            elif line.startswith('top_k:'):
-                config['defaults']['top_k'] = int(line.split(':', 1)[1].strip())
-            elif line.startswith('min_p:'):
-                config['defaults']['min_p'] = float(line.split(':', 1)[1].strip())
-            elif line.startswith('seed:'):
-                config['defaults']['seed'] = int(line.split(':', 1)[1].strip())
-            elif line.startswith('logprobs:'):
-                config['defaults']['logprobs'] = line.split(':', 1)[1].strip().lower() == 'true'
-            elif line.startswith('top_logprobs:'):
-                config['defaults']['top_logprobs'] = int(line.split(':', 1)[1].strip())
-            elif line.startswith('presence_penalty:'):
-                config['defaults']['presence_penalty'] = float(line.split(':', 1)[1].strip())
-            elif line.startswith('repetition_penalty:'):
-                config['defaults']['repetition_penalty'] = float(line.split(':', 1)[1].strip())
-            elif line.startswith('frequency_penalty:'):
-                config['defaults']['frequency_penalty'] = float(line.split(':', 1)[1].strip())
-            elif line.startswith('stop:'):
-                raw = line.split(':', 1)[1].strip()
-                try:
-                    parsed = json.loads(raw)
-                    config['defaults']['stop'] = parsed if isinstance(parsed, list) else [str(parsed)]
-                except (json.JSONDecodeError, ValueError):
-                    config['defaults']['stop'] = [s.strip() for s in raw.split(',')]
-            elif line.startswith('response_format:'):
-                raw = line.split(':', 1)[1].strip()
-                try:
-                    config['defaults']['response_format'] = json.loads(raw)
-                except (json.JSONDecodeError, ValueError):
-                    config['defaults']['response_format'] = raw
-            elif line.startswith('system:'):
-                config['defaults']['system'] = line.split(':', 1)[1].strip()
-            elif line.startswith('developer:'):
-                config['defaults']['developer'] = line.split(':', 1)[1].strip()
-            elif line.startswith('tools:'):
-                config['defaults']['tools'] = json.loads(line.split(':', 1)[1].strip())
-            elif line.startswith('expect:'):
-                config['defaults']['expect'] = json.loads(line.split(':', 1)[1].strip())
-            elif line.startswith('afm:'):
-                config['defaults']['afm'] = line.split(':', 1)[1].strip()
-            elif line.startswith('media:'):
-                config['defaults']['media'] = [p.strip() for p in line.split(':', 1)[1].strip().split(',')]
-            continue
-
-        # [all] section: every line is a prompt
-        if current_section == 'all':
-            config['all'].append(line)
-            continue
-
-        # Model/variant section: parse params or treat as prompt
-        sec = model_sections[current_section]
-        if line == 'skip':
-            sec['skip'] = True
-        elif line.startswith('max_tokens:'):
-            sec['params']['max_tokens'] = int(line.split(':', 1)[1].strip())
-        elif line.startswith('max_completion_tokens:'):
-            sec['params']['max_completion_tokens'] = int(line.split(':', 1)[1].strip())
-        elif line.startswith('temperature:'):
-            sec['params']['temperature'] = float(line.split(':', 1)[1].strip())
-        elif line.startswith('top_p:'):
-            sec['params']['top_p'] = float(line.split(':', 1)[1].strip())
-        elif line.startswith('top_k:'):
-            sec['params']['top_k'] = int(line.split(':', 1)[1].strip())
-        elif line.startswith('min_p:'):
-            sec['params']['min_p'] = float(line.split(':', 1)[1].strip())
-        elif line.startswith('seed:'):
-            sec['params']['seed'] = int(line.split(':', 1)[1].strip())
-        elif line.startswith('logprobs:'):
-            sec['params']['logprobs'] = line.split(':', 1)[1].strip().lower() == 'true'
-        elif line.startswith('top_logprobs:'):
-            sec['params']['top_logprobs'] = int(line.split(':', 1)[1].strip())
-        elif line.startswith('presence_penalty:'):
-            sec['params']['presence_penalty'] = float(line.split(':', 1)[1].strip())
-        elif line.startswith('repetition_penalty:'):
-            sec['params']['repetition_penalty'] = float(line.split(':', 1)[1].strip())
-        elif line.startswith('frequency_penalty:'):
-            sec['params']['frequency_penalty'] = float(line.split(':', 1)[1].strip())
-        elif line.startswith('stop:'):
-            raw = line.split(':', 1)[1].strip()
-            try:
-                parsed = json.loads(raw)
-                sec['params']['stop'] = parsed if isinstance(parsed, list) else [str(parsed)]
-            except (json.JSONDecodeError, ValueError):
-                sec['params']['stop'] = [s.strip() for s in raw.split(',')]
-        elif line.startswith('response_format:'):
-            raw = line.split(':', 1)[1].strip()
-            try:
-                sec['params']['response_format'] = json.loads(raw)
-            except (json.JSONDecodeError, ValueError):
-                sec['params']['response_format'] = raw
-        elif line.startswith('system:'):
-            sec['params']['system'] = line.split(':', 1)[1].strip()
-        elif line.startswith('developer:'):
-            sec['params']['developer'] = line.split(':', 1)[1].strip()
-        elif line.startswith('tools:'):
-            sec['params']['tools'] = json.loads(line.split(':', 1)[1].strip())
-        elif line.startswith('expect:'):
-            sec['params']['expect'] = json.loads(line.split(':', 1)[1].strip())
-        elif line.startswith('afm:'):
-            sec['afm'] = line.split(':', 1)[1].strip()
-        elif line.startswith('media:'):
-            sec['params']['media'] = [p.strip() for p in line.split(':', 1)[1].strip().split(',')]
-        else:
-            sec['prompts'].append(line)
-
-# Build ordered runs list (preserves file order)
-for key in model_sections:
-    config['runs'].append(model_sections[key])
-
-print(json.dumps(config))
-PYEOF
-  )
+  PARSED_CONFIG=$(PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c '
+import json, sys
+from mlx_model_test_config import parse_prompts_file
+print(json.dumps(parse_prompts_file(sys.argv[1])))
+' "$PROMPTS_FILE")
 
   if [ $? -ne 0 ]; then
     echo "Error: Failed to parse prompts file: $PROMPTS_FILE" >&2
@@ -885,8 +729,11 @@ result = {
     'temperature': temperature,
     'system': system,
     'developer': merge_param('developer'),
+    'instructions': merge_param('instructions'),
+    'requires': merge_param('requires') or [],
     'tools': merge_param('tools'),
     'expect': merge_param('expect'),
+    'expect_by_prompt': merge_param('expect_by_prompt'),
     'afm_args': afm_args,
     'top_p': merge_param('top_p'),
     'top_k': merge_param('top_k'),
@@ -930,6 +777,8 @@ print(json.dumps({
     'max_tokens': $max_tokens,
     'temperature': $temperature,
     'system': '$sys_prompt',
+    'instructions': '',
+    'requires': [],
     'afm_args': '$CLI_AFM_ARGS'
 }))
 "
@@ -982,6 +831,107 @@ escape_json() {
   python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" <<< "$1"
 }
 
+capability_cache_file() {
+  local run_config="$1"
+  local digest
+  digest=$(printf '%s' "$run_config" | shasum -a 256 | awk '{print $1}')
+  printf '%s/%s.json\n' "$CAPABILITY_CACHE_DIR" "$digest"
+}
+
+capture_server_capabilities() {
+  local model="$1"
+  local destination="$2"
+  python3 - "$model" "$destination" "$PORT" <<'PYEOF'
+import json
+import pathlib
+import sys
+import urllib.request
+
+requested_model, destination, port = sys.argv[1:]
+with urllib.request.urlopen(f"http://127.0.0.1:{port}/v1/models", timeout=5) as response:
+    payload = json.load(response)
+details = payload.get("models") or []
+selected = next((item for item in details if item.get("model") == requested_model), None)
+if selected is None:
+    selected = next(
+        (item for item in details if "embeddings" not in (item.get("capabilities") or [])),
+        None,
+    )
+capabilities = sorted(set((selected or {}).get("capabilities") or []))
+pathlib.Path(destination).write_text(json.dumps(capabilities), encoding="utf-8")
+print(json.dumps(capabilities))
+PYEOF
+}
+
+missing_required_capabilities() {
+  local run_config="$1"
+  local capability_file="$2"
+  _RUN_CONFIG="$run_config" python3 - "$capability_file" <<'PYEOF'
+import json
+import os
+import pathlib
+import sys
+
+required = set(json.loads(os.environ["_RUN_CONFIG"]).get("requires") or [])
+available = set(json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")))
+print(", ".join(sorted(required - available)))
+PYEOF
+}
+
+record_skipped_run() {
+  local run_config="$1"
+  local reason="$2"
+  _RUN_CONFIG="$run_config" _SKIP_REASON="$reason" PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 - <<'PYEOF' >> "$RESULTS_FILE"
+import json
+import os
+from mlx_model_test_oracle import (
+    classify_result_likelihood,
+    evaluation_lane,
+    expectation_for_prompt,
+)
+
+config = json.loads(os.environ["_RUN_CONFIG"])
+prompts = config.get("prompts") or [""]
+for prompt_index, prompt in enumerate(prompts):
+    is_baseline = prompt_index < config.get("num_baseline", 0)
+    prompt_config = dict(config, prompt_idx=prompt_index)
+    expectation = expectation_for_prompt(prompt_config)
+    model = config.get("model", "")
+    afm_args = config.get("afm_args", "")
+    print(json.dumps({
+        "model": model,
+        "label": config.get("label", ""),
+        "prompt": prompt,
+        "is_baseline": is_baseline,
+        "status": "SKIP",
+        "transport_status": "not_run",
+        "assertion_status": "not_run",
+        "overall_status": "skip",
+        "skip_reason": os.environ["_SKIP_REASON"],
+        "evaluation_lane": evaluation_lane(
+            model=model,
+            afm_args=afm_args,
+            is_baseline=is_baseline,
+            has_expectation=bool(expectation),
+        ),
+        "failure_classification": classify_result_likelihood(
+            model=model,
+            label=config.get("label", ""),
+            afm_args=afm_args,
+            is_baseline=is_baseline,
+            status="SKIP",
+        ),
+        "temperature": config.get("temperature"),
+        "max_tokens": config.get("max_tokens"),
+        "system_prompt": config.get("system", ""),
+        "developer_prompt": config.get("developer", ""),
+        "server_instructions": config.get("instructions", ""),
+        "required_capabilities": config.get("requires") or [],
+        "afm_args": afm_args,
+    }))
+PYEOF
+}
+
 # ── Send a single prompt and record result ────────────────────────────────────
 
 send_prompt() {
@@ -1011,7 +961,12 @@ print(json.dumps(c))
   # Single python3 block: builds OpenAI SDK call, sends request, outputs JSONL result
   METRICS=$(_SEND_CONFIG="$send_config" PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 - "$PORT" "$load_time" "$TIMEOUT_GENERATE" <<'SEND_PYEOF'
 import json, sys, time, os
-from mlx_model_test_oracle import evaluate_expectations, expectation_for_prompt
+from mlx_model_test_oracle import (
+    classify_result_likelihood,
+    evaluate_expectations,
+    evaluation_lane,
+    expectation_for_prompt,
+)
 
 # Read config from env var (stdin used by heredoc)
 config = json.loads(os.environ['_SEND_CONFIG'])
@@ -1033,6 +988,7 @@ label = config.get('label', '')
 prompt_text = config['prompt_text']
 system_prompt = config.get('system', '')
 developer_prompt = config.get('developer', '')
+server_instructions = config.get('instructions', '')
 max_tokens = config['max_tokens']
 max_completion_tokens = config.get('max_completion_tokens')
 temperature = config['temperature']
@@ -1152,6 +1108,11 @@ try:
     prompt_tokens = usage.prompt_tokens if usage else 0
     completion_tokens = usage.completion_tokens if usage else 0
     total_tokens = usage.total_tokens if usage else 0
+    prompt_token_details = getattr(usage, 'prompt_tokens_details', None) if usage else None
+    cached_input_tokens = (
+        getattr(prompt_token_details, 'cached_tokens', 0) or 0
+        if prompt_token_details is not None else 0
+    )
     tps = completion_tokens / gen_time if gen_time > 0 else 0
     tps_note = 'calculated'  # wall-clock / reported tokens (not engine-provided)
     content_preview = full_content[:300].replace('\n', ' ')
@@ -1184,6 +1145,7 @@ try:
         finish_reason=finish_reason,
         logprobs_count=logprobs_count,
         tool_calls=tool_calls,
+        cached_input_tokens=cached_input_tokens,
     )
     if is_valid_json is None:
         is_valid_json = oracle_valid_json
@@ -1199,10 +1161,25 @@ try:
         'transport_status': 'pass',
         'assertion_status': assertion_status,
         'overall_status': 'fail' if assertion_failures else 'pass',
+        'evaluation_lane': evaluation_lane(
+            model=model,
+            afm_args=afm_args,
+            is_baseline=is_baseline,
+            has_expectation=bool(expectation),
+        ),
+        'failure_classification': classify_result_likelihood(
+            model=model,
+            label=label,
+            afm_args=afm_args,
+            is_baseline=is_baseline,
+            status='OK',
+            failures=assertion_failures,
+        ),
         'assertion_failures': assertion_failures,
         'load_time_s': load_time,
         'gen_time_s': round(gen_time, 2),
         'prompt_tokens': prompt_tokens,
+        'cached_input_tokens': cached_input_tokens,
         'completion_tokens': completion_tokens,
         'total_tokens': total_tokens,
         'tokens_per_sec': round(tps, 2),
@@ -1212,6 +1189,8 @@ try:
         'max_completion_tokens': max_completion_tokens,
         'system_prompt': system_prompt,
         'developer_prompt': developer_prompt,
+        'server_instructions': server_instructions,
+        'required_capabilities': config.get('requires') or [],
         'afm_args': afm_args,
         'content_preview': content_preview,
         'content': msg,
@@ -1248,6 +1227,19 @@ except Exception as e:
         'transport_status': 'fail',
         'assertion_status': 'not_run',
         'overall_status': 'fail',
+        'evaluation_lane': evaluation_lane(
+            model=model,
+            afm_args=afm_args,
+            is_baseline=is_baseline,
+            has_expectation=bool(expectation),
+        ),
+        'failure_classification': classify_result_likelihood(
+            model=model,
+            label=label,
+            afm_args=afm_args,
+            is_baseline=is_baseline,
+            status='FAIL',
+        ),
         'error': error_msg,
         'load_time_s': load_time,
         'temperature': temperature,
@@ -1255,6 +1247,8 @@ except Exception as e:
         'max_completion_tokens': max_completion_tokens,
         'system_prompt': system_prompt,
         'developer_prompt': developer_prompt,
+        'server_instructions': server_instructions,
+        'required_capabilities': config.get('requires') or [],
         'afm_args': afm_args,
     }
     for key in ('top_p', 'top_k', 'min_p', 'seed', 'logprobs', 'top_logprobs',
@@ -1270,14 +1264,32 @@ SEND_PYEOF
 
   if ! printf '%s' "$METRICS" | python3 -c 'import json,sys; json.load(sys.stdin)' >/dev/null 2>&1; then
     local raw_metrics="$METRICS"
-    METRICS=$(_RAW_METRICS="$raw_metrics" _SEND_CONFIG="$send_config" python3 - <<'PYEOF'
+    METRICS=$(_RAW_METRICS="$raw_metrics" _SEND_CONFIG="$send_config" PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 - <<'PYEOF'
 import json, os
+from mlx_model_test_oracle import classify_result_likelihood, evaluation_lane
 config = json.loads(os.environ['_SEND_CONFIG'])
+model = config.get('model', '')
+afm_args = config.get('afm_args', '')
+is_baseline = config.get('prompt_idx', 0) < config.get('num_baseline', 0)
 print(json.dumps({
-    'model': config.get('model', ''),
+    'model': model,
     'label': config.get('label', ''),
     'prompt': config.get('prompt_text', ''),
     'status': 'FAIL',
+    'overall_status': 'fail',
+    'evaluation_lane': evaluation_lane(
+        model=model,
+        afm_args=afm_args,
+        is_baseline=is_baseline,
+        has_expectation=bool(config.get('expect')),
+    ),
+    'failure_classification': classify_result_likelihood(
+        model=model,
+        label=config.get('label', ''),
+        afm_args=afm_args,
+        is_baseline=is_baseline,
+        status='FAIL',
+    ),
     'error': 'Test client did not return valid JSON: ' + os.environ.get('_RAW_METRICS', '')[:400],
 }))
 PYEOF
@@ -1315,6 +1327,7 @@ print(f'local label={shlex.quote(c.get(\"label\", \"\"))}')
 print(f'local max_tokens={c[\"max_tokens\"]}')
 print(f'local temperature={c[\"temperature\"]}')
 print(f'local sys_prompt={shlex.quote(c.get(\"system\", \"\"))}')
+print(f'local server_instructions={shlex.quote(c.get(\"instructions\", \"\") or \"\")}')
 print(f'local afm_args={shlex.quote(c.get(\"afm_args\", \"\"))}')
 ")"
 
@@ -1349,6 +1362,8 @@ if c.get('stop') is not None: api_parts.append(f'stop={json.dumps(c[\"stop\"])}'
 if c.get('response_format') is not None: api_parts.append(f'response_format={c[\"response_format\"]}')
 if c.get('system'): api_parts.append(f'system=\"{c[\"system\"][:60]}...\"' if len(c.get('system',''))>60 else f'system=\"{c[\"system\"]}\"')
 if c.get('developer'): api_parts.append(f'developer=\"{c[\"developer\"][:60]}...\"' if len(c.get('developer',''))>60 else f'developer=\"{c[\"developer\"]}\"')
+if c.get('instructions'): api_parts.append(f'server_instructions=\"{c[\"instructions\"][:60]}...\"' if len(c.get('instructions',''))>60 else f'server_instructions=\"{c[\"instructions\"]}\"')
+if c.get('requires'): api_parts.append(f'requires={c[\"requires\"]}')
 if c.get('tools') is not None: api_parts.append(f'tools={len(c[\"tools\"])}')
 if c.get('stream') is not None: api_parts.append(f'stream={c[\"stream\"]}')
 api = ', '.join(api_parts)
@@ -1359,10 +1374,28 @@ print(f'API: {api}' if api else 'API: (none)')
     echo "$params_info" | while IFS= read -r line; do echo "  $line"; done
   fi
 
+  local capability_file
+  # Capabilities can vary with runtime and CLI flags, so cache them by the
+  # complete run configuration rather than only by model identity.
+  capability_file=$(capability_cache_file "$run_config")
+  local required_count
+  required_count=$(echo "$run_config" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('requires') or []))")
+  if [ "$required_count" -gt 0 ] && [ -f "$capability_file" ]; then
+    local missing
+    missing=$(missing_required_capabilities "$run_config" "$capability_file")
+    if [ -n "$missing" ]; then
+      local skip_reason="engine does not advertise required capabilities: $missing"
+      echo "  SKIP: $skip_reason"
+      record_skipped_run "$run_config" "$skip_reason"
+      echo ""
+      return
+    fi
+  fi
+
   # Build server args
   SERVER_EXTRA_ARGS=()
-  if [ -n "$sys_prompt" ]; then
-    SERVER_EXTRA_ARGS+=(-i "$sys_prompt")
+  if [ -n "$server_instructions" ]; then
+    SERVER_EXTRA_ARGS+=(-i "$server_instructions")
   fi
   # Append custom afm CLI args (shell-aware split to handle quoted values)
   if [ -n "$afm_args" ]; then
@@ -1397,7 +1430,7 @@ print(f'API: {api}' if api else 'API: (none)')
       fi
     fi
     echo "  FAIL: $error_msg"
-    echo "{\"model\":$(escape_json "$model"),\"label\":$(escape_json "$label"),\"status\":\"FAIL\",\"error\":$(escape_json "$error_msg"),\"load_time_s\":$load_time,\"temperature\":$temperature,\"max_tokens\":$max_tokens,\"system_prompt\":$(escape_json "$sys_prompt"),\"afm_args\":$(escape_json "$afm_args")}" >> "$RESULTS_FILE"
+    echo "{\"model\":$(escape_json "$model"),\"label\":$(escape_json "$label"),\"status\":\"FAIL\",\"error\":$(escape_json "$error_msg"),\"load_time_s\":$load_time,\"temperature\":$temperature,\"max_tokens\":$max_tokens,\"system_prompt\":$(escape_json "$sys_prompt"),\"server_instructions\":$(escape_json "$server_instructions"),\"afm_args\":$(escape_json "$afm_args")}" >> "$RESULTS_FILE"
     OVERALL_STATUS=1
     kill_server $SERVER_PID
     SERVER_PID=0
@@ -1408,6 +1441,25 @@ print(f'API: {api}' if api else 'API: (none)')
 
   load_time=$((SECONDS - load_start))
   echo "  Server ready in ${load_time}s"
+
+  local advertised_capabilities
+  if advertised_capabilities=$(capture_server_capabilities "$model" "$capability_file" 2>/dev/null); then
+    echo "  Capabilities: $advertised_capabilities"
+  fi
+  if [ "$required_count" -gt 0 ] && [ -f "$capability_file" ]; then
+    local missing
+    missing=$(missing_required_capabilities "$run_config" "$capability_file")
+    if [ -n "$missing" ]; then
+      local skip_reason="engine does not advertise required capabilities: $missing"
+      echo "  SKIP: $skip_reason"
+      record_skipped_run "$run_config" "$skip_reason"
+      kill_server $SERVER_PID
+      SERVER_PID=0
+      sleep 2
+      echo ""
+      return
+    fi
+  fi
 
   # Get prompts list
   local prompt_list
@@ -1566,12 +1618,14 @@ result = {
     'max_tokens': defaults.get('max_tokens', $DEFAULT_MAX_TOKENS),
     'temperature': defaults.get('temperature', $DEFAULT_TEMPERATURE),
     'system': defaults.get('system', ''),
+    'instructions': defaults.get('instructions', ''),
+    'requires': defaults.get('requires', []),
     'afm_args': defaults.get('afm', ''),
 }
 for key in ('top_p', 'top_k', 'min_p', 'seed', 'logprobs', 'top_logprobs',
             'presence_penalty', 'repetition_penalty', 'frequency_penalty',
             'stop', 'response_format', 'media', 'max_completion_tokens',
-            'developer', 'tools', 'expect'):
+            'developer', 'tools', 'expect', 'expect_by_prompt'):
     if key in defaults:
         result[key] = defaults[key]
 print(json.dumps(result))
@@ -1665,7 +1719,8 @@ report concise and scannable.
 
 CRITICAL — MACHINE-READABLE SCORES:
 At the very end of your output, you MUST include a scores block for the HTML report.
-Score EVERY JSONL line (by 0-based line index) on a 1-5 scale:
+Score every executed JSONL result (by 0-based result index) on a 1-5 scale.
+Do not score metadata records or capability-aware records whose status is SKIP:
   5 = excellent (correct, coherent, addresses prompt well)
   4 = good (minor issues but solid response)
   3 = acceptable (noticeable issues but usable)
@@ -1700,7 +1755,8 @@ Output the block EXACTLY like this (one line, valid JSON array):
 <!-- AI_SCORES [{"i":0,"s":5},{"i":1,"s":3},{"i":2,"s":1}] -->
 
 Rules:
-- Include an entry for EVERY line in the JSONL input, including failed ones (score 1)
+- Include an entry for every executed result, including failed ones (score 1)
+- Omit status=SKIP records from AI_SCORES; they were not executed and have no model output
 - The "i" field is the 0-based line index in the JSONL
 - The "s" field is the integer score 1-5
 - This line must be the LAST line of your output
@@ -1803,8 +1859,10 @@ for line in lines:
         comment_buf = []
     else:
         if not stripped.startswith(('temperature:', 'max_tokens:', 'stop:', 'afm:', 'system:',
+                                    'system_json:', 'instructions:', 'instructions_json:', 'requires:',
                                     'seed:', 'top_p:', 'top_k:', 'min_p:', 'response_format:',
-                                    'tools:', 'developer:', 'max_completion_tokens:', 'logprobs:',
+                                    'tools:', 'developer:', 'developer_json:', 'expect_by_prompt:',
+                                    'max_completion_tokens:', 'logprobs:',
                                     'top_logprobs:', 'presence_penalty:', 'repetition_penalty:',
                                     'frequency_penalty:', 'media:')):
             comment_buf = []  # reset on non-param, non-comment lines
@@ -1819,6 +1877,11 @@ print(json.dumps(specs))
         [ -z "$jsonl_line" ] && continue
         # Skip metadata lines
         if echo "$jsonl_line" | python3 -c "import json,sys; sys.exit(0 if json.load(sys.stdin).get('_meta') else 1)" 2>/dev/null; then
+          continue
+        fi
+        if echo "$jsonl_line" | python3 -c "import json,sys; sys.exit(0 if json.load(sys.stdin).get('status') == 'SKIP' else 1)" 2>/dev/null; then
+          echo "    [$((line_idx + 1))] skipped (capability unavailable; not AI-scored)"
+          line_idx=$((line_idx + 1))
           continue
         fi
         echo -n "    [$((line_idx + 1))/$total_lines] "
@@ -1906,6 +1969,18 @@ with open(results_file) as f:
         if r.get('_meta'):
             continue
 
+        if r.get('status') == 'SKIP' or r.get('overall_status') == 'skip':
+            model = r.get('model', '')
+            label = r.get('label', '')
+            label_suffix = f' @ {label}' if label else ''
+            name = model if not label_suffix or model.endswith(label_suffix) else model + label_suffix
+            report_lines.append(f'### {result_idx}. {name}')
+            report_lines.append(f'**Not scored** ⏭️ | Status: SKIP')
+            report_lines.append(f'> {r.get("skip_reason", "Required capability unavailable")}.')
+            report_lines.append('')
+            result_idx += 1
+            continue
+
         score_file = os.path.join(scores_dir, f'score_{result_idx}.txt')
         score_text = ''
         score_val = 3
@@ -1963,7 +2038,7 @@ $SMART_TEST_FILE_SECTION
         codex)
           # codex exec: use temp file to avoid ARG_MAX limit on command line
           # (91+ test results with full responses easily exceed OS argument length)
-          "$tool" exec --skip-git-repo-check "Read and follow the analysis instructions in $SMART_INPUT. Score every JSONL entry and output the AI_SCORES block as specified." </dev/null > "$SMART_REPORT" 2>/tmp/smart-${tool}-stderr-$$.log
+          "$tool" exec --skip-git-repo-check "Read and follow the analysis instructions in $SMART_INPUT. Score every executed JSONL result, omit metadata and status=SKIP records, and output the AI_SCORES block as specified." </dev/null > "$SMART_REPORT" 2>/tmp/smart-${tool}-stderr-$$.log
           ;;
         afm)
           # afm uses Apple Foundation Models — context window is limited (~4K tokens).

--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -1845,77 +1845,9 @@ print(payload['score'] if payload else '?')
 
       echo "  Assembling per-test report..."
 
-      # Build scores JSON + per-test markdown report
-      PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c "
-import json, sys, os
-from mlx_model_test_oracle import extract_score_payload
-
-scores_dir = sys.argv[1]
-results_file = sys.argv[2]
-
-scores = []
-report_lines = ['# Per-Test AI Analysis', '']
-result_idx = 0
-with open(results_file) as f:
-    for line in f:
-        line = line.strip()
-        if not line: continue
-        r = json.loads(line)
-        if r.get('_meta'):
-            continue
-
-        if r.get('status') == 'SKIP' or r.get('overall_status') == 'skip':
-            model = r.get('model', '')
-            label = r.get('label', '')
-            label_suffix = f' @ {label}' if label else ''
-            name = model if not label_suffix or model.endswith(label_suffix) else model + label_suffix
-            report_lines.append(f'### {result_idx}. {name}')
-            report_lines.append(f'**Not scored** ⏭️ | Status: SKIP')
-            report_lines.append(f'> {r.get("skip_reason", "Required capability unavailable")}.')
-            report_lines.append('')
-            result_idx += 1
-            continue
-
-        score_file = os.path.join(scores_dir, f'score_{result_idx}.txt')
-        score_text = ''
-        score_val = 3
-        reason = ''
-        if os.path.exists(score_file):
-            with open(score_file) as sf:
-                score_text = sf.read().strip()
-            payload = extract_score_payload(score_text)
-            if payload:
-                score_val = payload['score']
-                reason = str(payload.get('reason', ''))
-
-        scores.append({'i': result_idx, 's': score_val})
-
-        model = r.get('model', '')
-        label = r.get('label', '')
-        label_suffix = f' @ {label}' if label else ''
-        name = model if not label_suffix or model.endswith(label_suffix) else model + label_suffix
-        tps = r.get('tokens_per_sec', 0)
-        status = r.get('status', '')
-        emoji = {5:'✅', 4:'👍', 3:'⚠️', 2:'❌', 1:'💥'}.get(score_val, '❓')
-
-        report_lines.append(f'### {result_idx}. {name}')
-        report_lines.append(f'**Score: {score_val}/5** {emoji} | Status: {status} | {tps:.1f} tok/s')
-        if reason:
-            report_lines.append(f'> {reason}')
-        report_lines.append('')
-        result_idx += 1
-
-# Summary
-total = len(scores)
-pass_count = sum(1 for s in scores if s['s'] >= 4)
-fail_count = sum(1 for s in scores if s['s'] <= 2)
-report_lines.append('---')
-report_lines.append(f'**Summary**: {pass_count}/{total} passed (score ≥ 4), {fail_count} failed (score ≤ 2)')
-report_lines.append('')
-report_lines.append('<!-- AI_SCORES ' + json.dumps(scores) + ' -->')
-
-print('\n'.join(report_lines))
-" "$PERTEST_SCORES_DIR" "$RESULTS_FILE" > "$SMART_REPORT"
+      PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" \
+        python3 "$SCRIPT_DIR/assemble_smart_report.py" \
+        "$PERTEST_SCORES_DIR" "$RESULTS_FILE" > "$SMART_REPORT"
 
       rm -rf "$PERTEST_SCORES_DIR"
 

--- a/Scripts/mlx_model_test_config.py
+++ b/Scripts/mlx_model_test_config.py
@@ -1,0 +1,166 @@
+"""Parser for mlx-model-test prompt/config files."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from pathlib import Path
+
+
+INTEGER_PARAMETERS = {
+    "max_tokens",
+    "max_completion_tokens",
+    "top_k",
+    "seed",
+    "top_logprobs",
+}
+FLOAT_PARAMETERS = {
+    "temperature",
+    "top_p",
+    "min_p",
+    "presence_penalty",
+    "repetition_penalty",
+    "frequency_penalty",
+}
+BOOLEAN_PARAMETERS = {"logprobs"}
+JSON_PARAMETERS = {"tools", "expect", "expect_by_prompt"}
+
+
+def _json_string(value: str, parameter: str) -> str:
+    parsed = json.loads(value)
+    if not isinstance(parsed, str):
+        raise ValueError(f"{parameter} must contain a JSON string")
+    return parsed
+
+
+def _parse_stop(value: str) -> list[str]:
+    try:
+        parsed = json.loads(value)
+    except (json.JSONDecodeError, ValueError):
+        return [item.strip() for item in value.split(",")]
+    return parsed if isinstance(parsed, list) else [str(parsed)]
+
+
+def _parse_response_format(value: str):
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, ValueError):
+        return value
+
+
+def _parse_parameter(line: str):
+    if ":" not in line:
+        return None
+    key, raw_value = line.split(":", 1)
+    key = key.strip()
+    value = raw_value.strip()
+
+    if key in INTEGER_PARAMETERS:
+        return key, int(value)
+    if key in FLOAT_PARAMETERS:
+        return key, float(value)
+    if key in BOOLEAN_PARAMETERS:
+        return key, value.lower() == "true"
+    if key == "stop":
+        return key, _parse_stop(value)
+    if key == "response_format":
+        return key, _parse_response_format(value)
+    if key in {"system", "developer", "instructions", "afm"}:
+        return key, value
+    if key in {"system_json", "developer_json", "instructions_json"}:
+        target = key.removesuffix("_json")
+        return target, _json_string(value, key)
+    if key in JSON_PARAMETERS:
+        return key, json.loads(value)
+    if key == "media":
+        return key, [item.strip() for item in value.split(",")]
+    if key == "requires":
+        return key, [item.strip() for item in value.split(",") if item.strip()]
+    return None
+
+
+def parse_prompts_file(filepath: str | Path) -> dict:
+    config = {"defaults": {}, "all": [], "runs": []}
+    model_sections: dict[str, dict] = {}
+    current_section: str | None = None
+
+    with Path(filepath).open(encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            match = re.match(r"^\[(.+)\]$", line)
+            if match:
+                section_name = match.group(1).strip()
+                if section_name == "all":
+                    current_section = "all"
+                    continue
+                if section_name in model_sections:
+                    raise ValueError(
+                        f"line {line_number}: duplicate section [{section_name}]"
+                    )
+                current_section = section_name
+                if section_name.startswith("@ "):
+                    model_id = ""
+                    label = section_name[2:].strip()
+                elif " @ " in section_name:
+                    model_id, label = section_name.split(" @ ", 1)
+                    model_id = model_id.strip()
+                    label = label.strip()
+                else:
+                    model_id = section_name
+                    label = ""
+                model_sections[section_name] = {
+                    "model": model_id,
+                    "label": label,
+                    "prompts": [],
+                    "params": {},
+                    "afm": "",
+                    "skip": False,
+                }
+                continue
+
+            if current_section == "all":
+                config["all"].append(line)
+                continue
+
+            parsed_parameter = _parse_parameter(line)
+            if current_section is None:
+                if parsed_parameter is not None:
+                    key, value = parsed_parameter
+                    if key == "afm":
+                        config["defaults"]["afm"] = value
+                    else:
+                        config["defaults"][key] = value
+                continue
+
+            section = model_sections[current_section]
+            if line == "skip":
+                section["skip"] = True
+            elif line.startswith("afm:"):
+                section["afm"] = line.split(":", 1)[1].strip()
+            elif parsed_parameter is not None:
+                key, value = parsed_parameter
+                section["params"][key] = value
+            else:
+                section["prompts"].append(line)
+
+    config["runs"] = list(model_sections.values())
+    return config
+
+
+def expand_template_runs(config: dict, models: list[str]) -> dict:
+    expanded_config = copy.deepcopy(config)
+    expanded_runs = []
+    for run in expanded_config["runs"]:
+        if run["model"]:
+            expanded_runs.append(run)
+            continue
+        for model in models:
+            expanded = copy.deepcopy(run)
+            expanded["model"] = model
+            expanded_runs.append(expanded)
+    expanded_config["runs"] = expanded_runs
+    return expanded_config

--- a/Scripts/mlx_model_test_config.py
+++ b/Scripts/mlx_model_test_config.py
@@ -164,3 +164,59 @@ def expand_template_runs(config: dict, models: list[str]) -> dict:
             expanded_runs.append(expanded)
     expanded_config["runs"] = expanded_runs
     return expanded_config
+
+
+def parse_ai_intent_specs(filepath: str | Path) -> dict[str, dict[str, list[str]]]:
+    """Map model + label to the AI intent immediately preceding its section.
+
+    Template sections use an empty model key and serve as the fallback for every
+    expanded model. Named sections remain model-specific even when labels repeat.
+    """
+    specs: dict[str, dict[str, list[str]]] = {}
+    comment_buffer: list[str] = []
+
+    with Path(filepath).open(encoding="utf-8") as handle:
+        for raw_line in handle:
+            stripped = raw_line.strip()
+            if stripped.startswith("#"):
+                comment_buffer.append(stripped)
+                continue
+
+            match = re.match(r"^\[(.+)\]$", stripped)
+            if match:
+                section_name = match.group(1).strip()
+                model = ""
+                label = ""
+                if section_name.startswith("@ "):
+                    label = section_name[2:].strip()
+                elif " @ " in section_name:
+                    model, label = section_name.split(" @ ", 1)
+                    model = model.strip()
+                    label = label.strip()
+                if label:
+                    intent_lines = [
+                        line.replace("# AI:", "", 1).strip()
+                        for line in comment_buffer
+                        if "# AI:" in line
+                    ]
+                    if intent_lines:
+                        specs.setdefault(model, {})[label] = intent_lines
+                comment_buffer = []
+                continue
+
+            if (
+                stripped
+                and stripped != "skip"
+                and _parse_parameter(stripped) is None
+            ):
+                comment_buffer = []
+
+    return specs
+
+
+def ai_intent_for_result(
+    specs: dict[str, dict[str, list[str]]], model: str, label: str
+) -> list[str]:
+    if not label:
+        return []
+    return specs.get(model, {}).get(label) or specs.get("", {}).get(label) or []

--- a/Scripts/mlx_model_test_oracle.py
+++ b/Scripts/mlx_model_test_oracle.py
@@ -1,6 +1,54 @@
 """Deterministic response assertions for mlx-model-test.sh."""
 
 import json
+import re
+
+
+def evaluation_lane(*, model, afm_args="", is_baseline=False, has_expectation=True):
+    """Separate native protocol checks from explicit cross-family parser experiments."""
+    if is_baseline:
+        return "model_agent_behavior"
+    match = re.search(r"(?:^|\s)--tool-call-parser\s+(\S+)", afm_args or "")
+    if match:
+        parser = match.group(1).lower()
+        model_name = (model or "").lower()
+        native_family = (
+            (parser.startswith("qwen") and "qwen" in model_name)
+            or (parser.startswith("deepseek") and "deepseek" in model_name)
+            or (parser.startswith("nemotron") and "nemotron" in model_name)
+            or (parser.startswith("muse") and "muse" in model_name)
+        )
+        if not native_family:
+            return "forced_parser_compatibility"
+    if not has_expectation:
+        return "model_agent_behavior"
+    return "native_protocol"
+
+
+def classify_result_likelihood(
+    *, model, label, afm_args="", is_baseline=False, status="OK", failures=None
+):
+    """Return a conservative failure bucket without claiming component ownership."""
+    failures = failures or []
+    if status == "SKIP":
+        return "capability unavailable"
+    if status != "OK":
+        return "engine/runtime likely"
+    if not failures:
+        return "conformant"
+    lane = evaluation_lane(model=model, afm_args=afm_args, is_baseline=is_baseline)
+    if lane == "forced_parser_compatibility":
+        return "forced-parser compatibility experiment"
+    normalized_label = (label or "").lower()
+    engine_prefixes = (
+        "stop-", "logprobs", "agent-cached", "cache-", "batch-", "kv-",
+        "guided-", "response-format", "grammar-", "structured-", "seed-",
+    )
+    if normalized_label.startswith(engine_prefixes):
+        return "engine/runtime likely"
+    if normalized_label.startswith("tool-call"):
+        return "parser/model boundary needs triage"
+    return "model behavior likely"
 
 
 def extract_score_payload(text):
@@ -25,6 +73,10 @@ def expectation_for_prompt(config):
         # The global baseline is deliberately unrelated to every supplied tool.
         # A tool-enabled variant must therefore answer normally, not guess a call.
         return {"tool_calls": []} if config.get("tools") else {}
+    prompt_expectations = config.get("expect_by_prompt") or []
+    relative_index = config.get("prompt_idx", 0) - config.get("num_baseline", 0)
+    if 0 <= relative_index < len(prompt_expectations):
+        return prompt_expectations[relative_index] or {}
     return config.get("expect") or {}
 
 
@@ -62,6 +114,7 @@ def evaluate_expectations(
     finish_reason,
     logprobs_count,
     tool_calls,
+    cached_input_tokens=0,
 ):
     """Return (valid_json, failures) for a response and declarative expectation."""
     parsed_json = None
@@ -83,6 +136,14 @@ def evaluate_expectations(
     if expectation.get("logprobs_min") is not None and logprobs_count < int(expectation["logprobs_min"]):
         failures.append(
             f"logprobs_count expected >= {expectation['logprobs_min']}, got {logprobs_count}"
+        )
+    if (
+        expectation.get("cached_input_tokens_min") is not None
+        and cached_input_tokens < int(expectation["cached_input_tokens_min"])
+    ):
+        failures.append(
+            "cached_input_tokens expected >= "
+            f"{expectation['cached_input_tokens_min']}, got {cached_input_tokens}"
         )
 
     if expectation.get("content_equals") is not None and content != expectation["content_equals"]:

--- a/Scripts/mlx_model_test_oracle.py
+++ b/Scripts/mlx_model_test_oracle.py
@@ -42,7 +42,7 @@ def classify_result_likelihood(
     normalized_label = (label or "").lower()
     engine_prefixes = (
         "stop-", "logprobs", "agent-cached", "cache-", "batch-", "kv-",
-        "guided-", "response-format", "grammar-", "structured-", "seed-",
+        "guided-", "grammar-", "structured-", "seed-",
     )
     if normalized_label.startswith(engine_prefixes):
         return "engine/runtime likely"
@@ -78,6 +78,64 @@ def expectation_for_prompt(config):
     if 0 <= relative_index < len(prompt_expectations):
         return prompt_expectations[relative_index] or {}
     return config.get("expect") or {}
+
+
+def failed_run_records(config, *, error, load_time_s):
+    """Build one classified transport-failure record for each planned prompt."""
+    prompts = config.get("prompts") or [""]
+    records = []
+    for prompt_index, prompt in enumerate(prompts):
+        is_baseline = prompt_index < config.get("num_baseline", 0)
+        model = config.get("model", "")
+        label = config.get("label", "")
+        afm_args = config.get("afm_args", "")
+        record = {
+            "model": model,
+            "label": label,
+            "prompt": prompt,
+            "is_baseline": is_baseline,
+            "status": "FAIL",
+            "transport_status": "fail",
+            "assertion_status": "not_run",
+            "overall_status": "fail",
+            # Loading/transport failures are engine protocol failures even when
+            # the prompt would otherwise belong to the behavior-quality lane.
+            "evaluation_lane": "native_protocol",
+            "failure_classification": classify_result_likelihood(
+                model=model,
+                label=label,
+                afm_args=afm_args,
+                is_baseline=is_baseline,
+                status="FAIL",
+            ),
+            "error": error,
+            "load_time_s": load_time_s,
+            "temperature": config.get("temperature"),
+            "max_tokens": config.get("max_tokens"),
+            "max_completion_tokens": config.get("max_completion_tokens"),
+            "system_prompt": config.get("system", ""),
+            "developer_prompt": config.get("developer", ""),
+            "server_instructions": config.get("instructions", ""),
+            "required_capabilities": config.get("requires") or [],
+            "afm_args": afm_args,
+        }
+        for key in (
+            "top_p",
+            "top_k",
+            "min_p",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "presence_penalty",
+            "repetition_penalty",
+            "frequency_penalty",
+            "stop",
+            "response_format",
+        ):
+            if key in config:
+                record[key] = config[key]
+        records.append(record)
+    return records
 
 
 def _validate_schema(value, schema, path="$"):
@@ -144,6 +202,14 @@ def evaluate_expectations(
         failures.append(
             "cached_input_tokens expected >= "
             f"{expectation['cached_input_tokens_min']}, got {cached_input_tokens}"
+        )
+    if (
+        expectation.get("cached_input_tokens_max") is not None
+        and cached_input_tokens > int(expectation["cached_input_tokens_max"])
+    ):
+        failures.append(
+            "cached_input_tokens expected <= "
+            f"{expectation['cached_input_tokens_max']}, got {cached_input_tokens}"
         )
 
     if expectation.get("content_equals") is not None and content != expectation["content_equals"]:

--- a/Scripts/mlx_model_test_oracle.py
+++ b/Scripts/mlx_model_test_oracle.py
@@ -80,12 +80,97 @@ def expectation_for_prompt(config):
     return config.get("expect") or {}
 
 
+def request_configuration_fields(config, *, expectation=None):
+    """Return the request configuration that must survive every result path."""
+    fields = {
+        "temperature": config.get("temperature"),
+        "max_tokens": config.get("max_tokens"),
+        "max_completion_tokens": config.get("max_completion_tokens"),
+        "system_prompt": config.get("system", ""),
+        "developer_prompt": config.get("developer", ""),
+        "server_instructions": config.get("instructions", ""),
+        "required_capabilities": config.get("requires") or [],
+        "afm_args": config.get("afm_args", ""),
+    }
+    for key in (
+        "top_p",
+        "top_k",
+        "min_p",
+        "seed",
+        "logprobs",
+        "top_logprobs",
+        "presence_penalty",
+        "repetition_penalty",
+        "frequency_penalty",
+        "stop",
+        "response_format",
+        "media",
+        "tools",
+        "stream",
+    ):
+        if key in config and config[key] is not None:
+            fields[key] = config[key]
+    if expectation:
+        fields["expect"] = expectation
+    return fields
+
+
+def transport_failure_record(config, *, prompt, error, load_time_s):
+    """Build a complete result for a request/client/transport failure."""
+    is_baseline = config.get("prompt_idx", 0) < config.get("num_baseline", 0)
+    expectation = expectation_for_prompt(config)
+    model = config.get("model", "")
+    label = config.get("label", "")
+    afm_args = config.get("afm_args", "")
+    record = {
+        "model": model,
+        "label": label,
+        "prompt": prompt,
+        "is_baseline": is_baseline,
+        "status": "FAIL",
+        "transport_status": "fail",
+        "assertion_status": "not_run",
+        "overall_status": "fail",
+        "evaluation_lane": "native_protocol",
+        "failure_classification": classify_result_likelihood(
+            model=model,
+            label=label,
+            afm_args=afm_args,
+            is_baseline=is_baseline,
+            status="FAIL",
+        ),
+        "error": error,
+        "load_time_s": load_time_s,
+    }
+    record.update(request_configuration_fields(config, expectation=expectation))
+    return record
+
+
 def failed_run_records(config, *, error, load_time_s):
     """Build one classified transport-failure record for each planned prompt."""
     prompts = config.get("prompts") or [""]
     records = []
     for prompt_index, prompt in enumerate(prompts):
+        prompt_config = dict(config, prompt_idx=prompt_index)
+        records.append(
+            transport_failure_record(
+                prompt_config,
+                prompt=prompt,
+                error=error,
+                load_time_s=load_time_s,
+            )
+        )
+    return records
+
+
+def skipped_run_records(config, *, reason):
+    """Build complete capability-skip records without losing request metadata."""
+    prompts = config.get("prompts") or [""]
+    records = []
+    for prompt_index, prompt in enumerate(prompts):
+        prompt_config = dict(config, prompt_idx=prompt_index)
         is_baseline = prompt_index < config.get("num_baseline", 0)
+        expectation = expectation_for_prompt(prompt_config)
         model = config.get("model", "")
         label = config.get("label", "")
         afm_args = config.get("afm_args", "")
@@ -94,46 +179,26 @@ def failed_run_records(config, *, error, load_time_s):
             "label": label,
             "prompt": prompt,
             "is_baseline": is_baseline,
-            "status": "FAIL",
-            "transport_status": "fail",
+            "status": "SKIP",
+            "transport_status": "not_run",
             "assertion_status": "not_run",
-            "overall_status": "fail",
-            # Loading/transport failures are engine protocol failures even when
-            # the prompt would otherwise belong to the behavior-quality lane.
-            "evaluation_lane": "native_protocol",
+            "overall_status": "skip",
+            "skip_reason": reason,
+            "evaluation_lane": evaluation_lane(
+                model=model,
+                afm_args=afm_args,
+                is_baseline=is_baseline,
+                has_expectation=bool(expectation),
+            ),
             "failure_classification": classify_result_likelihood(
                 model=model,
                 label=label,
                 afm_args=afm_args,
                 is_baseline=is_baseline,
-                status="FAIL",
+                status="SKIP",
             ),
-            "error": error,
-            "load_time_s": load_time_s,
-            "temperature": config.get("temperature"),
-            "max_tokens": config.get("max_tokens"),
-            "max_completion_tokens": config.get("max_completion_tokens"),
-            "system_prompt": config.get("system", ""),
-            "developer_prompt": config.get("developer", ""),
-            "server_instructions": config.get("instructions", ""),
-            "required_capabilities": config.get("requires") or [],
-            "afm_args": afm_args,
         }
-        for key in (
-            "top_p",
-            "top_k",
-            "min_p",
-            "seed",
-            "logprobs",
-            "top_logprobs",
-            "presence_penalty",
-            "repetition_penalty",
-            "frequency_penalty",
-            "stop",
-            "response_format",
-        ):
-            if key in config:
-                record[key] = config[key]
+        record.update(request_configuration_fields(config, expectation=expectation))
         records.append(record)
     return records
 

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -90,13 +90,13 @@ classify_result() {
     return
   fi
   case "$group" in
-    Preflight|Lifecycle|Stop|Logprobs|Cache|Concurrent|Error|Structured|Grammar|Batch|StrictWiring|UnitTest)
+    Preflight|Lifecycle|Stop|Logprobs|Cache|Concurrent|Error|Structured|Grammar|Batch|StrictWiring|UnitTest|PairwiseSmoke)
       echo "engine/runtime likely"
       ;;
     Tools|XMLTools|AdaptiveXML|NullableSchema)
       echo "parser/model boundary needs triage"
       ;;
-    Think|PairwiseSmoke)
+    Think)
       echo "model behavior likely"
       ;;
     *)

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -27,6 +27,9 @@ STRICT_TOOL_GRAMMAR_CAPABILITY="${AFM_ASSERTIONS_STRICT_TOOL_GRAMMAR:-auto}"
 MODEL_SUPPORTS_TOOL_CALLING=true
 MODEL_SUPPORTS_STRUCTURED_OUTPUT=true
 MODEL_SUPPORTS_THINKING_TOGGLE=true
+ENGINE_SUPPORTS_LOGPROBS=true
+ENGINE_SUPPORTS_BATCH=true
+RUNTIME_IS_DWARFSTAR=false
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 REPORT_DIR="${AFM_ASSERTIONS_REPORT_DIR:-$PROJECT_ROOT/test-reports}"
@@ -70,6 +73,38 @@ TEST_START_TIME=$(date +%s)
 declare -a RESULTS=()
 CURRENT_TIER="smoke"
 
+classify_result() {
+  local group="$1"
+  local status="$2"
+  local actual="$3"
+  if [ "$status" = "PASS" ]; then
+    echo "conformant"
+    return
+  fi
+  if [ "$status" = "SKIP" ]; then
+    echo "capability unavailable"
+    return
+  fi
+  if echo "$actual" | grep -Eqi 'curl|HTTP|parse error|server|crash|timeout|invalid JSON|no choices'; then
+    echo "engine/runtime likely"
+    return
+  fi
+  case "$group" in
+    Preflight|Lifecycle|Stop|Logprobs|Cache|Concurrent|Error|Structured|Grammar|Batch|StrictWiring|UnitTest)
+      echo "engine/runtime likely"
+      ;;
+    Tools|XMLTools|AdaptiveXML|NullableSchema)
+      echo "parser/model boundary needs triage"
+      ;;
+    Think|PairwiseSmoke)
+      echo "model behavior likely"
+      ;;
+    *)
+      echo "needs triage"
+      ;;
+  esac
+}
+
 run_test() {
   local group="$1"
   local name="$2"
@@ -92,14 +127,15 @@ run_test() {
   fi
   local esc_expected=$(echo "$expected" | tr '|' '/')
   local esc_actual=$(echo "$actual" | tr '|' '/')
-  RESULTS+=("${actual}|${group}|${name}|${esc_expected}|${esc_actual}|${duration}|${CURRENT_TIER}|${TOTAL}")
-
-  # JSONL record
   local status_val="PASS"
-  [[ "$actual" = "PASS" ]] && status_val="PASS"
   [[ "$actual" = "SKIP" ]] && status_val="SKIP"
   [[ "$actual" != "PASS" && "$actual" != "SKIP" ]] && status_val="FAIL"
-  _GROUP="$group" _NAME="$name" _STATUS="$status_val" _DUR="$duration" _TIER="$CURRENT_TIER" _IDX="$TOTAL" python3 -c "
+  local category
+  category=$(classify_result "$group" "$status_val" "$actual")
+  RESULTS+=("${actual}|${group}|${name}|${esc_expected}|${esc_actual}|${duration}|${CURRENT_TIER}|${TOTAL}|${category}")
+
+  # JSONL record
+  _GROUP="$group" _NAME="$name" _STATUS="$status_val" _DUR="$duration" _TIER="$CURRENT_TIER" _IDX="$TOTAL" _CATEGORY="$category" python3 -c "
 import json, os
 print(json.dumps({
     'index': int(os.environ['_IDX']),
@@ -107,7 +143,8 @@ print(json.dumps({
     'name': os.environ['_NAME'],
     'status': os.environ['_STATUS'],
     'duration_ms': int(os.environ['_DUR']),
-    'tier': os.environ['_TIER']
+    'tier': os.environ['_TIER'],
+    'classification': os.environ['_CATEGORY']
 }))
 " >> "$JSONL_FILE"
 }
@@ -352,6 +389,46 @@ if [ -z "$MODEL" ]; then
 fi
 echo "  Model: $MODEL"
 
+capability_lines=$(python3 - "$MODEL" "$PORT" <<'PY' 2>/dev/null || true
+import json
+import sys
+import urllib.request
+
+model, port = sys.argv[1:]
+with urllib.request.urlopen(f"http://127.0.0.1:{port}/v1/models", timeout=5) as response:
+    payload = json.load(response)
+details = payload.get("models") or []
+selected = next((item for item in details if item.get("model") == model), None)
+if selected is None:
+    selected = next(
+        (item for item in details if "embeddings" not in (item.get("capabilities") or [])),
+        None,
+    )
+caps = set((selected or {}).get("capabilities") or [])
+if "dwarfstar_runtime" in caps:
+    print("RUNTIME_IS_DWARFSTAR=true")
+    print("ENGINE_SUPPORTS_LOGPROBS=false")
+    print("ENGINE_SUPPORTS_BATCH=false")
+    print("MODEL_SUPPORTS_STRUCTURED_OUTPUT=false")
+elif "mlx_runtime" in caps:
+    print("ENGINE_SUPPORTS_LOGPROBS=" + ("true" if "logprobs" in caps else "false"))
+    print("ENGINE_SUPPORTS_BATCH=" + ("true" if "batch" in caps else "false"))
+print("ADVERTISED_CAPABILITIES=" + ",".join(sorted(caps)))
+PY
+)
+while IFS='=' read -r cap_name cap_value; do
+  case "$cap_name" in
+    ENGINE_SUPPORTS_LOGPROBS) ENGINE_SUPPORTS_LOGPROBS="$cap_value" ;;
+    ENGINE_SUPPORTS_BATCH) ENGINE_SUPPORTS_BATCH="$cap_value" ;;
+    RUNTIME_IS_DWARFSTAR) RUNTIME_IS_DWARFSTAR="$cap_value" ;;
+    MODEL_SUPPORTS_STRUCTURED_OUTPUT) MODEL_SUPPORTS_STRUCTURED_OUTPUT="$cap_value" ;;
+    ADVERTISED_CAPABILITIES) ADVERTISED_CAPABILITIES="$cap_value" ;;
+  esac
+done <<< "$capability_lines"
+if [ -n "${ADVERTISED_CAPABILITIES:-}" ]; then
+  echo "  Capabilities: $ADVERTISED_CAPABILITIES"
+fi
+
 # Recurrent/linear-attention state cannot be rewound like a KV cache. For
 # hybrid models, rejecting a descendant cache state and reporting a cold
 # prefill is the correctness-preserving behavior.
@@ -484,6 +561,11 @@ print("false" if model_type in {"deepseek_v4", "deepseekv4", "muse_glimmer", "mu
 PY
     )
   fi
+fi
+if [ "$RUNTIME_IS_DWARFSTAR" = "true" ]; then
+  ENGINE_SUPPORTS_LOGPROBS=false
+  ENGINE_SUPPORTS_BATCH=false
+  MODEL_SUPPORTS_STRUCTURED_OUTPUT=false
 fi
 if [ "$SAFE_PARTIAL_CACHE_MISS" = "true" ]; then
   echo "  Cache policy: recurrent hybrid; safe cold fallback is valid"
@@ -678,6 +760,11 @@ if should_run_section 3; then
 echo ""
 echo "📊 Section 3: Logprobs"
 
+if [ "$ENGINE_SUPPORTS_LOGPROBS" != "true" ]; then
+  echo "  (Engine does not advertise logprobs — skipping logprob assertions)"
+  run_test "Logprobs" "Logprobs contract (engine capability unavailable)" "skip" "SKIP" "0"
+else
+
 # Test: logprobs structure
 t0=$(now_ms)
 resp=$(api_call '{"messages":[{"role":"user","content":"Hi"}],"max_tokens":5,"stream":false,"temperature":0,"logprobs":true,"top_logprobs":3}')
@@ -821,6 +908,7 @@ except Exception as e:
   else
     run_test "Logprobs" "top_logprobs=0 returns empty arrays" "empty top_logprobs" "$zero_valid" "$dur"
   fi
+fi
 fi
 CURRENT_TIER="smoke"
 fi # section 3
@@ -4043,6 +4131,11 @@ if should_run_section 15 && min_tier standard; then
   echo ""
   echo "📦 Section 15: Batch Dispatch API"
 
+  if [ "$ENGINE_SUPPORTS_BATCH" != "true" ]; then
+    echo "  (Engine does not advertise batch dispatch — skipping batch assertions)"
+    run_test "Batch" "Batch dispatch contract (engine capability unavailable)" "skip" "SKIP" "0"
+  else
+
   # ── Test 15.1: POST /v1/files upload ───────────────────────────────────
   BATCH_JSONL_LINE='{"custom_id":"assert-1","method":"POST","url":"/v1/chat/completions","body":{"model":"'"$MODEL"'","messages":[{"role":"user","content":"Say hello in 3 words"}],"max_tokens":20}}'
   BATCH_JSONL_LINE2='{"custom_id":"assert-2","method":"POST","url":"/v1/chat/completions","body":{"model":"'"$MODEL"'","messages":[{"role":"user","content":"What is 2+2? Just the number"}],"max_tokens":10}}'
@@ -4273,6 +4366,7 @@ else:
   fi
 
   rm -f "$BATCH_TMPFILE"
+  fi
 fi
 
 fi  # end: min_tier smoke (server-dependent sections)
@@ -4291,6 +4385,10 @@ if should_run_section 16 && min_tier standard; then
   CURRENT_TIER="standard"
   echo ""
   echo "🧪 Section 16: Pairwise Smoke — High-Risk Interactions"
+
+  if [ "$ENGINE_SUPPORTS_BATCH" != "true" ]; then
+    run_test "PairwiseSmoke" "MLX batched-dimension interactions" "engine supports MLX batch scheduler" "SKIP" "0"
+  else
 
   # Test 16.1: batch + top_k + streaming (was crashing: #72)
   t0=$(now_ms)
@@ -4334,6 +4432,7 @@ if should_run_section 16 && min_tier standard; then
     run_test "PairwiseSmoke" "batch + all sampling params combined" "response valid" "PASS" "$dur"
   else
     run_test "PairwiseSmoke" "batch + all sampling params combined" "response valid" "FAIL" "$dur"
+  fi
   fi
 
   # Test 16.5: streaming parity — same seed must produce same content
@@ -4496,16 +4595,17 @@ cat >> "$REPORT_FILE" <<EOF
 <div class="progress-bar"><div class="progress-fill" style="width:${PCT}%;background:${BAR_COLOR};"></div></div>
 <table>
 <thead>
-<tr><th>#</th><th>Test</th><th>Group</th><th>Coverage</th><th>Status</th><th>Duration</th><th>Details</th></tr>
+<tr><th>#</th><th>Test</th><th>Group</th><th>Coverage</th><th>Status</th><th>Classification</th><th>Duration</th><th>Details</th></tr>
 </thead>
 <tbody>
 EOF
 
 # Emit all rows in execution order with coverage tier badges
 for entry in "${RESULTS[@]}"; do
-  IFS='|' read -r status group name expected actual duration tier test_idx <<< "$entry"
+  IFS='|' read -r status group name expected actual duration tier test_idx classification <<< "$entry"
   tier="${tier:-smoke}"
   test_idx="${test_idx:-0}"
+  classification="${classification:-needs triage}"
 
   if [ "$status" = "PASS" ]; then
     badge='<span class="badge pass">PASS</span>'
@@ -4519,6 +4619,7 @@ for entry in "${RESULTS[@]}"; do
   fi
   detail_text=$(echo "$detail_text" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
   name_esc=$(echo "$name" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+  classification_esc=$(echo "$classification" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
 
   dur_s=""
   if [ -n "$duration" ] && [ "$duration" -gt 0 ] 2>/dev/null; then
@@ -4542,6 +4643,7 @@ for entry in "${RESULTS[@]}"; do
   <td><span class="group-badge $group">$group</span></td>
   <td>${tier_badges}</td>
   <td>$badge</td>
+  <td>${classification_esc}</td>
   <td><span class="duration">$dur_s</span></td>
   <td><div class="detail">$detail_text</div></td>
 </tr>

--- a/Scripts/test-llm-comprehensive.txt
+++ b/Scripts/test-llm-comprehensive.txt
@@ -116,6 +116,7 @@ Write a limerick about a cat.
 # AI: Expected: long essay, may contain some natural repetition of terms like "bread",
 # AI: "civilization", etc. Compare with with-penalty — this is the control.
 [@ no-penalty]
+requires: penalties
 temperature: 0.8
 max_tokens: 20000
 afm: --presence-penalty 0.0
@@ -125,6 +126,7 @@ Write a long essay about the history of bread making across civilizations.
 # AI: Expected: less repetition than no-penalty. Vocabulary should be more varied.
 # AI: If output becomes incoherent or too short, penalty may be too aggressive.
 [@ with-penalty]
+requires: penalties
 temperature: 0.8
 max_tokens: 20000
 afm: --presence-penalty 1.5
@@ -134,6 +136,7 @@ Write a long essay about the history of bread making across civilizations.
 # AI: Expected: reduced phrase-level repetition vs no-penalty. Different mechanism
 # AI: than presence penalty (multiplicative vs additive). Output should stay coherent.
 [@ repetition-penalty]
+requires: penalties
 temperature: 0.8
 max_tokens: 20000
 afm: --repetition-penalty 1.2
@@ -191,6 +194,7 @@ List exactly 5 animals, one per line, numbered 1-5. No other text.
 # AI: Expected: valid JSON matching schema {"name": string, "age": integer}. Output must
 # AI: be valid JSON that conforms to the schema — verify is_valid_json=true.
 [@ guided-json-simple]
+requires: structured
 temperature: 0.0
 max_tokens: 20000
 afm: --guided-json '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}'
@@ -201,6 +205,7 @@ Return a person record for Ada, age 37.
 # AI: Expected: valid JSON with "city", "population" (integer), and "landmarks" (array of
 # AI: 3+ strings). Verify schema conformance and is_valid_json=true.
 [@ guided-json-nested]
+requires: structured
 temperature: 0.0
 max_tokens: 20000
 afm: --guided-json '{"type":"object","properties":{"city":{"type":"string"},"population":{"type":"integer"},"landmarks":{"type":"array","items":{"type":"string"}}},"required":["city","population","landmarks"]}'
@@ -214,61 +219,31 @@ Describe Tokyo as a structured record with at least 3 landmarks.
 # should show significantly faster TTFT when caching is enabled.
 # ══════════════════════════════════════════════════════════════════════
 
-# AI: Baseline turn 1 (no caching). Feature: prefix caching disabled.
-# AI: Expected: coherent response about Swift code. Note the TTFT — this is the baseline.
-# AI: Compare TTFT with agent-cached-turn1 to see if caching speeds up prefill.
-[@ agent-no-cache-turn1]
+# AI: No-cache control sequence. All three requests run against one server process with
+# AI: the exact same multiline API system message. Prefix caching is disabled, so each
+# AI: request should report zero cached input tokens while still returning coherent answers.
+[@ agent-no-cache-sequence]
 temperature: 0.0
 max_tokens: 20000
-system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
-Read the file Sources/MacLocalAPI/main.swift and explain what it does.
+system_json: "You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nWhen modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor for HTTP, MLX for inference, and async/await for concurrency."
+Read the file Sources/AFMCLI/main.swift and summarize how the CLI starts the server.
+Describe a targeted implementation for a --timeout flag that sets request timeout seconds.
+Write an XCTest that verifies the proposed --timeout flag rejects non-positive values.
 
-# AI: Baseline turn 2 (no caching). Feature: prefix caching disabled.
-# AI: Expected: coherent code suggestion. TTFT should be similar to turn 1 since
-# AI: no caching — the system prompt is re-processed from scratch each time.
-[@ agent-no-cache-turn2]
-temperature: 0.0
-max_tokens: 20000
-system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
-Now add a --timeout flag to the CLI that sets a request timeout in seconds.
-
-# AI: Baseline turn 3 (no caching). Feature: prefix caching disabled.
-# AI: Expected: unit test code. TTFT should be similar to turns 1-2.
-[@ agent-no-cache-turn3]
-temperature: 0.0
-max_tokens: 20000
-system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
-Write a unit test for the timeout feature you just described.
-
-# AI: Cached turn 1 (caching enabled). Feature: --enable-prefix-caching.
-# AI: Expected: same quality as no-cache turn 1. This is the first request with this
-# AI: system prompt, so TTFT may be similar (cache miss). The cache gets populated here.
-[@ agent-cached-turn1]
+# AI: Cached request sequence. All three requests run sequentially against one persistent
+# AI: server process with one identical multiline API system message. Request 1 establishes
+# AI: the prefix; requests 2 and 3 must reuse it and report cached input tokens. Compare
+# AI: response quality with agent-no-cache-sequence, but judge cache reuse from telemetry.
+[@ agent-cached-sequence]
 temperature: 0.0
 max_tokens: 20000
 afm: --enable-prefix-caching
-system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
-Read the file Sources/MacLocalAPI/main.swift and explain what it does.
-
-# AI: Cached turn 2 (caching enabled). Feature: --enable-prefix-caching.
-# AI: Expected: same quality as no-cache turn 2, but TTFT should be significantly
-# AI: faster because the system prompt KV cache is reused from turn 1 (cache hit).
-[@ agent-cached-turn2]
-temperature: 0.0
-max_tokens: 20000
-afm: --enable-prefix-caching
-system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
-Now add a --timeout flag to the CLI that sets a request timeout in seconds.
-
-# AI: Cached turn 3 (caching enabled). Feature: --enable-prefix-caching.
-# AI: Expected: same quality as no-cache turn 3, TTFT should be fast (cache hit).
-# AI: Compare gen_time_s across all 3 cached turns vs all 3 no-cache turns.
-[@ agent-cached-turn3]
-temperature: 0.0
-max_tokens: 20000
-afm: --enable-prefix-caching
-system: You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nAlways think step by step. When modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor framework for HTTP server, MLX for GPU inference. The codebase uses async/await throughout. All model access goes through SerialAccessContainer for thread safety.
-Write a unit test for the timeout feature you just described.
+requires: prefix_cache
+expect_by_prompt: [{},{"cached_input_tokens_min":1},{"cached_input_tokens_min":1}]
+system_json: "You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nWhen modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor for HTTP, MLX for inference, and async/await for concurrency."
+Read the file Sources/AFMCLI/main.swift and summarize how the CLI starts the server.
+Describe a targeted implementation for a --timeout flag that sets request timeout seconds.
+Write an XCTest that verifies the proposed --timeout flag rejects non-positive values.
 
 # ══════════════════════════════════════════════════════════════════════
 # MAX TOKENS / OUTPUT LENGTH
@@ -297,6 +272,7 @@ Write a detailed recipe for chocolate chip cookies with ingredients, steps, tips
 # AI: Expected: correct answer "2", AND logprobs_count > 0 in JSONL. The response should
 # AI: include top-5 token probabilities per generated token. Trivial prompt for easy verification.
 [@ logprobs]
+requires: logprobs
 temperature: 0.0
 max_tokens: 20000
 logprobs: true
@@ -313,6 +289,7 @@ What is 1+1?
 # AI: Expected: coherent ML summary. With 2048 max KV, very long prompts would fail
 # AI: but this prompt is short enough to fit. Verify no truncation or crash.
 [@ small-kv]
+requires: context_window_override
 temperature: 0.7
 max_tokens: 20000
 afm: --max-kv-size 2048
@@ -322,6 +299,7 @@ Summarize the key ideas of machine learning in a few paragraphs.
 # AI: Expected: similar quality to small-kv (same prompt). KV quantization reduces memory
 # AI: but may slightly degrade quality. Compare output quality with small-kv.
 [@ kv-quantized]
+requires: kv_quantization
 temperature: 0.7
 max_tokens: 20000
 afm: --kv-bits 4
@@ -331,6 +309,7 @@ Summarize the key ideas of machine learning in a few paragraphs.
 # AI: Expected: coherent architecture analysis. This is the performance baseline — compare
 # AI: TTFT with prefill-large-4096 and prefill-small-256 (same prompt, different step sizes).
 [@ prefill-default]
+requires: prefill_tuning
 temperature: 0.0
 max_tokens: 20000
 system: You are an expert software architect reviewing a large codebase. The project is a Swift macOS application that serves LLM inference through an OpenAI-compatible API. It uses Vapor for HTTP, MLX for GPU compute, and supports streaming SSE responses. The architecture includes model services, controllers, request/response types, prompt caching, tool call parsing, logprobs computation, and a built-in WebUI. The codebase has vendor dependencies managed through a patch system. There are multiple model formats supported including Qwen, Gemma, Llama, DeepSeek, GLM, and others. Each model may have different tool call formats, chat templates, and tokenizer configurations. The server must handle concurrent requests safely using async/await and serial access containers.
@@ -340,6 +319,7 @@ Given this architecture, what are the top 3 performance bottlenecks you would in
 # AI: Expected: same output quality as prefill-default. TTFT may differ — larger steps
 # AI: process more tokens per GPU pass (faster prefill but more memory per pass).
 [@ prefill-large-4096]
+requires: prefill_tuning
 temperature: 0.0
 max_tokens: 20000
 afm: --prefill-step-size 4096
@@ -350,6 +330,7 @@ Given this architecture, what are the top 3 performance bottlenecks you would in
 # AI: Expected: same output quality. TTFT may be slower — smaller steps mean more
 # AI: GPU passes to process the long system prompt but use less memory per pass.
 [@ prefill-small-256]
+requires: prefill_tuning
 temperature: 0.0
 max_tokens: 20000
 afm: --prefill-step-size 256
@@ -518,6 +499,7 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_NONST
 # AI: Expected: JSON generation stops when "Tokyo" appears in a city name value.
 # AI: Output will be truncated JSON (not valid). finish_reason="stop".
 [@ stop-guided-json-value]
+requires: structured
 temperature: 0.0
 max_tokens: 20000
 stop: ["Tokyo"]
@@ -529,6 +511,7 @@ List 5 major world cities as a JSON array. Include Tokyo.
 # AI: Expected: stops at first comma in the JSON. Output will be something like {"name":"Alice"
 # AI: (truncated before the comma). Tests stop on syntax characters within constrained output.
 [@ stop-guided-json-comma]
+requires: structured
 temperature: 0.0
 max_tokens: 20000
 stop: [","]
@@ -540,6 +523,7 @@ Generate a person profile for someone named Alice who is 30 and lives in Paris.
 # AI: Expected: stops at first "}" — output is truncated JSON missing the final brace.
 # AI: Tests that stop applies even to schema-constrained structural tokens.
 [@ stop-guided-json-brace]
+requires: structured
 temperature: 0.0
 max_tokens: 20000
 stop: ["}"]
@@ -553,6 +537,7 @@ Describe the color blue with its hex code.
 # AI: Expected: JSON output stops when "age" key name appears. Output is truncated JSON.
 # AI: Unlike guided-json, json_object uses prompt injection — stop still applies to raw output.
 [@ stop-json-object-key]
+requires: structured
 temperature: 0.0
 max_tokens: 20000
 response_format: json_object
@@ -720,6 +705,7 @@ List 10 mountains, numbered 1 through 10, one per line.
 # AI: "Python", 1991, "Guido van Rossum". Verify is_valid_json=true. Uses prompt injection
 # AI: (not constrained decoding) — output may include markdown fences around JSON.
 [@ response-format-json]
+requires: structured
 temperature: 0.0
 max_tokens: 20000
 response_format: {"type":"json_object"}
@@ -729,6 +715,7 @@ Return a JSON object with keys "language", "year_created", and "creator" for Pyt
 # AI: Expected: valid JSON conforming to schema — "name" (string), "age" (integer),
 # AI: "hobbies" (array of strings). Verify is_valid_json=true and schema conformance.
 [@ response-format-schema]
+requires: structured
 temperature: 0.0
 max_tokens: 20000
 response_format: {"type":"json_schema","json_schema":{"name":"person","schema":{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"},"hobbies":{"type":"array","items":{"type":"string"}}},"required":["name","age","hobbies"]}}}
@@ -848,6 +835,7 @@ Hello, how are you?
 # AI: finish_reason="tool_calls". The parser should auto-detect xmlFunction for Qwen models.
 # AI: Verify tool_calls array in response contains valid function name and arguments.
 [@ tool-call-auto]
+requires: tools
 temperature: 0.0
 max_tokens: 20000
 expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"get_weather","arguments":{"city":"Tokyo"}}]}
@@ -858,6 +846,7 @@ Call get_weather exactly once for Tokyo. Call no other tools.
 # AI: Expected: get_weather tool call with city="Paris", unit="celsius".
 # AI: Same as tool-call-auto but explicitly sets the parser — verifies the flag works.
 [@ tool-call-xml]
+requires: tools
 temperature: 0.0
 max_tokens: 20000
 afm: --tool-call-parser qwen3_xml
@@ -869,6 +858,7 @@ Call get_weather exactly once for Paris with unit celsius. Call no other tools.
 # AI: Expected: TWO tool calls — get_weather(city="London") AND get_time(timezone="Asia/Tokyo").
 # AI: finish_reason="tool_calls". Tests that the parser handles multiple <tool_call> blocks.
 [@ tool-call-multi]
+requires: tools
 temperature: 0.0
 max_tokens: 20000
 expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"get_weather","arguments":{"city":"London"}},{"name":"get_time","arguments":{"timezone":"Asia/Tokyo"}}]}
@@ -879,6 +869,7 @@ Call get_weather exactly once for London and get_time exactly once for Asia/Toky
 # AI: Expected: search_files tool call with path="Sources/", pattern="*.swift",
 # AI: options={recursive: true, max_results: 50}. Tests nested JSON in tool arguments.
 [@ tool-call-complex]
+requires: tools
 temperature: 0.0
 max_tokens: 20000
 expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"search_files","arguments":{"path":"Sources/","pattern":"*.swift","options":{"recursive":true,"max_results":50}}}]}
@@ -889,6 +880,7 @@ Call search_files exactly once with path Sources/, pattern *.swift, recursive tr
 # AI: Expected: todowrite tool call with todos parameter as a JSON array ["Buy milk", "Call dentist", "Fix bug #42"],
 # AI: NOT a serialized string. finish_reason="tool_calls". Validates array params survive serialization.
 [@ tool-call-array-param]
+requires: tools
 temperature: 0.0
 max_tokens: 20000
 expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"todowrite","arguments":{"todos":["Buy milk","Call dentist","Fix bug #42"]}}]}
@@ -900,6 +892,7 @@ Call todowrite exactly once with these three items in order: Buy milk, Call dent
 # AI: anyOf [string, null] with default null — this must NOT crash Jinja template rendering.
 # AI: finish_reason="tool_calls". Validates nullable schemas don't cause server errors.
 [@ tool-call-nullable-param]
+requires: tools
 temperature: 0.0
 max_tokens: 20000
 expect: {"finish_reason":"tool_calls","tool_calls":[{"name":"get_weather","arguments":{"location":"Chicago"}}]}

--- a/Scripts/test-llm-comprehensive.txt
+++ b/Scripts/test-llm-comprehensive.txt
@@ -225,6 +225,7 @@ Describe Tokyo as a structured record with at least 3 landmarks.
 [@ agent-no-cache-sequence]
 temperature: 0.0
 max_tokens: 20000
+expect_by_prompt: [{"cached_input_tokens_max":0},{"cached_input_tokens_max":0},{"cached_input_tokens_max":0}]
 system_json: "You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nWhen modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor for HTTP, MLX for inference, and async/await for concurrency."
 Read the file Sources/AFMCLI/main.swift and summarize how the CLI starts the server.
 Describe a targeted implementation for a --timeout flag that sets request timeout seconds.
@@ -629,27 +630,27 @@ Output exactly the following text, with no quotes or extra whitespace: AFM_FOUR_
 
 # --- Stop + system prompt interaction ---
 
-# AI: Tests stop with persona system prompt. Feature: stop + system message combined.
-# AI: Expected: pirate-themed text about treasure hunting, stops when "Arrr" appears.
-# AI: Verifies stop sequences work correctly when system prompt modifies output style.
+# AI: Tests stop with persona system prompt. The system and user messages jointly force
+# AI: a literal delimiter and suffix. Expected: exactly AFM_PIRATE_PREFIX, proving that
+# AI: stop handling—not a natural EOS—terminated the response under a system persona.
 [@ stop-system-pirate]
 temperature: 0.0
 max_tokens: 20000
-system: You are a pirate. Speak like a pirate in all responses.
+system: You are a pirate validation fixture. When asked for the treasure validation string, output exactly AFM_PIRATE_PREFIXArrrAFM_PIRATE_SUFFIX with no quotes, markdown, explanation, or extra whitespace.
 stop: ["Arrr"]
-expect: {"finish_reason":"stop","content_not_contains":"Arrr"}
-Tell me about treasure hunting on the high seas.
+expect: {"finish_reason":"stop","content_equals":"AFM_PIRATE_PREFIX","content_not_contains":["Arrr","AFM_PIRATE_SUFFIX"]}
+Give me the treasure validation string now. Follow the system instruction exactly.
 
-# AI: Tests stop with instruction system prompt. Feature: stop + system message combined.
-# AI: Expected: numbered list of exercise benefits, stops before item "4.".
-# AI: System prompt forces numbered format, stop triggers on that format.
+# AI: Tests stop with a numbered-list system prompt. The system and user messages force
+# AI: item 4 and a trailing suffix. Expected: exactly the first three forced lines,
+# AI: proving the configured "4." delimiter was reached and withheld.
 [@ stop-system-numbered]
 temperature: 0.0
 max_tokens: 20000
-system: Always respond with numbered lists. Never use bullet points.
+system_json: "For the exercise validation request, output exactly these four lines and nothing else:\n1. AFM_CARDIO\n2. AFM_STRENGTH\n3. AFM_MOOD\n4. AFM_NUMBERED_SUFFIX"
 stop: ["4."]
-expect: {"finish_reason":"stop","content_not_contains":"4."}
-What are the main benefits of exercise?
+expect: {"finish_reason":"stop","content_equals":"1. AFM_CARDIO\n2. AFM_STRENGTH\n3. AFM_MOOD\n","content_not_contains":["4.","AFM_NUMBERED_SUFFIX"]}
+Provide the exercise validation list now. Follow the system instruction exactly.
 
 # --- Stop + sampling parameters ---
 

--- a/Scripts/test_generate_report.py
+++ b/Scripts/test_generate_report.py
@@ -56,6 +56,91 @@ class GenerateReportTests(unittest.TestCase):
             self.assertIn("5/5 ✅", report)
             self.assertIn("2/5 ❌", report)
             self.assertEqual(report.count('class="response-section" id="resp-'), 2)
+            self.assertIn("Separated Evaluation Totals", report)
+            self.assertIn("Native Protocol Conformance", report)
+            self.assertIn("Model / Agent Behavior Quality", report)
+            self.assertIn("Forced-Parser Compatibility Experiments", report)
+            self.assertIn(">1/2<", report)
+            self.assertGreaterEqual(report.count(">N/A<"), 2)
+
+    def test_separated_totals_do_not_mix_quality_and_protocol_lanes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            report_dir = root / "test-reports"
+            report_dir.mkdir()
+            results_path = root / "results.jsonl"
+            protocol = self.record("protocol", "pass", "OK")
+            protocol["evaluation_lane"] = "native_protocol"
+            quality = self.record("quality", "pass", "OK")
+            quality["evaluation_lane"] = "model_agent_behavior"
+            forced = self.record("forced", "fail", "OK")
+            forced["evaluation_lane"] = "forced_parser_compatibility"
+            results_path.write_text(
+                "".join(json.dumps(record) + "\n" for record in [protocol, quality, forced]),
+                encoding="utf-8",
+            )
+            smart_timestamp = "20260825_030405"
+            (report_dir / f"smart-analysis-codex-{smart_timestamp}.md").write_text(
+                '<!-- AI_SCORES [{"i":0,"s":2},{"i":1,"s":5},{"i":2,"s":5}] -->\n',
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env.update(
+                {
+                    "RESULTS_FILE": str(results_path),
+                    "REPORT_OUTPUT_DIR": str(root),
+                    "REPORT_TIMESTAMP": "20260825_070809",
+                    "SMART_TIMESTAMP": smart_timestamp,
+                    "AFM_REPORT_NO_OPEN": "1",
+                }
+            )
+            subprocess.run([sys.executable, str(SCRIPT)], env=env, check=True)
+            report = (
+                report_dir / "mlx-model-report-20260825_070809.html"
+            ).read_text(encoding="utf-8")
+            totals = report.split("<h2>Separated Evaluation Totals</h2>", 1)[1].split(
+                "<h2>Performance Ranking", 1
+            )[0]
+            self.assertIn("Native Protocol Conformance</div><div class=\"value green\">1/1", totals)
+            self.assertIn("Model / Agent Behavior Quality</div><div class=\"value blue\">1/1", totals)
+            self.assertIn("Forced-Parser Compatibility Experiments</div><div class=\"value yellow\">0/1", totals)
+
+    def test_skipped_result_has_intent_and_not_scored_ai_section(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            report_dir = root / "test-reports"
+            report_dir.mkdir()
+            results_path = root / "results.jsonl"
+            skipped = self.record("batch-case", "skip", "SKIP")
+            skipped.update(
+                {
+                    "skip_reason": "missing required capabilities: batch",
+                    "failure_classification": "capability unavailable",
+                    "required_capabilities": ["batch"],
+                }
+            )
+            results_path.write_text(json.dumps(skipped) + "\n", encoding="utf-8")
+            smart_timestamp = "20260825_020304"
+            (report_dir / f"smart-analysis-codex-{smart_timestamp}.md").write_text(
+                "# Analysis\n\n<!-- AI_SCORES [] -->\n", encoding="utf-8"
+            )
+            env = os.environ.copy()
+            env.update(
+                {
+                    "RESULTS_FILE": str(results_path),
+                    "REPORT_OUTPUT_DIR": str(root),
+                    "REPORT_TIMESTAMP": "20260825_060708",
+                    "SMART_TIMESTAMP": smart_timestamp,
+                    "AFM_REPORT_NO_OPEN": "1",
+                }
+            )
+            subprocess.run([sys.executable, str(SCRIPT)], env=env, check=True)
+            report = (
+                report_dir / "mlx-model-report-20260825_060708.html"
+            ).read_text(encoding="utf-8")
+            self.assertIn("Not AI-scored", report)
+            self.assertIn("capability unavailable", report)
+            self.assertIn("missing required capabilities: batch", report)
 
     def test_full_prompt_is_rendered_without_truncation(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/Scripts/test_generate_report.py
+++ b/Scripts/test_generate_report.py
@@ -170,6 +170,45 @@ class GenerateReportTests(unittest.TestCase):
             self.assertIn(long_prompt, report)
             self.assertNotIn("A" * 500 + "...", report)
 
+    def test_reused_label_keeps_model_specific_intent(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            report_dir = root / "test-reports"
+            report_dir.mkdir()
+            prompts_path = root / "prompts.txt"
+            prompts_path.write_text(
+                "# AI: Intent only for model A.\n"
+                "[a/model @ shared]\nPrompt A\n"
+                "# AI: Intent only for model B.\n"
+                "[b/model @ shared]\nPrompt B\n",
+                encoding="utf-8",
+            )
+            records = [
+                dict(self.record("shared", "pass", "OK"), model="a/model", prompt="Prompt A"),
+                dict(self.record("shared", "pass", "OK"), model="b/model", prompt="Prompt B"),
+            ]
+            results_path = root / "results.jsonl"
+            results_path.write_text(
+                "".join(json.dumps(record) + "\n" for record in records),
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env.update(
+                {
+                    "RESULTS_FILE": str(results_path),
+                    "REPORT_OUTPUT_DIR": str(root),
+                    "REPORT_TIMESTAMP": "20260825_080910",
+                    "PROMPTS_FILE": str(prompts_path),
+                    "AFM_REPORT_NO_OPEN": "1",
+                }
+            )
+            subprocess.run([sys.executable, str(SCRIPT)], env=env, check=True)
+            report = (
+                report_dir / "mlx-model-report-20260825_080910.html"
+            ).read_text(encoding="utf-8")
+            self.assertEqual(report.count("Intent only for model A."), 1)
+            self.assertEqual(report.count("Intent only for model B."), 1)
+
     @staticmethod
     def record(label, overall_status, status):
         return {

--- a/Scripts/test_mlx_model_test_config.py
+++ b/Scripts/test_mlx_model_test_config.py
@@ -3,7 +3,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from mlx_model_test_config import expand_template_runs, parse_prompts_file
+from mlx_model_test_config import (
+    ai_intent_for_result,
+    expand_template_runs,
+    parse_ai_intent_specs,
+    parse_prompts_file,
+)
 
 
 class MLXModelTestConfigTests(unittest.TestCase):
@@ -47,6 +52,24 @@ class MLXModelTestConfigTests(unittest.TestCase):
             expanded["runs"][0]["params"]["requires"],
             ["structured", "streaming"],
         )
+
+    def test_ai_intents_are_keyed_by_model_and_fall_back_to_template(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "prompts.txt"
+            path.write_text(
+                "# AI: model A intent\n"
+                "[a/model @ shared]\nPrompt A\n"
+                "# AI: model B intent\n"
+                "[b/model @ shared]\nPrompt B\n"
+                "# AI: template intent\n"
+                "[@ common]\nPrompt template\n",
+                encoding="utf-8",
+            )
+            specs = parse_ai_intent_specs(path)
+
+        self.assertEqual(ai_intent_for_result(specs, "a/model", "shared"), ["model A intent"])
+        self.assertEqual(ai_intent_for_result(specs, "b/model", "shared"), ["model B intent"])
+        self.assertEqual(ai_intent_for_result(specs, "any/model", "common"), ["template intent"])
 
 
 if __name__ == "__main__":

--- a/Scripts/test_mlx_model_test_config.py
+++ b/Scripts/test_mlx_model_test_config.py
@@ -1,0 +1,53 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from mlx_model_test_config import expand_template_runs, parse_prompts_file
+
+
+class MLXModelTestConfigTests(unittest.TestCase):
+    def parse(self, text):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "prompts.txt"
+            path.write_text(text, encoding="utf-8")
+            return parse_prompts_file(path)
+
+    def test_json_messages_decode_real_newlines_without_changing_literal_form(self):
+        config = self.parse(
+            'system: literal\\nseparator\n'
+            '[@ decoded]\n'
+            'system_json: "first\\nsecond"\n'
+            'developer_json: "dev\\tmessage"\n'
+            'instructions_json: "server\\ninstructions"\n'
+            'Prompt\n'
+        )
+
+        self.assertEqual(config["defaults"]["system"], r"literal\nseparator")
+        params = config["runs"][0]["params"]
+        self.assertEqual(params["system"], "first\nsecond")
+        self.assertEqual(params["developer"], "dev\tmessage")
+        self.assertEqual(params["instructions"], "server\ninstructions")
+
+    def test_duplicate_section_is_rejected_instead_of_silently_overwritten(self):
+        with self.assertRaisesRegex(ValueError, "duplicate section"):
+            self.parse("[@ duplicate]\nOne\n[@ duplicate]\nTwo\n")
+
+    def test_template_expansion_preserves_requirements(self):
+        config = self.parse(
+            "[@ structured]\n"
+            "requires: structured, streaming\n"
+            "Prompt\n"
+        )
+
+        expanded = expand_template_runs(config, ["org/one", "org/two"])
+
+        self.assertEqual([run["model"] for run in expanded["runs"]], ["org/one", "org/two"])
+        self.assertEqual(
+            expanded["runs"][0]["params"]["requires"],
+            ["structured", "streaming"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/test_mlx_model_test_oracle.py
+++ b/Scripts/test_mlx_model_test_oracle.py
@@ -1,5 +1,9 @@
+import json
+import tempfile
 import unittest
+from pathlib import Path
 
+from assemble_smart_report import assemble_per_test_report
 from mlx_model_test_oracle import (
     classify_result_likelihood,
     evaluate_expectations,
@@ -13,6 +17,49 @@ from mlx_model_test_oracle import (
 
 
 class ModelTestOracleTests(unittest.TestCase):
+    def test_per_test_report_assembler_handles_metadata_skip_and_score_reasons(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            results = root / "results.jsonl"
+            scores = root / "scores"
+            scores.mkdir()
+            results.write_text(
+                "\n".join(
+                    json.dumps(record)
+                    for record in (
+                        {"_meta": True},
+                        {
+                            "model": "model/a",
+                            "label": "skipped",
+                            "status": "SKIP",
+                            "overall_status": "skip",
+                            "skip_reason": "tools unavailable",
+                        },
+                        {
+                            "model": "model/a",
+                            "label": "working",
+                            "status": "OK",
+                            "tokens_per_sec": 12.34,
+                        },
+                    )
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (scores / "score_1.txt").write_text(
+                'noise\n{"score":5,"reason":"meets intent"}\n',
+                encoding="utf-8",
+            )
+
+            report = assemble_per_test_report(scores, results)
+
+        self.assertIn("### 0. model/a @ skipped", report)
+        self.assertIn("> tools unavailable.", report)
+        self.assertIn("### 1. model/a @ working", report)
+        self.assertIn("**Score: 5/5**", report)
+        self.assertIn("> meets intent", report)
+        self.assertIn('<!-- AI_SCORES [{"i": 1, "s": 5}] -->', report)
+
     def test_evaluation_lane_distinguishes_native_and_cross_family_parser_use(self):
         self.assertEqual(
             evaluation_lane(

--- a/Scripts/test_mlx_model_test_oracle.py
+++ b/Scripts/test_mlx_model_test_oracle.py
@@ -1,13 +1,55 @@
 import unittest
 
 from mlx_model_test_oracle import (
+    classify_result_likelihood,
     evaluate_expectations,
+    evaluation_lane,
     expectation_for_prompt,
     extract_score_payload,
 )
 
 
 class ModelTestOracleTests(unittest.TestCase):
+    def test_evaluation_lane_distinguishes_native_and_cross_family_parser_use(self):
+        self.assertEqual(
+            evaluation_lane(
+                model="mlx-community/Qwen3.8-27B-4bit",
+                afm_args="--tool-call-parser qwen3_xml",
+            ),
+            "native_protocol",
+        )
+        self.assertEqual(
+            evaluation_lane(
+                model="mlx-community/Muse-Glimmer-30B-4bit",
+                afm_args="--tool-call-parser qwen3_xml",
+            ),
+            "forced_parser_compatibility",
+        )
+        self.assertEqual(
+            evaluation_lane(model="test/model", has_expectation=False),
+            "model_agent_behavior",
+        )
+
+    def test_failure_classification_is_likelihood_not_component_ownership(self):
+        self.assertEqual(
+            classify_result_likelihood(
+                model="test/model",
+                label="stop-single",
+                status="OK",
+                failures=["content mismatch"],
+            ),
+            "engine/runtime likely",
+        )
+        self.assertEqual(
+            classify_result_likelihood(
+                model="test/model",
+                label="tool-call-auto",
+                status="OK",
+                failures=["tool call missing"],
+            ),
+            "parser/model boundary needs triage",
+        )
+
     def test_extracts_score_reason_with_escaped_quotes_from_cli_output(self):
         payload = extract_score_payload(
             'analysis noise\n{"score":5,"reason":"finish_reason=\\"tool_calls\\" is correct"}\n'
@@ -132,6 +174,33 @@ class ModelTestOracleTests(unittest.TestCase):
         )
         self.assertTrue(any("content expected exactly" in failure for failure in failures))
         self.assertTrue(any("must not contain 'AFM_SUFFIX'" in failure for failure in failures))
+
+    def test_per_prompt_expectation_and_cache_telemetry(self):
+        config = {
+            "prompt_idx": 2,
+            "num_baseline": 0,
+            "expect_by_prompt": [
+                {},
+                {},
+                {"cached_input_tokens_min": 10},
+            ],
+        }
+        expectation = expectation_for_prompt(config)
+
+        _, failures = evaluate_expectations(
+            expectation,
+            content="ok",
+            finish_reason="stop",
+            logprobs_count=0,
+            tool_calls=[],
+            cached_input_tokens=9,
+        )
+
+        self.assertEqual(expectation, {"cached_input_tokens_min": 10})
+        self.assertEqual(
+            failures,
+            ["cached_input_tokens expected >= 10, got 9"],
+        )
 
 
 if __name__ == "__main__":

--- a/Scripts/test_mlx_model_test_oracle.py
+++ b/Scripts/test_mlx_model_test_oracle.py
@@ -6,6 +6,7 @@ from mlx_model_test_oracle import (
     evaluation_lane,
     expectation_for_prompt,
     extract_score_payload,
+    failed_run_records,
 )
 
 
@@ -48,6 +49,15 @@ class ModelTestOracleTests(unittest.TestCase):
                 failures=["tool call missing"],
             ),
             "parser/model boundary needs triage",
+        )
+        self.assertEqual(
+            classify_result_likelihood(
+                model="test/model",
+                label="response-format-json",
+                status="OK",
+                failures=["invalid best-effort JSON"],
+            ),
+            "model behavior likely",
         )
 
     def test_extracts_score_reason_with_escaped_quotes_from_cli_output(self):
@@ -201,6 +211,45 @@ class ModelTestOracleTests(unittest.TestCase):
             failures,
             ["cached_input_tokens expected >= 10, got 9"],
         )
+
+        _, failures = evaluate_expectations(
+            {"cached_input_tokens_max": 0},
+            content="ok",
+            finish_reason="stop",
+            logprobs_count=0,
+            tool_calls=[],
+            cached_input_tokens=1,
+        )
+        self.assertEqual(
+            failures,
+            ["cached_input_tokens expected <= 0, got 1"],
+        )
+
+    def test_server_load_failure_records_every_prompt_with_engine_metadata(self):
+        records = failed_run_records(
+            {
+                "model": "test/model",
+                "label": "tool-call-auto",
+                "prompts": ["first", "second"],
+                "temperature": 0.0,
+                "max_tokens": 20,
+                "system": "system",
+                "instructions": "instructions",
+                "requires": ["tools"],
+                "afm_args": "--no-think",
+                "expect": {"tool_calls": [{"name": "weather"}]},
+            },
+            error="server died",
+            load_time_s=7,
+        )
+
+        self.assertEqual([record["prompt"] for record in records], ["first", "second"])
+        self.assertTrue(all(record["overall_status"] == "fail" for record in records))
+        self.assertTrue(
+            all(record["failure_classification"] == "engine/runtime likely" for record in records)
+        )
+        self.assertTrue(all(record["evaluation_lane"] == "native_protocol" for record in records))
+        self.assertTrue(all(record["required_capabilities"] == ["tools"] for record in records))
 
 
 if __name__ == "__main__":

--- a/Scripts/test_mlx_model_test_oracle.py
+++ b/Scripts/test_mlx_model_test_oracle.py
@@ -7,6 +7,8 @@ from mlx_model_test_oracle import (
     expectation_for_prompt,
     extract_score_payload,
     failed_run_records,
+    skipped_run_records,
+    transport_failure_record,
 )
 
 
@@ -237,7 +239,10 @@ class ModelTestOracleTests(unittest.TestCase):
                 "instructions": "instructions",
                 "requires": ["tools"],
                 "afm_args": "--no-think",
+                "media": ["fixture.png"],
+                "stop": ["END"],
                 "expect": {"tool_calls": [{"name": "weather"}]},
+                "tools": [{"type": "function", "function": {"name": "weather"}}],
             },
             error="server died",
             load_time_s=7,
@@ -250,6 +255,58 @@ class ModelTestOracleTests(unittest.TestCase):
         )
         self.assertTrue(all(record["evaluation_lane"] == "native_protocol" for record in records))
         self.assertTrue(all(record["required_capabilities"] == ["tools"] for record in records))
+        self.assertTrue(all(record["media"] == ["fixture.png"] for record in records))
+        self.assertTrue(all(record["stop"] == ["END"] for record in records))
+        self.assertTrue(all(record["tools"][0]["function"]["name"] == "weather" for record in records))
+        self.assertTrue(all(record["expect"]["tool_calls"][0]["name"] == "weather" for record in records))
+
+    def test_client_failure_for_baseline_is_always_native_protocol(self):
+        record = transport_failure_record(
+            {
+                "model": "test/model",
+                "label": "behavior-quality",
+                "prompt_idx": 0,
+                "num_baseline": 1,
+                "temperature": 0.7,
+                "max_tokens": 20,
+                "tools": [{"type": "function", "function": {"name": "weather"}}],
+                "expect_by_prompt": [{"content_equals": "unused"}],
+            },
+            prompt="ordinary baseline",
+            error="client JSON invalid",
+            load_time_s=2.5,
+        )
+
+        self.assertTrue(record["is_baseline"])
+        self.assertEqual(record["transport_status"], "fail")
+        self.assertEqual(record["assertion_status"], "not_run")
+        self.assertEqual(record["evaluation_lane"], "native_protocol")
+        self.assertEqual(record["failure_classification"], "engine/runtime likely")
+        self.assertEqual(record["expect"], {"tool_calls": []})
+        self.assertEqual(record["load_time_s"], 2.5)
+
+    def test_capability_skip_preserves_per_prompt_configuration(self):
+        records = skipped_run_records(
+            {
+                "model": "test/model",
+                "label": "structured",
+                "prompts": ["first", "second"],
+                "temperature": 0.0,
+                "max_tokens": 20,
+                "response_format": {"type": "json_schema"},
+                "media": ["fixture.png"],
+                "expect_by_prompt": [
+                    {"content_equals": "one"},
+                    {"content_equals": "two"},
+                ],
+            },
+            reason="structured unavailable",
+        )
+
+        self.assertEqual([record["expect"]["content_equals"] for record in records], ["one", "two"])
+        self.assertTrue(all(record["transport_status"] == "not_run" for record in records))
+        self.assertTrue(all(record["response_format"] == {"type": "json_schema"} for record in records))
+        self.assertTrue(all(record["media"] == ["fixture.png"] for record in records))
 
 
 if __name__ == "__main__":

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -822,7 +822,7 @@ struct MlxCommand: ParsableCommand {
             }
             try runDwarfStar(
                 checkpointPath: localModelPath(resolvedModel),
-                advertisedModelID: advertisedDwarfStarModelID(
+                advertisedModelID: AFMDwarfStarModelIdentity.advertisedModelID(
                     requestedModel: rawModel,
                     checkpointPath: localModelPath(resolvedModel)
                 ),
@@ -1343,22 +1343,6 @@ struct MlxCommand: ParsableCommand {
         signal(SIGTERM, handleShutdown)
         while shouldKeepRunning && runLoop.run(mode: .default, before: Date(timeIntervalSinceNow: 0.1)) {}
         print("Server shutdown complete.")
-    }
-
-    private func advertisedDwarfStarModelID(
-        requestedModel: String,
-        checkpointPath: String
-    ) -> String {
-        let trimmed = requestedModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        let components = trimmed.split(separator: "/", omittingEmptySubsequences: false)
-        let isRepositoryID = components.count == 2
-            && components.allSatisfy { !$0.isEmpty }
-            && !trimmed.hasPrefix("./")
-            && !trimmed.hasPrefix("../")
-        if isRepositoryID {
-            return trimmed
-        }
-        return URL(fileURLWithPath: checkpointPath).lastPathComponent
     }
 
     private func runSinglePrompt(

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -822,6 +822,10 @@ struct MlxCommand: ParsableCommand {
             }
             try runDwarfStar(
                 checkpointPath: localModelPath(resolvedModel),
+                advertisedModelID: advertisedDwarfStarModelID(
+                    requestedModel: rawModel,
+                    checkpointPath: localModelPath(resolvedModel)
+                ),
                 modelStore: modelStore,
                 chatTemplateKwargs: parsedKwargs,
                 forceDisableThinking: noThink,
@@ -1195,6 +1199,7 @@ struct MlxCommand: ParsableCommand {
 
     private func runDwarfStar(
         checkpointPath: String,
+        advertisedModelID: String,
         modelStore: AFMMLXModelStore,
         chatTemplateKwargs: [String: Any],
         forceDisableThinking: Bool,
@@ -1220,7 +1225,7 @@ struct MlxCommand: ParsableCommand {
         let residentSessions = max(1, concurrent ?? 1)
         let resolvedDSparkPath = dsparkSupportPath.map(localModelPath)
 
-        let modelID = URL(fileURLWithPath: checkpointPath).lastPathComponent
+        let modelID = advertisedModelID
         if openclawConfig {
             printOpenClawConfig(
                 model: modelID,
@@ -1338,6 +1343,22 @@ struct MlxCommand: ParsableCommand {
         signal(SIGTERM, handleShutdown)
         while shouldKeepRunning && runLoop.run(mode: .default, before: Date(timeIntervalSinceNow: 0.1)) {}
         print("Server shutdown complete.")
+    }
+
+    private func advertisedDwarfStarModelID(
+        requestedModel: String,
+        checkpointPath: String
+    ) -> String {
+        let trimmed = requestedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let components = trimmed.split(separator: "/", omittingEmptySubsequences: false)
+        let isRepositoryID = components.count == 2
+            && components.allSatisfy { !$0.isEmpty }
+            && !trimmed.hasPrefix("./")
+            && !trimmed.hasPrefix("../")
+        if isRepositoryID {
+            return trimmed
+        }
+        return URL(fileURLWithPath: checkpointPath).lastPathComponent
     }
 
     private func runSinglePrompt(

--- a/Sources/AFMServer/AFMDwarfStarModelIdentity.swift
+++ b/Sources/AFMServer/AFMDwarfStarModelIdentity.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+package enum AFMDwarfStarModelIdentity {
+    package static func advertisedModelID(
+        requestedModel: String,
+        checkpointPath: String
+    ) -> String {
+        advertisedModelID(
+            requestedModel: requestedModel,
+            checkpointPath: checkpointPath,
+            requestedPathExists: { FileManager.default.fileExists(atPath: $0) }
+        )
+    }
+
+    package static func advertisedModelID(
+        requestedModel: String,
+        checkpointPath: String,
+        requestedPathExists: (String) -> Bool
+    ) -> String {
+        let trimmed = requestedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let expandedPath = (trimmed as NSString).expandingTildeInPath
+        let explicitlyLocal = trimmed.hasPrefix("/")
+            || trimmed.hasPrefix("./")
+            || trimmed.hasPrefix("../")
+            || requestedPathExists(expandedPath)
+        guard !explicitlyLocal else {
+            return URL(fileURLWithPath: checkpointPath).lastPathComponent
+        }
+
+        let components = trimmed.split(separator: "/", omittingEmptySubsequences: false)
+        let isRepositoryID = components.count == 2
+            && components.allSatisfy { !$0.isEmpty }
+        return isRepositoryID
+            ? trimmed
+            : URL(fileURLWithPath: checkpointPath).lastPathComponent
+    }
+}

--- a/Sources/AFMServer/AFMMLXCapabilityPresentation.swift
+++ b/Sources/AFMServer/AFMMLXCapabilityPresentation.swift
@@ -19,6 +19,19 @@ enum AFMMLXCapabilityPresentation {
         labels.append(contentsOf: optionalLabels.compactMap { capability, label in
             capabilities.contains(capability) ? label : nil
         })
+        if descriptor?.providerID.rawValue == "mlx" {
+            labels.append(contentsOf: [
+                "mlx_runtime",
+                "batch",
+                "context_window_override",
+                "kv_quantization",
+                "logprobs",
+                "penalties",
+                "prefill_tuning",
+            ])
+        } else if descriptor?.providerID.rawValue == "dwarfstar" {
+            labels.append("dwarfstar_runtime")
+        }
         return labels
     }
 

--- a/Tests/MacLocalAPITests/AFMDwarfStarModelIdentityTests.swift
+++ b/Tests/MacLocalAPITests/AFMDwarfStarModelIdentityTests.swift
@@ -1,0 +1,37 @@
+@testable import AFMServer
+import XCTest
+
+final class AFMDwarfStarModelIdentityTests: XCTestCase {
+    func testRepositoryIDRemainsStableAtAPIBoundary() {
+        XCTAssertEqual(
+            AFMDwarfStarModelIdentity.advertisedModelID(
+                requestedModel: "owner/repository",
+                checkpointPath: "/cache/model-00001.gguf",
+                requestedPathExists: { _ in false }
+            ),
+            "owner/repository"
+        )
+    }
+
+    func testExistingTwoComponentRelativePathUsesCheckpointBasename() {
+        XCTAssertEqual(
+            AFMDwarfStarModelIdentity.advertisedModelID(
+                requestedModel: "models/checkpoint.gguf",
+                checkpointPath: "/workspace/models/checkpoint.gguf",
+                requestedPathExists: { $0 == "models/checkpoint.gguf" }
+            ),
+            "checkpoint.gguf"
+        )
+    }
+
+    func testExplicitLocalPathUsesCheckpointBasenameEvenBeforeExistenceCheck() {
+        XCTAssertEqual(
+            AFMDwarfStarModelIdentity.advertisedModelID(
+                requestedModel: "./models/checkpoint.gguf",
+                checkpointPath: "/workspace/models/checkpoint.gguf",
+                requestedPathExists: { _ in false }
+            ),
+            "checkpoint.gguf"
+        )
+    }
+}

--- a/Tests/MacLocalAPITests/MLXCapabilityPresentationTests.swift
+++ b/Tests/MacLocalAPITests/MLXCapabilityPresentationTests.swift
@@ -35,6 +35,13 @@ final class MLXCapabilityPresentationTests: XCTestCase {
                 "streaming",
                 "prefix_cache",
                 "speculative_decoding",
+                "mlx_runtime",
+                "batch",
+                "context_window_override",
+                "kv_quantization",
+                "logprobs",
+                "penalties",
+                "prefill_tuning",
             ]
         )
     }
@@ -59,8 +66,32 @@ final class MLXCapabilityPresentationTests: XCTestCase {
         XCTAssertFalse(AFMMLXCapabilityPresentation.supportsVision(descriptor: descriptor))
         XCTAssertEqual(
             Set(AFMMLXCapabilityPresentation.modelCapabilityLabels(descriptor: descriptor)),
-            ["chat", "completion", "streaming"]
+            [
+                "chat", "completion", "streaming", "mlx_runtime", "batch", "context_window_override", "kv_quantization",
+                "logprobs", "penalties", "prefill_tuning",
+            ]
         )
+    }
+
+    func testDwarfStarDescriptorDoesNotAdvertiseMLXOnlyEngineFeatures() {
+        let descriptor = AFMModelDescriptor(
+            providerID: "dwarfstar",
+            modelID: "deepseek",
+            displayName: "deepseek",
+            capabilities: [.text, .streaming, .reasoning, .toolCalling, .prefixCaching],
+            privacyBoundary: .device
+        )
+
+        let labels = Set(
+            AFMMLXCapabilityPresentation.modelCapabilityLabels(descriptor: descriptor)
+        )
+        XCTAssertTrue(labels.contains("tools"))
+        XCTAssertTrue(labels.contains("prefix_cache"))
+        XCTAssertTrue(labels.contains("dwarfstar_runtime"))
+        XCTAssertFalse(labels.contains("batch"))
+        XCTAssertFalse(labels.contains("logprobs"))
+        XCTAssertFalse(labels.contains("structured"))
+        XCTAssertFalse(labels.contains("penalties"))
     }
 
     func testDeclaredMediaDetectionDoesNotRequirePayloadField() {


### PR DESCRIPTION
## Problem

Comprehensive reports repeated an unrelated primary-colors baseline across feature variants, displayed variant intent beside that unrelated response, and could treat unsupported engine features as model failures. Stop tests did not always force their configured delimiters, and the summary mixed protocol conformance, model quality, and cross-family forced-parser experiments.

Closes #224.

## Approach

- replace repeated synthetic baselines with feature-specific deterministic prompts and assertions
- run cache control/cached prompts sequentially on one server and capture cached-token telemetry
- parse exact JSON-encoded system, developer, and server instruction values without duplicating API system text into CLI instructions
- gate unsupported checks using `/v1/models` capabilities and show explicit skips
- classify likely engine/runtime, parser/model-boundary, model behavior, and forced-parser failures conservatively
- split report totals into native protocol, model/agent quality, and forced-parser compatibility lanes
- render full prompts, actual stop JSON, AI intent, per-test Codex sections, cache telemetry, and skip reasons
- keep DwarfStar API model identity equal to the requested Hugging Face repository ID

## Validation

- 16 Python parser/oracle/report tests passed
- both modified shell harnesses pass `bash -n`
- capability presentation XCTest filter — 6/6 passed through `Scripts/swiftpm-reliable.sh`
- cancellation/resource containment XCTest filter — 3/3 passed through the wrapper
- paired local AFMKit release build completed successfully

## Summary by Sourcery

Improve evaluation accuracy and reporting by separating runtime capability limitations from model behavior while preserving precise prompt configuration and test intent.

New Features:
- Add capability-aware test execution with explicit skips for unsupported engine features.
- Add separated report totals for native protocol conformance, model/agent behavior quality, and forced-parser compatibility.
- Add support for exact JSON-encoded prompts, server instructions, per-prompt expectations, and cached-token telemetry.
- Add richer per-test reporting with full configuration, intent, classifications, skip reasons, and cache metrics.
- Preserve requested Hugging Face repository IDs in DwarfStar API model metadata.

Bug Fixes:
- Prevent unrelated baseline prompts and variant intents from being reused across feature variants.
- Ensure server instructions and API system/developer messages remain distinct and stop configurations are applied accurately.
- Avoid treating unsupported runtime capabilities as model failures.
- Prevent AI scoring and report totals from including unexecuted capability skips.

Enhancements:
- Centralize prompt parsing, intent resolution, deterministic oracle logic, failure classification, and smart-report assembly.
- Classify failures conservatively across engine/runtime, parser/model boundary, model behavior, and forced-parser experiment categories.
- Expose runtime-specific capability labels through the model API.

Tests:
- Add parser, oracle, report, capability presentation, and DwarfStar model identity coverage for the revised evaluation behavior.