### PR TITLE
Add explicit cache policy reinspection

### DIFF
--- a/Scripts/mlx_model_test_oracle.py
+++ b/Scripts/mlx_model_test_oracle.py
@@ -32,8 +32,8 @@ def configuration_allows_safe_partial_cache_miss(config):
     )
 
 
-def model_allows_safe_partial_cache_miss(model, environ=None):
-    """Inspect a local checkpoint without depending on a running AFM server."""
+def inspect_model_safe_partial_cache_miss(model, environ=None):
+    """Return a local checkpoint's cache policy, or None when it cannot be inspected."""
     environ = os.environ if environ is None else environ
     model_path = Path(model).expanduser()
     candidates = [model_path / "config.json"]
@@ -74,7 +74,12 @@ def model_allows_safe_partial_cache_miss(model, environ=None):
         except (OSError, json.JSONDecodeError):
             continue
         return configuration_allows_safe_partial_cache_miss(config)
-    return False
+    return None
+
+
+def model_allows_safe_partial_cache_miss(model, environ=None):
+    """Inspect a local checkpoint without depending on a running AFM server."""
+    return inspect_model_safe_partial_cache_miss(model, environ=environ) is True
 
 
 def evaluation_lane(*, model, afm_args="", is_baseline=False, has_expectation=True):

--- a/Scripts/reassess_mlx_results.py
+++ b/Scripts/reassess_mlx_results.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from mlx_model_test_oracle import (
     classify_result_likelihood,
     evaluate_expectations,
+    inspect_model_safe_partial_cache_miss,
     model_allows_safe_partial_cache_miss,
 )
 
@@ -21,7 +22,12 @@ def paths_refer_to_same_file(input_path, output_path):
         return False
 
 
-def reassess_record(record, *, safe_cache_labels=frozenset()):
+def reassess_record(
+    record,
+    *,
+    safe_cache_labels=frozenset(),
+    reinspect_cache_policy=False,
+):
     if record.get("_meta"):
         updated = dict(record)
         updated["oracle_reassessment"] = "recurrent-cache-aware-v1"
@@ -30,7 +36,26 @@ def reassess_record(record, *, safe_cache_labels=frozenset()):
         return record
 
     updated = dict(record)
-    if "safe_partial_cache_miss" in record:
+    if reinspect_cache_policy:
+        inspected_policy = inspect_model_safe_partial_cache_miss(
+            record.get("model", "")
+        )
+        if inspected_policy is None:
+            if "safe_partial_cache_miss" not in record:
+                raise ValueError(
+                    "cache policy reinspection unavailable and record has no "
+                    f"captured policy for model {record.get('model', '')!r}"
+                )
+            safe_partial_cache_miss = bool(record["safe_partial_cache_miss"])
+            updated["cache_policy_provenance"] = (
+                "recorded-result-reinspection-unavailable"
+            )
+        else:
+            safe_partial_cache_miss = inspected_policy
+            updated["cache_policy_provenance"] = (
+                "explicit-local-checkpoint-reinspection"
+            )
+    elif "safe_partial_cache_miss" in record:
         safe_partial_cache_miss = bool(record["safe_partial_cache_miss"])
         updated["cache_policy_provenance"] = "recorded-result"
     else:
@@ -83,6 +108,14 @@ def main():
         default=[],
         help="explicit scenario label allowed to use recurrent safe cold fallback",
     )
+    parser.add_argument(
+        "--reinspect-cache-policy",
+        action="store_true",
+        help=(
+            "derive cache policy from the local checkpoint even when the input "
+            "record contains a previously captured policy"
+        ),
+    )
     args = parser.parse_args()
 
     if paths_refer_to_same_file(args.input, args.output):
@@ -98,9 +131,12 @@ def main():
                     reassess_record(
                         json.loads(line),
                         safe_cache_labels=frozenset(args.allow_safe_partial_cache_label),
+                        reinspect_cache_policy=args.reinspect_cache_policy,
                     )
                 )
             except json.JSONDecodeError as error:
+                raise SystemExit(f"{args.input}:{line_number}: {error}") from error
+            except ValueError as error:
                 raise SystemExit(f"{args.input}:{line_number}: {error}") from error
 
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/Scripts/test_mlx_model_test_oracle.py
+++ b/Scripts/test_mlx_model_test_oracle.py
@@ -1,5 +1,7 @@
 import json
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -72,6 +74,127 @@ class ModelTestOracleTests(unittest.TestCase):
 
         self.assertEqual(updated["overall_status"], "pass")
         self.assertEqual(updated["cache_policy_provenance"], "recorded-result")
