### PR TITLE
Fix evaluation cache oracles and tool prompts

### DIFF
--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -1129,6 +1129,7 @@ try:
         logprobs_count=logprobs_count,
         tool_calls=tool_calls,
         cached_input_tokens=cached_input_tokens,
+        safe_partial_cache_miss=config.get('safe_partial_cache_miss', False),
     )
     if is_valid_json is None:
         is_valid_json = oracle_valid_json
@@ -1385,6 +1386,26 @@ print(f'API: {api}' if api else 'API: (none)')
       echo ""
       return
     fi
+  fi
+
+  # Resolve cache policy only after the server has loaded the checkpoint. A
+  # remote checkpoint may not exist in the local cache before this point.
+  local safe_partial_cache_miss
+  safe_partial_cache_miss=$(PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 - "$model" <<'PYEOF'
+import sys
+from mlx_model_test_oracle import model_allows_safe_partial_cache_miss
+
+print("true" if model_allows_safe_partial_cache_miss(sys.argv[1]) else "false")
+PYEOF
+  )
+  run_config=$(python3 -c '
+import json, sys
+config = json.loads(sys.argv[1])
+config["safe_partial_cache_miss"] = sys.argv[2] == "true"
+print(json.dumps(config))
+' "$run_config" "$safe_partial_cache_miss")
+  if [ "$safe_partial_cache_miss" = "true" ]; then
+    echo "  Cache oracle: recurrent hybrid; marked scenarios may use a safe cold fallback"
   fi
 
   # Get prompts list

--- a/Scripts/mlx_model_test_oracle.py
+++ b/Scripts/mlx_model_test_oracle.py
@@ -1,7 +1,80 @@
 """Deterministic response assertions for mlx-model-test.sh."""
 
 import json
+import os
 import re
+from pathlib import Path
+
+
+def configuration_allows_safe_partial_cache_miss(config):
+    """Return whether correctness may require a cold fallback for a hybrid cache."""
+    text_config = config.get("text_config") or {}
+    layer_types = (
+        text_config.get("layer_types")
+        or config.get("layer_types")
+        or text_config.get("layers_block_type")
+        or config.get("layers_block_type")
+        or []
+    )
+    recurrent_markers = ("linear", "mamba", "ssm", "delta", "recurrent")
+    if any(
+        any(marker in str(layer_type).lower() for marker in recurrent_markers)
+        for layer_type in layer_types
+    ):
+        return True
+
+    model_type = str(text_config.get("model_type") or config.get("model_type") or "").lower()
+    architectures = text_config.get("architectures") or config.get("architectures") or []
+    architecture_text = " ".join(str(architecture).lower() for architecture in architectures)
+    return any(
+        marker in model_type or marker in architecture_text
+        for marker in ("deepseek_v4", "deepseekv4")
+    )
+
+
+def model_allows_safe_partial_cache_miss(model, environ=None):
+    """Inspect a local checkpoint without depending on a running AFM server."""
+    environ = os.environ if environ is None else environ
+    model_path = Path(model).expanduser()
+    candidates = [model_path / "config.json"]
+
+    mac_cache_root = None
+    if environ.get("MACAFM_MLX_MODEL_CACHE"):
+        mac_cache_root = Path(environ["MACAFM_MLX_MODEL_CACHE"]).expanduser()
+        candidates.extend(
+            (
+                mac_cache_root / model / "config.json",
+                mac_cache_root / "models" / model / "config.json",
+            )
+        )
+
+    cache_roots = []
+    for key in ("HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE"):
+        if environ.get(key):
+            cache_roots.append(Path(environ[key]).expanduser())
+    if environ.get("HF_HOME"):
+        cache_roots.append(Path(environ["HF_HOME"]).expanduser() / "hub")
+    cache_roots.append(Path(environ.get("HOME", str(Path.home()))) / ".cache/huggingface/hub")
+
+    repo_directory_name = "models--" + model.replace("/", "--")
+    for cache_root in cache_roots:
+        candidates.append(cache_root / model / "config.json")
+        repo_directory = cache_root / repo_directory_name
+        main_ref = repo_directory / "refs/main"
+        if main_ref.is_file():
+            revision = main_ref.read_text(encoding="utf-8").strip()
+            if revision:
+                candidates.append(repo_directory / "snapshots" / revision / "config.json")
+
+    for config_path in candidates:
+        if not config_path.is_file():
+            continue
+        try:
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        return configuration_allows_safe_partial_cache_miss(config)
+    return False
 
 
 def evaluation_lane(*, model, afm_args="", is_baseline=False, has_expectation=True):
@@ -91,6 +164,7 @@ def request_configuration_fields(config, *, expectation=None):
         "server_instructions": config.get("instructions", ""),
         "required_capabilities": config.get("requires") or [],
         "afm_args": config.get("afm_args", ""),
+        "safe_partial_cache_miss": bool(config.get("safe_partial_cache_miss", False)),
     }
     for key in (
         "top_p",
@@ -238,6 +312,7 @@ def evaluate_expectations(
     logprobs_count,
     tool_calls,
     cached_input_tokens=0,
+    safe_partial_cache_miss=False,
 ):
     """Return (valid_json, failures) for a response and declarative expectation."""
     parsed_json = None
@@ -263,6 +338,11 @@ def evaluate_expectations(
     if (
         expectation.get("cached_input_tokens_min") is not None
         and cached_input_tokens < int(expectation["cached_input_tokens_min"])
+        and not (
+            expectation.get("allow_safe_partial_cache_miss") is True
+            and safe_partial_cache_miss
+            and cached_input_tokens == 0
+        )
     ):
         failures.append(
             "cached_input_tokens expected >= "

--- a/Scripts/reassess_mlx_results.py
+++ b/Scripts/reassess_mlx_results.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Reapply deterministic MLX result oracles without rerunning inference."""
+
+import argparse
+import json
+from pathlib import Path
+
+from mlx_model_test_oracle import (
+    classify_result_likelihood,
+    evaluate_expectations,
+    model_allows_safe_partial_cache_miss,
+)
+
+
+def paths_refer_to_same_file(input_path, output_path):
+    if input_path.resolve() == output_path.resolve():
+        return True
+    try:
+        return output_path.exists() and input_path.samefile(output_path)
+    except OSError:
+        return False
+
+
+def reassess_record(record, *, safe_cache_labels=frozenset()):
+    if record.get("_meta"):
+        updated = dict(record)
+        updated["oracle_reassessment"] = "recurrent-cache-aware-v1"
+        return updated
+    if record.get("status") != "OK":
+        return record
+
+    updated = dict(record)
+    if "safe_partial_cache_miss" in record:
+        safe_partial_cache_miss = bool(record["safe_partial_cache_miss"])
+        updated["cache_policy_provenance"] = "recorded-result"
+    else:
+        safe_partial_cache_miss = model_allows_safe_partial_cache_miss(
+            record.get("model", "")
+        )
+        updated["cache_policy_provenance"] = "legacy-local-checkpoint-inspection"
+    updated["safe_partial_cache_miss"] = safe_partial_cache_miss
+    expectation = dict(record.get("expect") or {})
+    if not expectation:
+        return updated
+    if record.get("label") in safe_cache_labels:
+        expectation["allow_safe_partial_cache_miss"] = True
+        updated["expect"] = expectation
+
+    valid_json, failures = evaluate_expectations(
+        expectation,
+        content=record.get("content", ""),
+        finish_reason=record.get("finish_reason"),
+        logprobs_count=record.get("logprobs_count", 0),
+        tool_calls=record.get("tool_calls") or [],
+        cached_input_tokens=record.get("cached_input_tokens", 0),
+        safe_partial_cache_miss=safe_partial_cache_miss,
+    )
+    updated["assertion_failures"] = failures
+    updated["assertion_status"] = "fail" if failures else "pass"
+    updated["overall_status"] = "fail" if failures else "pass"
+    updated["failure_classification"] = classify_result_likelihood(
+        model=record.get("model", ""),
+        label=record.get("label", ""),
+        afm_args=record.get("afm_args", ""),
+        is_baseline=record.get("is_baseline", False),
+        status=record.get("status", "OK"),
+        failures=failures,
+    )
+    if valid_json is not None:
+        updated["is_valid_json"] = valid_json
+    return updated
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Reapply deterministic oracles to an AFM JSONL result file."
+    )
+    parser.add_argument("input", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument(
+        "--allow-safe-partial-cache-label",
+        action="append",
+        default=[],
+        help="explicit scenario label allowed to use recurrent safe cold fallback",
+    )
+    args = parser.parse_args()
+
+    if paths_refer_to_same_file(args.input, args.output):
+        parser.error("input and output must differ so raw inference data stays immutable")
+
+    records = []
+    with args.input.open("r", encoding="utf-8") as source:
+        for line_number, line in enumerate(source, start=1):
+            if not line.strip():
+                continue
+            try:
+                records.append(
+                    reassess_record(
+                        json.loads(line),
+                        safe_cache_labels=frozenset(args.allow_safe_partial_cache_label),
+                    )
+                )
+            except json.JSONDecodeError as error:
+                raise SystemExit(f"{args.input}:{line_number}: {error}") from error
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as destination:
+        for record in records:
+            destination.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -1176,24 +1176,28 @@ except Exception as e:
 
   # Test: tool with array-type parameter (regression PR #37 — array params must not serialize as strings)
   t0=$(now_ms)
-  resp=$(api_call "{\"messages\":[{\"role\":\"user\",\"content\":\"Create todos: Buy milk, Call dentist, Fix bug\"}],\"tools\":$ARRAY_TOOL,\"max_tokens\":300,\"stream\":false,\"temperature\":0}")
+  resp=$(api_call "{\"messages\":[{\"role\":\"user\",\"content\":\"Call todowrite exactly once. Set todos to the JSON array [\\\"Buy milk\\\",\\\"Call dentist\\\",\\\"Fix bug\\\"] in that order. Do not answer with text.\"}],\"tools\":$ARRAY_TOOL,\"tool_choice\":\"required\",\"max_tokens\":300,\"stream\":false,\"temperature\":0}")
   dur=$(( $(now_ms) - t0 ))
   array_param=$(echo "$resp" | python3 -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
     tc = d['choices'][0]['message'].get('tool_calls', [])
-    if not tc:
-        print('FAIL: no tool calls')
+    if len(tc) != 1:
+        print(f'FAIL: expected exactly 1 tool call, got {len(tc)}')
+    elif tc[0].get('function', {}).get('name') != 'todowrite':
+        actual_name = tc[0].get('function', {}).get('name')
+        print(f'FAIL: expected todowrite, got {actual_name}')
     else:
         args = json.loads(tc[0]['function']['arguments'])
         todos = args.get('todos', args.get('items', None))
-        if isinstance(todos, list):
+        expected = ['Buy milk', 'Call dentist', 'Fix bug']
+        if todos == expected:
             print('PASS')
         elif isinstance(todos, str):
             print('FAIL: todos is string (not array)')
         else:
-            print(f'FAIL: todos type={type(todos).__name__}')
+            print(f'FAIL: todos expected {expected!r}, got {todos!r}')
 except Exception as e:
     print(f'FAIL: {e}')
 " 2>/dev/null || echo "FAIL: parse error")
@@ -2916,11 +2920,11 @@ else:
 
     # Test: tool call with array param via streaming (PR #37 streaming path)
     t0=$(now_ms)
-    stream_resp=$(api_stream "{\"messages\":[{\"role\":\"user\",\"content\":\"Create todos: Walk dog, Read book, Cook dinner.\"}],\"tools\":$ARRAY_TOOL,\"max_tokens\":1000,\"stream\":true,\"temperature\":0}")
+    stream_resp=$(api_stream "{\"messages\":[{\"role\":\"user\",\"content\":\"Call todowrite exactly once. Set todos to the JSON array [\\\"Walk dog\\\",\\\"Read book\\\",\\\"Cook dinner\\\"] in that order. Do not answer with text.\"}],\"tools\":$ARRAY_TOOL,\"tool_choice\":\"required\",\"max_tokens\":1000,\"stream\":true,\"temperature\":0}")
     dur=$(( $(now_ms) - t0 ))
     stream_array_ok=$(echo "$stream_resp" | python3 -c "
 import sys, json
-tool_args = ''
+tool_calls = {}
 found_finish = False
 for line in sys.stdin:
     line = line.strip()
@@ -2931,27 +2935,41 @@ for line in sys.stdin:
         delta = d.get('choices', [{}])[0].get('delta', {})
         tcs = delta.get('tool_calls', [])
         for tc in tcs:
+            index = tc.get('index', 0)
+            call = tool_calls.setdefault(index, {'name': '', 'arguments': ''})
             fn = tc.get('function', {})
+            if fn.get('name'):
+                call['name'] = fn['name']
             if fn.get('arguments'):
-                tool_args += fn['arguments']
+                call['arguments'] += fn['arguments']
         fr = d.get('choices', [{}])[0].get('finish_reason')
         if fr == 'tool_calls':
             found_finish = True
     except: pass
 if not found_finish:
     print('FAIL: no finish_reason=tool_calls')
-elif not tool_args:
-    print('FAIL: no arguments in stream')
+elif len(tool_calls) != 1:
+    print(f'FAIL: expected exactly 1 streamed tool call, got {len(tool_calls)}')
 else:
+    call = next(iter(tool_calls.values()))
+    tool_args = call['arguments']
+    if call['name'] != 'todowrite':
+        actual_name = call['name']
+        print(f'FAIL: expected todowrite, got {actual_name}')
+        raise SystemExit
+    if not tool_args:
+        print('FAIL: no arguments in stream')
+        raise SystemExit
     try:
         args = json.loads(tool_args)
         todos = args.get('todos', args.get('items', None))
-        if isinstance(todos, list) and len(todos) >= 2:
+        expected = ['Walk dog', 'Read book', 'Cook dinner']
+        if todos == expected:
             print('PASS')
         elif isinstance(todos, str):
             print('FAIL: todos is string in stream (not array)')
         else:
-            print(f'FAIL: todos={todos}')
+            print(f'FAIL: todos expected {expected!r}, got {todos!r}')
     except:
         print(f'FAIL: args not valid JSON: {tool_args[:100]}')
 " 2>/dev/null || echo "FAIL: parse error")

--- a/Scripts/test-llm-comprehensive.txt
+++ b/Scripts/test-llm-comprehensive.txt
@@ -233,14 +233,16 @@ Write an XCTest that verifies the proposed --timeout flag rejects non-positive v
 
 # AI: Cached request sequence. All three requests run sequentially against one persistent
 # AI: server process with one identical multiline API system message. Request 1 establishes
-# AI: the prefix; requests 2 and 3 must reuse it and report cached input tokens. Compare
-# AI: response quality with agent-no-cache-sequence, but judge cache reuse from telemetry.
+# AI: the prefix. Rewindable KV-cache models must report reuse for requests 2 and 3. A
+# AI: recurrent/hybrid model may instead report zero when rejecting non-rewindable state and
+# AI: performing a correctness-preserving cold fallback. Judge this from the recorded cache
+# AI: policy and telemetry; compare response quality with agent-no-cache-sequence.
 [@ agent-cached-sequence]
 temperature: 0.0
 max_tokens: 20000
 afm: --enable-prefix-caching
 requires: prefix_cache
-expect_by_prompt: [{},{"cached_input_tokens_min":1},{"cached_input_tokens_min":1}]
+expect_by_prompt: [{},{"cached_input_tokens_min":1,"allow_safe_partial_cache_miss":true},{"cached_input_tokens_min":1,"allow_safe_partial_cache_miss":true}]
 system_json: "You are an expert coding assistant. You have access to the following tools:\n\n1. read_file(path: string) - Read contents of a file\n2. write_file(path: string, content: string) - Write content to a file\n3. run_command(cmd: string) - Execute a shell command\n4. search_code(query: string, path: string) - Search for code patterns\n5. list_files(path: string) - List directory contents\n\nWhen modifying code, first read the existing file, understand the context, then make targeted changes. Never overwrite entire files when a small edit suffices. Follow the project's existing coding conventions. Write tests for new functionality. Handle errors gracefully.\n\nProject context: Swift macOS application using Vapor for HTTP, MLX for inference, and async/await for concurrency."
 Read the file Sources/AFMCLI/main.swift and summarize how the CLI starts the server.
 Describe a targeted implementation for a --timeout flag that sets request timeout seconds.

--- a/Scripts/test_mlx_model_test_oracle.py
+++ b/Scripts/test_mlx_model_test_oracle.py
@@ -1,22 +1,87 @@
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
 
 from assemble_smart_report import assemble_per_test_report
+from reassess_mlx_results import paths_refer_to_same_file, reassess_record
 from mlx_model_test_oracle import (
     classify_result_likelihood,
+    configuration_allows_safe_partial_cache_miss,
     evaluate_expectations,
     evaluation_lane,
     expectation_for_prompt,
     extract_score_payload,
     failed_run_records,
+    model_allows_safe_partial_cache_miss,
     skipped_run_records,
     transport_failure_record,
 )
 
 
 class ModelTestOracleTests(unittest.TestCase):
+    def test_reassessment_corrects_safe_recurrent_cache_false_negative(self):
+        with tempfile.TemporaryDirectory() as directory:
+            model = Path(directory) / "model"
+            model.mkdir()
+            (model / "config.json").write_text(
+                json.dumps({"model_type": "deepseek_v4"}),
+                encoding="utf-8",
+            )
+            record = {
+                "model": str(model),
+                "label": "agent-cached-sequence",
+                "status": "OK",
+                "overall_status": "fail",
+                "assertion_status": "fail",
+                "assertion_failures": [
+                    "cached_input_tokens expected >= 1, got 0"
+                ],
+                "content": "ok",
+                "finish_reason": "stop",
+                "cached_input_tokens": 0,
+                "expect": {"cached_input_tokens_min": 1},
+            }
+
+            updated = reassess_record(
+                record,
+                safe_cache_labels=frozenset({"agent-cached-sequence"}),
+            )
+
+        self.assertEqual(updated["overall_status"], "pass")
+        self.assertEqual(updated["assertion_failures"], [])
+        self.assertTrue(updated["safe_partial_cache_miss"])
+
+    def test_reassessment_prefers_recorded_cache_policy(self):
+        record = {
+            "model": "missing/model",
+            "label": "agent-cached-sequence",
+            "status": "OK",
+            "content": "ok",
+            "finish_reason": "stop",
+            "cached_input_tokens": 0,
+            "safe_partial_cache_miss": True,
+            "expect": {
+                "cached_input_tokens_min": 1,
+                "allow_safe_partial_cache_miss": True,
+            },
+        }
+
+        updated = reassess_record(record)
+
+        self.assertEqual(updated["overall_status"], "pass")
+        self.assertEqual(updated["cache_policy_provenance"], "recorded-result")
+
+    def test_reassessment_rejects_hardlinked_output(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source.jsonl"
+            output = Path(directory) / "output.jsonl"
+            source.write_text('{"_meta":true}\n', encoding="utf-8")
+            os.link(source, output)
+
+            self.assertTrue(paths_refer_to_same_file(source, output))
+
     def test_per_test_report_assembler_handles_metadata_skip_and_score_reasons(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -273,6 +338,131 @@ class ModelTestOracleTests(unittest.TestCase):
             failures,
             ["cached_input_tokens expected <= 0, got 1"],
         )
+
+    def test_recurrent_cache_oracle_accepts_only_safe_cold_fallback(self):
+        expectation = {
+            "cached_input_tokens_min": 10,
+            "allow_safe_partial_cache_miss": True,
+        }
+
+        _, failures = evaluate_expectations(
+            expectation,
+            content="ok",
+            finish_reason="stop",
+            logprobs_count=0,
+            tool_calls=[],
+            cached_input_tokens=0,
+            safe_partial_cache_miss=True,
+        )
+        self.assertEqual(failures, [])
+
+        _, failures = evaluate_expectations(
+            expectation,
+            content="ok",
+            finish_reason="stop",
+            logprobs_count=0,
+            tool_calls=[],
+            cached_input_tokens=9,
+            safe_partial_cache_miss=True,
+        )
+        self.assertEqual(
+            failures,
+            ["cached_input_tokens expected >= 10, got 9"],
+        )
+
+        _, failures = evaluate_expectations(
+            {"cached_input_tokens_min": 10},
+            content="ok",
+            finish_reason="stop",
+            logprobs_count=0,
+            tool_calls=[],
+            cached_input_tokens=0,
+            safe_partial_cache_miss=True,
+        )
+        self.assertEqual(
+            failures,
+            ["cached_input_tokens expected >= 10, got 0"],
+        )
+
+    def test_recurrent_cache_policy_uses_checkpoint_architecture(self):
+        self.assertTrue(
+            configuration_allows_safe_partial_cache_miss(
+                {"model_type": "deepseek_v4"}
+            )
+        )
+        self.assertTrue(
+            configuration_allows_safe_partial_cache_miss(
+                {"text_config": {"layer_types": ["attention", "mamba"]}}
+            )
+        )
+        self.assertFalse(
+            configuration_allows_safe_partial_cache_miss(
+                {"model_type": "llama", "layer_types": ["attention"]}
+            )
+        )
+
+    def test_recurrent_cache_policy_resolves_hugging_face_snapshot(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cache = Path(directory) / "hub"
+            repository = cache / "models--example--hybrid"
+            (repository / "refs").mkdir(parents=True)
+            (repository / "refs/main").write_text("revision", encoding="utf-8")
+            snapshot = repository / "snapshots/revision"
+            snapshot.mkdir(parents=True)
+            (snapshot / "config.json").write_text(
+                json.dumps({"layer_types": ["attention", "linear_attention"]}),
+                encoding="utf-8",
+            )
+
+            self.assertTrue(
+                model_allows_safe_partial_cache_miss(
+                    "example/hybrid",
+                    environ={"HF_HUB_CACHE": str(cache), "HOME": directory},
+                )
+            )
+
+    def test_recurrent_cache_policy_resolves_legacy_hugging_face_cache_variable(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cache = Path(directory) / "hub"
+            repository = cache / "models--example--hybrid"
+            (repository / "refs").mkdir(parents=True)
+            (repository / "refs/main").write_text("revision", encoding="utf-8")
+            snapshot = repository / "snapshots/revision"
+            snapshot.mkdir(parents=True)
+            (snapshot / "config.json").write_text(
+                json.dumps({"model_type": "deepseek_v4"}),
+                encoding="utf-8",
+            )
+
+            self.assertTrue(
+                model_allows_safe_partial_cache_miss(
+                    "example/hybrid",
+                    environ={
+                        "HUGGINGFACE_HUB_CACHE": str(cache),
+                        "HOME": directory,
+                    },
+                )
+            )
+
+    def test_recurrent_cache_policy_resolves_mac_cache_models_layout(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cache = Path(directory) / "curated"
+            checkpoint = cache / "models/example/hybrid"
+            checkpoint.mkdir(parents=True)
+            (checkpoint / "config.json").write_text(
+                json.dumps({"text_config": {"layer_types": ["mamba"]}}),
+                encoding="utf-8",
+            )
+
+            self.assertTrue(
+                model_allows_safe_partial_cache_miss(
+                    "example/hybrid",
+                    environ={
+                        "MACAFM_MLX_MODEL_CACHE": str(cache),
+                        "HOME": directory,
+                    },
+                )
+            )
 
     def test_server_load_failure_records_every_prompt_with_engine_metadata(self):
         records = failed_run_records(


### PR DESCRIPTION
Closes #231.

## Problem
The model evaluation harness treated correctness-preserving cold fallback on recurrent/hybrid caches as a protocol failure, and two Qwen array tool-call assertions did not force or precisely validate the requested call. Reassessment also needed to preserve raw evidence.

## Approach
- detect recurrent/hybrid cache policy from the loaded checkpoint across AFM-compatible cache layouts
- require explicit per-expectation opt-in before accepting an exact zero-token safe cold fallback
- add non-destructive reassessment with provenance and hardlink protection
- make Qwen array prompts require exactly one `todowrite` call and validate the ordered JSON array
- clarify AI intent and report classification metadata

## Validation
- `bash -n Scripts/mlx-model-test.sh Scripts/test-assertions.sh`
- `PYTHONPATH=Scripts python3 -m unittest Scripts/test_mlx_model_test_oracle.py` (21 tests)
- `python3 -m py_compile Scripts/mlx_model_test_oracle.py Scripts/reassess_mlx_results.py`
- `git diff --check`
- independent sub-agent review: approved with no remaining blockers

## Summary by Sourcery

Make MLX evaluation oracles cache-aware and tighten array tool-call validation while preserving and enriching reassessment evidence.

New Features:
- Add recurrent and hybrid cache awareness to evaluation scenarios, including explicit opt-in for accepting a safe zero-token cold fallback.
- Add a standalone tool for reassessing recorded MLX results while preserving raw evidence and recording cache-policy provenance.
- Strengthen Qwen array tool-call checks to require one `todowrite` call with the exact ordered JSON array in both regular and streaming tests.

Bug Fixes:
- Prevent correctness-preserving cold cache fallbacks from being incorrectly classified as evaluation failures.
- Correct tool-call assertions that previously accepted missing, incorrect, or imprecise array tool calls.

Enhancements:
- Classify reassessed results with updated assertion and failure metadata.
- Resolve cache policy from checkpoint configurations across supported local and Hugging Face cache layouts.

Tests:
- Expand oracle coverage for recurrent-cache handling, checkpoint discovery, reassessment provenance, and protection against hardlinked outputs.