### PR TITLE
Update AFMKit to 0.1.13

### DIFF
--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.12"
+        exact: "0.1.13"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "102a2332ab25954fc0ba1e1c21e9e2c02214d978c90b84da1b038f9622d6c600",
+  "originHash" : "a739ee70b3144e072b1ee26c2f5443c67f01ccf64cff2d600fc18e572623afd3",
   "pins" : [
     {
       "identity" : "afmkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "415e2c52a4f4db776a12b88fb1e0a1ba4a32e7b5",
-        "version" : "0.1.12"
+        "revision" : "8ab8cc9551249a43fbd9ba3afbd209e5bd81d77c",
+        "version" : "0.1.13"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.12"
+        exact: "0.1.13"
     )
 }
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -145,8 +145,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.12":
-        fail(f"{identity} must resolve the exact 0.1.12 release")
+    if pin["state"].get("version") != "0.1.13":
+        fail(f"{identity} must resolve the exact 0.1.13 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -289,7 +289,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.12"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.13"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.12",
+    "afmkit": "0.1.13",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -61,13 +61,13 @@ cat > "$fake_public_git" <<'SH'
 #!/usr/bin/env bash
 arguments=" $* "
 for ref in \
-  refs/tags/0.1.12 \
-  'refs/tags/0.1.12^{}' \
-  refs/tags/v0.1.12 \
-  'refs/tags/v0.1.12^{}'; do
+  refs/tags/0.1.13 \
+  'refs/tags/0.1.13^{}' \
+  refs/tags/v0.1.13 \
+  'refs/tags/v0.1.13^{}'; do
   [[ "$arguments" == *" $ref "* ]] || exit 2
 done
-printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.12^{}'
+printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.13^{}'
 SH
 chmod 700 "$fake_public_git"
 if ! EXPECTED_AFMKIT_REVISION="$expected_afmkit_revision" \
@@ -87,7 +87,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.12'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.13'
   }
   probe_public_source() {
     return 1
@@ -111,14 +111,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.12" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.12"
+[[ "$release_version" == "0.1.13" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.13"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.12'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.13'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -137,7 +137,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.12'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.13'
   }
   probe_public_source() {
     return 0

--- a/docs/afmkit-url-consumption.md
+++ b/docs/afmkit-url-consumption.md
@@ -6,7 +6,7 @@ one exact release and selects every provider product from it:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.12"
+    exact: "0.1.13"
 )
 ```
 
@@ -14,7 +14,7 @@ Do not use a branch or revision requirement for release builds.
 
 ## Production Blocker
 
-AFMKit is public and exposes `0.1.12`. AFM release publication remains
+AFMKit is public and exposes `0.1.13`. AFM release publication remains
 fail-closed unless AFMKit and every dependency in its root graph are
 anonymously readable and the tracked lock resolves that exact tag.
 
@@ -38,7 +38,7 @@ surface publishable.
 
 ## Dependency Resolution
 
-AFMKit 0.1.12 is public, so normal resolution requires no GitHub credential:
+AFMKit 0.1.13 is public, so normal resolution requires no GitHub credential:
 
 ```bash
 Scripts/resolve-release-dependencies.sh
@@ -55,7 +55,7 @@ The normal graph is independent of maclocal-api's dirty vendor worktrees:
 
 | Dependency | Requirement | Purpose |
 | --- | --- | --- |
-| `AFMKit` | exact `0.1.12` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
+| `AFMKit` | exact `0.1.13` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
 
 The MLX, mlx-c, Swift bindings, and mlx-swift-lm sources are snapshots inside
 AFMKit's `vendor/MLX` tree. They are not separate SwiftPM dependencies of

--- a/docs/vesta-integration.md
+++ b/docs/vesta-integration.md
@@ -11,7 +11,7 @@ Use the current exact public AFMKit release:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.12"
+    exact: "0.1.13"
 )
 ```
 


### PR DESCRIPTION
## Problem
maclocal-api 0.9.18 still pins AFMKit 0.1.12, which predates the speculative EOS fix required for correct GLM-5.3 Flash MTP termination.

## Approach
- Pin the single AFMKit package to exact v0.1.13 / `8ab8cc9551249a43fbd9ba3afbd209e5bd81d77c`.
- Refresh the tracked SwiftPM lock with the repository release resolver.
- Keep consumer boundary checks, public-release checks, examples, tests, and integration docs aligned with the exact package version.

## Validation
- `Scripts/swiftpm-reliable.sh build -c release --product afm`
- `Scripts/tests/test-release-tooling.sh`
- `Scripts/check-public-release-eligibility.sh`
- `.build/release/afm --version` → `v0.9.18`

AFMKit v0.1.13 independently passed its full local no-Actions release gate, all 15 downstream consumer products, and the full GLM MTP checkpoint returned exactly `GLM_MTP_OK` before release.

Related: scouzi1966/AFMKit#52

## Summary by Sourcery

Pin the project and its release tooling to AFMKit 0.1.13.

Bug Fixes:
- Update AFMKit to 0.1.13 to include the release needed for correct GLM-5.3 Flash MTP termination.

Enhancements:
- Refresh the SwiftPM lockfile and align consumer boundary and public-release validation with the exact AFMKit 0.1.13 release.

Documentation:
- Update AFMKit integration documentation and examples to reference exact version 0.1.13.

Tests:
- Update release-tooling tests to validate AFMKit 0.1.13 tags and version requirements.