### PR TITLE
Expose GLM-5.3 conversion with storage preflight

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,18 +10,8 @@ on:
   workflow_dispatch:  # Enables manual trigger from GitHub UI
 
 jobs:
-  private-dependency-notice:
-    name: Private dependency notice
-    if: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]') }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: Explain unavailable Swift analysis
-      run: |
-        echo "::notice::Swift CodeQL is skipped for fork and Dependabot pull requests while AFMKit is private. Secrets are never exposed to untrusted pull request code; a maintainer must run the authenticated workflow on a trusted branch."
-
   analyze:
     name: Analyze Swift
-    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]') }}
     runs-on: macos-latest
     permissions:
       actions: read
@@ -53,14 +43,8 @@ jobs:
         languages: swift
         queries: security-and-quality
 
-    - name: Resolve authenticated private AFMKit graph
-      env:
-        AFMKIT_READ_TOKEN: ${{ secrets.AFMKIT_READ_TOKEN }}
+    - name: Resolve public AFMKit graph
       run: |
-        if [[ -z "$AFMKIT_READ_TOKEN" ]]; then
-          echo "::error::AFMKIT_READ_TOKEN is required while AFMKit is private. Configure the read-only repository secret for trusted branches; fork PRs are intentionally skipped."
-          exit 1
-        fi
         Scripts/resolve-release-dependencies.sh
 
     - name: Manual Build

