### PR TITLE
Update AFMKit to 0.1.12

### DIFF
--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.11"
+        exact: "0.1.12"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "32644ce23bf144200297779ca55feb9741b3c8496852c4c4027fbd9b1e26ad8a",
+  "originHash" : "102a2332ab25954fc0ba1e1c21e9e2c02214d978c90b84da1b038f9622d6c600",
   "pins" : [
     {
       "identity" : "afmkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "e98c756a25fa78662a924d14d823039b90cb0587",
-        "version" : "0.1.11"
+        "revision" : "415e2c52a4f4db776a12b88fb1e0a1ba4a32e7b5",
+        "version" : "0.1.12"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.11"
+        exact: "0.1.12"
     )
 }
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -145,8 +145,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.11":
-        fail(f"{identity} must resolve the exact 0.1.11 release")
+    if pin["state"].get("version") != "0.1.12":
+        fail(f"{identity} must resolve the exact 0.1.12 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -289,7 +289,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.11"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.12"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.11",
+    "afmkit": "0.1.12",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -61,13 +61,13 @@ cat > "$fake_public_git" <<'SH'
 #!/usr/bin/env bash
 arguments=" $* "
 for ref in \
-  refs/tags/0.1.11 \
-  'refs/tags/0.1.11^{}' \
-  refs/tags/v0.1.11 \
-  'refs/tags/v0.1.11^{}'; do
+  refs/tags/0.1.12 \
+  'refs/tags/0.1.12^{}' \
+  refs/tags/v0.1.12 \
+  'refs/tags/v0.1.12^{}'; do
   [[ "$arguments" == *" $ref "* ]] || exit 2
 done
-printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.11^{}'
+printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.12^{}'
 SH
 chmod 700 "$fake_public_git"
 if ! EXPECTED_AFMKIT_REVISION="$expected_afmkit_revision" \
@@ -87,7 +87,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.11'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.12'
   }
   probe_public_source() {
     return 1
@@ -111,14 +111,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.11" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.11"
+[[ "$release_version" == "0.1.12" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.12"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.11'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.12'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -137,7 +137,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.11'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.12'
   }
   probe_public_source() {
     return 0

--- a/docs/afmkit-url-consumption.md
+++ b/docs/afmkit-url-consumption.md
@@ -6,7 +6,7 @@ one exact release and selects every provider product from it:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.11"
+    exact: "0.1.12"
 )
 ```
 
@@ -14,7 +14,7 @@ Do not use a branch or revision requirement for release builds.
 
 ## Production Blocker
 
-AFMKit is public and exposes `0.1.11`. AFM release publication remains
+AFMKit is public and exposes `0.1.12`. AFM release publication remains
 fail-closed unless AFMKit and every dependency in its root graph are
 anonymously readable and the tracked lock resolves that exact tag.
 
@@ -38,7 +38,7 @@ surface publishable.
 
 ## Dependency Resolution
 
-AFMKit 0.1.11 is public, so normal resolution requires no GitHub credential:
+AFMKit 0.1.12 is public, so normal resolution requires no GitHub credential:
 
 ```bash
 Scripts/resolve-release-dependencies.sh
@@ -55,7 +55,7 @@ The normal graph is independent of maclocal-api's dirty vendor worktrees:
 
 | Dependency | Requirement | Purpose |
 | --- | --- | --- |
-| `AFMKit` | exact `0.1.11` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
+| `AFMKit` | exact `0.1.12` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
 
 The MLX, mlx-c, Swift bindings, and mlx-swift-lm sources are snapshots inside
 AFMKit's `vendor/MLX` tree. They are not separate SwiftPM dependencies of

--- a/docs/vesta-integration.md
+++ b/docs/vesta-integration.md
@@ -11,7 +11,7 @@ Use the current exact public AFMKit release:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.11"
+    exact: "0.1.12"
 )
 ```
 


### PR DESCRIPTION
## Problem

maclocal-api was pinned to AFMKit 0.1.11 and could not consume the qualified GLM-5.3 Flash text, vision, and embedded-MTP support released in AFMKit 0.1.12.

## Approach

- Bump the single exact AFMKit dependency and lock to v0.1.12 / 415e2c52a4f4db776a12b88fb1e0a1ba4a32e7b5.
- Advance fail-closed consumer/release guards and their regression fixtures.
- Update the standalone consumer example and integration documentation.

No provider implementation is duplicated in maclocal-api.

## Validation

- AFMKit v0.1.12 release: 15 API baselines, 15 isolated XCTest targets, 91 case-isolated tests, Swift Testing, and 15 clean downstream consumers passed.
- `Scripts/resolve-release-dependencies.sh --refresh-lock`
- `Scripts/tests/test-release-tooling.sh`
- `Scripts/check-public-release-eligibility.sh`
- `Scripts/swiftpm-reliable.sh build -c release --product afm`
- `Scripts/swiftpm-reliable.sh test -c release`: XCTest 290 tests, 1 skip, 0 failures; Swift Testing 139 tests in 17 suites passed.

Implemented AFMKit issues #33, #35, #43, #44, and #47 are closed and annotated with the v0.1.12 release.

## Summary by Sourcery

Adopt AFMKit 0.1.12 across the project and update dependency guards, tooling fixtures, and integration guidance accordingly.

Enhancements:
- Update the project and standalone consumer to use the exact AFMKit 0.1.12 release, enabling its latest supported provider capabilities.
- Advance release eligibility and consumer-boundary checks to enforce the AFMKit 0.1.12 dependency.
- Refresh release-tooling regression fixtures for the new AFMKit release.

Build:
- Update the resolved AFMKit dependency to version 0.1.12 at its locked revision.

Documentation:
- Update AFMKit consumption and Vesta integration documentation for version 0.1.12.