### PR TITLE
Preserve evaluation intent during reanalysis

### DIFF
--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -158,6 +158,14 @@ NO_REPORT=false
 TEST_INDICES=""
 CLI_AFM_ARGS=""
 OVERALL_STATUS=0
+RECOVERED_PROMPTS_TEMP=""
+
+cleanup_recovered_prompts() {
+  if [ -n "$RECOVERED_PROMPTS_TEMP" ]; then
+    rm -f "$RECOVERED_PROMPTS_TEMP"
+  fi
+}
+trap cleanup_recovered_prompts EXIT
 
 # Parse arguments
 args=("$@")
@@ -484,6 +492,49 @@ fi
 # ── Reanalyse mode: skip tests, jump straight to smart analysis + report ──
 if [ -n "$REANALYSE_FILE" ]; then
   RESULTS_FILE="$REANALYSE_FILE"
+  if [ -z "$PROMPTS_FILE" ]; then
+    RECORDED_PROMPTS_FILE=$(PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c '
+import sys
+from mlx_model_test_config import materialize_verified_prompts_snapshot
+try:
+    snapshot = materialize_verified_prompts_snapshot(sys.argv[1])
+except (OSError, ValueError) as error:
+    print(f"Error: {error}", file=sys.stderr)
+    raise SystemExit(2)
+print(snapshot or "")
+' "$RESULTS_FILE")
+    RECORDED_PROMPTS_STATUS=$?
+    if [ "$RECORDED_PROMPTS_STATUS" -ne 0 ]; then
+      echo "Error: recorded prompt snapshot verification failed; pass --prompts explicitly to override" >&2
+      exit 1
+    elif [ -n "$RECORDED_PROMPTS_FILE" ]; then
+      PROMPTS_FILE="$RECORDED_PROMPTS_FILE"
+      RECOVERED_PROMPTS_TEMP="$RECORDED_PROMPTS_FILE"
+      echo "Recovered verified prompt snapshot from result metadata: $PROMPTS_FILE"
+    else
+      RECORDED_RUN_USED_PROMPTS=$(PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c '
+import sys
+from mlx_model_test_config import results_metadata_declares_prompts
+try:
+    declared = results_metadata_declares_prompts(sys.argv[1])
+except (OSError, ValueError) as error:
+    print(f"Error: {error}", file=sys.stderr)
+    raise SystemExit(2)
+print("true" if declared else "false")
+' "$RESULTS_FILE")
+      RECORDED_RUN_STATUS=$?
+      if [ "$RECORDED_RUN_STATUS" -ne 0 ]; then
+        echo "Error: result metadata cannot safely determine prompt provenance" >&2
+        echo "Pass --prompts explicitly to override" >&2
+        exit 1
+      elif [ "$RECORDED_RUN_USED_PROMPTS" = "true" ]; then
+        echo "Error: legacy results used a prompts file but contain no verified snapshot" >&2
+        echo "Pass --prompts explicitly to preserve test intent during reanalysis" >&2
+        exit 1
+      fi
+      echo "Note: results contain no prompt spec; using generic quality judging" >&2
+    fi
+  fi
   line_count=$(wc -l < "$RESULTS_FILE" | tr -d ' ')
   echo "=== Re-analysing existing results: $RESULTS_FILE ($line_count lines) ==="
   echo ""
@@ -509,10 +560,55 @@ AFM_VERSION=$("$AFM" --version 2>/dev/null || echo "unknown")
 AFM_RESOLVED_PATH=$(command -v "$AFM" 2>/dev/null || printf '%s' "$AFM")
 AFM_BINARY_DIGEST=$(shasum -a 256 "$AFM_RESOLVED_PATH" | awk '{print $1}')
 TEST_COMMAND="mlx-model-test.sh $*"
-export AFM_VERSION AFM_RESOLVED_PATH AFM_BINARY_DIGEST TEST_COMMAND
+PROMPTS_FILE_METADATA=""
+PROMPTS_SNAPSHOT_NAME=""
+PROMPTS_FILE_SHA256=""
+if [ -n "$PROMPTS_FILE" ]; then
+  PROMPTS_FILE_METADATA=$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve())' "$PROMPTS_FILE")
+  PROMPTS_SNAPSHOT_CAPTURE=$(PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c '
+import json
+import sys
+from mlx_model_test_config import capture_prompts_snapshot
+
+try:
+    snapshot, digest = capture_prompts_snapshot(sys.argv[1], sys.argv[2])
+except (OSError, ValueError) as error:
+    print(f"Error: failed to capture prompt snapshot: {error}", file=sys.stderr)
+    raise SystemExit(2)
+print(json.dumps({"path": str(snapshot), "sha256": digest}))
+' "$PROMPTS_FILE" "$RESULTS_FILE")
+  PROMPTS_SNAPSHOT_STATUS=$?
+  if [ "$PROMPTS_SNAPSHOT_STATUS" -ne 0 ]; then
+    exit 1
+  fi
+  PROMPTS_SNAPSHOT_PATH=$(python3 -c 'import json, sys; print(json.loads(sys.argv[1])["path"])' "$PROMPTS_SNAPSHOT_CAPTURE")
+  PROMPTS_FILE_SHA256=$(python3 -c 'import json, sys; print(json.loads(sys.argv[1])["sha256"])' "$PROMPTS_SNAPSHOT_CAPTURE")
+  PROMPTS_SNAPSHOT_NAME=$(basename "$PROMPTS_SNAPSHOT_PATH")
+  PROMPTS_FILE="$PROMPTS_SNAPSHOT_PATH"
+fi
+export AFM_VERSION AFM_RESOLVED_PATH AFM_BINARY_DIGEST TEST_COMMAND PROMPTS_FILE_METADATA
+export PROMPTS_SNAPSHOT_NAME PROMPTS_FILE_SHA256
 
 # Write metadata record as first JSONL line
-echo "{\"_meta\":true,\"afm_version\":\"$AFM_VERSION\",\"test_command\":\"$TEST_COMMAND\",\"afm_binary\":\"$AFM_RESOLVED_PATH\",\"afm_binary_sha256\":\"$AFM_BINARY_DIGEST\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "$RESULTS_FILE"
+python3 -c '
+import datetime
+import json
+import os
+
+record = {
+    "_meta": True,
+    "afm_version": os.environ["AFM_VERSION"],
+    "test_command": os.environ["TEST_COMMAND"],
+    "afm_binary": os.environ["AFM_RESOLVED_PATH"],
+    "afm_binary_sha256": os.environ["AFM_BINARY_DIGEST"],
+    "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+}
+if os.environ.get("PROMPTS_FILE_METADATA"):
+    record["prompts_file"] = os.environ["PROMPTS_FILE_METADATA"]
+    record["prompts_snapshot"] = os.environ["PROMPTS_SNAPSHOT_NAME"]
+    record["prompts_sha256"] = os.environ["PROMPTS_FILE_SHA256"]
+print(json.dumps(record, separators=(",", ":")))
+' >> "$RESULTS_FILE"
 
 # ── Parse prompts file into JSON config ───────────────────────────────────────
 
@@ -1767,10 +1863,11 @@ PER_TEST_PROMPT_END
   for tool in "${SMART_TOOL_LIST[@]}"; do
     echo "=== Running AI analysis with: $tool ==="
     SMART_REPORT="$(pwd)/test-reports/smart-analysis-${tool}-${SMART_TIMESTAMP}.md"
+    mkdir -p "$(dirname "$SMART_REPORT")"
 
     # ── SMART_BATCH=1: per-test mode ──────────────────────────────────────
     if [ "$SMART_BATCH" = "1" ]; then
-      PERTEST_SCORES_DIR="$(mktemp -d /tmp/smart-pertest-XXXXXX)"
+      PERTEST_SCORES_DIR="$(mktemp -d "$(dirname "$SMART_REPORT")/.smart-pertest-XXXXXX")"
       total_lines=$(python3 -c "
 import json, sys
 print(sum(1 for line in open(sys.argv[1]) if line.strip() and not json.loads(line).get('_meta')))
@@ -1866,11 +1963,20 @@ print(payload['score'] if payload else '?')
 
       echo "  Assembling per-test report..."
 
-      PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" \
+      SMART_REPORT_TMP=$(mktemp "$(dirname "$SMART_REPORT")/.smart-analysis-XXXXXX.md")
+      if PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" \
         python3 "$SCRIPT_DIR/assemble_smart_report.py" \
-        "$PERTEST_SCORES_DIR" "$RESULTS_FILE" > "$SMART_REPORT"
-
-      rm -rf "$PERTEST_SCORES_DIR"
+        "$PERTEST_SCORES_DIR" "$RESULTS_FILE" > "$SMART_REPORT_TMP" && \
+        PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c \
+          'import sys; from mlx_model_test_config import publish_report_atomically; publish_report_atomically(sys.argv[1], sys.argv[2])' \
+          "$SMART_REPORT_TMP" "$SMART_REPORT"; then
+        rm -rf "$PERTEST_SCORES_DIR"
+      else
+        rm -f "$SMART_REPORT_TMP"
+        echo "  Error: failed to assemble per-test report" >&2
+        echo "  Preserved per-test scores: $PERTEST_SCORES_DIR" >&2
+        exit 1
+      fi
 
     # ── SMART_BATCH=0: one big swoop (default) ───────────────────────────
     else

--- a/Scripts/mlx_model_test_config.py
+++ b/Scripts/mlx_model_test_config.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
+import os
 import re
+import shlex
+import stat
+import tempfile
 from pathlib import Path
 
 
@@ -25,6 +30,135 @@ FLOAT_PARAMETERS = {
 }
 BOOLEAN_PARAMETERS = {"logprobs"}
 JSON_PARAMETERS = {"tools", "expect", "expect_by_prompt"}
+
+
+def capture_prompts_snapshot(
+    prompts_file: str | Path, results_file: str | Path
+) -> tuple[Path, str]:
+    """Atomically snapshot the exact prompt bytes that inference will consume."""
+    source_path = Path(prompts_file)
+    results_path = Path(results_file).resolve()
+    destination = (
+        results_path.with_suffix(".prompts.txt")
+        if results_path.suffix == ".jsonl"
+        else Path(f"{results_path}.prompts.txt")
+    )
+    contents = source_path.read_bytes()
+    digest = hashlib.sha256(contents).hexdigest()
+
+    temporary_descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(temporary_descriptor, "wb") as handle:
+            handle.write(contents)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, destination)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+    if destination.is_symlink() or not destination.is_file():
+        raise ValueError("captured prompt snapshot is not a regular file")
+    if hashlib.sha256(destination.read_bytes()).hexdigest() != digest:
+        raise ValueError("captured prompt snapshot failed digest verification")
+    return destination, digest
+
+
+def publish_report_atomically(temporary_file: str | Path, report_file: str | Path) -> None:
+    """Publish a completed report without accepting a directory as its target."""
+    temporary_path = Path(temporary_file)
+    report_path = Path(report_file)
+    if report_path.is_dir():
+        raise IsADirectoryError(f"report destination is a directory: {report_path}")
+    os.replace(temporary_path, report_path)
+
+
+def materialize_verified_prompts_snapshot(filepath: str | Path) -> Path | None:
+    """Copy a verified sibling prompt snapshot to a private judge input file."""
+    results_path = Path(filepath).resolve()
+    with Path(filepath).open(encoding="utf-8") as handle:
+        for raw_line in handle:
+            if not raw_line.strip():
+                continue
+            record = json.loads(raw_line)
+            if not record.get("_meta"):
+                return None
+
+            snapshot_name = record.get("prompts_snapshot")
+            expected_digest = record.get("prompts_sha256")
+            if not isinstance(snapshot_name, str) or not isinstance(
+                expected_digest, str
+            ):
+                return None
+            if Path(snapshot_name).name != snapshot_name:
+                raise ValueError("prompt snapshot must be a sibling of the results file")
+            if not re.fullmatch(r"[0-9a-f]{64}", expected_digest):
+                raise ValueError("prompt snapshot metadata has an invalid SHA-256 digest")
+
+            snapshot_path = results_path.parent / snapshot_name
+            try:
+                descriptor = os.open(snapshot_path, os.O_RDONLY | os.O_NOFOLLOW)
+            except OSError as error:
+                raise ValueError(
+                    f"prompt snapshot is unavailable or unsafe: {snapshot_path}"
+                ) from error
+            try:
+                snapshot_stat = os.fstat(descriptor)
+                if not stat.S_ISREG(snapshot_stat.st_mode):
+                    raise ValueError("prompt snapshot must be a regular file")
+                with os.fdopen(descriptor, "rb", closefd=False) as handle:
+                    contents = handle.read()
+            finally:
+                os.close(descriptor)
+
+            actual_digest = hashlib.sha256(contents).hexdigest()
+            if actual_digest != expected_digest:
+                raise ValueError(
+                    f"prompt snapshot digest mismatch: expected {expected_digest}, "
+                    f"got {actual_digest}"
+                )
+
+            report_directory = results_path.parent / "test-reports"
+            report_directory.mkdir(parents=True, exist_ok=True)
+            copy_descriptor, copy_path = tempfile.mkstemp(
+                prefix=".verified-prompts-",
+                suffix=".txt",
+                dir=report_directory,
+            )
+            with os.fdopen(copy_descriptor, "wb") as copy_handle:
+                copy_handle.write(contents)
+            return Path(copy_path)
+    return None
+
+
+def results_metadata_declares_prompts(filepath: str | Path) -> bool:
+    """Return whether a run metadata record says it used a prompts file."""
+    with Path(filepath).open(encoding="utf-8") as handle:
+        for raw_line in handle:
+            if not raw_line.strip():
+                continue
+            record = json.loads(raw_line)
+            if not record.get("_meta"):
+                return False
+            if record.get("prompts_file") or record.get("prompts_snapshot"):
+                return True
+            command = record.get("test_command", "")
+            if not isinstance(command, str):
+                return False
+            try:
+                arguments = shlex.split(command)
+            except ValueError as error:
+                raise ValueError("legacy test command metadata is malformed") from error
+            return any(
+                argument == "--prompts" or argument.startswith("--prompts=")
+                for argument in arguments
+            )
+    return False
 
 
 def _json_string(value: str, parameter: str) -> str:

--- a/Scripts/test_mlx_model_test_config.py
+++ b/Scripts/test_mlx_model_test_config.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import tempfile
 import unittest
@@ -5,9 +6,13 @@ from pathlib import Path
 
 from mlx_model_test_config import (
     ai_intent_for_result,
+    capture_prompts_snapshot,
     expand_template_runs,
+    materialize_verified_prompts_snapshot,
     parse_ai_intent_specs,
     parse_prompts_file,
+    publish_report_atomically,
+    results_metadata_declares_prompts,
 )
 
 
@@ -70,6 +75,179 @@ class MLXModelTestConfigTests(unittest.TestCase):
         self.assertEqual(ai_intent_for_result(specs, "a/model", "shared"), ["model A intent"])
         self.assertEqual(ai_intent_for_result(specs, "b/model", "shared"), ["model B intent"])
         self.assertEqual(ai_intent_for_result(specs, "any/model", "common"), ["template intent"])
+
+    def test_prompts_snapshot_is_recovered_after_digest_verification(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results = Path(directory) / "results.jsonl"
+            snapshot = Path(directory) / "results.prompts.txt"
+            snapshot.write_text("# AI: expected behavior\n", encoding="utf-8")
+            digest = hashlib.sha256(snapshot.read_bytes()).hexdigest()
+            results.write_text(
+                json.dumps(
+                    {
+                        "_meta": True,
+                        "prompts_snapshot": snapshot.name,
+                        "prompts_sha256": digest,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            verified_copy = materialize_verified_prompts_snapshot(results)
+            self.assertIsNotNone(verified_copy)
+            self.assertEqual(verified_copy.read_bytes(), snapshot.read_bytes())
+            self.assertEqual(verified_copy.parent, results.resolve().parent / "test-reports")
+            verified_copy.unlink()
+
+    def test_capture_prompts_snapshot_is_atomic_and_uses_captured_bytes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            prompts = Path(directory) / "prompts.txt"
+            results = Path(directory) / "run.jsonl"
+            prompts.write_text("# AI: original intent\n", encoding="utf-8")
+
+            snapshot, digest = capture_prompts_snapshot(prompts, results)
+            prompts.write_text("# AI: changed later\n", encoding="utf-8")
+
+            self.assertEqual(snapshot, Path(directory).resolve() / "run.prompts.txt")
+            self.assertEqual(snapshot.read_text(encoding="utf-8"), "# AI: original intent\n")
+            self.assertEqual(digest, hashlib.sha256(snapshot.read_bytes()).hexdigest())
+
+    def test_capture_prompts_snapshot_rejects_destination_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            prompts = Path(directory) / "prompts.txt"
+            results = Path(directory) / "run.jsonl"
+            prompts.write_text("# AI: intent\n", encoding="utf-8")
+            (Path(directory) / "run.prompts.txt").mkdir()
+
+            with self.assertRaises(OSError):
+                capture_prompts_snapshot(prompts, results)
+            self.assertEqual(
+                list(Path(directory).glob(".run.prompts.txt.*.tmp")),
+                [],
+            )
+
+    def test_atomic_report_publish_rejects_destination_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            temporary_report = Path(directory) / ".report.tmp"
+            report = Path(directory) / "report.md"
+            temporary_report.write_text("complete report\n", encoding="utf-8")
+            report.mkdir()
+
+            with self.assertRaises(IsADirectoryError):
+                publish_report_atomically(temporary_report, report)
+            self.assertTrue(temporary_report.is_file())
+            self.assertTrue(report.is_dir())
+
+    def test_atomic_report_publish_replaces_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            temporary_report = Path(directory) / ".report.tmp"
+            report = Path(directory) / "report.md"
+            temporary_report.write_text("complete report\n", encoding="utf-8")
+            report.write_text("old report\n", encoding="utf-8")
+
+            publish_report_atomically(temporary_report, report)
+
+            self.assertFalse(temporary_report.exists())
+            self.assertEqual(report.read_text(encoding="utf-8"), "complete report\n")
+
+    def test_prompts_snapshot_rejects_path_traversal(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results = Path(directory) / "results.jsonl"
+            results.write_text(
+                json.dumps(
+                    {
+                        "_meta": True,
+                        "prompts_snapshot": "../private.txt",
+                        "prompts_sha256": "0" * 64,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "must be a sibling"):
+                materialize_verified_prompts_snapshot(results)
+
+    def test_prompts_snapshot_rejects_digest_mismatch(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results = Path(directory) / "results.jsonl"
+            snapshot = Path(directory) / "results.prompts.txt"
+            snapshot.write_text("changed expectations\n", encoding="utf-8")
+            results.write_text(
+                json.dumps(
+                    {
+                        "_meta": True,
+                        "prompts_snapshot": snapshot.name,
+                        "prompts_sha256": "0" * 64,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "digest mismatch"):
+                materialize_verified_prompts_snapshot(results)
+
+    def test_prompts_snapshot_rejects_symlink(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results = Path(directory) / "results.jsonl"
+            outside = Path(directory).parent / f"{Path(directory).name}-outside-prompts.txt"
+            outside.write_text("private contents\n", encoding="utf-8")
+            snapshot = Path(directory) / "results.prompts.txt"
+            snapshot.symlink_to(outside)
+            digest = hashlib.sha256(outside.read_bytes()).hexdigest()
+            results.write_text(
+                json.dumps(
+                    {
+                        "_meta": True,
+                        "prompts_snapshot": snapshot.name,
+                        "prompts_sha256": digest,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            try:
+                with self.assertRaisesRegex(ValueError, "unavailable or unsafe"):
+                    materialize_verified_prompts_snapshot(results)
+            finally:
+                outside.unlink()
+
+    def test_legacy_metadata_declares_prompts_without_dereferencing_path(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results = Path(directory) / "results.jsonl"
+            results.write_text(
+                json.dumps(
+                    {
+                        "_meta": True,
+                        "test_command": "mlx-model-test.sh --prompts /private/file.txt",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertTrue(results_metadata_declares_prompts(results))
+            self.assertIsNone(materialize_verified_prompts_snapshot(results))
+
+    def test_malformed_legacy_command_fails_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            results = Path(directory) / "results.jsonl"
+            results.write_text(
+                json.dumps(
+                    {
+                        "_meta": True,
+                        "test_command": "mlx-model-test.sh --prompts 'unterminated",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "metadata is malformed"):
+                results_metadata_declares_prompts(results)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #236.

## Problem
JSONL reanalysis could silently omit the original prompt/test intent, and per-test score assembly assumed `test-reports/` already existed. An assembly error then discarded the completed temporary score files.

## Approach
- atomically snapshot the exact prompt bytes inference consumes beside each new JSONL result and record SHA-256 provenance
- recover only a verified sibling regular-file snapshot using no-follow I/O, then judge from a private verified copy
- fail closed for legacy prompt-based results unless `--prompts` is supplied explicitly
- create report directories before judging
- assemble and publish reports atomically; preserve failed per-test scores under `test-reports/`
- encode run metadata with Python JSON rather than string interpolation

## Validation
- `bash -n Scripts/mlx-model-test.sh`
- 44 focused Python tests, including symlink, digest-mismatch, path-traversal, malformed metadata, snapshot destination collision, and report publication collision
- Python bytecode compilation
- `git diff --check`
- manual legacy-results check confirms missing snapshots fail before Codex scoring
- manual shell snapshot-collision check aborts before inference
- independent sub-agent adversarial review and follow-up review

No GitHub Actions are required.