--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.9"
+        exact: "0.1.10"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "d801788693fe40089a5ab4ce42f5cad3e947d4a1b001fe9255615e27056e9094",
+  "originHash" : "78e462c604453e5e4b21b7f463cdd797e36448b5472b7306a7de568b6ad3a634",
   "pins" : [
     {
       "identity" : "afmkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "5ba478382dec5a2a2edca9208ee67c2b015c727b",
-        "version" : "0.1.9"
+        "revision" : "69bdd0721f8cc3f745e52a4923a373e16a9401c0",
+        "version" : "0.1.10"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.9"
+        exact: "0.1.10"
     )
 }
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -145,8 +145,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.9":
-        fail(f"{identity} must resolve the exact 0.1.9 release")
+    if pin["state"].get("version") != "0.1.10":
+        fail(f"{identity} must resolve the exact 0.1.10 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -289,7 +289,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.9"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.10"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.9",
+    "afmkit": "0.1.10",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -54,13 +54,13 @@ cat > "$fake_public_git" <<'SH'
 #!/usr/bin/env bash
 arguments=" $* "
 for ref in \
-  refs/tags/0.1.9 \
-  'refs/tags/0.1.9^{}' \
-  refs/tags/v0.1.9 \
-  'refs/tags/v0.1.9^{}'; do
+  refs/tags/0.1.10 \
+  'refs/tags/0.1.10^{}' \
+  refs/tags/v0.1.10 \
+  'refs/tags/v0.1.10^{}'; do
   [[ "$arguments" == *" $ref "* ]] || exit 2
 done
-printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.9^{}'
+printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.10^{}'
 SH
 chmod 700 "$fake_public_git"
 if ! EXPECTED_AFMKIT_REVISION="$expected_afmkit_revision" \
@@ -80,7 +80,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.9'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.10'
   }
   probe_public_source() {
     return 1
@@ -104,14 +104,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.9" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.9"
+[[ "$release_version" == "0.1.10" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.10"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.9'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.10'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -130,7 +130,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.9'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.10'
   }
   probe_public_source() {
     return 0

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -13,6 +13,13 @@ fail() {
 
 "$ROOT_DIR/Scripts/check-afmkit-consumer-boundary.sh"
 
+codeql_workflow="$ROOT_DIR/.github/workflows/codeql-analysis.yml"
+if grep -Eq 'AFMKIT_READ_TOKEN|private-dependency-notice|while AFMKit is private' "$codeql_workflow"; then
+  fail "CodeQL still treats the public AFMKit release as a private dependency"
+fi
+grep -Fq 'Scripts/resolve-release-dependencies.sh' "$codeql_workflow" || \
+  fail "CodeQL does not resolve the tracked public release graph"
+
 mkdir -p "$WORK_ROOT/nested/AFMKit_AFMKitMLX.bundle/Contents/Resources"
 printf 'fixture' > "$WORK_ROOT/nested/AFMKit_AFMKitMLX.bundle/Contents/Resources/default.metallib"
 resolved="$($ROOT_DIR/Scripts/resolve-afmkit-resource.sh --metallib "$WORK_ROOT/nested")"

--- a/Sources/AFMCLI/MLXConvertCommand.swift
+++ b/Sources/AFMCLI/MLXConvertCommand.swift
@@ -66,11 +66,29 @@ struct MLXConvertCommand: ParsableCommand {
             throw ValidationError(
                 "--template-gguf is only valid with the DeepSeek dwarfstar-executor profile")
         }
+        if let templateURL {
+            // Parse the metadata before the potentially long tensor conversion,
+            // but only after option/model compatibility has been established so
+            // the CLI reports the most actionable validation error first.
+            try AFMDwarfStarProjection.validateMetadataTemplate(at: templateURL)
+        }
+        let verifiedCompletedOutputBytes: Int64
+        if !overwrite, inspection.requiredDestinationFreeBytes != nil {
+            verifiedCompletedOutputBytes = try AFMMLXCheckpointConverter.inspectResume(
+                source: sourceURL,
+                output: outputURL,
+                profile: selectedProfile,
+                sourceRevision: inspection.sourceRevision)
+                .verifiedCompletedOutputBytes
+        } else {
+            verifiedCompletedOutputBytes = 0
+        }
         let storage = try MLXConversionStoragePreflight.validate(
             source: sourceURL,
             output: outputURL,
             inspection: inspection,
-            overwrite: overwrite)
+            overwrite: overwrite,
+            verifiedCompletedOutputBytes: verifiedCompletedOutputBytes)
         if let required = storage.requiredBytes, let available = storage.availableBytes {
             print("Destination preflight: \(Self.bytes(available)) free; \(Self.bytes(required)) required")
         }

--- a/Sources/AFMCLI/MLXConvertCommand.swift
+++ b/Sources/AFMCLI/MLXConvertCommand.swift
@@ -43,6 +43,10 @@ struct MLXConvertCommand: ParsableCommand {
     mutating func run() throws {
         let sourceURL = URL(fileURLWithPath: source, isDirectory: true)
         let outputURL = URL(fileURLWithPath: output, isDirectory: true)
+        try MLXConversionStoragePreflight.validateProfileName(profile)
+        _ = try MLXConversionStoragePreflight.validateLocalPaths(
+            source: sourceURL, output: outputURL)
+        let templateURL = try MLXConversionStoragePreflight.validateTemplateFile(templateGGUF)
         let inspection = try AFMMLXCheckpointConverter.inspect(
             source: sourceURL,
             sourceRevision: sourceRevision)
@@ -65,7 +69,8 @@ struct MLXConvertCommand: ParsableCommand {
         let storage = try MLXConversionStoragePreflight.validate(
             source: sourceURL,
             output: outputURL,
-            inspection: inspection)
+            inspection: inspection,
+            overwrite: overwrite)
         if let required = storage.requiredBytes, let available = storage.availableBytes {
             print("Destination preflight: \(Self.bytes(available)) free; \(Self.bytes(required)) required")
         }
@@ -83,12 +88,16 @@ struct MLXConvertCommand: ParsableCommand {
         try converter.run()
 
         if needsDwarfStarTemplate {
+            guard let templateURL else {
+                throw ValidationError(
+                    "--template-gguf is required for dwarfstar-executor so the converted checkpoint is self-contained")
+            }
             let templateOutput = URL(fileURLWithPath: output, isDirectory: true)
                 .appendingPathComponent(
                     AFMDwarfStarCheckpointCatalog.bundledTemplateFilename,
                     isDirectory: false)
             try AFMDwarfStarProjection.writeMetadataTemplate(
-                from: URL(fileURLWithPath: templateGGUF!),
+                from: templateURL,
                 to: templateOutput)
             print("Bundled DwarfStar metadata template: \(templateOutput.path)")
         }

--- a/Sources/AFMCLI/MLXConvertCommand.swift
+++ b/Sources/AFMCLI/MLXConvertCommand.swift
@@ -1,3 +1,4 @@
+import AFMKit
 import AFMKitMLX
 import AFMKitDwarfStar
 import ArgumentParser
@@ -6,10 +7,13 @@ import Foundation
 struct MLXConvertCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "mlx-convert",
-        abstract: "Convert an official DeepSeek V4 checkpoint to native AFM/MLX format"
+        abstract: "Convert a supported local checkpoint to native AFM/MLX format"
     )
 
-    @Option(name: .long, help: "Official DeepSeek V4 checkpoint directory")
+    @Option(
+        name: .long,
+        help: "Existing local checkpoint directory (automatic model download is disabled)"
+    )
     var source: String
 
     @Option(name: .long, help: "Persistent output directory for the converted checkpoint")
@@ -20,9 +24,15 @@ struct MLXConvertCommand: ParsableCommand {
 
     @Option(
         name: .long,
-        help: "Conversion profile: native, dwarfstar-executor, dwarfstar-q8, dwarfstar-q8-0, dwarfstar-symmetric-q8, dwarfstar-symmetric-q8-interleaved-mxfp4, or dwarfstar-symmetric-q8-aligned-mxfp4"
+        help: "Conversion profile. Defaults to native for DeepSeek V4 and mlx-affine-4 for GLM-5.3 Flash"
     )
-    var profile = DeepseekV4CheckpointConverter.Profile.native.rawValue
+    var profile: String?
+
+    @Option(
+        name: .long,
+        help: "Pinned 40-character Hugging Face source commit (required for GLM unless inferable from the local snapshot)"
+    )
+    var sourceRevision: String?
 
     @Option(
         name: .long,
@@ -31,32 +41,61 @@ struct MLXConvertCommand: ParsableCommand {
     var templateGGUF: String?
 
     mutating func run() throws {
-        guard let conversionProfile = DeepseekV4CheckpointConverter.Profile(rawValue: profile) else {
+        let sourceURL = URL(fileURLWithPath: source, isDirectory: true)
+        let outputURL = URL(fileURLWithPath: output, isDirectory: true)
+        let inspection = try AFMMLXCheckpointConverter.inspect(
+            source: sourceURL,
+            sourceRevision: sourceRevision)
+        let selectedProfile = profile ?? inspection.defaultProfile
+        guard inspection.supportedProfiles.contains(selectedProfile) else {
             throw ValidationError(
-                "Unknown profile '\(profile)'. Expected: \(DeepseekV4CheckpointConverter.Profile.allCases.map(\.rawValue).joined(separator: ", "))")
+                "Unknown profile '\(selectedProfile)' for \(inspection.modelKind.rawValue). Expected: \(inspection.supportedProfiles.joined(separator: ", "))")
         }
-        let converter = DeepseekV4CheckpointConverter(
-            source: URL(fileURLWithPath: source),
-            output: URL(fileURLWithPath: output),
+        let needsDwarfStarTemplate = inspection.modelKind == .deepseekV4
+            && selectedProfile
+                == DeepseekV4CheckpointConverter.Profile.dwarfstarExecutor.rawValue
+        if needsDwarfStarTemplate, templateGGUF?.isEmpty != false {
+            throw ValidationError(
+                "--template-gguf is required for dwarfstar-executor so the converted checkpoint is self-contained")
+        }
+        if !needsDwarfStarTemplate, templateGGUF != nil {
+            throw ValidationError(
+                "--template-gguf is only valid with the DeepSeek dwarfstar-executor profile")
+        }
+        let storage = try MLXConversionStoragePreflight.validate(
+            source: sourceURL,
+            output: outputURL,
+            inspection: inspection)
+        if let required = storage.requiredBytes, let available = storage.availableBytes {
+            print("Destination preflight: \(Self.bytes(available)) free; \(Self.bytes(required)) required")
+        }
+        if let revision = inspection.sourceRevision {
+            print("Pinned source revision: \(revision)")
+        }
+
+        let converter = AFMMLXCheckpointConverter(
+            source: sourceURL,
+            output: outputURL,
             overwrite: overwrite,
-            profile: conversionProfile,
+            profile: selectedProfile,
+            sourceRevision: inspection.sourceRevision,
             progress: { print($0) })
         try converter.run()
 
-        if conversionProfile == .dwarfstarExecutor {
-            guard let templateGGUF, !templateGGUF.isEmpty else {
-                throw ValidationError(
-                    "--template-gguf is required for dwarfstar-executor so the converted checkpoint is self-contained")
-            }
+        if needsDwarfStarTemplate {
             let templateOutput = URL(fileURLWithPath: output, isDirectory: true)
                 .appendingPathComponent(
                     AFMDwarfStarCheckpointCatalog.bundledTemplateFilename,
                     isDirectory: false)
             try AFMDwarfStarProjection.writeMetadataTemplate(
-                from: URL(fileURLWithPath: templateGGUF),
+                from: URL(fileURLWithPath: templateGGUF!),
                 to: templateOutput)
             print("Bundled DwarfStar metadata template: \(templateOutput.path)")
         }
+    }
+
+    private static func bytes(_ value: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: value, countStyle: .decimal)
     }
 }
 

--- a/Sources/AFMKit/MLXConversionStoragePreflight.swift
+++ b/Sources/AFMKit/MLXConversionStoragePreflight.swift
@@ -170,12 +170,7 @@ public enum MLXConversionStoragePreflight {
         }
         guard !overwrite, verifiedCompletedOutputBytes > 0
         else { return initial }
-        guard let estimated = inspection.estimatedOutputBytes,
-              verifiedCompletedOutputBytes <= estimated
-        else {
-            throw PreflightError.invalidOption(
-                "Provider-verified completed output bytes exceed the estimated conversion output.")
-        }
+        guard let estimated = inspection.estimatedOutputBytes else { return initial }
         let completed = verifiedCompletedOutputBytes
         let remainingEstimate = max(0, estimated - completed)
         return max(
@@ -190,14 +185,18 @@ public enum MLXConversionStoragePreflight {
         return Array(child.prefix(parent.count)) == parent
     }
 
-    private static func isFilesystemOrVolumeRoot(_ url: URL) -> Bool {
-        let resolved = url.standardizedFileURL.resolvingSymlinksInPath()
-        if resolved.path == "/" { return true }
-        return FileManager.default.mountedVolumeURLs(
+    static func isFilesystemOrVolumeRoot(
+        _ url: URL,
+        mountedVolumes: [URL]? = nil
+    ) -> Bool {
+        let resolvedPath = url.standardizedFileURL.resolvingSymlinksInPath().path
+        if resolvedPath == "/" { return true }
+        let volumes = mountedVolumes ?? FileManager.default.mountedVolumeURLs(
             includingResourceValuesForKeys: nil,
-            options: [.skipHiddenVolumes])?.contains {
-                $0.standardizedFileURL.resolvingSymlinksInPath() == resolved
-            } ?? false
+            options: []) ?? []
+        return volumes.contains {
+            $0.standardizedFileURL.resolvingSymlinksInPath().path == resolvedPath
+        }
     }
 
     private static func nearestExistingDirectory(to output: URL) throws -> URL {

--- a/Sources/AFMKit/MLXConversionStoragePreflight.swift
+++ b/Sources/AFMKit/MLXConversionStoragePreflight.swift
@@ -1,0 +1,130 @@
+import AFMKitMLX
+import Foundation
+
+/// Application-level storage policy for AFMKit checkpoint conversion.
+/// Conversion math and checkpoint ownership remain in AFMKit; maclocal-api
+/// validates the local source and destination volume before starting a job.
+public enum MLXConversionStoragePreflight {
+    public struct Report: Sendable, Equatable {
+        public let source: URL
+        public let output: URL
+        public let capacityProbe: URL
+        public let availableBytes: Int64?
+        public let requiredBytes: Int64?
+    }
+
+    public enum PreflightError: LocalizedError, Equatable {
+        case missingLocalSource(String)
+        case unsafeOutput(String)
+        case capacityUnavailable(String)
+        case insufficientCapacity(required: Int64, available: Int64, volume: String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .missingLocalSource(let message), .unsafeOutput(let message),
+                 .capacityUnavailable(let message):
+                message
+            case .insufficientCapacity(let required, let available, let volume):
+                "Conversion requires at least \(Self.bytes(required)) free at \(volume), but only \(Self.bytes(available)) is available."
+            }
+        }
+
+        private static func bytes(_ value: Int64) -> String {
+            ByteCountFormatter.string(fromByteCount: value, countStyle: .decimal)
+        }
+    }
+
+    public static func validate(
+        source: URL,
+        output: URL,
+        inspection: AFMMLXCheckpointConverter.Inspection,
+        capacity: ((URL) throws -> Int64?)? = nil
+    ) throws -> Report {
+        let fm = FileManager.default
+        let sourceURL = source.standardizedFileURL
+        let outputURL = output.standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard sourceURL.isFileURL,
+              fm.fileExists(atPath: sourceURL.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            throw PreflightError.missingLocalSource(
+                "--source must be an existing local checkpoint directory; automatic model download is disabled for conversion.")
+        }
+        guard outputURL.isFileURL else {
+            throw PreflightError.unsafeOutput(
+                "--output must be a local filesystem directory.")
+        }
+        let resolvedSource = sourceURL.resolvingSymlinksInPath()
+        guard outputURL != sourceURL,
+              !outputURL.path.hasPrefix(sourceURL.path + "/")
+        else {
+            throw PreflightError.unsafeOutput(
+                "Conversion output must differ from and cannot be inside the source checkpoint.")
+        }
+
+        let probe = try nearestExistingDirectory(to: outputURL)
+        let resolvedProbe = probe.resolvingSymlinksInPath()
+        guard resolvedProbe != resolvedSource,
+              !resolvedProbe.path.hasPrefix(resolvedSource.path + "/")
+        else {
+            throw PreflightError.unsafeOutput(
+                "Conversion output resolves inside the source checkpoint.")
+        }
+
+        let required = inspection.requiredDestinationFreeBytes
+        let available: Int64?
+        if let capacity {
+            available = try capacity(probe)
+        } else {
+            let values = try probe.resourceValues(forKeys: [
+                .volumeAvailableCapacityForImportantUsageKey,
+                .volumeAvailableCapacityKey,
+            ])
+            if let important = values.volumeAvailableCapacityForImportantUsage {
+                available = important
+            } else if let ordinary = values.volumeAvailableCapacity {
+                available = Int64(ordinary)
+            } else {
+                available = nil
+            }
+        }
+        if let required {
+            guard let available else {
+                throw PreflightError.capacityUnavailable(
+                    "Cannot determine free capacity for conversion destination \(probe.path).")
+            }
+            guard available >= required else {
+                throw PreflightError.insufficientCapacity(
+                    required: required, available: available, volume: probe.path)
+            }
+        }
+        return Report(
+            source: sourceURL,
+            output: outputURL,
+            capacityProbe: probe,
+            availableBytes: available,
+            requiredBytes: required)
+    }
+
+    private static func nearestExistingDirectory(to output: URL) throws -> URL {
+        let fm = FileManager.default
+        var candidate = output
+        while !fm.fileExists(atPath: candidate.path) {
+            let parent = candidate.deletingLastPathComponent()
+            guard parent.path != candidate.path else {
+                throw PreflightError.capacityUnavailable(
+                    "Cannot find an existing parent directory for \(output.path).")
+            }
+            candidate = parent
+        }
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: candidate.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            throw PreflightError.capacityUnavailable(
+                "Capacity probe path is not a directory: \(candidate.path).")
+        }
+        return candidate
+    }
+}

--- a/Sources/AFMKit/MLXConversionStoragePreflight.swift
+++ b/Sources/AFMKit/MLXConversionStoragePreflight.swift
@@ -1,5 +1,4 @@
 import AFMKitMLX
-import CryptoKit
 import Foundation
 
 /// Application-level storage policy for AFMKit checkpoint conversion.
@@ -49,13 +48,14 @@ public enum MLXConversionStoragePreflight {
         output: URL,
         inspection: AFMMLXCheckpointConverter.Inspection,
         overwrite: Bool = false,
+        verifiedCompletedOutputBytes: Int64 = 0,
         capacity: ((URL) throws -> Int64?)? = nil
     ) throws -> Report {
         let paths = try validateLocalPaths(source: source, output: output)
         let required = try effectiveRequiredBytes(
-            output: paths.output,
             inspection: inspection,
-            overwrite: overwrite)
+            overwrite: overwrite,
+            verifiedCompletedOutputBytes: verifiedCompletedOutputBytes)
         guard let required else {
             return Report(
                 source: paths.source,
@@ -115,11 +115,12 @@ public enum MLXConversionStoragePreflight {
         }
         let resolvedSource = sourceURL.resolvingSymlinksInPath()
         let resolvedOutput = outputURL.resolvingSymlinksInPath()
-        guard !contains(resolvedSource, resolvedOutput),
+        guard !isFilesystemOrVolumeRoot(resolvedOutput),
+              !contains(resolvedSource, resolvedOutput),
               !contains(resolvedOutput, resolvedSource)
         else {
             throw PreflightError.unsafeOutput(
-                "Conversion source and output must be separate directories; neither may contain the other, including through symlinks.")
+                "Conversion output cannot be a filesystem or volume root, and source/output must be separate directories with neither containing the other, including through symlinks.")
         }
 
         let probe = try nearestExistingDirectory(to: outputURL)
@@ -158,71 +159,45 @@ public enum MLXConversionStoragePreflight {
     }
 
     private static func effectiveRequiredBytes(
-        output: URL,
         inspection: AFMMLXCheckpointConverter.Inspection,
-        overwrite: Bool
+        overwrite: Bool,
+        verifiedCompletedOutputBytes: Int64
     ) throws -> Int64? {
         guard let initial = inspection.requiredDestinationFreeBytes else { return nil }
-        guard !overwrite,
-              let completed = try verifiedCompletedBytes(
-                output: output, sourceRevision: inspection.sourceRevision),
-              completed > 0
+        guard verifiedCompletedOutputBytes >= 0 else {
+            throw PreflightError.invalidOption(
+                "Provider-verified completed output bytes cannot be negative.")
+        }
+        guard !overwrite, verifiedCompletedOutputBytes > 0
         else { return initial }
-        let remainingEstimate = max(0, (inspection.estimatedOutputBytes ?? 0) - completed)
+        guard let estimated = inspection.estimatedOutputBytes,
+              verifiedCompletedOutputBytes <= estimated
+        else {
+            throw PreflightError.invalidOption(
+                "Provider-verified completed output bytes exceed the estimated conversion output.")
+        }
+        let completed = verifiedCompletedOutputBytes
+        let remainingEstimate = max(0, estimated - completed)
         return max(
             0,
             max(initial - completed, remainingEstimate + resumeAtomicMarginBytes))
     }
 
-    private static func verifiedCompletedBytes(
-        output: URL,
-        sourceRevision: String?
-    ) throws -> Int64? {
-        let stateURL = output.appendingPathComponent(".afm-mlx-conversion.json")
-        guard FileManager.default.fileExists(atPath: stateURL.path),
-              let object = try JSONSerialization.jsonObject(
-                with: Data(contentsOf: stateURL)) as? [String: Any],
-              object["sourceRevision"] as? String == sourceRevision,
-              let completed = object["completed"] as? [String: Any]
-        else { return nil }
-        var seen = Set<String>()
-        var total: Int64 = 0
-        for raw in completed.values {
-            guard let item = raw as? [String: Any],
-                  let name = item["outputFile"] as? String,
-                  URL(fileURLWithPath: name).lastPathComponent == name,
-                  let expectedSize = (item["outputSize"] as? NSNumber)?.int64Value,
-                  let expectedSHA256 = item["outputSHA256"] as? String,
-                  expectedSize >= 0,
-                  expectedSHA256.count == 64,
-                  expectedSHA256.allSatisfy(\.isHexDigit),
-                  seen.insert(name).inserted
-            else { return nil }
-            let url = output.appendingPathComponent(name)
-            guard FileManager.default.fileExists(atPath: url.path),
-                  Int64(try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? -1)
-                    == expectedSize,
-                  try sha256File(url) == expectedSHA256
-            else { return nil }
-            let sum = total.addingReportingOverflow(expectedSize)
-            guard !sum.overflow else { return nil }
-            total = sum.partialValue
-        }
-        return total
-    }
-
-    private static func sha256File(_ url: URL) throws -> String {
-        let handle = try FileHandle(forReadingFrom: url)
-        defer { try? handle.close() }
-        var digest = SHA256()
-        while let chunk = try handle.read(upToCount: 4 * 1024 * 1024), !chunk.isEmpty {
-            digest.update(data: chunk)
-        }
-        return digest.finalize().map { String(format: "%02x", $0) }.joined()
-    }
-
     private static func contains(_ directory: URL, _ candidate: URL) -> Bool {
-        directory == candidate || candidate.path.hasPrefix(directory.path + "/")
+        let parent = directory.standardizedFileURL.pathComponents
+        let child = candidate.standardizedFileURL.pathComponents
+        guard parent.count <= child.count else { return false }
+        return Array(child.prefix(parent.count)) == parent
+    }
+
+    private static func isFilesystemOrVolumeRoot(_ url: URL) -> Bool {
+        let resolved = url.standardizedFileURL.resolvingSymlinksInPath()
+        if resolved.path == "/" { return true }
+        return FileManager.default.mountedVolumeURLs(
+            includingResourceValuesForKeys: nil,
+            options: [.skipHiddenVolumes])?.contains {
+                $0.standardizedFileURL.resolvingSymlinksInPath() == resolved
+            } ?? false
     }
 
     private static func nearestExistingDirectory(to output: URL) throws -> URL {

--- a/Sources/AFMKit/MLXConversionStoragePreflight.swift
+++ b/Sources/AFMKit/MLXConversionStoragePreflight.swift
@@ -1,10 +1,19 @@
 import AFMKitMLX
+import CryptoKit
 import Foundation
 
 /// Application-level storage policy for AFMKit checkpoint conversion.
 /// Conversion math and checkpoint ownership remain in AFMKit; maclocal-api
 /// validates the local source and destination volume before starting a job.
 public enum MLXConversionStoragePreflight {
+    private static let resumeAtomicMarginBytes: Int64 = 64_000_000_000
+
+    public struct PathReport: Sendable, Equatable {
+        public let source: URL
+        public let output: URL
+        public let capacityProbe: URL
+    }
+
     public struct Report: Sendable, Equatable {
         public let source: URL
         public let output: URL
@@ -16,13 +25,14 @@ public enum MLXConversionStoragePreflight {
     public enum PreflightError: LocalizedError, Equatable {
         case missingLocalSource(String)
         case unsafeOutput(String)
+        case invalidOption(String)
         case capacityUnavailable(String)
         case insufficientCapacity(required: Int64, available: Int64, volume: String)
 
         public var errorDescription: String? {
             switch self {
             case .missingLocalSource(let message), .unsafeOutput(let message),
-                 .capacityUnavailable(let message):
+                 .invalidOption(let message), .capacityUnavailable(let message):
                 message
             case .insufficientCapacity(let required, let available, let volume):
                 "Conversion requires at least \(Self.bytes(required)) free at \(volume), but only \(Self.bytes(available)) is available."
@@ -38,8 +48,56 @@ public enum MLXConversionStoragePreflight {
         source: URL,
         output: URL,
         inspection: AFMMLXCheckpointConverter.Inspection,
+        overwrite: Bool = false,
         capacity: ((URL) throws -> Int64?)? = nil
     ) throws -> Report {
+        let paths = try validateLocalPaths(source: source, output: output)
+        let required = try effectiveRequiredBytes(
+            output: paths.output,
+            inspection: inspection,
+            overwrite: overwrite)
+        guard let required else {
+            return Report(
+                source: paths.source,
+                output: paths.output,
+                capacityProbe: paths.capacityProbe,
+                availableBytes: nil,
+                requiredBytes: nil)
+        }
+
+        let available: Int64?
+        if let capacity {
+            available = try capacity(paths.capacityProbe)
+        } else {
+            let values = try paths.capacityProbe.resourceValues(forKeys: [
+                .volumeAvailableCapacityForImportantUsageKey,
+                .volumeAvailableCapacityKey,
+            ])
+            if let important = values.volumeAvailableCapacityForImportantUsage {
+                available = important
+            } else if let ordinary = values.volumeAvailableCapacity {
+                available = Int64(ordinary)
+            } else {
+                available = nil
+            }
+        }
+        guard let available else {
+            throw PreflightError.capacityUnavailable(
+                "Cannot determine free capacity for conversion destination \(paths.capacityProbe.path).")
+        }
+        guard available >= required else {
+            throw PreflightError.insufficientCapacity(
+                required: required, available: available, volume: paths.capacityProbe.path)
+        }
+        return Report(
+            source: paths.source,
+            output: paths.output,
+            capacityProbe: paths.capacityProbe,
+            availableBytes: available,
+            requiredBytes: required)
+    }
+
+    public static func validateLocalPaths(source: URL, output: URL) throws -> PathReport {
         let fm = FileManager.default
         let sourceURL = source.standardizedFileURL
         let outputURL = output.standardizedFileURL
@@ -56,55 +114,115 @@ public enum MLXConversionStoragePreflight {
                 "--output must be a local filesystem directory.")
         }
         let resolvedSource = sourceURL.resolvingSymlinksInPath()
-        guard outputURL != sourceURL,
-              !outputURL.path.hasPrefix(sourceURL.path + "/")
+        let resolvedOutput = outputURL.resolvingSymlinksInPath()
+        guard !contains(resolvedSource, resolvedOutput),
+              !contains(resolvedOutput, resolvedSource)
         else {
             throw PreflightError.unsafeOutput(
-                "Conversion output must differ from and cannot be inside the source checkpoint.")
+                "Conversion source and output must be separate directories; neither may contain the other, including through symlinks.")
         }
 
         let probe = try nearestExistingDirectory(to: outputURL)
-        let resolvedProbe = probe.resolvingSymlinksInPath()
-        guard resolvedProbe != resolvedSource,
-              !resolvedProbe.path.hasPrefix(resolvedSource.path + "/")
-        else {
-            throw PreflightError.unsafeOutput(
-                "Conversion output resolves inside the source checkpoint.")
-        }
-
-        let required = inspection.requiredDestinationFreeBytes
-        let available: Int64?
-        if let capacity {
-            available = try capacity(probe)
-        } else {
-            let values = try probe.resourceValues(forKeys: [
-                .volumeAvailableCapacityForImportantUsageKey,
-                .volumeAvailableCapacityKey,
-            ])
-            if let important = values.volumeAvailableCapacityForImportantUsage {
-                available = important
-            } else if let ordinary = values.volumeAvailableCapacity {
-                available = Int64(ordinary)
-            } else {
-                available = nil
-            }
-        }
-        if let required {
-            guard let available else {
-                throw PreflightError.capacityUnavailable(
-                    "Cannot determine free capacity for conversion destination \(probe.path).")
-            }
-            guard available >= required else {
-                throw PreflightError.insufficientCapacity(
-                    required: required, available: available, volume: probe.path)
-            }
-        }
-        return Report(
+        return PathReport(
             source: sourceURL,
             output: outputURL,
-            capacityProbe: probe,
-            availableBytes: available,
-            requiredBytes: required)
+            capacityProbe: probe)
+    }
+
+    public static func validateProfileName(_ profile: String?) throws {
+        guard let profile else { return }
+        let supported = Set(
+            DeepseekV4CheckpointConverter.Profile.allCases.map(\.rawValue)
+                + GLM5NextCheckpointConverter.Profile.allCases.map(\.rawValue))
+        guard supported.contains(profile) else {
+            throw PreflightError.invalidOption(
+                "Unknown conversion profile '\(profile)'. Expected one of: \(supported.sorted().joined(separator: ", ")).")
+        }
+    }
+
+    public static func validateTemplateFile(_ path: String?) throws -> URL? {
+        guard let path else { return nil }
+        guard !path.isEmpty else {
+            throw PreflightError.missingLocalSource(
+                "--template-gguf must name an existing local GGUF file.")
+        }
+        let url = URL(fileURLWithPath: path).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
+              !isDirectory.boolValue
+        else {
+            throw PreflightError.missingLocalSource(
+                "--template-gguf must name an existing local GGUF file.")
+        }
+        return url
+    }
+
+    private static func effectiveRequiredBytes(
+        output: URL,
+        inspection: AFMMLXCheckpointConverter.Inspection,
+        overwrite: Bool
+    ) throws -> Int64? {
+        guard let initial = inspection.requiredDestinationFreeBytes else { return nil }
+        guard !overwrite,
+              let completed = try verifiedCompletedBytes(
+                output: output, sourceRevision: inspection.sourceRevision),
+              completed > 0
+        else { return initial }
+        let remainingEstimate = max(0, (inspection.estimatedOutputBytes ?? 0) - completed)
+        return max(
+            0,
+            max(initial - completed, remainingEstimate + resumeAtomicMarginBytes))
+    }
+
+    private static func verifiedCompletedBytes(
+        output: URL,
+        sourceRevision: String?
+    ) throws -> Int64? {
+        let stateURL = output.appendingPathComponent(".afm-mlx-conversion.json")
+        guard FileManager.default.fileExists(atPath: stateURL.path),
+              let object = try JSONSerialization.jsonObject(
+                with: Data(contentsOf: stateURL)) as? [String: Any],
+              object["sourceRevision"] as? String == sourceRevision,
+              let completed = object["completed"] as? [String: Any]
+        else { return nil }
+        var seen = Set<String>()
+        var total: Int64 = 0
+        for raw in completed.values {
+            guard let item = raw as? [String: Any],
+                  let name = item["outputFile"] as? String,
+                  URL(fileURLWithPath: name).lastPathComponent == name,
+                  let expectedSize = (item["outputSize"] as? NSNumber)?.int64Value,
+                  let expectedSHA256 = item["outputSHA256"] as? String,
+                  expectedSize >= 0,
+                  expectedSHA256.count == 64,
+                  expectedSHA256.allSatisfy(\.isHexDigit),
+                  seen.insert(name).inserted
+            else { return nil }
+            let url = output.appendingPathComponent(name)
+            guard FileManager.default.fileExists(atPath: url.path),
+                  Int64(try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? -1)
+                    == expectedSize,
+                  try sha256File(url) == expectedSHA256
+            else { return nil }
+            let sum = total.addingReportingOverflow(expectedSize)
+            guard !sum.overflow else { return nil }
+            total = sum.partialValue
+        }
+        return total
+    }
+
+    private static func sha256File(_ url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var digest = SHA256()
+        while let chunk = try handle.read(upToCount: 4 * 1024 * 1024), !chunk.isEmpty {
+            digest.update(data: chunk)
+        }
+        return digest.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func contains(_ directory: URL, _ candidate: URL) -> Bool {
+        directory == candidate || candidate.path.hasPrefix(directory.path + "/")
     }
 
     private static func nearestExistingDirectory(to output: URL) throws -> URL {

--- a/Tests/MacLocalAPITests/MLXConversionStoragePreflightTests.swift
+++ b/Tests/MacLocalAPITests/MLXConversionStoragePreflightTests.swift
@@ -1,0 +1,127 @@
+import AFMKit
+import AFMKitMLX
+import Foundation
+import XCTest
+
+final class MLXConversionStoragePreflightTests: XCTestCase {
+    func testGLMDestinationRequiresSixHundredGigabytes() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("source", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        let output = root.appendingPathComponent("converted/model", isDirectory: true)
+        let inspection = makeInspection(required: 600_000_000_000)
+
+        XCTAssertThrowsError(try MLXConversionStoragePreflight.validate(
+            source: source,
+            output: output,
+            inspection: inspection,
+            capacity: { _ in 599_999_999_999 })) { error in
+                guard case MLXConversionStoragePreflight.PreflightError.insufficientCapacity(
+                    let required, let available, _) = error
+                else { return XCTFail("Unexpected error: \(error)") }
+                XCTAssertEqual(required, 600_000_000_000)
+                XCTAssertEqual(available, 599_999_999_999)
+            }
+    }
+
+    func testCapacityProbeUsesNearestExistingDestinationParent() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("source", isDirectory: true)
+        let destinationRoot = root.appendingPathComponent("destination", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: destinationRoot, withIntermediateDirectories: true)
+        let output = destinationRoot.appendingPathComponent("new/model", isDirectory: true)
+        var probed: URL?
+
+        let report = try MLXConversionStoragePreflight.validate(
+            source: source,
+            output: output,
+            inspection: makeInspection(required: 600_000_000_000),
+            capacity: { url in
+                probed = url
+                return 700_000_000_000
+            })
+
+        XCTAssertEqual(probed, destinationRoot)
+        XCTAssertEqual(report.capacityProbe, destinationRoot)
+        XCTAssertEqual(report.availableBytes, 700_000_000_000)
+    }
+
+    func testRemoteOrMissingSourceIsRejectedBeforeCapacityProbe() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        var didProbe = false
+
+        XCTAssertThrowsError(try MLXConversionStoragePreflight.validate(
+            source: root.appendingPathComponent("missing"),
+            output: root.appendingPathComponent("output"),
+            inspection: makeInspection(required: 600_000_000_000),
+            capacity: { _ in
+                didProbe = true
+                return Int64.max
+            })) { error in
+                XCTAssertTrue(error.localizedDescription.contains("existing local"))
+            }
+        XCTAssertFalse(didProbe)
+    }
+
+    func testOutputInsideSourceIsRejected() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("source", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(try MLXConversionStoragePreflight.validate(
+            source: source,
+            output: source.appendingPathComponent("converted"),
+            inspection: makeInspection(required: nil),
+            capacity: { _ in Int64.max })) { error in
+                XCTAssertTrue(error.localizedDescription.contains("cannot be inside"))
+            }
+    }
+
+    func testDeepSeekWithoutPublishedEstimatePreservesExistingBehavior() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("source", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+
+        let report = try MLXConversionStoragePreflight.validate(
+            source: source,
+            output: root.appendingPathComponent("output"),
+            inspection: AFMMLXCheckpointConverter.Inspection(
+                modelKind: .deepseekV4,
+                defaultProfile: "native",
+                supportedProfiles: ["native"],
+                sourceRevision: nil,
+                sourceBytes: 1,
+                estimatedOutputBytes: nil,
+                requiredDestinationFreeBytes: nil),
+            capacity: { _ in 1 })
+
+        XCTAssertNil(report.requiredBytes)
+    }
+
+    private func makeInspection(
+        required: Int64?
+    ) -> AFMMLXCheckpointConverter.Inspection {
+        AFMMLXCheckpointConverter.Inspection(
+            modelKind: .glm5Next,
+            defaultProfile: "mlx-affine-4",
+            supportedProfiles: ["mlx-affine-4"],
+            sourceRevision: String(repeating: "a", count: 40),
+            sourceBytes: 328_326_771_576,
+            estimatedOutputBytes: 190_700_000_000,
+            requiredDestinationFreeBytes: required)
+    }
+
+    private func makeRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+}

--- a/Tests/MacLocalAPITests/MLXConversionStoragePreflightTests.swift
+++ b/Tests/MacLocalAPITests/MLXConversionStoragePreflightTests.swift
@@ -1,5 +1,6 @@
 import AFMKit
 import AFMKitMLX
+import CryptoKit
 import Foundation
 import XCTest
 
@@ -79,8 +80,113 @@ final class MLXConversionStoragePreflightTests: XCTestCase {
             output: source.appendingPathComponent("converted"),
             inspection: makeInspection(required: nil),
             capacity: { _ in Int64.max })) { error in
-                XCTAssertTrue(error.localizedDescription.contains("cannot be inside"))
+                XCTAssertTrue(error.localizedDescription.contains("neither may contain"))
             }
+    }
+
+    func testOutputAncestorOfSourceIsRejectedBeforeOverwrite() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("models/source", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(try MLXConversionStoragePreflight.validate(
+            source: source,
+            output: root,
+            inspection: makeInspection(required: nil),
+            overwrite: true,
+            capacity: { _ in Int64.max })) { error in
+                XCTAssertTrue(error.localizedDescription.contains("neither may contain"))
+            }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
+    }
+
+    func testSymlinkedOutputAncestorOfSourceIsRejected() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let real = root.appendingPathComponent("real", isDirectory: true)
+        let source = real.appendingPathComponent("source", isDirectory: true)
+        let alias = root.appendingPathComponent("alias", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: real)
+
+        XCTAssertThrowsError(try MLXConversionStoragePreflight.validate(
+            source: source,
+            output: alias,
+            inspection: makeInspection(required: nil),
+            capacity: { _ in Int64.max })) { error in
+                XCTAssertTrue(error.localizedDescription.contains("neither may contain"))
+            }
+    }
+
+    func testResumeCreditsOnlyChecksummedCompletedOutput() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("source", isDirectory: true)
+        let output = root.appendingPathComponent("output", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        let contents = Data("done".utf8)
+        let completedURL = output.appendingPathComponent("model-00001.safetensors")
+        try contents.write(to: completedURL)
+        let revision = String(repeating: "a", count: 40)
+        let state: [String: Any] = [
+            "sourceRevision": revision,
+            "completed": [
+                "unit": [
+                    "outputFile": completedURL.lastPathComponent,
+                    "outputSize": contents.count,
+                    "outputSHA256": SHA256.hash(data: contents).map {
+                        String(format: "%02x", $0)
+                    }.joined(),
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: state, options: [.sortedKeys]).write(
+            to: output.appendingPathComponent(".afm-mlx-conversion.json"))
+
+        let report = try MLXConversionStoragePreflight.validate(
+            source: source,
+            output: output,
+            inspection: makeInspection(required: 600_000_000_000),
+            capacity: { _ in 599_999_999_996 })
+        XCTAssertEqual(report.requiredBytes, 599_999_999_996)
+
+        XCTAssertThrowsError(try MLXConversionStoragePreflight.validate(
+            source: source,
+            output: output,
+            inspection: makeInspection(required: 600_000_000_000),
+            overwrite: true,
+            capacity: { _ in 599_999_999_996 }))
+    }
+
+    func testCorruptCompletedOutputReceivesNoResumeCredit() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("source", isDirectory: true)
+        let output = root.appendingPathComponent("output", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        try Data("bad".utf8).write(
+            to: output.appendingPathComponent("model-00001.safetensors"))
+        let state: [String: Any] = [
+            "sourceRevision": String(repeating: "a", count: 40),
+            "completed": [
+                "unit": [
+                    "outputFile": "model-00001.safetensors",
+                    "outputSize": 3,
+                    "outputSHA256": String(repeating: "0", count: 64),
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: state).write(
+            to: output.appendingPathComponent(".afm-mlx-conversion.json"))
+
+        XCTAssertThrowsError(try MLXConversionStoragePreflight.validate(
+            source: source,
+            output: output,
+            inspection: makeInspection(required: 600_000_000_000),
+            capacity: { _ in 599_999_999_999 }))
     }
 
     func testDeepSeekWithoutPublishedEstimatePreservesExistingBehavior() throws {
@@ -89,6 +195,7 @@ final class MLXConversionStoragePreflightTests: XCTestCase {
         let source = root.appendingPathComponent("source", isDirectory: true)
         try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
 
+        var didProbe = false
         let report = try MLXConversionStoragePreflight.validate(
             source: source,
             output: root.appendingPathComponent("output"),
@@ -100,9 +207,25 @@ final class MLXConversionStoragePreflightTests: XCTestCase {
                 sourceBytes: 1,
                 estimatedOutputBytes: nil,
                 requiredDestinationFreeBytes: nil),
-            capacity: { _ in 1 })
+            capacity: { _ in
+                didProbe = true
+                throw CocoaError(.fileReadUnknown)
+            })
 
         XCTAssertNil(report.requiredBytes)
+        XCTAssertNil(report.availableBytes)
+        XCTAssertFalse(didProbe)
+    }
+
+    func testInvalidProfileAndMissingTemplateFailBeforeModelInspection() throws {
+        XCTAssertThrowsError(try MLXConversionStoragePreflight.validateProfileName(
+            "not-a-profile")) { error in
+                XCTAssertTrue(error.localizedDescription.contains("Unknown conversion profile"))
+            }
+        XCTAssertThrowsError(try MLXConversionStoragePreflight.validateTemplateFile(
+            "/definitely/missing/template.gguf")) { error in
+                XCTAssertTrue(error.localizedDescription.contains("existing local GGUF"))
+            }
     }
 
     private func makeInspection(

--- a/Tests/MacLocalAPITests/MLXConversionStoragePreflightTests.swift
+++ b/Tests/MacLocalAPITests/MLXConversionStoragePreflightTests.swift
@@ -1,4 +1,4 @@
-import AFMKit
+@testable import AFMKit
 import AFMKitMLX
 import Foundation
 import XCTest
@@ -136,6 +136,17 @@ final class MLXConversionStoragePreflightTests: XCTestCase {
         }
     }
 
+    func testInjectedHiddenMountedRootIsRecognized() throws {
+        let root = try makeRoot()
+        let hiddenMount = root.appendingPathComponent("nobrowse-volume", isDirectory: true)
+        try FileManager.default.createDirectory(at: hiddenMount, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        XCTAssertTrue(MLXConversionStoragePreflight.isFilesystemOrVolumeRoot(
+            hiddenMount,
+            mountedVolumes: [hiddenMount]))
+    }
+
     func testResumeCreditsOnlyProviderVerifiedCompletedOutput() throws {
         let root = try makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -188,20 +199,21 @@ final class MLXConversionStoragePreflightTests: XCTestCase {
             capacity: { _ in 599_999_999_999 }))
     }
 
-    func testImpossibleProviderResumeCreditIsRejected() throws {
+    func testProviderResumeMayExceedTensorEstimateBySafeTensorOverhead() throws {
         let root = try makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let source = root.appendingPathComponent("source", isDirectory: true)
         try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
 
-        XCTAssertThrowsError(try MLXConversionStoragePreflight.validate(
+        let report = try MLXConversionStoragePreflight.validate(
             source: source,
             output: root.appendingPathComponent("output"),
             inspection: makeInspection(required: 600_000_000_000),
             verifiedCompletedOutputBytes: 190_700_000_001,
-            capacity: { _ in Int64.max })) { error in
-                XCTAssertTrue(error.localizedDescription.contains("exceed the estimated"))
-            }
+            capacity: { _ in 409_299_999_999 })
+
+        XCTAssertEqual(report.requiredBytes, 409_299_999_999)
+        XCTAssertEqual(report.availableBytes, 409_299_999_999)
     }
 
     func testDeepSeekWithoutPublishedEstimatePreservesExistingBehavior() throws {

--- a/Tests/MacLocalAPITests/MLXConversionStoragePreflightTests.swift
+++ b/Tests/MacLocalAPITests/MLXConversionStoragePreflightTests.swift
@@ -1,6 +1,5 @@
 import AFMKit
 import AFMKitMLX
-import CryptoKit
 import Foundation
 import XCTest
 
@@ -80,7 +79,7 @@ final class MLXConversionStoragePreflightTests: XCTestCase {
             output: source.appendingPathComponent("converted"),
             inspection: makeInspection(required: nil),
             capacity: { _ in Int64.max })) { error in
-                XCTAssertTrue(error.localizedDescription.contains("neither may contain"))
+                XCTAssertTrue(error.localizedDescription.contains("source/output must be separate"))
             }
     }
 
@@ -96,7 +95,7 @@ final class MLXConversionStoragePreflightTests: XCTestCase {
             inspection: makeInspection(required: nil),
             overwrite: true,
             capacity: { _ in Int64.max })) { error in
-                XCTAssertTrue(error.localizedDescription.contains("neither may contain"))
+                XCTAssertTrue(error.localizedDescription.contains("source/output must be separate"))
             }
         XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
     }
@@ -115,40 +114,41 @@ final class MLXConversionStoragePreflightTests: XCTestCase {
             output: alias,
             inspection: makeInspection(required: nil),
             capacity: { _ in Int64.max })) { error in
-                XCTAssertTrue(error.localizedDescription.contains("neither may contain"))
+                XCTAssertTrue(error.localizedDescription.contains("source/output must be separate"))
             }
     }
 
-    func testResumeCreditsOnlyChecksummedCompletedOutput() throws {
+    func testFilesystemRootAndRootSymlinkAreRejected() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("source", isDirectory: true)
+        let alias = root.appendingPathComponent("root-alias", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: alias, withDestinationURL: URL(fileURLWithPath: "/", isDirectory: true))
+
+        for output in [URL(fileURLWithPath: "/", isDirectory: true), alias] {
+            XCTAssertThrowsError(try MLXConversionStoragePreflight.validateLocalPaths(
+                source: source,
+                output: output)) { error in
+                    XCTAssertTrue(error.localizedDescription.contains("filesystem or volume root"))
+                }
+        }
+    }
+
+    func testResumeCreditsOnlyProviderVerifiedCompletedOutput() throws {
         let root = try makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let source = root.appendingPathComponent("source", isDirectory: true)
         let output = root.appendingPathComponent("output", isDirectory: true)
         try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
-        let contents = Data("done".utf8)
-        let completedURL = output.appendingPathComponent("model-00001.safetensors")
-        try contents.write(to: completedURL)
-        let revision = String(repeating: "a", count: 40)
-        let state: [String: Any] = [
-            "sourceRevision": revision,
-            "completed": [
-                "unit": [
-                    "outputFile": completedURL.lastPathComponent,
-                    "outputSize": contents.count,
-                    "outputSHA256": SHA256.hash(data: contents).map {
-                        String(format: "%02x", $0)
-                    }.joined(),
-                ],
-            ],
-        ]
-        try JSONSerialization.data(withJSONObject: state, options: [.sortedKeys]).write(
-            to: output.appendingPathComponent(".afm-mlx-conversion.json"))
 
         let report = try MLXConversionStoragePreflight.validate(
             source: source,
             output: output,
             inspection: makeInspection(required: 600_000_000_000),
+            verifiedCompletedOutputBytes: 4,
             capacity: { _ in 599_999_999_996 })
         XCTAssertEqual(report.requiredBytes, 599_999_999_996)
 
@@ -157,18 +157,17 @@ final class MLXConversionStoragePreflightTests: XCTestCase {
             output: output,
             inspection: makeInspection(required: 600_000_000_000),
             overwrite: true,
+            verifiedCompletedOutputBytes: 4,
             capacity: { _ in 599_999_999_996 }))
     }
 
-    func testCorruptCompletedOutputReceivesNoResumeCredit() throws {
+    func testConsumerDoesNotInferCreditFromPrivateManifest() throws {
         let root = try makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let source = root.appendingPathComponent("source", isDirectory: true)
         let output = root.appendingPathComponent("output", isDirectory: true)
         try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
-        try Data("bad".utf8).write(
-            to: output.appendingPathComponent("model-00001.safetensors"))
         let state: [String: Any] = [
             "sourceRevision": String(repeating: "a", count: 40),
             "completed": [
@@ -187,6 +186,22 @@ final class MLXConversionStoragePreflightTests: XCTestCase {
             output: output,
             inspection: makeInspection(required: 600_000_000_000),
             capacity: { _ in 599_999_999_999 }))
+    }
+
+    func testImpossibleProviderResumeCreditIsRejected() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("source", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(try MLXConversionStoragePreflight.validate(
+            source: source,
+            output: root.appendingPathComponent("output"),
+            inspection: makeInspection(required: 600_000_000_000),
+            verifiedCompletedOutputBytes: 190_700_000_001,
+            capacity: { _ in Int64.max })) { error in
+                XCTAssertTrue(error.localizedDescription.contains("exceed the estimated"))
+            }
     }
 
     func testDeepSeekWithoutPublishedEstimatePreservesExistingBehavior() throws {

--- a/docs/afmkit-url-consumption.md
+++ b/docs/afmkit-url-consumption.md
@@ -6,7 +6,7 @@ one exact release and selects every provider product from it:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.9"
+    exact: "0.1.10"
 )
 ```
 
@@ -14,7 +14,7 @@ Do not use a branch or revision requirement for release builds.
 
 ## Production Blocker
 
-AFMKit is public and exposes `0.1.9`. AFM release publication remains
+AFMKit is public and exposes `0.1.10`. AFM release publication remains
 fail-closed unless AFMKit and every dependency in its root graph are
 anonymously readable and the tracked lock resolves that exact tag.
 
@@ -38,7 +38,7 @@ surface publishable.
 
 ## Dependency Resolution
 
-AFMKit 0.1.9 is public, so normal resolution requires no GitHub credential:
+AFMKit 0.1.10 is public, so normal resolution requires no GitHub credential:
 
 ```bash
 Scripts/resolve-release-dependencies.sh
@@ -55,7 +55,7 @@ The normal graph is independent of maclocal-api's dirty vendor worktrees:
 
 | Dependency | Requirement | Purpose |
 | --- | --- | --- |
-| `AFMKit` | exact `0.1.9` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
+| `AFMKit` | exact `0.1.10` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
 
 The MLX, mlx-c, Swift bindings, and mlx-swift-lm sources are snapshots inside
 AFMKit's `vendor/MLX` tree. They are not separate SwiftPM dependencies of

--- a/docs/glm-5.3-flash-conversion.md
+++ b/docs/glm-5.3-flash-conversion.md
@@ -20,11 +20,15 @@ afm mlx-convert \
 ```
 
 The command fails before conversion unless the source is a local directory,
-the destination is outside it, every indexed shard is present, and the
-destination volume reports at least 600 GB free. The output-size estimate is
-calculated from the actual source headers; the conservative 600 GB floor also
-allows atomic partial output and resume state. This is a storage floor, not an
-assertion that the final checkpoint will occupy 600 GB.
+the source and destination are disjoint after resolving symlinks, every
+indexed shard and required processor/tokenizer/template asset is present, and
+the destination volume reports at least 600 GB free. The output-size estimate
+is calculated from the actual source headers; the conservative 600 GB floor
+also allows atomic partial output and resume state. On a verified resume, AFM
+credits checksummed completed units and retains a 64 GB atomic-unit margin, so
+the initial floor does not incorrectly block a job merely because its own
+partial output consumed space. This is a storage floor, not an assertion that
+the final checkpoint will occupy 600 GB.
 
 Conversion behavior:
 
@@ -33,10 +37,12 @@ Conversion behavior:
 - decodes E4M3 and applies the declared 128 x 128 inverse scales in FP32 before
   bounded affine 4-bit/group-64 quantization;
 - reconstructs numerically ordered routed experts across source shards;
-- converts the complete text and vision namespaces and copies the processor,
-  tokenizer, and chat-template assets needed by the multimodal checkpoint;
+- converts the complete text and vision namespaces, including the required
+  PyTorch-to-MLX Conv3d patch-embedding and Conv2d downsample layouts, and
+  atomically copies the processor, tokenizer, and chat-template assets;
 - writes atomic per-unit SafeTensor outputs and a checksummed resume manifest
-  tied to the source revision, config, index, and shard fingerprints;
+  tied to consistent local revision evidence, config, index, full shard
+  content hashes, and support-asset hashes;
 - explicitly omits the one MTP layer, sets `num_nextn_predict_layers` to zero,
   and records that omission in `config.json` provenance.
 
@@ -50,7 +56,7 @@ machine with ample unified memory and without another large model loaded.
 ## Validation limit
 
 The FP8 decoder, block scaling, quantization error bound, cross-shard expert
-ordering, complete vision-name mapping, multimodal assets, MTP omission,
+ordering, complete vision-name and convolution-layout mapping, multimodal assets, MTP omission,
 dispatcher, storage preflight, and resumability are covered with synthetic
 SafeTensor fixtures. The full 328 GB checkpoint was not present locally during
 implementation, so no claim is made yet for full-checkpoint conversion time,

--- a/docs/glm-5.3-flash-conversion.md
+++ b/docs/glm-5.3-flash-conversion.md
@@ -20,12 +20,15 @@ afm mlx-convert \
 ```
 
 The command fails before conversion unless the source is a local directory,
-the source and destination are disjoint after resolving symlinks, every
+the destination is not a filesystem or mounted-volume root, the source and
+destination are disjoint after resolving symlinks, every
 indexed shard and required processor/tokenizer/template asset is present, and
 the destination volume reports at least 600 GB free. The output-size estimate
 is calculated from the actual source headers; the conservative 600 GB floor
 also allows atomic partial output and resume state. On a verified resume, AFM
-credits checksummed completed units and retains a 64 GB atomic-unit margin, so
+asks AFMKit to revalidate the complete private manifest, current conversion
+plan, source revision/config/index/assets/full shard hashes, and SafeTensor
+outputs before crediting completed bytes. It retains a 64 GB atomic-unit margin, so
 the initial floor does not incorrectly block a job merely because its own
 partial output consumed space. This is a storage floor, not an assertion that
 the final checkpoint will occupy 600 GB.

--- a/docs/glm-5.3-flash-conversion.md
+++ b/docs/glm-5.3-flash-conversion.md
@@ -30,8 +30,10 @@ asks AFMKit to revalidate the complete private manifest, current conversion
 plan, source revision/config/index/assets/full shard hashes, and SafeTensor
 outputs before crediting completed bytes. It retains a 64 GB atomic-unit margin, so
 the initial floor does not incorrectly block a job merely because its own
-partial output consumed space. This is a storage floor, not an assertion that
-the final checkpoint will occupy 600 GB.
+partial output consumed space. Provider-verified physical output bytes include
+SafeTensor headers and may therefore exceed the tensor-payload estimate; the
+remaining payload estimate is clamped to zero in that case. This is a storage
+floor, not an assertion that the final checkpoint will occupy 600 GB.
 
 Conversion behavior:
 

--- a/docs/glm-5.3-flash-conversion.md
+++ b/docs/glm-5.3-flash-conversion.md
@@ -1,0 +1,59 @@
+# GLM-5.3 Flash checkpoint conversion
+
+`afm mlx-convert` can convert a complete, already-local copy of the official
+[`zai-org/GLM-5.3-Flash`](https://huggingface.co/zai-org/GLM-5.3-Flash)
+raw FP8 multimodal checkpoint into the self-contained MLX layout used by AFM.
+AFM does not download this checkpoint as part of conversion.
+
+The source revision validated during implementation is
+`04c4e9e95c5da8862dced7e5056455116f83a7e0`. Its SafeTensor index declares
+62 shards, 76,108 tensors, and 328,326,771,576 bytes of tensor payload. Pin the
+same full revision on the command line unless the local directory is already a
+Hugging Face `snapshots/<revision>` directory:
+
+```sh
+afm mlx-convert \
+  --source /Volumes/edata2/models/zai-org/GLM-5.3-Flash \
+  --output /Volumes/edata2/models/GLM-5.3-Flash-AFM-MLX-4bit \
+  --source-revision 04c4e9e95c5da8862dced7e5056455116f83a7e0 \
+  --profile mlx-affine-4
+```
+
+The command fails before conversion unless the source is a local directory,
+the destination is outside it, every indexed shard is present, and the
+destination volume reports at least 600 GB free. The output-size estimate is
+calculated from the actual source headers; the conservative 600 GB floor also
+allows atomic partial output and resume state. This is a storage floor, not an
+assertion that the final checkpoint will occupy 600 GB.
+
+Conversion behavior:
+
+- validates SafeTensor header dtypes and accepts FP8 only when the header says
+  `F8_E4M3`; ordinary `U8` is never inferred to be FP8;
+- decodes E4M3 and applies the declared 128 x 128 inverse scales in FP32 before
+  bounded affine 4-bit/group-64 quantization;
+- reconstructs numerically ordered routed experts across source shards;
+- converts the complete text and vision namespaces and copies the processor,
+  tokenizer, and chat-template assets needed by the multimodal checkpoint;
+- writes atomic per-unit SafeTensor outputs and a checksummed resume manifest
+  tied to the source revision, config, index, and shard fingerprints;
+- explicitly omits the one MTP layer, sets `num_nextn_predict_layers` to zero,
+  and records that omission in `config.json` provenance.
+
+The implementation bounds working data to one source shard and one routed
+expert projection unit rather than materializing the full 328 GB checkpoint.
+Based on the 62-shard layout and published model dimensions, expected peak
+working memory is in the low tens of gigabytes, but that estimate has not yet
+been measured against the complete source. Conversion should be run on a
+machine with ample unified memory and without another large model loaded.
+
+## Validation limit
+
+The FP8 decoder, block scaling, quantization error bound, cross-shard expert
+ordering, complete vision-name mapping, multimodal assets, MTP omission,
+dispatcher, storage preflight, and resumability are covered with synthetic
+SafeTensor fixtures. The full 328 GB checkpoint was not present locally during
+implementation, so no claim is made yet for full-checkpoint conversion time,
+measured peak memory, final output size, or end-to-end generated text/image
+parity. The GLM runtime architecture remains a separate AFMKit change; a
+converted checkpoint requires that runtime support before inference.

--- a/docs/vesta-integration.md
+++ b/docs/vesta-integration.md
@@ -11,7 +11,7 @@ Use the current exact public AFMKit release:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.9"
+    exact: "0.1.10"
 )
 ```
 


### PR DESCRIPTION
Closes #227.

Provider dependency fulfilled by scouzi1966/AFMKit#36, released publicly as AFMKit 0.1.10 at exact commit 69bdd0721f8cc3f745e52a4923a373e16a9401c0.

## Problem

AFMKit owns checkpoint conversion, while the afm application needs a thin built-in dispatcher and conservative destination policy for the approximately 328 GB GLM-5.3 Flash source. Conversion must never trigger an implicit download, damage its source through an unsafe output path, or start on an undersized volume.

## Approach

- make afm mlx-convert auto-detect supported DeepSeek V4 and GLM5Next checkpoints
- require an existing local source and accept a pinned full source revision
- validate options, source/output paths, and optional DwarfStar template before expensive checkpoint inspection
- preserve model-specific profiles and DeepSeek behavior
- reject roots and source/output containment in either direction, including symlink aliases and all mounted volume roots
- probe destination capacity only when a converter publishes a requirement
- apply the AFMKit 600 GB initial GLM floor; on resume, credit only provider-verified physical output and keep a 64 GB atomic-write margin
- correctly allow verified SafeTensor physical bytes to exceed the tensor-payload estimate and clamp remaining payload to zero
- document provenance, storage, FP8/vision transforms, MTP omission, and validation limits

## Dependency state

- rebased cleanly onto maclocal-api main at 261a27eb601811e13b07c0dda9f3d6fdfa4ffe77, which includes #230
- Package.swift pins public AFMKit 0.1.10 exactly
- Package.resolved pins AFMKit commit 69bdd0721f8cc3f745e52a4923a373e16a9401c0
- no local path, branch, revision, token, or private dependency is required

## Validation

- Scripts/check-afmkit-consumer-boundary.sh: passed
- Scripts/check-public-release-eligibility.sh: passed; exact dependency is anonymously fetchable
- Scripts/tests/test-release-tooling.sh: passed
- Scripts/swiftpm-reliable.sh test -c release --filter MLXConversionStoragePreflightTests: 13 passed
- Scripts/swiftpm-reliable.sh test -c release: 139 tests in 17 suites passed
- make build: passed through mandated native retry; release product built successfully
- Makefile binary and copied-portability smoke tests: passed
- afm --version: v0.9.18
- release binary SHA-256: e577caa5f9139ef2f35d904df661f86e2d7c0ef569f7e13dd134269c735b6094

The full raw checkpoint is not installed locally, so no full 328 GB conversion was run and no measured peak RAM, duration, final size, or inference parity is claimed.

## Summary by Sourcery

Expose safe local conversion for supported DeepSeek V4 and GLM-5.3 checkpoints with storage-aware preflight and the public AFMKit 0.1.10 dependency.

New Features:
- Add automatic DeepSeek V4 and GLM-5.3 Flash checkpoint detection to `afm mlx-convert`, including model-specific default profiles and pinned local-source handling.
- Add conservative destination storage preflight with resume-aware capacity checks, path safety validation, and support for provider-reported conversion requirements.

Bug Fixes:
- Prevent conversion from implicitly downloading checkpoints, using unsafe or overlapping source/output paths, starting on undersized volumes, or miscalculating resumable storage requirements.

Enhancements:
- Validate conversion options, checkpoint metadata, source assets, and optional DwarfStar templates before expensive conversion work.
- Preserve existing DeepSeek conversion behavior while supporting GLM-5.3 FP8 and multimodal conversion workflows.

Build:
- Pin AFMKit and the core consumer example to the public AFMKit 0.1.10 release and corresponding resolved revision.

CI:
- Update CodeQL and release-tooling checks to resolve and validate the public AFMKit dependency without private repository credentials.

Documentation:
- Document GLM-5.3 Flash conversion requirements, storage policy, conversion behavior, provenance, and validation limits.
- Update AFMKit URL-consumption and Vesta integration documentation for AFMKit 0.1.10.

Tests:
- Add coverage for storage capacity requirements, resume accounting, source/output safety, symlink and volume-root rejection, validation ordering, and DeepSeek compatibility.