+
+    def test_reassessment_can_explicitly_reinspect_stale_recorded_cache_policy(self):
+        with tempfile.TemporaryDirectory() as directory:
+            model = Path(directory) / "model"
+            model.mkdir()
+            (model / "config.json").write_text(
+                json.dumps({"model_type": "deepseek_v4"}),
+                encoding="utf-8",
+            )
+            record = {
+                "model": str(model),
+                "label": "agent-cached-sequence",
+                "status": "OK",
+                "content": "ok",
+                "finish_reason": "stop",
+                "cached_input_tokens": 0,
+                "safe_partial_cache_miss": False,
+                "expect": {"cached_input_tokens_min": 1},
+            }
+
+            updated = reassess_record(
+                record,
+                safe_cache_labels=frozenset({"agent-cached-sequence"}),
+                reinspect_cache_policy=True,
+            )
+
+        self.assertEqual(updated["overall_status"], "pass")
+        self.assertEqual(updated["assertion_failures"], [])
+        self.assertTrue(updated["safe_partial_cache_miss"])
+        self.assertEqual(
+            updated["cache_policy_provenance"],
+            "explicit-local-checkpoint-reinspection",
+        )
+
+    def test_reinspection_preserves_recorded_policy_when_checkpoint_is_missing(self):
+        record = {
+            "model": "missing/model",
+            "label": "agent-cached-sequence",
+            "status": "OK",
+            "content": "ok",
+            "finish_reason": "stop",
+            "cached_input_tokens": 0,
+            "safe_partial_cache_miss": True,
+            "expect": {
+                "cached_input_tokens_min": 1,
+                "allow_safe_partial_cache_miss": True,
+            },
+        }
+
+        updated = reassess_record(record, reinspect_cache_policy=True)
+
+        self.assertEqual(updated["overall_status"], "pass")
+        self.assertTrue(updated["safe_partial_cache_miss"])
+        self.assertEqual(
+            updated["cache_policy_provenance"],
+            "recorded-result-reinspection-unavailable",
+        )
+
+    def test_reinspection_preserves_recorded_policy_when_config_is_malformed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            model = Path(directory) / "model"
+            model.mkdir()
+            (model / "config.json").write_text("{not-json", encoding="utf-8")
+            record = {
+                "model": str(model),
+                "label": "agent-cached-sequence",
+                "status": "OK",
+                "content": "ok",
+                "finish_reason": "stop",
+                "cached_input_tokens": 0,
+                "safe_partial_cache_miss": True,
+                "expect": {
+                    "cached_input_tokens_min": 1,
+                    "allow_safe_partial_cache_miss": True,
+                },
+            }
+
+            updated = reassess_record(record, reinspect_cache_policy=True)
+
+        self.assertEqual(updated["overall_status"], "pass")
+        self.assertEqual(
+            updated["cache_policy_provenance"],
+            "recorded-result-reinspection-unavailable",
+        )
+
+    def test_reinspection_cli_fails_when_no_policy_can_be_established(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source.jsonl"
+            output = root / "output.jsonl"
+            source.write_text(
+                json.dumps(
+                    {
+                        "model": "missing/model",
+                        "label": "agent-cached-sequence",
+                        "status": "OK",
+                        "content": "ok",
+                        "finish_reason": "stop",
+                        "cached_input_tokens": 0,
+                        "expect": {"cached_input_tokens_min": 1},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("reassess_mlx_results.py")),
+                    "--reinspect-cache-policy",
+                    str(source),
+                    str(output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("reinspection unavailable", completed.stderr)
 
     def test_reassessment_rejects_hardlinked_output(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Problem

Historical raw eval records can contain a stale cache-policy classification. Reassessment correctly preserves recorded policy by default, but needed a transparent opt-in path to repair derived reports without altering raw inference data.

## Approach

- Add `--reinspect-cache-policy` to derive policy from the local checkpoint even when a record contains a policy
- Record `explicit-local-checkpoint-reinspection` provenance
- Preserve the existing recorded-policy-first default
- Add regression coverage for overriding a stale false policy on DeepSeek V4

## Validation

- 22 oracle/reassessment unit tests pass
- Python compile checks pass
- `git diff --check`
- DeepSeek derived reassessment: 84 pass, 1 fail, 6 skip; all three cache-sequence records now pass with explicit provenance

Closes #234.

## Summary by Sourcery

Add explicit cache-policy reinspection to repair derived reassessment results without changing recorded inference data.

New Features:
- Add an opt-in reassessment mode that derives cache policy from the local model checkpoint and records its provenance.

Bug Fixes:
- Allow stale recorded cache-policy classifications to be corrected while preserving raw inference records.

Enhancements:
- Preserve recorded-policy precedence by default and fall back safely when checkpoint inspection is unavailable.

Tests:
- Add regression coverage for stale-policy correction, unavailable or malformed checkpoints, and CLI failure when no policy can be established.