### PR TITLE
Update AFMKit to 0.1.9

### DIFF
--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.8"
+        exact: "0.1.9"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "f4ed20f78cc9ed43e0bd67b48ce68b962697e417cc8a91aaccea32e9e9c2da95",
+  "originHash" : "d801788693fe40089a5ab4ce42f5cad3e947d4a1b001fe9255615e27056e9094",
   "pins" : [
     {
       "identity" : "afmkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "740c6f83f1f386b8b0ce194c54d25e762e355be4",
-        "version" : "0.1.8"
+        "revision" : "5ba478382dec5a2a2edca9208ee67c2b015c727b",
+        "version" : "0.1.9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.8"
+        exact: "0.1.9"
     )
 }
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -145,8 +145,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.8":
-        fail(f"{identity} must resolve the exact 0.1.8 release")
+    if pin["state"].get("version") != "0.1.9":
+        fail(f"{identity} must resolve the exact 0.1.9 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -289,7 +289,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.8"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.9"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.8",
+    "afmkit": "0.1.9",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -54,13 +54,13 @@ cat > "$fake_public_git" <<'SH'
 #!/usr/bin/env bash
 arguments=" $* "
 for ref in \
-  refs/tags/0.1.8 \
-  'refs/tags/0.1.8^{}' \
-  refs/tags/v0.1.8 \
-  'refs/tags/v0.1.8^{}'; do
+  refs/tags/0.1.9 \
+  'refs/tags/0.1.9^{}' \
+  refs/tags/v0.1.9 \
+  'refs/tags/v0.1.9^{}'; do
   [[ "$arguments" == *" $ref "* ]] || exit 2
 done
-printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.8^{}'
+printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.9^{}'
 SH
 chmod 700 "$fake_public_git"
 if ! EXPECTED_AFMKIT_REVISION="$expected_afmkit_revision" \
@@ -80,7 +80,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.8'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.9'
   }
   probe_public_source() {
     return 1
@@ -104,14 +104,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.8" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.8"
+[[ "$release_version" == "0.1.9" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.9"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.8'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.9'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -130,7 +130,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.8'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.9'
   }
   probe_public_source() {
     return 0

--- a/docs/afmkit-url-consumption.md
+++ b/docs/afmkit-url-consumption.md
@@ -6,7 +6,7 @@ one exact release and selects every provider product from it:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.8"
+    exact: "0.1.9"
 )
 ```
 
@@ -14,7 +14,7 @@ Do not use a branch or revision requirement for release builds.
 
 ## Production Blocker
 
-AFMKit is public and exposes `0.1.8`. AFM release publication remains
+AFMKit is public and exposes `0.1.9`. AFM release publication remains
 fail-closed unless AFMKit and every dependency in its root graph are
 anonymously readable and the tracked lock resolves that exact tag.
 
@@ -38,7 +38,7 @@ surface publishable.
 
 ## Dependency Resolution
 
-AFMKit 0.1.8 is public, so normal resolution requires no GitHub credential:
+AFMKit 0.1.9 is public, so normal resolution requires no GitHub credential:
 
 ```bash
 Scripts/resolve-release-dependencies.sh
@@ -55,7 +55,7 @@ The normal graph is independent of maclocal-api's dirty vendor worktrees:
 
 | Dependency | Requirement | Purpose |
 | --- | --- | --- |
-| `AFMKit` | exact `0.1.8` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
+| `AFMKit` | exact `0.1.9` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
 
 The MLX, mlx-c, Swift bindings, and mlx-swift-lm sources are snapshots inside
 AFMKit's `vendor/MLX` tree. They are not separate SwiftPM dependencies of

--- a/docs/vesta-integration.md
+++ b/docs/vesta-integration.md
@@ -6,18 +6,18 @@ imports provider products directly; it does not import maclocal-api's
 
 ## Package Dependency
 
-Until AFMKit publishes its first tag, use the immutable checkpoint:
+Use the current exact public AFMKit release:
 
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    revision: "4c1b868df6c3aaa41e0f4d546e2353b8d6b55dce"
+    exact: "0.1.9"
 )
 ```
 
-This revision is a development checkpoint, not a versioned public installation
-contract. Production consumers must switch to an exact public AFMKit semantic
-version and commit the matching resolved version/revision before publication.
+Production consumers must commit the matching resolved version and revision
+before publication. Do not use a branch or revision requirement for release
+builds.
 
 Select only the products the app target needs:
 


### PR DESCRIPTION
Closes #229

## Problem

The consumer remained pinned to AFMKit 0.1.8 and therefore could not use the published Qwen capability and serial multi-tool fixes.

## Approach

- pin the single AFMKit dependency and lock to exact 0.1.9 / `5ba478382dec5a2a2edca9208ee67c2b015c727b`;
- update the fail-closed boundary and anonymous-release policy fixtures;
- update the core-only example and URL-consumption documentation.

## Validation

- AFMKit v0.1.9 full local release qualification: all 15 API baselines, isolated release tests, and all 15 clean downstream products;
- `Scripts/check-afmkit-consumer-boundary.sh`;
- `Scripts/check-public-release-eligibility.sh`;
- `Scripts/tests/test-release-tooling.sh`;
- `Scripts/swiftpm-reliable.sh build -c release --product afm`;
- `Scripts/swiftpm-reliable.sh test -c release`: 139/139 passed;
- binary reports `v0.9.18`, SHA-256 `8fbe8d13895a4304a7954755b88baeafb9a844be64d04979b903aedca5d136ea`.

No GitHub Actions dependency is introduced.

## Summary by Sourcery

Adopt AFMKit 0.1.9 across the project and release tooling.

Enhancements:
- Update the project and core-only consumer to use AFMKit 0.1.9 as the exact public dependency.
- Align release boundary checks, public-release eligibility fixtures, and documentation with the AFMKit 0.1.9 release contract.

Documentation:
- Update AFMKit consumption and Vesta integration guidance to use the exact 0.1.9 release.

Tests:
- Update release tooling tests and dependency validation checks for AFMKit 0.1.9.