### PR TITLE
Fix single-capacity batch dispatch

### DIFF
--- a/Sources/AFMServer/Controllers/AFMChatServing.swift
+++ b/Sources/AFMServer/Controllers/AFMChatServing.swift
@@ -135,6 +135,10 @@ typealias AFMChatStreamingResult = (
 /// intentionally not part of this API.
 protocol AFMChatServing: Sendable {
     var maxConcurrent: Int { get }
+    /// Whether a successfully returned streaming response owns and releases
+    /// the slot reserved by the caller. Controllers use this explicit contract
+    /// instead of inferring ownership from the configured capacity.
+    var generatedStreamOwnsSlotReservation: Bool { get }
     var servingConfiguration: AFMChatServingConfiguration { get }
     var defaultGuidedJsonSchema: ResponseFormat? { get }
 

--- a/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
+++ b/Sources/AFMServer/Controllers/AFMKitMLXChatServingAdapter.swift
@@ -107,6 +107,17 @@ final class AFMKitMLXChatServingAdapter: AFMChatServing, AFMGenerationAdmitterPr
     }
 
     var maxConcurrent: Int { mlxServing?.maxConcurrent ?? fixedMaxConcurrent }
+    var generatedStreamOwnsSlotReservation: Bool {
+        if mlxServing != nil {
+            // Concurrent MLX streams are submitted to the scheduler, which
+            // releases the reservation on termination. Serial MLX generation
+            // remains caller-owned.
+            return maxConcurrent >= 2
+        }
+        // Generic provider streams release their admission gate in the
+        // adapter's producer task regardless of configured capacity.
+        return genericAdmission != nil
+    }
     var providerGenerationAdmitter: AnyAFMGenerationAdmitter? {
         fixedModel.generationAdmitter
     }

--- a/Sources/AFMServer/Controllers/BatchAPIController.swift
+++ b/Sources/AFMServer/Controllers/BatchAPIController.swift
@@ -4,6 +4,10 @@ import AFMKitMLX
 import Foundation
 
 struct BatchAPIController: RouteCollection {
+    /// Match the ordinary chat endpoint's bounded admission wait. Serial-only
+    /// models must queue batch members instead of rejecting every sibling.
+    private static let slotQueueTimeout: TimeInterval = 240
+
     private let service: any AFMChatServing
     private let store: BatchStore
     private let modelID: String
@@ -186,9 +190,9 @@ struct BatchAPIController: RouteCollection {
         await store.markBatchInProgress(batchId)
 
         // Dispatch all requests in background.
-        // Each request individually reserves a slot via tryReserveSlot() in processOneRequest.
-        // This allows partial batch execution — some requests may get 503 while others succeed,
-        // which is acceptable per OpenAI batch semantics (per-request errors don't fail the batch).
+        // Each request queues for and individually reserves a generation slot
+        // in processOneRequest. Per-request timeout errors do not fail the
+        // enclosing batch.
         let dispatchTask = Task {
             defer { service.releaseBatchReference() }
             await self.dispatchBatchRequests(batchId: batchId, requests: inputLines)
@@ -272,7 +276,8 @@ struct BatchAPIController: RouteCollection {
 
         do {
             // Reserve slot
-            guard service.tryReserveSlot() else {
+            guard await service.waitForSlot(timeout: Self.slotQueueTimeout) else {
+                guard !Task.isCancelled else { return }
                 let result = BatchResultLine(
                     id: resultId, customId: inputLine.customId,
                     response: nil,
@@ -287,6 +292,7 @@ struct BatchAPIController: RouteCollection {
                     service.releaseSlot()
                 }
             }
+            try Task.checkCancellation()
 
             let effectiveModel = service.normalizeModel(chatReq.model ?? modelID)
             let effectiveMaxTokens = chatReq.effectiveMaxTokens ?? maxTokens ?? Int.max
@@ -313,7 +319,7 @@ struct BatchAPIController: RouteCollection {
                 preserveStructuralTags: false,
                 requestId: requestId
             )
-            reservationTransferred = true
+            reservationTransferred = service.generatedStreamOwnsSlotReservation
 
             // Determine if model supports thinking
             let extractThinking = streamResult.thinkStartTag != nil

--- a/Sources/AFMServer/Controllers/BatchCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/BatchCompletionsController.swift
@@ -7,6 +7,9 @@ import os
 struct BatchCompletionsController: RouteCollection {
     /// Maximum requests allowed in a single SSE multiplex batch.
     private static let maxBatchSize = 64
+    /// Match the ordinary chat endpoint's bounded admission wait. Serial-only
+    /// models must queue batch members instead of rejecting every sibling.
+    private static let slotQueueTimeout: TimeInterval = 240
 
     private let service: any AFMChatServing
     private let modelID: String
@@ -103,50 +106,54 @@ struct BatchCompletionsController: RouteCollection {
         let sd = seed
 
         response.body = .init(asyncStream: { writer in
+            defer { svc.releaseBatchReference() }
             let encoder = JSONEncoder()
+            // Per-request streams feed into a shared async channel. A writer
+            // failure escapes the throwing group so queued/generating child
+            // requests are cancelled when the client disconnects.
+            let (mergedStream, mergedContinuation) = AsyncStream<String>.makeStream()
 
-            await withTaskGroup(of: Void.self) { group in
-                // Per-request streams feed into a shared async channel
-                let (mergedStream, mergedContinuation) = AsyncStream<String>.makeStream()
-                let activeCount = OSAllocatedUnfairLock(initialState: batchReq.requests.count)
+            do {
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    let activeCount = OSAllocatedUnfairLock(initialState: batchReq.requests.count)
 
-                for item in batchReq.requests {
-                    group.addTask {
-                        await self.processRequest(
-                            item: item,
-                            service: svc,
-                            modelID: mdlID,
-                            temperature: temp,
-                            topP: tp,
-                            maxTokens: mt,
-                            repetitionPenalty: rp,
-                            topK: tk,
-                            minP: mp,
-                            presencePenalty: pp,
-                            seed: sd,
-                            encoder: encoder,
-                            continuation: mergedContinuation,
-                            activeCount: activeCount
-                        )
-                    }
-                }
-
-                // Writer task: read from merged stream and write to SSE
-                group.addTask {
-                    for await sseData in mergedStream {
-                        do {
-                            try await writer.write(.buffer(.init(string: sseData)))
-                        } catch {
-                            break
+                    for item in batchReq.requests {
+                        group.addTask {
+                            await self.processRequest(
+                                item: item,
+                                service: svc,
+                                modelID: mdlID,
+                                temperature: temp,
+                                topP: tp,
+                                maxTokens: mt,
+                                repetitionPenalty: rp,
+                                topK: tk,
+                                minP: mp,
+                                presencePenalty: pp,
+                                seed: sd,
+                                encoder: encoder,
+                                continuation: mergedContinuation,
+                                activeCount: activeCount
+                            )
                         }
                     }
-                    // Write final DONE
-                    try? await writer.write(.buffer(.init(string: "data: [DONE]\n\n")))
-                    try? await writer.write(.end)
-                }
-            }
 
-            svc.releaseBatchReference()
+                    // Writer task: read from merged stream and write to SSE
+                    group.addTask {
+                        for await sseData in mergedStream {
+                            try await writer.write(.buffer(.init(string: sseData)))
+                        }
+                        // Write final DONE
+                        try await writer.write(.buffer(.init(string: "data: [DONE]\n\n")))
+                        try await writer.write(.end)
+                    }
+
+                    try await group.waitForAll()
+                }
+            } catch {
+                mergedContinuation.finish()
+                try? await writer.write(.end)
+            }
         })
 
         return response
@@ -173,7 +180,11 @@ struct BatchCompletionsController: RouteCollection {
         let isStreaming = chatReq.stream ?? false
 
         do {
-            guard service.tryReserveSlot() else {
+            guard await service.waitForSlot(timeout: Self.slotQueueTimeout) else {
+                guard !Task.isCancelled else {
+                    decrementAndFinishIfDone(activeCount: activeCount, continuation: continuation)
+                    return
+                }
                 let errorEvent = makeErrorEvent(customId: customId, message: "Server at capacity", type: "server_error", encoder: encoder)
                 continuation.yield(errorEvent)
                 decrementAndFinishIfDone(activeCount: activeCount, continuation: continuation)
@@ -185,6 +196,7 @@ struct BatchCompletionsController: RouteCollection {
                     service.releaseSlot()
                 }
             }
+            try Task.checkCancellation()
 
             let effectiveModel = service.normalizeModel(chatReq.model ?? modelID)
             let effectiveMaxTokens = chatReq.effectiveMaxTokens ?? maxTokens ?? Int.max
@@ -212,7 +224,7 @@ struct BatchCompletionsController: RouteCollection {
                 preserveStructuralTags: false,
                 requestId: nil
             )
-            reservationTransferred = true
+            reservationTransferred = service.generatedStreamOwnsSlotReservation
 
             let extractThinking = streamResult.thinkStartTag != nil
             let thinkStart = streamResult.thinkStartTag ?? "<think>"

--- a/Tests/MacLocalAPITests/BatchDispatchTests.swift
+++ b/Tests/MacLocalAPITests/BatchDispatchTests.swift
@@ -10,10 +10,17 @@ import Testing
 
 // MARK: - Fake Service for Batch Tests
 
+private enum BatchDispatchTestTiming {
+    static let delayedStreamNanoseconds: UInt64 = 50_000_000
+    static let pollIntervalNanoseconds: UInt64 = 50_000_000
+    static let pollAttempts = 40
+}
+
 /// A fake AFMChatServing that supports batch-mode protocol methods.
 /// Configurable per-test: control slot reservation, streaming results, errors, and concurrency tracking.
 private final class FakeBatchService: AFMChatServing, @unchecked Sendable {
-    let maxConcurrent: Int
+    var maxConcurrent: Int
+    var generatedStreamOwnsSlotReservation = true
     let toolCallParser: String? = nil
     var supportsStrictToolGrammar: Bool = false
     let thinkStartTag: String? = nil
@@ -40,10 +47,14 @@ private final class FakeBatchService: AFMChatServing, @unchecked Sendable {
     private(set) var generateStreamingCallCount = 0
     private(set) var reserveSlotCallCount = 0
     private(set) var releaseSlotCallCount = 0
+    private(set) var streamOwnedReleaseCount = 0
+    private var activeReservations = 0
+    private var peakActiveReservations = 0
 
     // Configuration
     var shouldFailEnsureBatchMode = false
     var shouldFailReserveSlot = false
+    var enforceCapacity = false
     var streamingResultFactory: (([Message]) -> AFMChatStreamingResult)?
     private let defaultStreamingResult: AFMChatStreamingResult
 
@@ -61,13 +72,53 @@ private final class FakeBatchService: AFMChatServing, @unchecked Sendable {
     func tryReserveSlot() -> Bool {
         _lock.withLock {
             reserveSlotCallCount += 1
-            return !shouldFailReserveSlot
+            guard !shouldFailReserveSlot else { return false }
+            guard enforceCapacity else { return true }
+            guard activeReservations < maxConcurrent else { return false }
+            activeReservations += 1
+            peakActiveReservations = max(peakActiveReservations, activeReservations)
+            return true
         }
+    }
+
+    func waitForSlot(timeout: TimeInterval) async -> Bool {
+        if shouldFailReserveSlot || Task.isCancelled { return false }
+        if tryReserveSlot() { return true }
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while ContinuousClock.now < deadline {
+            do {
+                try await Task.sleep(nanoseconds: 1_000_000)
+            } catch {
+                return false
+            }
+            if tryReserveSlot() { return true }
+        }
+        return false
     }
 
     func releaseSlot() {
         _lock.withLock {
             releaseSlotCallCount += 1
+            if enforceCapacity {
+                activeReservations = max(0, activeReservations - 1)
+            }
+        }
+    }
+
+    var activeReservationCount: Int {
+        _lock.withLock { activeReservations }
+    }
+
+    var peakActiveReservationCount: Int {
+        _lock.withLock { peakActiveReservations }
+    }
+
+    private func releaseStreamOwnedSlot() {
+        _lock.withLock {
+            streamOwnedReleaseCount += 1
+            if enforceCapacity {
+                activeReservations = max(0, activeReservations - 1)
+            }
         }
     }
 
@@ -127,7 +178,32 @@ private final class FakeBatchService: AFMChatServing, @unchecked Sendable {
         _lock.withLock {
             generateStreamingCallCount += 1
         }
-        return streamingResultFactory?(messages) ?? defaultStreamingResult
+        let result = streamingResultFactory?(messages) ?? defaultStreamingResult
+        guard generatedStreamOwnsSlotReservation else { return result }
+
+        let ownedStream = AsyncThrowingStream<AFMServerStreamChunk, Error> { continuation in
+            let task = Task {
+                defer { self.releaseStreamOwnedSlot() }
+                do {
+                    for try await chunk in result.stream {
+                        continuation.yield(chunk)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+        return (
+            modelID: result.modelID,
+            stream: ownedStream,
+            promptTokens: result.promptTokens,
+            toolCallStartTag: result.toolCallStartTag,
+            toolCallEndTag: result.toolCallEndTag,
+            thinkStartTag: result.thinkStartTag,
+            thinkEndTag: result.thinkEndTag
+        )
     }
 
     func generateStreaming(
@@ -178,6 +254,43 @@ private final class FakeBatchService: AFMChatServing, @unchecked Sendable {
                 continuation.yield(chunk)
             }
             continuation.finish()
+        }
+        return (
+            modelID: "test-model",
+            stream: stream,
+            promptTokens: 10,
+            toolCallStartTag: "<tool_call>",
+            toolCallEndTag: "</tool_call>",
+            thinkStartTag: nil,
+            thinkEndTag: nil
+        )
+    }
+
+    static func makeDelayedStreamingResult(
+        text: String,
+        delayNanoseconds: UInt64
+    ) -> AFMChatStreamingResult {
+        let stream = AsyncThrowingStream<AFMServerStreamChunk, Error> { continuation in
+            let task = Task {
+                do {
+                    try await Task.sleep(nanoseconds: delayNanoseconds)
+                    continuation.yield(AFMServerStreamChunk(text: text))
+                    continuation.yield(
+                        AFMServerStreamChunk(
+                            text: "",
+                            promptTokens: 10,
+                            completionTokens: 2,
+                            cachedTokens: 0,
+                            promptTime: 0.01,
+                            generateTime: 0.02
+                        )
+                    )
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
         }
         return (
             modelID: "test-model",
@@ -1087,6 +1200,77 @@ final class BatchAPIControllerTests: XCTestCase {
         }
     }
 
+    func testSingleCapacityBatchDispatchSerializesAndReleasesForLaterRequests() async throws {
+        service.maxConcurrent = 1
+        service.generatedStreamOwnsSlotReservation = false
+        service.enforceCapacity = true
+        service.streamingResultFactory = { messages in
+            let text = messages.first?.textContent ?? "missing"
+            return FakeBatchService.makeDelayedStreamingResult(
+                text: "response: \(text)",
+                delayNanoseconds: BatchDispatchTestTiming.delayedStreamNanoseconds
+            )
+        }
+
+        let jsonl = """
+        {"custom_id":"serial-1","method":"POST","url":"/v1/chat/completions","body":{"model":"test","messages":[{"role":"user","content":"first"}]}}
+        {"custom_id":"serial-2","method":"POST","url":"/v1/chat/completions","body":{"model":"test","messages":[{"role":"user","content":"second"}]}}
+        """
+        let file = await store.storeFile(
+            filename: "serial-input.jsonl",
+            purpose: "batch",
+            data: Data(jsonl.utf8)
+        )
+        let requestBody = """
+        {"input_file_id":"\(file.id)","endpoint":"/v1/chat/completions","completion_window":"24h"}
+        """
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        var batchId = ""
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/batches",
+            headers: headers,
+            body: ByteBuffer(string: requestBody)
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            batchId = (try? response.content.decode(BatchObject.self).id) ?? ""
+        }
+
+        for _ in 0..<BatchDispatchTestTiming.pollAttempts {
+            if await store.getBatch(batchId)?.status == "completed" { break }
+            try await Task.sleep(
+                nanoseconds: BatchDispatchTestTiming.pollIntervalNanoseconds
+            )
+        }
+
+        let batch = await store.getBatch(batchId)
+        XCTAssertEqual(batch?.status, "completed")
+        XCTAssertEqual(batch?.requestCounts.completed, 2)
+        XCTAssertEqual(batch?.requestCounts.failed, 0)
+        XCTAssertEqual(service.generateStreamingCallCount, 2)
+        XCTAssertEqual(service.releaseSlotCallCount, 2)
+        XCTAssertEqual(service.activeReservationCount, 0)
+
+        if let outputFileId = batch?.outputFileId {
+            try await app.testable(method: .running(port: 0)).test(
+                .GET,
+                "/v1/files/\(outputFileId)/content"
+            ) { response async in
+                XCTAssertEqual(response.status, .ok)
+                XCTAssertContains(response.body.string, "\"serial-1\"")
+                XCTAssertContains(response.body.string, "\"serial-2\"")
+                XCTAssertFalse(response.body.string.contains("\"error\":"))
+            }
+        } else {
+            XCTFail("Completed serial batch did not produce an output file")
+        }
+
+        XCTAssertTrue(service.tryReserveSlot(), "Serial slot leaked after batch completion")
+        service.releaseSlot()
+    }
+
     func testBatchDispatchRecordsErrorOnSlotReservationFailure() async throws {
         service.shouldFailReserveSlot = true
 
@@ -1324,6 +1508,112 @@ final class BatchCompletionsControllerTests: XCTestCase {
         }
 
         XCTAssertEqual(service.releaseSlotCallCount, 0, "The scheduler owns submitted streaming reservations")
+    }
+
+    func testSingleCapacityMultiplexSerializesAndReleasesForLaterRequests() async throws {
+        service.maxConcurrent = 1
+        service.generatedStreamOwnsSlotReservation = false
+        service.enforceCapacity = true
+        service.streamingResultFactory = { messages in
+            let text = messages.first?.textContent ?? "missing"
+            return FakeBatchService.makeDelayedStreamingResult(
+                text: "response: \(text)",
+                delayNanoseconds: BatchDispatchTestTiming.delayedStreamNanoseconds
+            )
+        }
+
+        let json = """
+        {"requests":[{"custom_id":"serial-a","body":{"model":"m","messages":[{"role":"user","content":"first"}]}},{"custom_id":"serial-b","body":{"model":"m","messages":[{"role":"user","content":"second"}]}}]}
+        """
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/batch/completions",
+            headers: headers,
+            body: ByteBuffer(string: json)
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertContains(response.body.string, "\"serial-a\"")
+            XCTAssertContains(response.body.string, "\"serial-b\"")
+            XCTAssertFalse(response.body.string.contains("batch.error"))
+            XCTAssertContains(response.body.string, "data: [DONE]")
+        }
+
+        XCTAssertEqual(service.generateStreamingCallCount, 2)
+        XCTAssertEqual(service.releaseSlotCallCount, 2)
+        XCTAssertEqual(service.activeReservationCount, 0)
+        XCTAssertTrue(service.tryReserveSlot(), "Serial slot leaked after multiplex completion")
+        service.releaseSlot()
+    }
+
+    func testSingleCapacityStreamOwnedReservationsDoNotDoubleReleaseQueuedRequests() async throws {
+        service.maxConcurrent = 1
+        service.generatedStreamOwnsSlotReservation = true
+        service.enforceCapacity = true
+        service.streamingResultFactory = { _ in
+            FakeBatchService.makeDelayedStreamingResult(
+                text: "owned",
+                delayNanoseconds: BatchDispatchTestTiming.delayedStreamNanoseconds
+            )
+        }
+
+        let json = """
+        {"requests":[{"custom_id":"owned-a","body":{"model":"m","messages":[{"role":"user","content":"first"}]}},{"custom_id":"owned-b","body":{"model":"m","messages":[{"role":"user","content":"second"}]}},{"custom_id":"owned-c","body":{"model":"m","messages":[{"role":"user","content":"third"}]}}]}
+        """
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/batch/completions",
+            headers: headers,
+            body: ByteBuffer(string: json)
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertContains(response.body.string, "data: [DONE]")
+        }
+
+        XCTAssertEqual(service.generateStreamingCallCount, 3)
+        XCTAssertEqual(service.releaseSlotCallCount, 0, "Only the returned streams own these reservations")
+        XCTAssertEqual(service.streamOwnedReleaseCount, 3)
+        XCTAssertEqual(service.peakActiveReservationCount, 1)
+        XCTAssertEqual(service.activeReservationCount, 0)
+    }
+
+    func testTwoCapacityStreamOwnedReservationsQueueThirdRequest() async throws {
+        service.maxConcurrent = 2
+        service.generatedStreamOwnsSlotReservation = true
+        service.enforceCapacity = true
+        service.streamingResultFactory = { _ in
+            FakeBatchService.makeDelayedStreamingResult(
+                text: "owned",
+                delayNanoseconds: BatchDispatchTestTiming.delayedStreamNanoseconds
+            )
+        }
+
+        let json = """
+        {"requests":[{"custom_id":"cap-a","body":{"model":"m","messages":[{"role":"user","content":"first"}]}},{"custom_id":"cap-b","body":{"model":"m","messages":[{"role":"user","content":"second"}]}},{"custom_id":"cap-c","body":{"model":"m","messages":[{"role":"user","content":"third"}]}}]}
+        """
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/batch/completions",
+            headers: headers,
+            body: ByteBuffer(string: json)
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertContains(response.body.string, "data: [DONE]")
+        }
+
+        XCTAssertEqual(service.generateStreamingCallCount, 3)
+        XCTAssertEqual(service.releaseSlotCallCount, 0)
+        XCTAssertEqual(service.streamOwnedReleaseCount, 3)
+        XCTAssertEqual(service.peakActiveReservationCount, 2)
+        XCTAssertEqual(service.activeReservationCount, 0)
     }
 
     func testCallsEnsureBatchMode() async throws {

--- a/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
+++ b/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
@@ -1650,6 +1650,7 @@ private final class FakeMLXChatService: AFMChatServing, AFMMLXMediaRequestServin
     AFMGenerationAdmitterProviding, @unchecked Sendable
 {
     let maxConcurrent: Int
+    var generatedStreamOwnsSlotReservation: Bool { maxConcurrent >= 2 }
     let toolCallParser: String?
     let supportsStrictToolGrammar: Bool
     let thinkStartTag: String?


### PR DESCRIPTION
Closes #222.

## Problem

Single-capacity MLX models such as Muse Glimmer rejected sibling batch requests and leaked the serial reservation after batch teardown, causing later ordinary chat requests to hang. Reservation ownership also differs between serial MLX, scheduled MLX, and generic provider streams.

## Approach

- queue batch members with the same bounded admission wait as ordinary chat requests
- make returned-stream reservation ownership an explicit server adapter contract
- keep serial MLX reservations caller-owned while preserving scheduler/generic stream-owned release
- cancel queued/generating multiplex children when the SSE writer disconnects
- add capacity-enforced regressions for serial capacity 1, stream-owned capacity 1, and stream-owned capacity 2 with a queued third request

## Validation

- `Scripts/swiftpm-reliable.sh test -c release` — 139 tests in 17 suites passed
- `Scripts/swiftpm-reliable.sh test -c release --filter BatchDispatchTests` — 70 tests in 8 suites passed
- live Muse Glimmer Section 15 assertion run — 13/13 passed
- ordinary chat request after batch auto-teardown completed generation (40 tokens; no hang)
- independent sub-agent review: APPROVE after resolving all four initial findings

The live report is kept untracked at `/Volumes/edata2/afm-test-work/20260827-v0918-beta/muse-issue222/assertions-report-20260827_194642.html`.

## Summary by Sourcery

Fix batch dispatch admission and reservation lifecycle handling across chat completion endpoints.

Bug Fixes:
- Queue batch requests for bounded admission instead of rejecting sibling requests on single-capacity models.
- Prevent slot reservations from leaking after batch teardown, avoiding hangs in subsequent chat requests.
- Cancel queued and generating multiplex requests when the SSE client disconnects.

Enhancements:
- Make streaming reservation ownership explicit across serial MLX, scheduled MLX, and generic provider adapters.

Tests:
- Add capacity-enforced regressions covering serial capacity-one dispatch, stream-owned capacity-one dispatch, and queued requests at capacity two.