### PR TITLE
Add OpenAI Responses and Anthropic Messages APIs

### DIFF
--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -82,6 +82,12 @@ struct ServeCommand: ParsableCommand {
     @Flag(name: .long, help: "Disable streaming responses (streaming is enabled by default)")
     var noStreaming: Bool = false
 
+    @Option(name: .long, help: "Maximum chat-shaped requests per client in each rate-limit window (0 disables; default: 600)")
+    var rateLimitRequests: Int = 600
+
+    @Option(name: .long, help: "Rate-limit window in seconds (default: 60)")
+    var rateLimitWindow: Double = 60
+
     @Option(name: [.short, .long], help: "Custom instructions for the AI assistant")
     var instructions: String = "You are a helpful assistant"
     
@@ -125,6 +131,12 @@ struct ServeCommand: ParsableCommand {
     var guidedJson: String?
 
     func run() throws {
+        guard rateLimitRequests >= 0 else {
+            throw ValidationError("--rate-limit-requests must be zero or greater")
+        }
+        guard rateLimitWindow > 0 else {
+            throw ValidationError("--rate-limit-window must be greater than zero")
+        }
         // Validate temperature parameter
         if let temp = temperature {
             guard temp >= 0.0 && temp <= 1.0 else {
@@ -199,7 +211,7 @@ struct ServeCommand: ParsableCommand {
         // Start server in async context
         _ = Task {
             do {
-                let server = try await Server(port: chosenPort, hostname: hostname, verbose: verbose, veryVerbose: veryVerbose || vv, trace: vv, streamingEnabled: !noStreaming, instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails, stop: stop, webuiEnabled: webui, gatewayEnabled: gateway, prewarmEnabled: prewarmEnabled, telegramConfiguration: telegramConfiguration, defaultGuidedJsonSchema: defaultGuidedJsonSchema)
+                let server = try await Server(port: chosenPort, hostname: hostname, verbose: verbose, veryVerbose: veryVerbose || vv, trace: vv, streamingEnabled: !noStreaming, instructions: instructions, adapter: adapter, temperature: temperature, randomness: randomness, permissiveGuardrails: permissiveGuardrails, stop: stop, webuiEnabled: webui, gatewayEnabled: gateway, prewarmEnabled: prewarmEnabled, telegramConfiguration: telegramConfiguration, defaultGuidedJsonSchema: defaultGuidedJsonSchema, rateLimitRequests: rateLimitRequests, rateLimitWindowSeconds: rateLimitWindow)
                 globalServer = server
                 try await server.start()
             } catch {
@@ -415,6 +427,12 @@ struct MlxCommand: ParsableCommand {
     @Flag(name: .long, help: "Disable streaming responses (streaming is enabled by default)")
     var noStreaming: Bool = false
 
+    @Option(name: .long, help: "Maximum chat-shaped requests per client in each rate-limit window (0 disables; default: 600)")
+    var rateLimitRequests: Int = 600
+
+    @Option(name: .long, help: "Rate-limit window in seconds (default: 60)")
+    var rateLimitWindow: Double = 60
+
     @Flag(name: .long, help: "Output raw model content without extracting <think> tags into reasoning_content")
     var raw: Bool = false
 
@@ -600,6 +618,13 @@ struct MlxCommand: ParsableCommand {
         if helpJson {
             printHelpJson(command: "afm mlx")
             return
+        }
+
+        guard rateLimitRequests >= 0 else {
+            throw ValidationError("--rate-limit-requests must be zero or greater")
+        }
+        guard rateLimitWindow > 0 else {
+            throw ValidationError("--rate-limit-window must be greater than zero")
         }
 
         let evaluationAction = try AFMEvaluationCLIPlan.resolve(
@@ -1055,7 +1080,9 @@ struct MlxCommand: ParsableCommand {
                     mlxPresencePenalty: presencePenalty,
                     mlxSeed: seed,
                     mlxMaxLogprobs: maxLogprobs,
-                    contextWindow: contextWindow
+                    contextWindow: contextWindow,
+                    rateLimitRequests: rateLimitRequests,
+                    rateLimitWindowSeconds: rateLimitWindow
                 )
                 globalServer = server
                 if !explicitPort && chosenPort != 9999 {
@@ -1326,7 +1353,9 @@ struct MlxCommand: ParsableCommand {
                     mlxMinP: minP,
                     mlxSeed: seed,
                     mlxMaxLogprobs: maxLogprobs,
-                    contextWindow: 32_768)
+                    contextWindow: 32_768,
+                    rateLimitRequests: rateLimitRequests,
+                    rateLimitWindowSeconds: rateLimitWindow)
                 globalServer = server
                 if !explicitPort && chosenPort != 9999 {
                     print("DwarfStar API URL: http://\(hostname):\(chosenPort)")
@@ -1943,6 +1972,8 @@ struct MacLocalAPI: ParsableCommand {
           --stop: Stop sequences, comma-separated
           --guided-json: Constrain output to JSON schema (auto-disables thinking on reasoning models)
           --no-streaming: Disable streaming
+          --rate-limit-requests: Chat-shaped requests allowed per client/window (0 disables; default: 600)
+          --rate-limit-window: Rate-limit window in seconds (default: 60)
           --prewarm: Pre-warm model on startup (y/n, default: y)
           --help-json: Print machine-readable JSON capability card for AI agents and exit
         skill:
@@ -2095,6 +2126,12 @@ struct RootCommand: ParsableCommand {
     @Flag(name: .long, help: "Disable streaming responses (streaming is enabled by default)")
     var noStreaming: Bool = false
 
+    @Option(name: .long, help: "Maximum chat-shaped requests per client in each rate-limit window (0 disables; default: 600)")
+    var rateLimitRequests: Int = 600
+
+    @Option(name: .long, help: "Rate-limit window in seconds (default: 60)")
+    var rateLimitWindow: Double = 60
+
     @Option(name: [.customShort("a"), .long], help: "Path to a .fmadapter file for LoRA adapter fine-tuning")
     var adapter: String?
 
@@ -2153,6 +2190,13 @@ struct RootCommand: ParsableCommand {
         if helpJson {
             printHelpJson(command: "afm")
             return
+        }
+
+        guard rateLimitRequests >= 0 else {
+            throw ValidationError("--rate-limit-requests must be zero or greater")
+        }
+        guard rateLimitWindow > 0 else {
+            throw ValidationError("--rate-limit-window must be greater than zero")
         }
 
         // Validate temperature parameter
@@ -2248,6 +2292,8 @@ struct RootCommand: ParsableCommand {
         if verbose { args.append("--verbose") }
         if veryVerbose { args.append("--very-verbose") }
         if noStreaming { args.append("--no-streaming") }
+        args += ["--rate-limit-requests", "\(rateLimitRequests)"]
+        args += ["--rate-limit-window", "\(rateLimitWindow)"]
         if permissiveGuardrails { args.append("--permissive-guardrails") }
         if webui { args.append("--webui") }
         if gateway { args.append("--gateway") }

--- a/Sources/AFMServer/ChatTransportSupport.swift
+++ b/Sources/AFMServer/ChatTransportSupport.swift
@@ -1,0 +1,259 @@
+import Vapor
+import AFMKit
+import Foundation
+
+private struct MultiChatCompletionResponse: Content {
+    let id: String
+    let object: String
+    let created: Int
+    let model: String
+    let choices: [Choice]
+    let usage: Usage
+    let timings: StreamTimings?
+    let systemFingerprint: String?
+    let afmProfile: AFMProfile?
+    let afmProfileExtended: AFMProfileExtended?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case object
+        case created
+        case model
+        case choices
+        case usage
+        case timings
+        case systemFingerprint = "system_fingerprint"
+        case afmProfile = "afm_profile"
+        case afmProfileExtended = "afm_profile_extended"
+    }
+}
+
+/// Runs one real non-streaming generation per requested choice and combines
+/// the resulting OpenAI envelopes. Keeping this at the HTTP boundary avoids
+/// changing the immutable AFMKit provider contract while ensuring `n` is not a
+/// transport-only decoration.
+func generateChatChoices(
+    request: Request,
+    count: Int,
+    handler: (Request) async throws -> Response
+) async throws -> Response {
+    guard let body = request.body.data else {
+        throw Abort(.badRequest, reason: "Request body is required.")
+    }
+    let sourceData = Data(buffer: body)
+    guard var object = try JSONSerialization.jsonObject(with: sourceData) as? [String: Any] else {
+        throw Abort(.badRequest, reason: "Request body must be a JSON object.")
+    }
+    object["n"] = 1
+    object["stream"] = false
+    let singleChoiceData = try JSONSerialization.data(withJSONObject: object)
+
+    var completions: [ChatCompletionResponse] = []
+    var firstHTTPResponse: Response?
+    completions.reserveCapacity(count)
+
+    for _ in 0..<count {
+        var headers = request.headers
+        headers.replaceOrAdd(name: .contentLength, value: String(singleChoiceData.count))
+        var childBody = request.byteBufferAllocator.buffer(capacity: singleChoiceData.count)
+        childBody.writeBytes(singleChoiceData)
+        let child = Request(
+            application: request.application,
+            method: request.method,
+            url: request.url,
+            version: request.version,
+            headersNoUpdate: headers,
+            collectedBody: childBody,
+            remoteAddress: request.remoteAddress,
+            logger: request.logger,
+            byteBufferAllocator: request.byteBufferAllocator,
+            on: request.eventLoop
+        )
+        if !request.afmRequestID.isEmpty {
+            await child.storage.setWithAsyncShutdown(
+                RequestIDKey.self,
+                to: request.afmRequestID
+            )
+        }
+
+        let response = try await handler(child)
+        guard response.status.code >= 200, response.status.code < 300 else {
+            return response
+        }
+        guard let responseBody = response.body.data else {
+            throw Abort(.internalServerError, reason: "Choice generation returned an empty response.")
+        }
+        let completion = try JSONDecoder().decode(
+            ChatCompletionResponse.self,
+            from: responseBody
+        )
+        guard completion.choices.count == 1 else {
+            throw Abort(
+                .internalServerError,
+                reason: "Single-choice generation returned \(completion.choices.count) choices."
+            )
+        }
+        if firstHTTPResponse == nil {
+            firstHTTPResponse = response
+        }
+        completions.append(completion)
+    }
+
+    guard let first = completions.first, let response = firstHTTPResponse else {
+        throw Abort(.internalServerError, reason: "No completion choices were generated.")
+    }
+
+    let choices = completions.enumerated().map { index, completion in
+        let choice = completion.choices[0]
+        return Choice(
+            index: index,
+            message: choice.message,
+            logprobs: choice.logprobs,
+            finishReason: choice.finishReason
+        )
+    }
+    let promptTokens = completions.reduce(0) { $0 + $1.usage.promptTokens }
+    let completionTokens = completions.reduce(0) { $0 + $1.usage.completionTokens }
+    let cachedTokenValues = completions.compactMap { $0.usage.promptTokensDetails?.cachedTokens }
+    let completionTimes = completions.compactMap(\.usage.completionTime)
+    let promptTimes = completions.compactMap(\.usage.promptTime)
+    let peakMemoryValues = completions.compactMap(\.usage.peakMemoryGib)
+    let usage = Usage(
+        promptTokens: promptTokens,
+        completionTokens: completionTokens,
+        totalTokens: promptTokens + completionTokens,
+        cachedTokens: cachedTokenValues.isEmpty ? nil : cachedTokenValues.reduce(0, +),
+        completionTime: completionTimes.isEmpty ? nil : completionTimes.reduce(0, +),
+        promptTime: promptTimes.isEmpty ? nil : promptTimes.reduce(0, +),
+        peakMemoryGib: peakMemoryValues.max()
+    )
+    let envelope = MultiChatCompletionResponse(
+        id: first.id,
+        object: first.object,
+        created: first.created,
+        model: first.model,
+        choices: choices,
+        usage: usage,
+        timings: first.timings,
+        systemFingerprint: first.systemFingerprint,
+        afmProfile: first.afmProfile,
+        afmProfileExtended: first.afmProfileExtended
+    )
+    try response.content.encode(envelope)
+    return response
+}
+
+struct ChatRateLimitConfiguration: Sendable, Equatable {
+    static let defaultRequestLimit = 600
+    static let defaultWindowSeconds: TimeInterval = 60
+
+    let requestLimit: Int
+    let windowSeconds: TimeInterval
+
+    var isEnabled: Bool { requestLimit > 0 }
+}
+
+actor ChatRateLimiter {
+    struct Decision: Sendable, Equatable {
+        let allowed: Bool
+        let limit: Int
+        let remaining: Int
+        let resetAfter: TimeInterval
+    }
+
+    private struct Bucket {
+        var startedAt: Date
+        var used: Int
+    }
+
+    private let configuration: ChatRateLimitConfiguration
+    private var buckets: [String: Bucket] = [:]
+
+    init(configuration: ChatRateLimitConfiguration) {
+        self.configuration = configuration
+    }
+
+    func consume(key: String, now: Date = Date()) -> Decision {
+        precondition(configuration.requestLimit > 0)
+        precondition(configuration.windowSeconds > 0)
+
+        var bucket = buckets[key] ?? Bucket(startedAt: now, used: 0)
+        let elapsed = now.timeIntervalSince(bucket.startedAt)
+        if elapsed >= configuration.windowSeconds || elapsed < 0 {
+            bucket = Bucket(startedAt: now, used: 0)
+        }
+
+        let allowed = bucket.used < configuration.requestLimit
+        if allowed {
+            bucket.used += 1
+        }
+        buckets[key] = bucket
+
+        return Decision(
+            allowed: allowed,
+            limit: configuration.requestLimit,
+            remaining: max(0, configuration.requestLimit - bucket.used),
+            resetAfter: max(0, configuration.windowSeconds - now.timeIntervalSince(bucket.startedAt))
+        )
+    }
+}
+
+struct ChatRateLimitMiddleware: AsyncMiddleware {
+    private let limiter: ChatRateLimiter
+
+    init(configuration: ChatRateLimitConfiguration) {
+        self.limiter = ChatRateLimiter(configuration: configuration)
+    }
+
+    static func applies(to request: Request) -> Bool {
+        guard request.method == .POST else { return false }
+        return request.url.path == "/v1/chat/completions"
+            || request.url.path == "/v1/responses"
+    }
+
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        guard Self.applies(to: request) else {
+            return try await next.respond(to: request)
+        }
+
+        let clientKey = request.remoteAddress?.ipAddress ?? "local"
+        let decision = await limiter.consume(key: clientKey)
+        if !decision.allowed {
+            let response = Response(status: .tooManyRequests)
+            response.headers.add(name: .contentType, value: "application/json")
+            response.headers.add(name: .accessControlAllowOrigin, value: "*")
+            response.headers.replaceOrAdd(
+                name: .retryAfter,
+                value: String(max(1, Int(ceil(decision.resetAfter))))
+            )
+            try response.content.encode(OpenAIError(
+                message: "Rate limit exceeded. Retry after the current window resets.",
+                type: "rate_limit_error",
+                code: "rate_limit_exceeded",
+                requestId: request.afmRequestID.isEmpty ? nil : request.afmRequestID
+            ))
+            addHeaders(for: decision, to: response)
+            return response
+        }
+
+        let response = try await next.respond(to: request)
+        addHeaders(for: decision, to: response)
+        return response
+    }
+
+    private func addHeaders(for decision: ChatRateLimiter.Decision, to response: Response) {
+        response.headers.replaceOrAdd(
+            name: "X-RateLimit-Limit-Requests",
+            value: String(decision.limit)
+        )
+        response.headers.replaceOrAdd(
+            name: "X-RateLimit-Remaining-Requests",
+            value: String(decision.remaining)
+        )
+        let resetMilliseconds = max(1, Int(ceil(decision.resetAfter * 1_000)))
+        response.headers.replaceOrAdd(
+            name: "X-RateLimit-Reset-Requests",
+            value: "\(resetMilliseconds)ms"
+        )
+    }
+}

--- a/Sources/AFMServer/ChatTransportSupport.swift
+++ b/Sources/AFMServer/ChatTransportSupport.swift
@@ -209,6 +209,7 @@ struct ChatRateLimitMiddleware: AsyncMiddleware {
         guard request.method == .POST else { return false }
         return request.url.path == "/v1/chat/completions"
             || request.url.path == "/v1/responses"
+            || request.url.path == "/v1/messages"
     }
 
     func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {

--- a/Sources/AFMServer/ChatTransportSupport.swift
+++ b/Sources/AFMServer/ChatTransportSupport.swift
@@ -28,6 +28,25 @@ private struct MultiChatCompletionResponse: Content {
     }
 }
 
+/// Decodes the OpenAI chat request while accepting both documented shapes for
+/// `stop`. The pinned AFMKit DTO models the canonical array representation, so
+/// normalize the bare-string wire form at the HTTP boundary until that shared
+/// contract can represent the union directly.
+func decodeChatCompletionRequest(_ request: Request) throws -> ChatCompletionRequest {
+    guard let body = request.body.data else {
+        return try request.content.decode(ChatCompletionRequest.self)
+    }
+    let sourceData = Data(buffer: body)
+    guard var object = try? JSONSerialization.jsonObject(with: sourceData) as? [String: Any],
+          let stop = object["stop"] as? String else {
+        return try request.content.decode(ChatCompletionRequest.self)
+    }
+
+    object["stop"] = [stop]
+    let normalizedData = try JSONSerialization.data(withJSONObject: object)
+    return try JSONDecoder().decode(ChatCompletionRequest.self, from: normalizedData)
+}
+
 /// Runs one real non-streaming generation per requested choice and combines
 /// the resulting OpenAI envelopes. Keeping this at the HTTP boundary avoids
 /// changing the immutable AFMKit provider contract while ensuring `n` is not a

--- a/Sources/AFMServer/Controllers/ChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/ChatCompletionsController.swift
@@ -55,6 +55,20 @@ struct ChatCompletionsController: RouteCollection {
     }
     
     func chatCompletions(req: Request) async throws -> Response {
+        if let choiceCount = requestedChatChoiceCount(req), choiceCount != 1 {
+            telemetry.recordRejection(.validation)
+            return try await createErrorResponse(
+                req: req,
+                error: OpenAIError(
+                    message: "This server supports exactly one completion choice per request (n must be 1).",
+                    type: "invalid_request_error",
+                    code: "unsupported_n",
+                    param: "n",
+                    requestId: req.afmRequestID.isEmpty ? nil : req.afmRequestID
+                ),
+                status: .badRequest
+            )
+        }
         var fallbackModel = "foundation"
         var fallbackMessages: [Message] = []
         var fallbackMaxTokens = 2000

--- a/Sources/AFMServer/Controllers/ChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/ChatCompletionsController.swift
@@ -55,19 +55,40 @@ struct ChatCompletionsController: RouteCollection {
     }
     
     func chatCompletions(req: Request) async throws -> Response {
-        if let choiceCount = requestedChatChoiceCount(req), choiceCount != 1 {
-            telemetry.recordRejection(.validation)
-            return try await createErrorResponse(
-                req: req,
-                error: OpenAIError(
-                    message: "This server supports exactly one completion choice per request (n must be 1).",
-                    type: "invalid_request_error",
-                    code: "unsupported_n",
-                    param: "n",
-                    requestId: req.afmRequestID.isEmpty ? nil : req.afmRequestID
-                ),
-                status: .badRequest
-            )
+        if let choiceCount = requestedChatChoiceCount(req) {
+            guard (1...128).contains(choiceCount) else {
+                telemetry.recordRejection(.validation)
+                return try await createErrorResponse(
+                    req: req,
+                    error: OpenAIError(
+                        message: "n must be between 1 and 128.",
+                        type: "invalid_request_error",
+                        code: "invalid_n",
+                        param: "n",
+                        requestId: req.afmRequestID.isEmpty ? nil : req.afmRequestID
+                    ),
+                    status: .badRequest
+                )
+            }
+            if choiceCount > 1 {
+                guard !requestedChatStreaming(req) else {
+                    telemetry.recordRejection(.validation)
+                    return try await createErrorResponse(
+                        req: req,
+                        error: OpenAIError(
+                            message: "Streaming multiple choices is not supported; set stream to false when n is greater than 1.",
+                            type: "invalid_request_error",
+                            code: "unsupported_streaming_n",
+                            param: "n",
+                            requestId: req.afmRequestID.isEmpty ? nil : req.afmRequestID
+                        ),
+                        status: .badRequest
+                    )
+                }
+                return try await generateChatChoices(request: req, count: choiceCount) { child in
+                    try await self.chatCompletions(req: child)
+                }
+            }
         }
         var fallbackModel = "foundation"
         var fallbackMessages: [Message] = []

--- a/Sources/AFMServer/Controllers/ChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/ChatCompletionsController.swift
@@ -949,6 +949,10 @@ struct ChatCompletionsController: RouteCollection {
         v1.on(.POST, "chat", "completions", body: .collect(maxSize: "100mb"), use: unavailable)
     }
 
+    func chatCompletions(req: Request) async throws -> Response {
+        try await unavailable(req: req)
+    }
+
     static func resolveStrictJsonSchema(
         requestFormat: ResponseFormat?,
         serverDefault: ResponseFormat?

--- a/Sources/AFMServer/Controllers/ChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/ChatCompletionsController.swift
@@ -94,7 +94,7 @@ struct ChatCompletionsController: RouteCollection {
         var fallbackMessages: [Message] = []
         var fallbackMaxTokens = 2000
         do {
-            let chatRequest = try req.content.decode(ChatCompletionRequest.self)
+            let chatRequest = try decodeChatCompletionRequest(req)
             fallbackModel = chatRequest.model ?? "foundation"
             fallbackMessages = chatRequest.messages
             fallbackMaxTokens = chatRequest.effectiveMaxTokens ?? 2000

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -260,19 +260,40 @@ struct MLXChatCompletionsController: RouteCollection {
     }
 
     func chatCompletions(req: Request) async throws -> Response {
-        if let choiceCount = requestedChatChoiceCount(req), choiceCount != 1 {
-            telemetry.recordRejection(.validation)
-            return try await createErrorResponse(
-                req: req,
-                error: OpenAIError(
-                    message: "This server supports exactly one completion choice per request (n must be 1).",
-                    type: "invalid_request_error",
-                    code: "unsupported_n",
-                    param: "n",
-                    requestId: req.afmRequestID.isEmpty ? nil : req.afmRequestID
-                ),
-                status: .badRequest
-            )
+        if let choiceCount = requestedChatChoiceCount(req) {
+            guard (1...128).contains(choiceCount) else {
+                telemetry.recordRejection(.validation)
+                return try await createErrorResponse(
+                    req: req,
+                    error: OpenAIError(
+                        message: "n must be between 1 and 128.",
+                        type: "invalid_request_error",
+                        code: "invalid_n",
+                        param: "n",
+                        requestId: req.afmRequestID.isEmpty ? nil : req.afmRequestID
+                    ),
+                    status: .badRequest
+                )
+            }
+            if choiceCount > 1 {
+                guard !requestedChatStreaming(req) else {
+                    telemetry.recordRejection(.validation)
+                    return try await createErrorResponse(
+                        req: req,
+                        error: OpenAIError(
+                            message: "Streaming multiple choices is not supported; set stream to false when n is greater than 1.",
+                            type: "invalid_request_error",
+                            code: "unsupported_streaming_n",
+                            param: "n",
+                            requestId: req.afmRequestID.isEmpty ? nil : req.afmRequestID
+                        ),
+                        status: .badRequest
+                    )
+                }
+                return try await generateChatChoices(request: req, count: choiceCount) { child in
+                    try await self.chatCompletions(req: child)
+                }
+            }
         }
         // RequestIDMiddleware sets this; controller piggybacks for log correlation. (T1.1)
         let reqId = req.afmRequestID

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -260,6 +260,20 @@ struct MLXChatCompletionsController: RouteCollection {
     }
 
     func chatCompletions(req: Request) async throws -> Response {
+        if let choiceCount = requestedChatChoiceCount(req), choiceCount != 1 {
+            telemetry.recordRejection(.validation)
+            return try await createErrorResponse(
+                req: req,
+                error: OpenAIError(
+                    message: "This server supports exactly one completion choice per request (n must be 1).",
+                    type: "invalid_request_error",
+                    code: "unsupported_n",
+                    param: "n",
+                    requestId: req.afmRequestID.isEmpty ? nil : req.afmRequestID
+                ),
+                status: .badRequest
+            )
+        }
         // RequestIDMiddleware sets this; controller piggybacks for log correlation. (T1.1)
         let reqId = req.afmRequestID
         let inflightRegistry = req.application.inflightRegistry

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -311,7 +311,7 @@ struct MLXChatCompletionsController: RouteCollection {
         var requestRegistered = requestRegistration != nil
         do {
             let httpArrival = Self.debugPipeline ? Date() : Date.distantPast
-            let chatRequest = try req.content.decode(ChatCompletionRequest.self)
+            let chatRequest = try decodeChatCompletionRequest(req)
             if veryVerbose {
                 print("\(Self.pink)[\(Self.timestamp())] RECV MLX full request:\n\(Self.redactedRequestJSON(chatRequest))\(Self.reset)"); fflush(stdout)
                 if let lastUser = chatRequest.messages.last(where: { $0.role == "user" }) {

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -800,7 +800,19 @@ struct MLXChatCompletionsController: RouteCollection {
                 await inflightRegistry.release(id: reqId, registration: requestRegistration)
                 requestRegistered = false
             }
-            return try await createSuccessResponse(req: req, response: response, grammarDowngraded: grammarDowngraded)
+            let success = try await createSuccessResponse(req: req, response: response, grammarDowngraded: grammarDowngraded)
+            if req.headers.first(name: "X-AFM-Report-Matched-Stop") == "1",
+               let matchedStop = Self.matchedStopSequence(
+                   in: result.content,
+                   stopSequences: effectiveStop,
+                   stoppedBySequence: result.stoppedBySequence
+               ) {
+                success.headers.replaceOrAdd(
+                    name: "X-AFM-Matched-Stop-Base64",
+                    value: Data(matchedStop.utf8).base64EncodedString()
+                )
+            }
+            return success
         } catch let decodingError as DecodingError {
             if requestRegistered {
                 await inflightRegistry.release(id: reqId, registration: requestRegistration)
@@ -2447,6 +2459,22 @@ struct MLXChatCompletionsController: RouteCollection {
         }
         guard let earliest else { return (text, false) }
         return (String(text[..<earliest.lowerBound]), true)
+    }
+
+    static func matchedStopSequence(
+        in text: String,
+        stopSequences: [String]?,
+        stoppedBySequence: Bool
+    ) -> String? {
+        guard let stopSequences, !stopSequences.isEmpty else { return nil }
+        let matches = stopSequences.compactMap { stop -> (String, Range<String.Index>)? in
+            guard !stop.isEmpty, let range = text.range(of: stop) else { return nil }
+            return (stop, range)
+        }
+        if let first = matches.min(by: { $0.1.lowerBound < $1.1.lowerBound }) {
+            return first.0
+        }
+        return stoppedBySequence && stopSequences.count == 1 ? stopSequences[0] : nil
     }
 
     static func applyToolChoice(_ toolCalls: [ResponseToolCall]?, toolChoice: ToolChoice?) -> [ResponseToolCall]? {

--- a/Sources/AFMServer/Controllers/MessagesController.swift
+++ b/Sources/AFMServer/Controllers/MessagesController.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Vapor
+
+/// Anthropic Messages compatibility over AFM's Chat Completions transport.
+/// External SSE is deliberately buffered: the internal Chat request is always
+/// non-streaming, then emitted as one complete, valid Anthropic lifecycle.
+struct MessagesController: RouteCollection {
+    typealias ChatHandler = @Sendable (Request) async throws -> Response
+
+    let model: String
+    let chatHandler: ChatHandler
+
+    func boot(routes: RoutesBuilder) throws {
+        routes.grouped("v1").on(.POST, "messages", body: .collect(maxSize: "100mb"), use: create)
+    }
+
+    func create(req: Request) async throws -> Response {
+        do {
+            guard let data = req.body.data.map({ Data(buffer: $0) }) else {
+                return try Self.error("request body is required")
+            }
+            let body = try JSONDecoder().decode(ResponsesJSON.self, from: data)
+            guard let object = body.objectValue,
+                  let sourceMessages = object["messages"]?.arrayValue,
+                  let maxTokens = object["max_tokens"]?.intValue else {
+                return try Self.error("messages and max_tokens are required")
+            }
+            let chatRequest = try Self.makeChatRequest(
+                object: object, sourceMessages: sourceMessages,
+                maxTokens: maxTokens, defaultModel: model
+            )
+            let result = try await executeChat(chatRequest, from: req)
+            let resource = try Self.makeMessage(chat: result, request: object, defaultModel: model)
+            return object["stream"]?.boolValue == true
+                ? try Self.streamingResponse(resource)
+                : try Self.json(resource)
+        } catch let abort as AbortError {
+            return try Self.error(abort.reason, status: abort.status)
+        } catch {
+            return try Self.error("invalid_request_error: \(error)")
+        }
+    }
+
+    private func executeChat(_ body: ResponsesJSON, from request: Request) async throws -> ResponsesJSON {
+        let encodedBody = try JSONEncoder().encode(body)
+        var buffer = request.byteBufferAllocator.buffer(capacity: encodedBody.count)
+        buffer.writeBytes(encodedBody)
+        var headers = request.headers
+        headers.contentType = .json
+        headers.replaceOrAdd(name: .contentLength, value: String(encodedBody.count))
+        let chatRequest = Request(
+            application: request.application, method: .POST, url: URI(path: "/v1/chat/completions"),
+            version: request.version, headersNoUpdate: headers, collectedBody: buffer,
+            remoteAddress: request.remoteAddress, peerCertificateChain: request.peerCertificateChain,
+            logger: request.logger, byteBufferAllocator: request.byteBufferAllocator, on: request.eventLoop
+        )
+        let response = try await chatHandler(chatRequest)
+        guard let output = try await response.body.collect(on: chatRequest.eventLoop).get() else {
+            throw Abort(.internalServerError, reason: "chat backend returned an empty response")
+        }
+        return try JSONDecoder().decode(ResponsesJSON.self, from: Data(buffer: output))
+    }
+
+    static func makeChatRequest(object: [String: ResponsesJSON], sourceMessages: [ResponsesJSON], maxTokens: Int, defaultModel: String) throws -> ResponsesJSON {
+        var messages: [ResponsesJSON] = []
+        if let system = object["system"] {
+            let systemText = text(from: system)
+            if !systemText.isEmpty {
+                messages.append(.object(["role": .string("system"), "content": .string(systemText)]))
+            }
+        }
+        for source in sourceMessages {
+            guard let message = source.objectValue,
+                  let role = message["role"]?.stringValue,
+                  ["user", "assistant"].contains(role) else {
+                throw Abort(.badRequest, reason: "messages must contain user or assistant turns")
+            }
+            messages.append(.object([
+                "role": .string(role), "content": .string(text(from: message["content"] ?? .null))
+            ]))
+        }
+        var request: [String: ResponsesJSON] = [
+            "model": object["model"] ?? .string(defaultModel), "messages": .array(messages),
+            "max_tokens": .number(Double(maxTokens)), "stream": .bool(false)
+        ]
+        for key in ["temperature", "top_p", "top_k", "stop_sequences"] {
+            if let value = object[key] { request[key == "stop_sequences" ? "stop" : key] = value }
+        }
+        return .object(request)
+    }
+
+    static func makeMessage(chat: ResponsesJSON, request: [String: ResponsesJSON], defaultModel: String) throws -> ResponsesJSON {
+        guard let choice = chat["choices"]?.arrayValue?.first?.objectValue else {
+            throw Abort(.internalServerError, reason: "chat backend returned no choices")
+        }
+        let output = choice["message"]?.objectValue ?? [:]
+        let visibleText = output["content"]?.stringValue ?? ""
+        let reasoning = output["reasoning_content"]?.stringValue
+        let thinkingEnabled = request["thinking"]?["type"]?.stringValue == "enabled"
+        var content: [ResponsesJSON] = []
+        if thinkingEnabled, let reasoning, !reasoning.isEmpty {
+            content.append(.object(["type": .string("thinking"), "thinking": .string(reasoning)]))
+        }
+        content.append(.object(["type": .string("text"), "text": .string(visibleText)]))
+        let finish = choice["finish_reason"]?.stringValue ?? "stop"
+        let stops = request["stop_sequences"]?.arrayValue?.compactMap(\.stringValue) ?? []
+        let matchedStop = stops.first(where: { visibleText.contains($0) })
+        let reason = matchedStop != nil ? "stop_sequence" : finish == "length" ? "max_tokens" : finish == "tool_calls" ? "tool_use" : "end_turn"
+        let usage = chat["usage"]?.objectValue ?? [:]
+        return .object([
+            "id": .string("msg_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"),
+            "type": .string("message"), "role": .string("assistant"),
+            "model": chat["model"] ?? request["model"] ?? .string(defaultModel), "content": .array(content),
+            "stop_reason": .string(reason), "stop_sequence": matchedStop.map(ResponsesJSON.string) ?? .null,
+            "usage": .object(["input_tokens": usage["prompt_tokens"] ?? .number(0), "output_tokens": usage["completion_tokens"] ?? .number(0)])
+        ])
+    }
+
+    static func text(from value: ResponsesJSON) -> String {
+        if let text = value.stringValue { return text }
+        return value.arrayValue?.compactMap { $0["text"]?.stringValue ?? $0["thinking"]?.stringValue }.joined(separator: "\n") ?? ""
+    }
+
+    static func streamingEvents(for message: ResponsesJSON) -> [ResponsesJSON] {
+        let content = message["content"]?.arrayValue ?? []
+        var events: [ResponsesJSON] = [.object(["type": .string("message_start"), "message": message])]
+        for (index, block) in content.enumerated() {
+            let type = block["type"]?.stringValue ?? "text"
+            let field = type == "thinking" ? "thinking" : "text"
+            let value = block[field]?.stringValue ?? ""
+            events.append(.object(["type": .string("content_block_start"), "index": .number(Double(index)), "content_block": .object(["type": .string(type), field: .string("")])]))
+            if !value.isEmpty {
+                events.append(.object(["type": .string("content_block_delta"), "index": .number(Double(index)), "delta": .object(["type": .string(type == "thinking" ? "thinking_delta" : "text_delta"), field: .string(value)])]))
+            }
+            events.append(.object(["type": .string("content_block_stop"), "index": .number(Double(index))]))
+        }
+        events.append(.object(["type": .string("message_delta"), "delta": .object(["stop_reason": message["stop_reason"] ?? .string("end_turn"), "stop_sequence": message["stop_sequence"] ?? .null]), "usage": message["usage"] ?? .object([:])]))
+        events.append(.object(["type": .string("message_stop")]))
+        return events
+    }
+
+    static func streamingResponse(_ message: ResponsesJSON) throws -> Response {
+        let frames = try streamingEvents(for: message).map { event in
+            let type = event["type"]?.stringValue ?? "message"
+            return "event: \(type)\ndata: \(String(decoding: try JSONEncoder().encode(event), as: UTF8.self))\n\n"
+        }
+        let response = Response(status: .ok)
+        response.headers.replaceOrAdd(name: .contentType, value: "text/event-stream")
+        response.headers.replaceOrAdd(name: .cacheControl, value: "no-cache")
+        response.body = .init(string: frames.joined())
+        return response
+    }
+
+    static func json(_ value: ResponsesJSON) throws -> Response {
+        let response = Response(status: .ok)
+        response.headers.contentType = .json
+        response.body = .init(data: try JSONEncoder().encode(value))
+        return response
+    }
+
+    static func error(_ message: String, status: HTTPStatus = .badRequest) throws -> Response {
+        let response = Response(status: status)
+        response.headers.contentType = .json
+        response.body = .init(data: try JSONEncoder().encode(.object([
+            "type": .string("error"), "error": .object(["type": .string("invalid_request_error"), "message": .string(message)])
+        ]) as ResponsesJSON))
+        return response
+    }
+}

--- a/Sources/AFMServer/Controllers/MessagesController.swift
+++ b/Sources/AFMServer/Controllers/MessagesController.swift
@@ -78,13 +78,28 @@ struct MessagesController: RouteCollection {
                 messages.append(.object(["role": .string("system"), "content": .string(systemText)]))
             }
         }
-        for source in sourceMessages {
+        let assistantPrefill = sourceMessages.last.flatMap(prefillText(from:))
+        let translatedSources = assistantPrefill == nil ? sourceMessages : Array(sourceMessages.dropLast())
+        for source in translatedSources {
             guard let message = source.objectValue,
                   let role = message["role"]?.stringValue,
                   ["user", "assistant"].contains(role) else {
                 throw Abort(.badRequest, reason: "messages must contain user or assistant turns")
             }
             messages.append(contentsOf: try chatMessages(from: message, role: role))
+        }
+        if let assistantPrefill {
+            // AFMKit's current ChatCompletionRequest contract has no
+            // `continue_final_message` flag. Convert Anthropic's required
+            // unfinished-final-assistant semantics into an explicit final turn
+            // instead of sending a completed assistant turn that native chat
+            // templates close before adding their generation prompt.
+            messages.append(.object([
+                "role": .string("user"),
+                "content": .string(
+                    "Continue the unfinished assistant answer below. Return only the exact continuation after the prefix; do not repeat the prefix or start a new answer.\n\nUnfinished assistant prefix:\n\(assistantPrefill)"
+                )
+            ]))
         }
         var request: [String: ResponsesJSON] = [
             "model": object["model"] ?? .string(defaultModel), "messages": .array(messages),
@@ -111,8 +126,24 @@ struct MessagesController: RouteCollection {
         }
         if let choice = object["tool_choice"] {
             request["tool_choice"] = chatToolChoice(choice)
+            if choice["disable_parallel_tool_use"]?.boolValue == true {
+                request["parallel_tool_calls"] = .bool(false)
+            }
         }
         return .object(request)
+    }
+
+    /// Anthropic defines a final assistant text turn as a generation prefill.
+    /// Tool-use turns are structured history, not a textual prefill.
+    static func prefillText(from source: ResponsesJSON) -> String? {
+        guard let message = source.objectValue,
+              message["role"]?.stringValue == "assistant" else { return nil }
+        if let blocks = message["content"]?.arrayValue,
+           blocks.contains(where: { $0["type"]?.stringValue == "tool_use" }) {
+            return nil
+        }
+        let value = text(from: message["content"] ?? .null)
+        return value.isEmpty ? nil : value
     }
 
     /// Converts Message blocks without discarding tool or image semantics.

--- a/Sources/AFMServer/Controllers/MessagesController.swift
+++ b/Sources/AFMServer/Controllers/MessagesController.swift
@@ -48,6 +48,7 @@ struct MessagesController: RouteCollection {
         var headers = request.headers
         headers.contentType = .json
         headers.replaceOrAdd(name: .contentLength, value: String(encodedBody.count))
+        headers.replaceOrAdd(name: "X-AFM-Report-Matched-Stop", value: "1")
         let chatRequest = Request(
             application: request.application, method: .POST, url: URI(path: "/v1/chat/completions"),
             version: request.version, headersNoUpdate: headers, collectedBody: buffer,
@@ -58,7 +59,15 @@ struct MessagesController: RouteCollection {
         guard let output = try await response.body.collect(on: chatRequest.eventLoop).get() else {
             throw Abort(.internalServerError, reason: "chat backend returned an empty response")
         }
-        return try JSONDecoder().decode(ResponsesJSON.self, from: Data(buffer: output))
+        let decoded = try JSONDecoder().decode(ResponsesJSON.self, from: Data(buffer: output))
+        guard let encodedStop = response.headers.first(name: "X-AFM-Matched-Stop-Base64"),
+              let stopData = Data(base64Encoded: encodedStop),
+              let stop = String(data: stopData, encoding: .utf8),
+              var object = decoded.objectValue else {
+            return decoded
+        }
+        object["_afm_matched_stop"] = .string(stop)
+        return .object(object)
     }
 
     static func makeChatRequest(object: [String: ResponsesJSON], sourceMessages: [ResponsesJSON], maxTokens: Int, defaultModel: String) throws -> ResponsesJSON {
@@ -83,6 +92,9 @@ struct MessagesController: RouteCollection {
         ]
         for key in ["temperature", "top_p", "top_k", "stop_sequences"] {
             if let value = object[key] { request[key == "stop_sequences" ? "stop" : key] = value }
+        }
+        if object["thinking"]?["type"]?.stringValue == "enabled" {
+            request["reasoning_effort"] = .string("low")
         }
         if let tools = object["tools"]?.arrayValue {
             request["tools"] = .array(tools.compactMap { tool in
@@ -204,7 +216,8 @@ struct MessagesController: RouteCollection {
         }
         let finish = choice["finish_reason"]?.stringValue ?? "stop"
         let stops = request["stop_sequences"]?.arrayValue?.compactMap(\.stringValue) ?? []
-        let matchedStop = stops.first(where: { visibleText.contains($0) })
+        let matchedStop = chat["_afm_matched_stop"]?.stringValue
+            ?? stops.first(where: { visibleText.contains($0) })
         let reason = matchedStop != nil ? "stop_sequence" : finish == "length" ? "max_tokens" : finish == "tool_calls" ? "tool_use" : "end_turn"
         let usage = chat["usage"]?.objectValue ?? [:]
         return .object([

--- a/Sources/AFMServer/Controllers/MessagesController.swift
+++ b/Sources/AFMServer/Controllers/MessagesController.swift
@@ -75,9 +75,7 @@ struct MessagesController: RouteCollection {
                   ["user", "assistant"].contains(role) else {
                 throw Abort(.badRequest, reason: "messages must contain user or assistant turns")
             }
-            messages.append(.object([
-                "role": .string(role), "content": .string(text(from: message["content"] ?? .null))
-            ]))
+            messages.append(contentsOf: try chatMessages(from: message, role: role))
         }
         var request: [String: ResponsesJSON] = [
             "model": object["model"] ?? .string(defaultModel), "messages": .array(messages),
@@ -86,7 +84,94 @@ struct MessagesController: RouteCollection {
         for key in ["temperature", "top_p", "top_k", "stop_sequences"] {
             if let value = object[key] { request[key == "stop_sequences" ? "stop" : key] = value }
         }
+        if let tools = object["tools"]?.arrayValue {
+            request["tools"] = .array(tools.compactMap { tool in
+                guard let tool = tool.objectValue, let name = tool["name"] else { return nil }
+                return .object([
+                    "type": .string("function"),
+                    "function": .object([
+                        "name": name,
+                        "description": tool["description"] ?? .null,
+                        "parameters": tool["input_schema"] ?? .object([:])
+                    ])
+                ])
+            })
+        }
+        if let choice = object["tool_choice"] {
+            request["tool_choice"] = chatToolChoice(choice)
+        }
         return .object(request)
+    }
+
+    /// Converts Message blocks without discarding tool or image semantics.
+    static func chatMessages(from message: [String: ResponsesJSON], role: String) throws -> [ResponsesJSON] {
+        let content = message["content"] ?? .null
+        guard let blocks = content.arrayValue else {
+            return [.object(["role": .string(role), "content": content])]
+        }
+        var textParts: [ResponsesJSON] = []
+        var toolCalls: [ResponsesJSON] = []
+        var toolResults: [ResponsesJSON] = []
+        for block in blocks {
+            guard let block = block.objectValue else { continue }
+            switch block["type"]?.stringValue {
+            case "text", "thinking":
+                let value = block["text"] ?? block["thinking"] ?? .string("")
+                textParts.append(.object(["type": .string("text"), "text": value]))
+            case "image":
+                if let image = chatImagePart(block) { textParts.append(image) }
+            case "tool_use":
+                let input = block["input"] ?? .object([:])
+                let arguments = String(decoding: try JSONEncoder().encode(input), as: UTF8.self)
+                toolCalls.append(.object([
+                    "id": block["id"] ?? .string("call_\(UUID().uuidString.lowercased().prefix(12))"),
+                    "type": .string("function"),
+                    "function": .object(["name": block["name"] ?? .string(""), "arguments": .string(arguments)])
+                ]))
+            case "tool_result":
+                toolResults.append(.object([
+                    "role": .string("tool"),
+                    "tool_call_id": block["tool_use_id"] ?? .string(""),
+                    "content": .string(text(from: block["content"] ?? .null))
+                ]))
+            default:
+                continue
+            }
+        }
+        var result: [ResponsesJSON] = []
+        if !textParts.isEmpty || (toolCalls.isEmpty && toolResults.isEmpty) {
+            let translated: ResponsesJSON = textParts.count == 1 && textParts[0]["type"]?.stringValue == "text"
+                ? textParts[0]["text"] ?? .string("") : .array(textParts)
+            result.append(.object(["role": .string(role), "content": translated]))
+        }
+        if !toolCalls.isEmpty {
+            result.append(.object(["role": .string("assistant"), "content": .null, "tool_calls": .array(toolCalls)]))
+        }
+        result.append(contentsOf: toolResults)
+        return result
+    }
+
+    static func chatImagePart(_ block: [String: ResponsesJSON]) -> ResponsesJSON? {
+        guard let source = block["source"]?.objectValue else { return nil }
+        if source["type"]?.stringValue == "base64", let data = source["data"]?.stringValue {
+            let mediaType = source["media_type"]?.stringValue ?? "image/png"
+            return .object(["type": .string("image_url"), "image_url": .object(["url": .string("data:\(mediaType);base64,\(data)")])])
+        }
+        if source["type"]?.stringValue == "url", let url = source["url"] {
+            return .object(["type": .string("image_url"), "image_url": .object(["url": url])])
+        }
+        return nil
+    }
+
+    static func chatToolChoice(_ choice: ResponsesJSON) -> ResponsesJSON {
+        guard let object = choice.objectValue else { return choice }
+        switch object["type"]?.stringValue {
+        case "any": return .string("required")
+        case "tool":
+            return .object(["type": .string("function"), "function": .object(["name": object["name"] ?? .string("")])])
+        case "auto", "none": return object["type"] ?? .string("auto")
+        default: return choice
+        }
     }
 
     static func makeMessage(chat: ResponsesJSON, request: [String: ResponsesJSON], defaultModel: String) throws -> ResponsesJSON {
@@ -101,7 +186,22 @@ struct MessagesController: RouteCollection {
         if thinkingEnabled, let reasoning, !reasoning.isEmpty {
             content.append(.object(["type": .string("thinking"), "thinking": .string(reasoning)]))
         }
-        content.append(.object(["type": .string("text"), "text": .string(visibleText)]))
+        if !visibleText.isEmpty || output["tool_calls"] == nil {
+            content.append(.object(["type": .string("text"), "text": .string(visibleText)]))
+        }
+        if let calls = output["tool_calls"]?.arrayValue {
+            for call in calls {
+                guard let call = call.objectValue, let function = call["function"]?.objectValue else { continue }
+                let rawInput = function["arguments"]?.stringValue ?? "{}"
+                let input = (try? JSONDecoder().decode(ResponsesJSON.self, from: Data(rawInput.utf8))) ?? .object([:])
+                content.append(.object([
+                    "type": .string("tool_use"),
+                    "id": call["id"] ?? .string("toolu_\(UUID().uuidString.lowercased().prefix(12))"),
+                    "name": function["name"] ?? .string(""),
+                    "input": input
+                ]))
+            }
+        }
         let finish = choice["finish_reason"]?.stringValue ?? "stop"
         let stops = request["stop_sequences"]?.arrayValue?.compactMap(\.stringValue) ?? []
         let matchedStop = stops.first(where: { visibleText.contains($0) })
@@ -126,10 +226,22 @@ struct MessagesController: RouteCollection {
         var events: [ResponsesJSON] = [.object(["type": .string("message_start"), "message": message])]
         for (index, block) in content.enumerated() {
             let type = block["type"]?.stringValue ?? "text"
-            let field = type == "thinking" ? "thinking" : "text"
+            let field = type == "thinking" ? "thinking" : type == "tool_use" ? "input" : "text"
             let value = block[field]?.stringValue ?? ""
-            events.append(.object(["type": .string("content_block_start"), "index": .number(Double(index)), "content_block": .object(["type": .string(type), field: .string("")])]))
-            if !value.isEmpty {
+            var start: [String: ResponsesJSON] = ["type": .string(type)]
+            if type == "tool_use" {
+                start["id"] = block["id"] ?? .string("")
+                start["name"] = block["name"] ?? .string("")
+                start["input"] = .object([:])
+            } else {
+                start[field] = .string("")
+            }
+            events.append(.object(["type": .string("content_block_start"), "index": .number(Double(index)), "content_block": .object(start)]))
+            if type == "tool_use" {
+                let input = block["input"] ?? .object([:])
+                let partial = (try? String(decoding: JSONEncoder().encode(input), as: UTF8.self)) ?? "{}"
+                events.append(.object(["type": .string("content_block_delta"), "index": .number(Double(index)), "delta": .object(["type": .string("input_json_delta"), "partial_json": .string(partial)])]))
+            } else if !value.isEmpty {
                 events.append(.object(["type": .string("content_block_delta"), "index": .number(Double(index)), "delta": .object(["type": .string(type == "thinking" ? "thinking_delta" : "text_delta"), field: .string(value)])]))
             }
             events.append(.object(["type": .string("content_block_stop"), "index": .number(Double(index))]))

--- a/Sources/AFMServer/Controllers/MessagesController.swift
+++ b/Sources/AFMServer/Controllers/MessagesController.swift
@@ -7,6 +7,10 @@ import Vapor
 struct MessagesController: RouteCollection {
     typealias ChatHandler = @Sendable (Request) async throws -> Response
 
+    private static let successfulStatusCodes: Range<UInt> = 200..<300
+    private static let serverErrorStatusCodes: Range<UInt> = 500..<600
+    private static let overloadedStatusCode: UInt = 529
+
     let model: String
     let chatHandler: ChatHandler
 
@@ -59,7 +63,17 @@ struct MessagesController: RouteCollection {
         guard let output = try await response.body.collect(on: chatRequest.eventLoop).get() else {
             throw Abort(.internalServerError, reason: "chat backend returned an empty response")
         }
-        let decoded = try JSONDecoder().decode(ResponsesJSON.self, from: Data(buffer: output))
+        let outputData = Data(buffer: output)
+        guard Self.successfulStatusCodes.contains(response.status.code) else {
+            let decoded = try? JSONDecoder().decode(ResponsesJSON.self, from: outputData)
+            let reason = decoded?["error"]?["message"]?.stringValue
+                ?? decoded?["detail"]?.stringValue
+                ?? "chat backend failed with status \(response.status.code)"
+            throw Abort(response.status, reason: reason)
+        }
+        guard let decoded = try? JSONDecoder().decode(ResponsesJSON.self, from: outputData) else {
+            throw Abort(.internalServerError, reason: "chat backend returned malformed JSON")
+        }
         guard let encodedStop = response.headers.first(name: "X-AFM-Matched-Stop-Base64"),
               let stopData = Data(base64Encoded: encodedStop),
               let stop = String(data: stopData, encoding: .utf8),
@@ -181,16 +195,18 @@ struct MessagesController: RouteCollection {
                 continue
             }
         }
-        var result: [ResponsesJSON] = []
-        if !textParts.isEmpty || (toolCalls.isEmpty && toolResults.isEmpty) {
-            let translated: ResponsesJSON = textParts.count == 1 && textParts[0]["type"]?.stringValue == "text"
-                ? textParts[0]["text"] ?? .string("") : .array(textParts)
-            result.append(.object(["role": .string(role), "content": translated]))
-        }
+        var result = toolResults
+        let translatedContent: ResponsesJSON = textParts.count == 1 && textParts[0]["type"]?.stringValue == "text"
+            ? textParts[0]["text"] ?? .string("") : .array(textParts)
         if !toolCalls.isEmpty {
-            result.append(.object(["role": .string("assistant"), "content": .null, "tool_calls": .array(toolCalls)]))
+            result.append(.object([
+                "role": .string("assistant"),
+                "content": textParts.isEmpty ? .null : translatedContent,
+                "tool_calls": .array(toolCalls)
+            ]))
+        } else if !textParts.isEmpty || toolResults.isEmpty {
+            result.append(.object(["role": .string(role), "content": translatedContent]))
         }
-        result.append(contentsOf: toolResults)
         return result
     }
 
@@ -267,7 +283,19 @@ struct MessagesController: RouteCollection {
 
     static func streamingEvents(for message: ResponsesJSON) -> [ResponsesJSON] {
         let content = message["content"]?.arrayValue ?? []
-        var events: [ResponsesJSON] = [.object(["type": .string("message_start"), "message": message])]
+        let finalUsage = message["usage"]?.objectValue ?? [:]
+        var initialMessage = message.objectValue ?? [:]
+        initialMessage["content"] = .array([])
+        initialMessage["stop_reason"] = .null
+        initialMessage["stop_sequence"] = .null
+        initialMessage["usage"] = .object([
+            "input_tokens": finalUsage["input_tokens"] ?? .number(0),
+            "output_tokens": .number(0)
+        ])
+        var events: [ResponsesJSON] = [.object([
+            "type": .string("message_start"),
+            "message": .object(initialMessage)
+        ])]
         for (index, block) in content.enumerated() {
             let type = block["type"]?.stringValue ?? "text"
             let field = type == "thinking" ? "thinking" : type == "tool_use" ? "input" : "text"
@@ -290,7 +318,14 @@ struct MessagesController: RouteCollection {
             }
             events.append(.object(["type": .string("content_block_stop"), "index": .number(Double(index))]))
         }
-        events.append(.object(["type": .string("message_delta"), "delta": .object(["stop_reason": message["stop_reason"] ?? .string("end_turn"), "stop_sequence": message["stop_sequence"] ?? .null]), "usage": message["usage"] ?? .object([:])]))
+        events.append(.object([
+            "type": .string("message_delta"),
+            "delta": .object([
+                "stop_reason": message["stop_reason"] ?? .string("end_turn"),
+                "stop_sequence": message["stop_sequence"] ?? .null
+            ]),
+            "usage": .object(["output_tokens": finalUsage["output_tokens"] ?? .number(0)])
+        ]))
         events.append(.object(["type": .string("message_stop")]))
         return events
     }
@@ -318,8 +353,18 @@ struct MessagesController: RouteCollection {
         let response = Response(status: status)
         response.headers.contentType = .json
         response.body = .init(data: try JSONEncoder().encode(.object([
-            "type": .string("error"), "error": .object(["type": .string("invalid_request_error"), "message": .string(message)])
+            "type": .string("error"), "error": .object([
+                "type": .string(errorType(for: status)),
+                "message": .string(message)
+            ])
         ]) as ResponsesJSON))
         return response
+    }
+
+    private static func errorType(for status: HTTPStatus) -> String {
+        if status.code == overloadedStatusCode { return "overloaded_error" }
+        if status == .tooManyRequests { return "rate_limit_error" }
+        if serverErrorStatusCodes.contains(status.code) { return "api_error" }
+        return "invalid_request_error"
     }
 }

--- a/Sources/AFMServer/Controllers/OpenAPIController.swift
+++ b/Sources/AFMServer/Controllers/OpenAPIController.swift
@@ -399,6 +399,17 @@ struct OpenAPIController: RouteCollection {
             }
           }
         },
+        "/v1/messages/count_tokens": {
+          "post": {
+            "tags": ["tokenize"],
+            "summary": "Count tokens for an Anthropic Messages conversation",
+            "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object", "required": ["messages"], "properties": { "model": { "type": "string" }, "system": {}, "messages": { "type": "array" } } } } } },
+            "responses": {
+              "200": { "description": "Token count", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CountTokensResponse" } } } },
+              "422": { "description": "No MLX model loaded", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } }
+            }
+          }
+        },
         "/v1/embeddings": {
           "post": {
             "tags": ["embeddings"],

--- a/Sources/AFMServer/Controllers/OpenAPIController.swift
+++ b/Sources/AFMServer/Controllers/OpenAPIController.swift
@@ -54,7 +54,7 @@ struct OpenAPIController: RouteCollection {
     """
 
     /// Hand-curated OpenAPI 3.1 spec. Intentionally kept compact — describes
-    /// the surface agents actually call rather than every property of every
+/// the surface agents actually call rather than every property of every
     /// payload. JSON-encoded inline so we don't fight SPM resource bundling.
     static let specJSON: String = #"""
     {
@@ -70,6 +70,7 @@ struct OpenAPIController: RouteCollection {
       ],
       "tags": [
         { "name": "chat", "description": "Chat completions" },
+        { "name": "responses", "description": "OpenAI Responses API" },
         { "name": "embeddings", "description": "Text embeddings" },
         { "name": "audio", "description": "Speech transcription and synthesis" },
         { "name": "vision", "description": "Apple Vision OCR" },
@@ -178,6 +179,32 @@ struct OpenAPIController: RouteCollection {
               "model": { "type": "string" },
               "choices": { "type": "array" },
               "usage": { "type": "object" }
+            }
+          },
+          "ResponsesRequest": {
+            "type": "object",
+            "required": ["input"],
+            "properties": {
+              "model": { "type": "string" },
+              "input": { "description": "A string or array of Responses input items, including input_text, input_image, function_call, and function_call_output." },
+              "instructions": { "type": "string" },
+              "previous_response_id": { "type": "string" },
+              "background": { "type": "boolean" },
+              "stream": { "type": "boolean" },
+              "max_output_tokens": { "type": "integer" },
+              "tools": { "type": "array", "items": { "type": "object" } },
+              "text": { "type": "object", "description": "Structured output configuration in text.format." }
+            }
+          },
+          "ResponsesResponse": {
+            "type": "object",
+            "required": ["id", "object", "status", "output"],
+            "properties": {
+              "id": { "type": "string" },
+              "object": { "type": "string", "const": "response" },
+              "status": { "type": "string", "enum": ["in_progress", "completed", "failed", "incomplete"] },
+              "output": { "type": "array", "items": { "type": "object" } },
+              "usage": { "type": ["object", "null"] }
             }
           },
           "CompletionRequest": {
@@ -315,6 +342,26 @@ struct OpenAPIController: RouteCollection {
               "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
               "503": { "description": "Server full / queue saturated", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } }
             }
+          }
+        },
+        "/v1/responses": {
+          "post": {
+            "tags": ["responses"],
+            "summary": "Create a response",
+            "description": "Supports text, Qwen VLM image input, tools, structured output, streaming lifecycle events, previous_response_id chaining, and background execution.",
+            "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ResponsesRequest" } } } },
+            "responses": {
+              "200": { "description": "Completed response or Responses SSE stream.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ResponsesResponse" } }, "text/event-stream": { "schema": { "type": "string" } } } },
+              "202": { "description": "Background response accepted.", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ResponsesResponse" } } } }
+            }
+          }
+        },
+        "/v1/responses/{response_id}": {
+          "get": {
+            "tags": ["responses"],
+            "summary": "Retrieve a stored or background response",
+            "parameters": [{ "name": "response_id", "in": "path", "required": true, "schema": { "type": "string" } }],
+            "responses": { "200": { "description": "Stored response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ResponsesResponse" } } } } }
           }
         },
         "/v1/chat/completions/{id}/cancel": {

--- a/Sources/AFMServer/Controllers/OpenAPIController.swift
+++ b/Sources/AFMServer/Controllers/OpenAPIController.swift
@@ -410,6 +410,17 @@ struct OpenAPIController: RouteCollection {
             }
           }
         },
+        "/v1/messages": {
+          "post": {
+            "tags": ["chat"],
+            "summary": "Create an Anthropic-compatible message",
+            "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object", "required": ["messages", "max_tokens"], "properties": { "model": { "type": "string" }, "system": {}, "messages": { "type": "array" }, "max_tokens": { "type": "integer" }, "stream": { "type": "boolean" } } } } } },
+            "responses": {
+              "200": { "description": "Message or Anthropic SSE event stream" },
+              "400": { "description": "Invalid Anthropic Messages request" }
+            }
+          }
+        },
         "/v1/embeddings": {
           "post": {
             "tags": ["embeddings"],

--- a/Sources/AFMServer/Controllers/ResponsesController.swift
+++ b/Sources/AFMServer/Controllers/ResponsesController.swift
@@ -1,0 +1,664 @@
+import Vapor
+import Foundation
+
+/// A small, transport-owned JSON value used by the Responses adapter. Keeping
+/// this type in AFMServer avoids adding Responses API wire types to AFMKit's
+/// provider contracts.
+enum ResponsesJSON: Codable, Sendable, Equatable {
+    case object([String: ResponsesJSON])
+    case array([ResponsesJSON])
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() { self = .null }
+        else if let value = try? container.decode(Bool.self) { self = .bool(value) }
+        else if let value = try? container.decode(Double.self) { self = .number(value) }
+        else if let value = try? container.decode(String.self) { self = .string(value) }
+        else if let value = try? container.decode([ResponsesJSON].self) { self = .array(value) }
+        else { self = .object(try container.decode([String: ResponsesJSON].self)) }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .object(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .string(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
+        case .bool(let value): try container.encode(value)
+        case .null: try container.encodeNil()
+        }
+    }
+
+    var objectValue: [String: ResponsesJSON]? {
+        guard case .object(let value) = self else { return nil }
+        return value
+    }
+
+    var arrayValue: [ResponsesJSON]? {
+        guard case .array(let value) = self else { return nil }
+        return value
+    }
+
+    var stringValue: String? {
+        guard case .string(let value) = self else { return nil }
+        return value
+    }
+
+    var boolValue: Bool? {
+        guard case .bool(let value) = self else { return nil }
+        return value
+    }
+
+    var intValue: Int? {
+        guard case .number(let value) = self else { return nil }
+        return Int(value)
+    }
+
+    subscript(_ key: String) -> ResponsesJSON? { objectValue?[key] }
+}
+
+struct StoredResponse: Sendable {
+    let messages: [ResponsesJSON]
+    let resource: ResponsesJSON
+}
+
+actor ResponsesStore {
+    private static let maximumStoredResponses = 1_024
+    private var responses: [String: StoredResponse] = [:]
+    private var insertionOrder: [String] = []
+
+    func get(_ id: String) -> StoredResponse? { responses[id] }
+
+    func put(id: String, messages: [ResponsesJSON], resource: ResponsesJSON) {
+        if responses[id] == nil {
+            insertionOrder.append(id)
+        }
+        responses[id] = StoredResponse(messages: messages, resource: resource)
+        while insertionOrder.count > Self.maximumStoredResponses {
+            responses.removeValue(forKey: insertionOrder.removeFirst())
+        }
+    }
+}
+
+/// Implements the OpenAI Responses surface by translating it at the HTTP
+/// boundary into the already-qualified Chat Completions pipeline. This keeps
+/// model loading, media preflight, structured output, tools, and reasoning in
+/// one inference path.
+struct ResponsesController: RouteCollection {
+    typealias ChatHandler = @Sendable (Request) async throws -> Response
+
+    private let defaultModelID: String
+    private let chatHandler: ChatHandler
+    private let store: ResponsesStore
+
+    init(
+        defaultModelID: String,
+        store: ResponsesStore = ResponsesStore(),
+        chatHandler: @escaping ChatHandler
+    ) {
+        self.defaultModelID = defaultModelID
+        self.store = store
+        self.chatHandler = chatHandler
+    }
+
+    func boot(routes: RoutesBuilder) throws {
+        let v1 = routes.grouped("v1")
+        v1.on(.POST, "responses", body: .collect(maxSize: "100mb"), use: createResponse)
+        v1.get("responses", ":response_id", use: getResponse)
+        v1.on(.OPTIONS, "responses", use: handleOptions)
+    }
+
+    func handleOptions(req: Request) async throws -> Response {
+        let response = Response(status: .ok)
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        response.headers.add(name: .accessControlAllowMethods, value: "POST, GET, OPTIONS")
+        response.headers.add(name: .accessControlAllowHeaders, value: "Content-Type, Authorization, X-AFM-Profile")
+        return response
+    }
+
+    func getResponse(req: Request) async throws -> Response {
+        guard let id = req.parameters.get("response_id"),
+              let stored = await store.get(id) else {
+            throw Abort(.notFound, reason: "Response not found")
+        }
+        return try encodeJSONResponse(stored.resource)
+    }
+
+    func createResponse(req: Request) async throws -> Response {
+        guard let inputData = req.body.data.map({ Data(buffer: $0) }) else {
+            throw Abort(.badRequest, reason: "Missing request body")
+        }
+        let request = try JSONDecoder().decode(ResponsesJSON.self, from: inputData)
+        guard let body = request.objectValue else {
+            throw Abort(.badRequest, reason: "Request body must be a JSON object")
+        }
+
+        let responseID = "resp_\(UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: ""))"
+        let model = body["model"]?.stringValue ?? defaultModelID
+        let previousID = body["previous_response_id"]?.stringValue
+        let priorMessages: [ResponsesJSON]
+        if let previousID {
+            guard let previous = await store.get(previousID) else {
+                throw Abort(.notFound, reason: "Unknown previous_response_id: \(previousID)")
+            }
+            priorMessages = previous.messages
+        } else {
+            priorMessages = []
+        }
+
+        let newMessages = try Self.translateInput(body)
+        let messages = priorMessages + newMessages
+        let chatBody = try Self.makeChatBody(body, model: model, messages: messages)
+        let background = body["background"]?.boolValue ?? false
+
+        if background {
+            let initial = Self.makeResource(
+                request: body,
+                id: responseID,
+                model: model,
+                previousID: previousID,
+                status: "in_progress",
+                output: [],
+                usage: nil,
+                background: true
+            )
+            await store.put(id: responseID, messages: messages, resource: initial)
+
+            let handler = chatHandler
+            let responseStore = store
+            Task {
+                do {
+                    let completed = try await Self.executeChat(
+                        request: req,
+                        chatBody: chatBody,
+                        requestBody: body,
+                        responseID: responseID,
+                        model: model,
+                        previousID: previousID,
+                        background: true,
+                        handler: handler
+                    )
+                    await responseStore.put(
+                        id: responseID,
+                        messages: messages + completed.assistantMessages,
+                        resource: completed.resource
+                    )
+                } catch {
+                    let failed = Self.makeResource(
+                        request: body,
+                        id: responseID,
+                        model: model,
+                        previousID: previousID,
+                        status: "failed",
+                        output: [],
+                        usage: nil,
+                        background: true,
+                        error: error.localizedDescription
+                    )
+                    await responseStore.put(id: responseID, messages: messages, resource: failed)
+                }
+            }
+            return try encodeJSONResponse(initial, status: .accepted)
+        }
+
+        let completed = try await Self.executeChat(
+            request: req,
+            chatBody: chatBody,
+            requestBody: body,
+            responseID: responseID,
+            model: model,
+            previousID: previousID,
+            background: false,
+            handler: chatHandler
+        )
+        await store.put(
+            id: responseID,
+            messages: messages + completed.assistantMessages,
+            resource: completed.resource
+        )
+
+        if body["stream"]?.boolValue == true {
+            return try Self.makeStreamingResponse(completed.resource)
+        }
+        return try encodeJSONResponse(completed.resource)
+    }
+
+    private struct CompletedChat: Sendable {
+        let resource: ResponsesJSON
+        let assistantMessages: [ResponsesJSON]
+    }
+
+    private static func executeChat(
+        request: Request,
+        chatBody: ResponsesJSON,
+        requestBody: [String: ResponsesJSON],
+        responseID: String,
+        model: String,
+        previousID: String?,
+        background: Bool,
+        handler: ChatHandler
+    ) async throws -> CompletedChat {
+        let encodedBody = try JSONEncoder().encode(chatBody)
+        var buffer = request.byteBufferAllocator.buffer(capacity: encodedBody.count)
+        buffer.writeBytes(encodedBody)
+        var headers = request.headers
+        headers.contentType = .json
+        headers.replaceOrAdd(name: .contentLength, value: String(encodedBody.count))
+        let chatRequest = Request(
+            application: request.application,
+            method: .POST,
+            url: URI(path: "/v1/chat/completions"),
+            version: request.version,
+            headersNoUpdate: headers,
+            collectedBody: buffer,
+            remoteAddress: request.remoteAddress,
+            peerCertificateChain: request.peerCertificateChain,
+            logger: request.logger,
+            byteBufferAllocator: request.byteBufferAllocator,
+            on: request.eventLoop
+        )
+        let chatResponse = try await handler(chatRequest)
+        guard (200..<300).contains(chatResponse.status.code) else {
+            throw Abort(chatResponse.status, reason: "Chat generation failed")
+        }
+        guard let buffer = try await chatResponse.body.collect(on: chatRequest.eventLoop).get() else {
+            throw Abort(.internalServerError, reason: "Chat generation returned an empty body")
+        }
+        let envelope = try JSONDecoder().decode(ResponsesJSON.self, from: Data(buffer: buffer))
+        guard let choice = envelope["choices"]?.arrayValue?.first?.objectValue,
+              let message = choice["message"]?.objectValue else {
+            throw Abort(.internalServerError, reason: "Chat generation returned an invalid response")
+        }
+
+        let output = makeOutput(message: message)
+        let usage = makeUsage(envelope["usage"])
+        let finishReason = choice["finish_reason"]?.stringValue
+        let responseStatus = finishReason == "length" ? "incomplete" : "completed"
+        let resource = makeResource(
+            request: requestBody,
+            id: responseID,
+            model: envelope["model"]?.stringValue ?? model,
+            previousID: previousID,
+            status: responseStatus,
+            output: output,
+            usage: usage,
+            background: background,
+            incompleteReason: finishReason == "length" ? "max_output_tokens" : nil
+        )
+        return CompletedChat(resource: resource, assistantMessages: [makeStoredAssistantMessage(message)])
+    }
+
+    private static func translateInput(_ body: [String: ResponsesJSON]) throws -> [ResponsesJSON] {
+        var messages: [ResponsesJSON] = []
+        if let instructions = body["instructions"]?.stringValue, !instructions.isEmpty {
+            messages.append(.object(["role": .string("system"), "content": .string(instructions)]))
+        }
+
+        guard let input = body["input"] else {
+            throw Abort(.badRequest, reason: "input is required")
+        }
+        if let text = input.stringValue {
+            messages.append(.object(["role": .string("user"), "content": .string(text)]))
+            return messages
+        }
+        guard let items = input.arrayValue else {
+            throw Abort(.badRequest, reason: "input must be a string or an array")
+        }
+
+        for item in items {
+            guard let object = item.objectValue else { continue }
+            switch object["type"]?.stringValue {
+            case "function_call":
+                let callID = object["call_id"]?.stringValue ?? "call_\(UUID().uuidString.lowercased().prefix(12))"
+                messages.append(.object([
+                    "role": .string("assistant"),
+                    "content": .null,
+                    "tool_calls": .array([.object([
+                        "id": .string(callID),
+                        "type": .string("function"),
+                        "function": .object([
+                            "name": object["name"] ?? .string(""),
+                            "arguments": object["arguments"] ?? .string("{}")
+                        ])
+                    ])])
+                ]))
+            case "function_call_output":
+                messages.append(.object([
+                    "role": .string("tool"),
+                    "tool_call_id": object["call_id"] ?? .string(""),
+                    "content": object["output"] ?? .string("")
+                ]))
+            default:
+                let role = object["role"]?.stringValue ?? "user"
+                let content = translateContent(object["content"])
+                messages.append(.object(["role": .string(role), "content": content]))
+            }
+        }
+        return messages
+    }
+
+    private static func translateContent(_ value: ResponsesJSON?) -> ResponsesJSON {
+        if let text = value?.stringValue { return .string(text) }
+        guard let parts = value?.arrayValue else { return .string("") }
+        return .array(parts.compactMap { part in
+            guard let object = part.objectValue else { return nil }
+            switch object["type"]?.stringValue {
+            case "input_image":
+                guard let imageURL = object["image_url"] else { return nil }
+                return .object([
+                    "type": .string("image_url"),
+                    "image_url": .object(["url": imageURL])
+                ])
+            case "input_text", "output_text", "text":
+                return .object([
+                    "type": .string("text"),
+                    "text": object["text"] ?? .string("")
+                ])
+            default:
+                return nil
+            }
+        })
+    }
+
+    private static func makeChatBody(
+        _ request: [String: ResponsesJSON],
+        model: String,
+        messages: [ResponsesJSON]
+    ) throws -> ResponsesJSON {
+        var body: [String: ResponsesJSON] = [
+            "model": .string(model),
+            "messages": .array(messages),
+            "stream": .bool(false)
+        ]
+        let mappings = [
+            ("temperature", "temperature"),
+            ("top_p", "top_p"),
+            ("max_output_tokens", "max_tokens"),
+            ("parallel_tool_calls", "parallel_tool_calls"),
+            ("presence_penalty", "presence_penalty"),
+            ("frequency_penalty", "frequency_penalty")
+        ]
+        for (source, destination) in mappings where request[source] != nil {
+            body[destination] = request[source]
+        }
+        if let effort = request["reasoning"]?["effort"]?.stringValue {
+            body["reasoning_effort"] = .string(effort)
+        }
+        if let tools = request["tools"]?.arrayValue {
+            body["tools"] = .array(tools.compactMap { tool in
+                guard let object = tool.objectValue,
+                      object["type"]?.stringValue == "function" else { return nil }
+                return .object([
+                    "type": .string("function"),
+                    "function": .object([
+                        "name": object["name"] ?? .string(""),
+                        "description": object["description"] ?? .null,
+                        "parameters": object["parameters"] ?? .null,
+                        "strict": object["strict"] ?? .null
+                    ])
+                ])
+            })
+        }
+        if let choice = request["tool_choice"] {
+            if let object = choice.objectValue, object["type"]?.stringValue == "function" {
+                body["tool_choice"] = .object([
+                    "type": .string("function"),
+                    "function": .object(["name": object["name"] ?? .string("")])
+                ])
+            } else {
+                body["tool_choice"] = choice
+            }
+        }
+        if let format = request["text"]?["format"]?.objectValue,
+           let type = format["type"]?.stringValue {
+            if type == "json_schema" {
+                body["response_format"] = .object([
+                    "type": .string("json_schema"),
+                    "json_schema": .object([
+                        "name": format["name"] ?? .string("response"),
+                        "description": format["description"] ?? .null,
+                        "schema": format["schema"] ?? .object([:]),
+                        "strict": format["strict"] ?? .bool(true)
+                    ])
+                ])
+            } else if type == "json_object" {
+                body["response_format"] = .object(["type": .string("json_object")])
+            }
+        }
+        return .object(body)
+    }
+
+    private static func makeOutput(message: [String: ResponsesJSON]) -> [ResponsesJSON] {
+        var output: [ResponsesJSON] = []
+        if let reasoning = message["reasoning_content"]?.stringValue, !reasoning.isEmpty {
+            output.append(.object([
+                "type": .string("reasoning"),
+                "id": .string("rs_\(UUID().uuidString.lowercased().prefix(12))"),
+                "content": .array([.object(["type": .string("reasoning_text"), "text": .string(reasoning)])]),
+                "summary": .array([])
+            ]))
+        }
+        if let toolCalls = message["tool_calls"]?.arrayValue {
+            for call in toolCalls {
+                guard let object = call.objectValue,
+                      let function = object["function"]?.objectValue else { continue }
+                let callID = object["id"]?.stringValue ?? "call_\(UUID().uuidString.lowercased().prefix(12))"
+                output.append(.object([
+                    "type": .string("function_call"),
+                    "id": .string("fc_\(UUID().uuidString.lowercased().prefix(12))"),
+                    "call_id": .string(callID),
+                    "name": function["name"] ?? .string(""),
+                    "arguments": function["arguments"] ?? .string("{}"),
+                    "status": .string("completed")
+                ]))
+            }
+        }
+        if let content = message["content"]?.stringValue, !content.isEmpty || output.isEmpty {
+            output.append(.object([
+                "type": .string("message"),
+                "id": .string("msg_\(UUID().uuidString.lowercased().prefix(12))"),
+                "status": .string("completed"),
+                "role": .string("assistant"),
+                "content": .array([.object([
+                    "type": .string("output_text"),
+                    "text": .string(content),
+                    "annotations": .array([])
+                ])])
+            ]))
+        }
+        return output
+    }
+
+    private static func makeStoredAssistantMessage(_ message: [String: ResponsesJSON]) -> ResponsesJSON {
+        var stored: [String: ResponsesJSON] = ["role": .string("assistant")]
+        stored["content"] = message["content"] ?? .null
+        if let toolCalls = message["tool_calls"] { stored["tool_calls"] = toolCalls }
+        if let reasoning = message["reasoning_content"] { stored["reasoning_content"] = reasoning }
+        return .object(stored)
+    }
+
+    private static func makeUsage(_ chatUsage: ResponsesJSON?) -> ResponsesJSON? {
+        guard let usage = chatUsage?.objectValue else { return nil }
+        let input = usage["prompt_tokens"]?.intValue ?? 0
+        let output = usage["completion_tokens"]?.intValue ?? 0
+        let cached = usage["prompt_tokens_details"]?["cached_tokens"]?.intValue ?? 0
+        return .object([
+            "input_tokens": .number(Double(input)),
+            "output_tokens": .number(Double(output)),
+            "total_tokens": .number(Double(input + output)),
+            "input_tokens_details": .object(["cached_tokens": .number(Double(cached))]),
+            "output_tokens_details": .object(["reasoning_tokens": .number(0)])
+        ])
+    }
+
+    private static func makeResource(
+        request: [String: ResponsesJSON],
+        id: String,
+        model: String,
+        previousID: String?,
+        status: String,
+        output: [ResponsesJSON],
+        usage: ResponsesJSON?,
+        background: Bool,
+        error: String? = nil,
+        incompleteReason: String? = nil
+    ) -> ResponsesJSON {
+        let now = Int(Date().timeIntervalSince1970)
+        let tools = request["tools"]?.arrayValue?.map { tool -> ResponsesJSON in
+            guard var object = tool.objectValue else { return tool }
+            if object["description"] == nil { object["description"] = .null }
+            if object["parameters"] == nil { object["parameters"] = .null }
+            if object["strict"] == nil { object["strict"] = .null }
+            return .object(object)
+        } ?? []
+        let text = request["text"] ?? .object(["format": .object(["type": .string("text")])])
+        let reasoning: ResponsesJSON
+        if var reasoningObject = request["reasoning"]?.objectValue {
+            if reasoningObject["effort"] == nil { reasoningObject["effort"] = .null }
+            if reasoningObject["summary"] == nil { reasoningObject["summary"] = .null }
+            reasoning = .object(reasoningObject)
+        } else {
+            reasoning = .null
+        }
+        let errorValue: ResponsesJSON = error.map {
+            .object(["code": .string("server_error"), "message": .string($0)])
+        } ?? .null
+        return .object([
+            "id": .string(id),
+            "object": .string("response"),
+            "created_at": .number(Double(now)),
+            "completed_at": status == "completed" || status == "failed" ? .number(Double(now)) : .null,
+            "status": .string(status),
+            "incomplete_details": incompleteReason.map {
+                .object(["reason": .string($0)])
+            } ?? .null,
+            "model": .string(model),
+            "previous_response_id": previousID.map(ResponsesJSON.string) ?? .null,
+            "instructions": request["instructions"] ?? .null,
+            "output": .array(output),
+            "error": errorValue,
+            "tools": .array(tools),
+            "tool_choice": request["tool_choice"] ?? .string("auto"),
+            "truncation": request["truncation"] ?? .string("disabled"),
+            "parallel_tool_calls": request["parallel_tool_calls"] ?? .bool(true),
+            "text": text,
+            "top_p": request["top_p"] ?? .number(1),
+            "presence_penalty": request["presence_penalty"] ?? .number(0),
+            "frequency_penalty": request["frequency_penalty"] ?? .number(0),
+            "top_logprobs": request["top_logprobs"] ?? .number(0),
+            "temperature": request["temperature"] ?? .number(1),
+            "reasoning": reasoning,
+            "usage": usage ?? .null,
+            "max_output_tokens": request["max_output_tokens"] ?? .null,
+            "max_tool_calls": request["max_tool_calls"] ?? .null,
+            "store": request["store"] ?? .bool(true),
+            "background": .bool(background),
+            "service_tier": request["service_tier"] ?? .string("default"),
+            "metadata": request["metadata"] ?? .object([:]),
+            "safety_identifier": request["safety_identifier"] ?? .null,
+            "prompt_cache_key": request["prompt_cache_key"] ?? .null
+        ])
+    }
+
+    private static func makeStreamingResponse(_ resource: ResponsesJSON) throws -> Response {
+        guard let object = resource.objectValue,
+              let output = object["output"]?.arrayValue else {
+            throw Abort(.internalServerError, reason: "Invalid Responses resource")
+        }
+        var created = object
+        created["status"] = .string("in_progress")
+        created["completed_at"] = .null
+        created["output"] = .array([])
+        created["usage"] = .null
+
+        var sequence = 0
+        var events: [ResponsesJSON] = [event("response.created", sequence: &sequence, fields: ["response": .object(created)])]
+        events.append(event("response.in_progress", sequence: &sequence, fields: ["response": .object(created)]))
+
+        for (index, item) in output.enumerated() {
+            guard let itemObject = item.objectValue else { continue }
+            let itemID = itemObject["id"]?.stringValue ?? "item_\(index)"
+            events.append(event("response.output_item.added", sequence: &sequence, fields: [
+                "output_index": .number(Double(index)), "item": item
+            ]))
+            if itemObject["type"]?.stringValue == "message",
+               let part = itemObject["content"]?.arrayValue?.first,
+               let text = part["text"]?.stringValue {
+                let emptyPart: ResponsesJSON = .object([
+                    "type": .string("output_text"), "text": .string(""), "annotations": .array([])
+                ])
+                events.append(event("response.content_part.added", sequence: &sequence, fields: [
+                    "item_id": .string(itemID), "output_index": .number(Double(index)),
+                    "content_index": .number(0), "part": emptyPart
+                ]))
+                if !text.isEmpty {
+                    events.append(event("response.output_text.delta", sequence: &sequence, fields: [
+                        "item_id": .string(itemID), "output_index": .number(Double(index)),
+                        "content_index": .number(0), "delta": .string(text)
+                    ]))
+                }
+                events.append(event("response.output_text.done", sequence: &sequence, fields: [
+                    "item_id": .string(itemID), "output_index": .number(Double(index)),
+                    "content_index": .number(0), "text": .string(text)
+                ]))
+                events.append(event("response.content_part.done", sequence: &sequence, fields: [
+                    "item_id": .string(itemID), "output_index": .number(Double(index)),
+                    "content_index": .number(0), "part": part
+                ]))
+            } else if itemObject["type"]?.stringValue == "function_call" {
+                let arguments = itemObject["arguments"]?.stringValue ?? "{}"
+                events.append(event("response.function_call_arguments.delta", sequence: &sequence, fields: [
+                    "item_id": .string(itemID), "output_index": .number(Double(index)), "delta": .string(arguments)
+                ]))
+                events.append(event("response.function_call_arguments.done", sequence: &sequence, fields: [
+                    "item_id": .string(itemID), "output_index": .number(Double(index)), "arguments": .string(arguments)
+                ]))
+            }
+            events.append(event("response.output_item.done", sequence: &sequence, fields: [
+                "output_index": .number(Double(index)), "item": item
+            ]))
+        }
+        let terminalType = object["status"]?.stringValue == "incomplete"
+            ? "response.incomplete"
+            : "response.completed"
+        events.append(event(terminalType, sequence: &sequence, fields: ["response": resource]))
+
+        let encoder = JSONEncoder()
+        let chunks = try events.map { event -> String in
+            let type = event["type"]?.stringValue ?? "message"
+            let data = try encoder.encode(event)
+            return "event: \(type)\ndata: \(String(decoding: data, as: UTF8.self))\n\n"
+        }
+        let response = Response(status: .ok)
+        response.headers.replaceOrAdd(name: .contentType, value: "text/event-stream")
+        response.headers.replaceOrAdd(name: .cacheControl, value: "no-cache")
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        response.body = .init(string: chunks.joined() + "data: [DONE]\n\n")
+        return response
+    }
+
+    private static func event(
+        _ type: String,
+        sequence: inout Int,
+        fields: [String: ResponsesJSON]
+    ) -> ResponsesJSON {
+        var object = fields
+        object["type"] = .string(type)
+        object["sequence_number"] = .number(Double(sequence))
+        sequence += 1
+        return .object(object)
+    }
+
+    private func encodeJSONResponse(_ value: ResponsesJSON, status: HTTPStatus = .ok) throws -> Response {
+        let response = Response(status: status)
+        response.headers.contentType = .json
+        response.headers.add(name: .accessControlAllowOrigin, value: "*")
+        response.body = .init(data: try JSONEncoder().encode(value))
+        return response
+    }
+}

--- a/Sources/AFMServer/Controllers/ResponsesController.swift
+++ b/Sources/AFMServer/Controllers/ResponsesController.swift
@@ -152,9 +152,18 @@ struct ResponsesController: RouteCollection {
         }
 
         let newMessages = try Self.translateInput(body)
-        let messages = priorMessages + newMessages
+        let conversationMessages = priorMessages + newMessages
+        var messages = conversationMessages
+        if let instructions = body["instructions"]?.stringValue, !instructions.isEmpty {
+            messages.insert(.object(["role": .string("system"), "content": .string(instructions)]), at: 0)
+        }
         let chatBody = try Self.makeChatBody(body, model: model, messages: messages)
         let background = body["background"]?.boolValue ?? false
+        let shouldStore = body["store"]?.boolValue ?? true
+
+        if background && !shouldStore {
+            throw Abort(.badRequest, reason: "background responses require store to be true")
+        }
 
         if background {
             let initial = Self.makeResource(
@@ -167,7 +176,7 @@ struct ResponsesController: RouteCollection {
                 usage: nil,
                 background: true
             )
-            await store.put(id: responseID, messages: messages, resource: initial)
+            await store.put(id: responseID, messages: conversationMessages, resource: initial)
 
             let handler = chatHandler
             let responseStore = store
@@ -185,7 +194,7 @@ struct ResponsesController: RouteCollection {
                     )
                     await responseStore.put(
                         id: responseID,
-                        messages: messages + completed.assistantMessages,
+                        messages: conversationMessages + completed.assistantMessages,
                         resource: completed.resource
                     )
                 } catch {
@@ -200,7 +209,7 @@ struct ResponsesController: RouteCollection {
                         background: true,
                         error: error.localizedDescription
                     )
-                    await responseStore.put(id: responseID, messages: messages, resource: failed)
+                    await responseStore.put(id: responseID, messages: conversationMessages, resource: failed)
                 }
             }
             return try encodeJSONResponse(initial, status: .accepted)
@@ -216,11 +225,13 @@ struct ResponsesController: RouteCollection {
             background: false,
             handler: chatHandler
         )
-        await store.put(
-            id: responseID,
-            messages: messages + completed.assistantMessages,
-            resource: completed.resource
-        )
+        if shouldStore {
+            await store.put(
+                id: responseID,
+                messages: conversationMessages + completed.assistantMessages,
+                resource: completed.resource
+            )
+        }
 
         if body["stream"]?.boolValue == true {
             return try Self.makeStreamingResponse(completed.resource)
@@ -295,10 +306,6 @@ struct ResponsesController: RouteCollection {
 
     private static func translateInput(_ body: [String: ResponsesJSON]) throws -> [ResponsesJSON] {
         var messages: [ResponsesJSON] = []
-        if let instructions = body["instructions"]?.stringValue, !instructions.isEmpty {
-            messages.append(.object(["role": .string("system"), "content": .string(instructions)]))
-        }
-
         guard let input = body["input"] else {
             throw Abort(.badRequest, reason: "input is required")
         }

--- a/Sources/AFMServer/Controllers/TokenizeController.swift
+++ b/Sources/AFMServer/Controllers/TokenizeController.swift
@@ -230,7 +230,7 @@ enum MessagesCountContent: Content {
         switch self {
         case .text(let value): return value
         case .blocks(let blocks):
-            return blocks.compactMap(\.text).joined(separator: "\n")
+            return blocks.compactMap(\.effectiveText).joined(separator: "\n")
         }
     }
 
@@ -255,6 +255,11 @@ enum MessagesCountContent: Content {
 struct MessagesCountBlock: Content {
     let type: String
     let text: String?
+    let thinking: String?
+
+    var effectiveText: String? {
+        text ?? thinking
+    }
 }
 
 // MARK: - Errors rendered in OpenAI shape

--- a/Sources/AFMServer/Controllers/TokenizeController.swift
+++ b/Sources/AFMServer/Controllers/TokenizeController.swift
@@ -34,6 +34,12 @@ struct TokenizeController: RouteCollection {
         v1.on(.OPTIONS, "tokenize", use: handleOptions)
         v1.on(.POST, "count_tokens", body: .collect(maxSize: "8mb"), use: countTokens)
         v1.on(.OPTIONS, "count_tokens", use: handleOptions)
+        // Anthropic-compatible token budgeting surface.  This intentionally
+        // lives beside the existing generic endpoint: clients using the
+        // Messages API address this path, while OpenAI/vLLM clients use
+        // /v1/count_tokens or /v1/tokenize.
+        v1.on(.POST, "messages", "count_tokens", body: .collect(maxSize: "8mb"), use: countMessageTokens)
+        v1.on(.OPTIONS, "messages", "count_tokens", use: handleOptions)
     }
 
     func handleOptions(req: Request) async throws -> Response {
@@ -68,6 +74,35 @@ struct TokenizeController: RouteCollection {
             model: mlxModelID ?? body.model ?? "unknown"
         )
         return try Self.jsonResponse(payload)
+    }
+
+    /// Anthropic's `POST /v1/messages/count_tokens` accepts a conversation
+    /// rather than one flat prompt. AFM's public tokenizer capability only
+    /// exposes text tokenization, so we preserve each textual block in order
+    /// and tokenize the resulting transcript. This is deliberately useful for
+    /// context budgeting without claiming exact model-template accounting;
+    /// template-exact counting requires a new AFMKit tokenizer capability.
+    func countMessageTokens(req: Request) async throws -> Response {
+        let body: MessagesCountTokensRequest
+        do {
+            body = try req.content.decode(MessagesCountTokensRequest.self)
+        } catch {
+            throw TokenizeBadRequestError(
+                message: "invalid messages/count_tokens request body: \(error.localizedDescription)",
+                requestId: req.afmRequestID
+            )
+        }
+        guard !body.effectiveText.isEmpty else {
+            throw TokenizeBadRequestError(
+                message: "request must include at least one textual message or system block",
+                requestId: req.afmRequestID
+            )
+        }
+        let tokens = try await encode(body.effectiveText, requestedModel: body.model, on: req)
+        return try Self.jsonResponse(CountTokensResponse(
+            inputTokens: tokens.count,
+            model: mlxModelID ?? body.model ?? "unknown"
+        ))
     }
 
     // MARK: - Internals
@@ -162,6 +197,64 @@ struct CountTokensResponse: Content {
         case inputTokens = "input_tokens"
         case model
     }
+}
+
+// MARK: - Anthropic Messages token-count request
+
+/// The subset of Anthropic Messages content needed for token budgeting. It
+/// accepts the normal string shorthand and arrays of content blocks, retaining
+/// text/thinking blocks and safely ignoring non-text media/tool payloads.
+struct MessagesCountTokensRequest: Content {
+    let model: String?
+    let system: MessagesCountContent?
+    let messages: [MessagesCountMessage]
+
+    var effectiveText: String {
+        let parts = (system.map { [$0.text] } ?? []) + messages.map(\.content.text)
+        return parts
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+}
+
+struct MessagesCountMessage: Content {
+    let role: String
+    let content: MessagesCountContent
+}
+
+enum MessagesCountContent: Content {
+    case text(String)
+    case blocks([MessagesCountBlock])
+
+    var text: String {
+        switch self {
+        case .text(let value): return value
+        case .blocks(let blocks):
+            return blocks.compactMap(\.text).joined(separator: "\n")
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let text = try? container.decode(String.self) {
+            self = .text(text)
+        } else {
+            self = .blocks(try container.decode([MessagesCountBlock].self))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .text(let value): try container.encode(value)
+        case .blocks(let blocks): try container.encode(blocks)
+        }
+    }
+}
+
+struct MessagesCountBlock: Content {
+    let type: String
+    let text: String?
 }
 
 // MARK: - Errors rendered in OpenAI shape

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -972,6 +972,7 @@ public class Server: @unchecked Sendable {
                     try await mlxController.chatCompletions(req: request)
                 }
             ))
+            try app.register(collection: MessagesController(model: mlxModelID, chatHandler: { request in try await mlxController.chatCompletions(req: request) }))
             if let rawTextGenerator {
                 try app.register(collection: CompletionsController(
                     modelID: mlxModelID,
@@ -1042,6 +1043,12 @@ public class Server: @unchecked Sendable {
             try app.register(collection: chatController)
             try app.register(collection: ResponsesController(
                 defaultModelID: "foundation",
+                chatHandler: { request in
+                    try await chatController.chatCompletions(req: request)
+                }
+            ))
+            try app.register(collection: MessagesController(
+                model: "foundation",
                 chatHandler: { request in
                     try await chatController.chatCompletions(req: request)
                 }

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -29,11 +29,9 @@ extension Request {
     }
 }
 
-/// `ChatCompletionRequest` deliberately lives in AFMKit, and older immutable
-/// AFMKit releases did not expose OpenAI's `n` field. Inspect the wire body at
-/// the HTTP boundary so this server never silently accepts a request for
-/// multiple choices and returns one. A future AFMKit DTO can replace this with
-/// typed validation while preserving this safety net for pinned consumers.
+/// `ChatCompletionRequest` deliberately lives in AFMKit, and the immutable
+/// pinned release does not expose OpenAI's `n` field. Inspect the wire body at
+/// the HTTP boundary until the provider-neutral DTO grows that field.
 func requestedChatChoiceCount(_ request: Request) -> Int? {
     guard let body = request.body.data else { return nil }
     let data = Data(buffer: body)
@@ -41,6 +39,15 @@ func requestedChatChoiceCount(_ request: Request) -> Int? {
         return nil
     }
     return object["n"] as? Int
+}
+
+func requestedChatStreaming(_ request: Request) -> Bool {
+    guard let body = request.body.data else { return false }
+    let data = Data(buffer: body)
+    guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return false
+    }
+    return object["stream"] as? Bool ?? false
 }
 
 /// Mints or echoes a stable request ID for every HTTP request and copies it
@@ -361,6 +368,7 @@ public class Server: @unchecked Sendable {
     private let mlxSeed: Int?
     private let mlxMaxLogprobs: Int
     private let contextWindow: Int?
+    private let chatRateLimitConfiguration: ChatRateLimitConfiguration
     private let telemetry: AFMServerTelemetryAdapter
     private var telegramBridge: TelegramBridge?
     private let webRuntimeManager = AFMWebRuntimeManager()
@@ -370,7 +378,13 @@ public class Server: @unchecked Sendable {
         return false
     }()
 
-    public init(port: Int, hostname: String, verbose: Bool, veryVerbose: Bool = false, trace: Bool = false, streamingEnabled: Bool, instructions: String, adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil, permissiveGuardrails: Bool = false, stop: String? = nil, webuiEnabled: Bool = false, gatewayEnabled: Bool = false, prewarmEnabled: Bool = true, telegramConfiguration: TelegramConfiguration? = nil, defaultGuidedJsonSchema: ResponseFormat? = nil, defaultChatTemplateKwargs: [String: AnyCodable]? = nil, forceDisableThinking: Bool = false, mlxModelID: String? = nil, mlxModel: AFMMLXModel? = nil, afmModel: AnyAFMModel? = nil, mlxRepetitionPenalty: Double? = nil, mlxTopP: Double? = nil, mlxMaxTokens: Int? = nil, mlxRawOutput: Bool = false, mlxTopK: Int? = nil, mlxMinP: Double? = nil, mlxPresencePenalty: Double? = nil, mlxSeed: Int? = nil, mlxMaxLogprobs: Int? = nil, contextWindow: Int? = nil, telemetry: AFMServerTelemetryAdapter? = nil) async throws {
+    public init(port: Int, hostname: String, verbose: Bool, veryVerbose: Bool = false, trace: Bool = false, streamingEnabled: Bool, instructions: String, adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil, permissiveGuardrails: Bool = false, stop: String? = nil, webuiEnabled: Bool = false, gatewayEnabled: Bool = false, prewarmEnabled: Bool = true, telegramConfiguration: TelegramConfiguration? = nil, defaultGuidedJsonSchema: ResponseFormat? = nil, defaultChatTemplateKwargs: [String: AnyCodable]? = nil, forceDisableThinking: Bool = false, mlxModelID: String? = nil, mlxModel: AFMMLXModel? = nil, afmModel: AnyAFMModel? = nil, mlxRepetitionPenalty: Double? = nil, mlxTopP: Double? = nil, mlxMaxTokens: Int? = nil, mlxRawOutput: Bool = false, mlxTopK: Int? = nil, mlxMinP: Double? = nil, mlxPresencePenalty: Double? = nil, mlxSeed: Int? = nil, mlxMaxLogprobs: Int? = nil, contextWindow: Int? = nil, rateLimitRequests: Int = 600, rateLimitWindowSeconds: TimeInterval = 60, telemetry: AFMServerTelemetryAdapter? = nil) async throws {
+        guard rateLimitRequests >= 0 else {
+            throw Abort(.badRequest, reason: "rateLimitRequests must be zero or greater.")
+        }
+        guard rateLimitWindowSeconds > 0 else {
+            throw Abort(.badRequest, reason: "rateLimitWindowSeconds must be greater than zero.")
+        }
         self.port = port
         self.hostname = hostname
         self.verbose = verbose
@@ -404,6 +418,10 @@ public class Server: @unchecked Sendable {
         self.mlxSeed = mlxSeed
         self.mlxMaxLogprobs = mlxMaxLogprobs ?? 20
         self.contextWindow = contextWindow
+        self.chatRateLimitConfiguration = ChatRateLimitConfiguration(
+            requestLimit: rateLimitRequests,
+            windowSeconds: rateLimitWindowSeconds
+        )
         let resolvedTelemetry = telemetry ?? .standalone()
         self.telemetry = resolvedTelemetry
         if let observer = resolvedTelemetry.providerTelemetryObserver {
@@ -451,6 +469,14 @@ public class Server: @unchecked Sendable {
         // Render typed errors (TokenizeUnsupportedError, etc.) in OpenAI shape. (T1.6)
         app.middleware.use(OpenAIErrorRenderingMiddleware())
 
+        // Apply real per-client admission accounting to generation-shaped chat
+        // routes. A zero request limit explicitly disables this middleware.
+        if chatRateLimitConfiguration.isEnabled {
+            app.middleware.use(ChatRateLimitMiddleware(
+                configuration: chatRateLimitConfiguration
+            ))
+        }
+
         // Add custom error middleware to handle payload too large errors
         app.middleware.use(PayloadTooLargeMiddleware())
         // Track concurrent client connections for /metrics' afm:num_active_connections gauge.
@@ -462,7 +488,8 @@ public class Server: @unchecked Sendable {
     private static let foundationWebValueOptions: Set<String> = [
         "--instructions", "--adapter", "--temperature", "--randomness", "--stop",
         "--prewarm", "--guided-json", "--telegram-bot-token", "--telegram-allow",
-        "--telegram-format", "--telegram-require-prefix"
+        "--telegram-format", "--telegram-require-prefix", "--rate-limit-requests",
+        "--rate-limit-window"
     ]
     private static let foundationWebFlagOptions: Set<String> = [
         "--verbose", "--very-verbose", "--vv", "--no-streaming",
@@ -477,7 +504,7 @@ public class Server: @unchecked Sendable {
         "--concurrent", "--mtp-depth", "--mtp-model", "--dspark-support", "--dspark-draft-tokens",
         "--dspark-confidence", "--eagle3", "--cache-profile-path", "--gpu-capture",
         "--gpu-trace", "--chat-template", "--dtype", "--telegram-bot-token", "--telegram-allow", "--telegram-format",
-        "--telegram-require-prefix"
+        "--telegram-require-prefix", "--rate-limit-requests", "--rate-limit-window"
     ]
     private static let mlxWebFlagOptions: Set<String> = [
         "--verbose", "--very-verbose", "--vv", "--no-streaming", "--raw", "--vlm",

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -29,6 +29,20 @@ extension Request {
     }
 }
 
+/// `ChatCompletionRequest` deliberately lives in AFMKit, and older immutable
+/// AFMKit releases did not expose OpenAI's `n` field. Inspect the wire body at
+/// the HTTP boundary so this server never silently accepts a request for
+/// multiple choices and returns one. A future AFMKit DTO can replace this with
+/// typed validation while preserving this safety net for pinned consumers.
+func requestedChatChoiceCount(_ request: Request) -> Int? {
+    guard let body = request.body.data else { return nil }
+    let data = Data(buffer: body)
+    guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return nil
+    }
+    return object["n"] as? Int
+}
+
 /// Mints or echoes a stable request ID for every HTTP request and copies it
 /// to the response headers. Honors inbound `X-Request-ID` (most common) and
 /// `OpenAI-Request-ID` (OpenAI SDK convention); otherwise mints `req_<uuid12>`

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -952,6 +952,12 @@ public class Server: @unchecked Sendable {
                 telemetry: telemetry
             )
             try app.register(collection: mlxController)
+            try app.register(collection: ResponsesController(
+                defaultModelID: mlxModelID,
+                chatHandler: { request in
+                    try await mlxController.chatCompletions(req: request)
+                }
+            ))
             if let rawTextGenerator {
                 try app.register(collection: CompletionsController(
                     modelID: mlxModelID,
@@ -1020,6 +1026,12 @@ public class Server: @unchecked Sendable {
                 telemetry: telemetry
             )
             try app.register(collection: chatController)
+            try app.register(collection: ResponsesController(
+                defaultModelID: "foundation",
+                chatHandler: { request in
+                    try await chatController.chatCompletions(req: request)
+                }
+            ))
         }
 
         // Prometheus metrics — always on, regardless of backend.

--- a/Tests/MacLocalAPITests/ChatTransportFrontierTests.swift
+++ b/Tests/MacLocalAPITests/ChatTransportFrontierTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+import Vapor
+import XCTVapor
+import AFMKit
+
+@testable import AFMServer
+
+final class ChatTransportFrontierTests: XCTestCase {
+    func testSharedChoiceFanoutInvokesHandlerOncePerChoice() async throws {
+        let app = try await Application.make(.testing)
+        let body = ByteBuffer(string: #"{"model":"foundation","n":3,"stream":false,"messages":[{"role":"user","content":"Hi"}]}"#)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        headers.replaceOrAdd(name: .contentLength, value: String(body.readableBytes))
+        let request = Request(
+            application: app,
+            method: .POST,
+            url: URI(path: "/v1/chat/completions"),
+            headersNoUpdate: headers,
+            collectedBody: body,
+            on: app.eventLoopGroup.next()
+        )
+        var invocationCount = 0
+
+        let response = try await generateChatChoices(request: request, count: 3) { _ in
+            invocationCount += 1
+            let generated = ChatCompletionResponse(
+                model: "foundation",
+                content: "choice-\(invocationCount)",
+                promptTokens: 2,
+                completionTokens: 1
+            )
+            let response = Response(status: .ok)
+            try response.content.encode(generated)
+            return response
+        }
+
+        XCTAssertEqual(invocationCount, 3)
+        guard let responseData = response.body.data else {
+            return XCTFail("missing fan-out response body")
+        }
+        let object = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
+        let choices = object?["choices"] as? [[String: Any]]
+        XCTAssertEqual(choices?.compactMap { $0["index"] as? Int }, [0, 1, 2])
+        XCTAssertEqual(
+            choices?.compactMap { ($0["message"] as? [String: Any])?["content"] as? String },
+            ["choice-1", "choice-2", "choice-3"]
+        )
+        try await app.asyncShutdown()
+    }
+
+    func testFixedWindowLimiterTracksRealRemainingQuotaAndReset() async {
+        let limiter = ChatRateLimiter(configuration: .init(
+            requestLimit: 2,
+            windowSeconds: 10
+        ))
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        let first = await limiter.consume(key: "client", now: start)
+        XCTAssertTrue(first.allowed)
+        XCTAssertEqual(first.limit, 2)
+        XCTAssertEqual(first.remaining, 1)
+        XCTAssertEqual(first.resetAfter, 10, accuracy: 0.001)
+
+        let second = await limiter.consume(
+            key: "client",
+            now: start.addingTimeInterval(2)
+        )
+        XCTAssertTrue(second.allowed)
+        XCTAssertEqual(second.remaining, 0)
+        XCTAssertEqual(second.resetAfter, 8, accuracy: 0.001)
+
+        let exhausted = await limiter.consume(
+            key: "client",
+            now: start.addingTimeInterval(3)
+        )
+        XCTAssertFalse(exhausted.allowed)
+        XCTAssertEqual(exhausted.remaining, 0)
+        XCTAssertEqual(exhausted.resetAfter, 7, accuracy: 0.001)
+
+        let reset = await limiter.consume(
+            key: "client",
+            now: start.addingTimeInterval(10)
+        )
+        XCTAssertTrue(reset.allowed)
+        XCTAssertEqual(reset.remaining, 1)
+        XCTAssertEqual(reset.resetAfter, 10, accuracy: 0.001)
+    }
+
+    func testRateLimitMiddlewareReturnsAccurateHeadersAndOpenAIError() async throws {
+        let app = try await Application.make(.testing)
+        app.middleware.use(RequestIDMiddleware())
+        app.middleware.use(ChatRateLimitMiddleware(configuration: .init(
+            requestLimit: 1,
+            windowSeconds: 60
+        )))
+        app.post("v1", "chat", "completions") { _ in
+            Response(status: .ok)
+        }
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/chat/completions"
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertEqual(response.headers.first(name: "X-RateLimit-Limit-Requests"), "1")
+            XCTAssertEqual(response.headers.first(name: "X-RateLimit-Remaining-Requests"), "0")
+            XCTAssertTrue(
+                response.headers.first(name: "X-RateLimit-Reset-Requests")?.hasSuffix("ms") == true
+            )
+        }
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/chat/completions"
+        ) { response async in
+            XCTAssertEqual(response.status, .tooManyRequests)
+            XCTAssertEqual(response.headers.first(name: "X-RateLimit-Limit-Requests"), "1")
+            XCTAssertEqual(response.headers.first(name: "X-RateLimit-Remaining-Requests"), "0")
+            XCTAssertNotNil(response.headers.first(name: .retryAfter))
+            let object = try? JSONSerialization.jsonObject(
+                with: Data(buffer: response.body)
+            ) as? [String: Any]
+            let error = object?["error"] as? [String: Any]
+            XCTAssertEqual(error?["type"] as? String, "rate_limit_error")
+            XCTAssertEqual(error?["code"] as? String, "rate_limit_exceeded")
+        }
+        try await app.asyncShutdown()
+    }
+
+    func testRateLimitMiddlewareCoversResponsesButNotReadOnlyRoutes() async throws {
+        let app = try await Application.make(.testing)
+        app.middleware.use(ChatRateLimitMiddleware(configuration: .init(
+            requestLimit: 2,
+            windowSeconds: 60
+        )))
+        app.post("v1", "responses") { _ in Response(status: .ok) }
+        app.get("v1", "models") { _ in Response(status: .ok) }
+
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/responses") { response async in
+            XCTAssertEqual(response.headers.first(name: "X-RateLimit-Remaining-Requests"), "1")
+        }
+        try await app.testable(method: .running(port: 0)).test(.GET, "/v1/models") { response async in
+            XCTAssertNil(response.headers.first(name: "X-RateLimit-Limit-Requests"))
+        }
+        try await app.asyncShutdown()
+    }
+}

--- a/Tests/MacLocalAPITests/ChatTransportFrontierTests.swift
+++ b/Tests/MacLocalAPITests/ChatTransportFrontierTests.swift
@@ -6,6 +6,32 @@ import AFMKit
 @testable import AFMServer
 
 final class ChatTransportFrontierTests: XCTestCase {
+    func testMatchedStopSequenceReportsOnlyKnownIdentity() {
+        XCTAssertEqual(
+            MLXChatCompletionsController.matchedStopSequence(
+                in: "alpha beta gamma",
+                stopSequences: ["gamma", "beta"],
+                stoppedBySequence: false
+            ),
+            "beta"
+        )
+        XCTAssertEqual(
+            MLXChatCompletionsController.matchedStopSequence(
+                in: "alpha",
+                stopSequences: ["beta"],
+                stoppedBySequence: true
+            ),
+            "beta"
+        )
+        XCTAssertNil(
+            MLXChatCompletionsController.matchedStopSequence(
+                in: "alpha",
+                stopSequences: ["beta", "gamma"],
+                stoppedBySequence: true
+            )
+        )
+    }
+
     func testSharedChoiceFanoutInvokesHandlerOncePerChoice() async throws {
         let app = try await Application.make(.testing)
         let body = ByteBuffer(string: #"{"model":"foundation","n":3,"stream":false,"messages":[{"role":"user","content":"Hi"}]}"#)
@@ -128,17 +154,21 @@ final class ChatTransportFrontierTests: XCTestCase {
         try await app.asyncShutdown()
     }
 
-    func testRateLimitMiddlewareCoversResponsesButNotReadOnlyRoutes() async throws {
+    func testRateLimitMiddlewareCoversChatShapedRoutesButNotReadOnlyRoutes() async throws {
         let app = try await Application.make(.testing)
         app.middleware.use(ChatRateLimitMiddleware(configuration: .init(
             requestLimit: 2,
             windowSeconds: 60
         )))
         app.post("v1", "responses") { _ in Response(status: .ok) }
+        app.post("v1", "messages") { _ in Response(status: .ok) }
         app.get("v1", "models") { _ in Response(status: .ok) }
 
         try await app.testable(method: .running(port: 0)).test(.POST, "/v1/responses") { response async in
             XCTAssertEqual(response.headers.first(name: "X-RateLimit-Remaining-Requests"), "1")
+        }
+        try await app.testable(method: .running(port: 0)).test(.POST, "/v1/messages") { response async in
+            XCTAssertEqual(response.headers.first(name: "X-RateLimit-Remaining-Requests"), "0")
         }
         try await app.testable(method: .running(port: 0)).test(.GET, "/v1/models") { response async in
             XCTAssertNil(response.headers.first(name: "X-RateLimit-Limit-Requests"))

--- a/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
+++ b/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
@@ -760,6 +760,57 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
         }
     }
 
+    func testNonStreamingControllerAcceptsAndHonorsBareStringStop() async throws {
+        let service = FakeMLXChatService(
+            generateResult: (
+                modelID: "test-model",
+                content: "alpha beta gamma",
+                promptTokens: 4,
+                completionTokens: 3,
+                tokenLogprobs: nil,
+                toolCalls: nil,
+                cachedTokens: 0,
+                promptTime: 0.01,
+                generateTime: 0.01,
+                stoppedBySequence: false
+            ),
+            streamingResult: makeStreamingResult(chunks: [])
+        )
+        try MLXChatCompletionsController(
+            modelID: "test-model",
+            service: service,
+            temperature: nil,
+            repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let body = try requestBody(
+            stream: false,
+            prompt: "Say exactly: alpha beta gamma",
+            toolsJSON: "[]",
+            stopJSON: #""beta""#
+        )
+        let headers = requestHeaders(for: body)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/chat/completions",
+            headers: headers,
+            body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            guard let data = response.body.getData(
+                at: response.body.readerIndex,
+                length: response.body.readableBytes
+            ),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let choices = object["choices"] as? [[String: Any]],
+                  let message = choices.first?["message"] as? [String: Any] else {
+                return XCTFail("missing chat completion response")
+            }
+            XCTAssertEqual(message["content"] as? String, "alpha ")
+        }
+    }
+
     func testStreamingControllerNarrowsToolsToNamedFunctionChoiceBeforeGeneration() async throws {
         let service = FakeMLXChatService(
             toolCallParser: "afm_adaptive_xml",

--- a/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
+++ b/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
@@ -28,6 +28,74 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
         XCTAssertEqual(filter.flush(), "")
     }
 
+    func testNonStreamingNProducesExactlyNGeneratedChoices() async throws {
+        let service = FakeMLXChatService(
+            generateResult: (
+                modelID: "test-model",
+                content: "Neon Badgers",
+                promptTokens: 4,
+                completionTokens: 2,
+                tokenLogprobs: nil,
+                toolCalls: nil,
+                cachedTokens: 0,
+                promptTime: 0.01,
+                generateTime: 0.02,
+                stoppedBySequence: false
+            ),
+            streamingResult: makeStreamingResult(chunks: [])
+        )
+        try MLXChatCompletionsController(
+            modelID: "test-model",
+            service: service,
+            temperature: nil,
+            repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let body = ByteBuffer(string: #"{"model":"test-model","n":2,"stream":false,"messages":[{"role":"user","content":"Invent a band name."}]}"#)
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/chat/completions",
+            headers: requestHeaders(for: body),
+            body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            let object = try? JSONSerialization.jsonObject(
+                with: Data(buffer: response.body)
+            ) as? [String: Any]
+            let choices = object?["choices"] as? [[String: Any]]
+            XCTAssertEqual(choices?.count, 2)
+            XCTAssertEqual(choices?.compactMap { $0["index"] as? Int }, [0, 1])
+            let usage = object?["usage"] as? [String: Any]
+            XCTAssertEqual(usage?["prompt_tokens"] as? Int, 8)
+            XCTAssertEqual(usage?["completion_tokens"] as? Int, 4)
+        }
+        XCTAssertEqual(service.generateCount, 2)
+    }
+
+    func testStreamingNIsRejectedExplicitly() async throws {
+        let service = FakeMLXChatService(
+            streamingResult: makeStreamingResult(chunks: [])
+        )
+        try MLXChatCompletionsController(
+            modelID: "test-model",
+            service: service,
+            temperature: nil,
+            repetitionPenalty: nil
+        ).boot(routes: app)
+
+        let body = ByteBuffer(string: #"{"model":"test-model","n":2,"stream":true,"messages":[{"role":"user","content":"Hi"}]}"#)
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/chat/completions",
+            headers: requestHeaders(for: body),
+            body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            XCTAssertContains(response.body.string, "unsupported_streaming_n")
+        }
+        XCTAssertEqual(service.generateCount, 0)
+    }
+
     func testStreamingStopFilterFlushesUnmatchedPartialDelimiter() {
         var filter = StreamingStopSequenceFilter(stopSequences: ["STOP"])
 
@@ -1687,11 +1755,13 @@ private final class FakeMLXChatService: AFMChatServing, AFMMLXMediaRequestServin
     private var _mediaPreflightCount = 0
     private var _withPreflightedMediaCount = 0
     private var _releaseSlotCount = 0
+    private var _generateCount = 0
     private var _recordedIgnoreEndOfSequence: [Bool] = []
     private(set) var recordedGenerateMediaPartCounts: [Int] = []
     var mediaPreflightCount: Int { stateLock.withLock { _mediaPreflightCount } }
     var withPreflightedMediaCount: Int { stateLock.withLock { _withPreflightedMediaCount } }
     var releaseSlotCount: Int { stateLock.withLock { _releaseSlotCount } }
+    var generateCount: Int { stateLock.withLock { _generateCount } }
     var recordedIgnoreEndOfSequence: [Bool] { stateLock.withLock { _recordedIgnoreEndOfSequence } }
 
     init(
@@ -1854,7 +1924,10 @@ private final class FakeMLXChatService: AFMChatServing, AFMMLXMediaRequestServin
         responseFormat: ResponseFormat?,
         chatTemplateKwargs: [String: AnyCodable]?
     ) async throws -> AFMChatGenerationResult {
-        stateLock.withLock { _recordedIgnoreEndOfSequence.append(AFMGenerationContext.ignoreEndOfSequence) }
+        stateLock.withLock {
+            _generateCount += 1
+            _recordedIgnoreEndOfSequence.append(AFMGenerationContext.ignoreEndOfSequence)
+        }
         recordGenerateTools(tools)
         if let generateProbe {
             try await generateProbe.suspendUntilCancelled()

--- a/Tests/MacLocalAPITests/ResponsesControllerTests.swift
+++ b/Tests/MacLocalAPITests/ResponsesControllerTests.swift
@@ -1,0 +1,233 @@
+import XCTest
+import Vapor
+import XCTVapor
+
+@testable import AFMServer
+
+final class ResponsesControllerTests: XCTestCase {
+    private var app: Application!
+
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
+    func testNonStreamingResponseTranslatesVisionInputAndUsage() async throws {
+        let recorder = ResponsesChatRecorder()
+        try register(recorder: recorder, content: "I see a red square.")
+
+        let body = #"""
+        {
+          "model":"test-model",
+          "input":[{"role":"user","content":[
+            {"type":"input_text","text":"What is shown?"},
+            {"type":"input_image","image_url":"data:image/png;base64,ZmFrZQ=="}
+          ]}],
+          "max_output_tokens":32
+        }
+        """#
+
+        try await post(body) { response in
+            XCTAssertEqual(response.status, .ok)
+            let json = try Self.json(response.body.string)
+            XCTAssertEqual(json["object"] as? String, "response")
+            XCTAssertEqual(json["status"] as? String, "completed")
+            XCTAssertEqual(json["model"] as? String, "test-model")
+            let output = try XCTUnwrap(json["output"] as? [[String: Any]])
+            let content = try XCTUnwrap(output.last?["content"] as? [[String: Any]])
+            XCTAssertEqual(content.first?["text"] as? String, "I see a red square.")
+            let usage = try XCTUnwrap(json["usage"] as? [String: Any])
+            XCTAssertEqual(usage["input_tokens"] as? Int, 7)
+            XCTAssertEqual(usage["output_tokens"] as? Int, 5)
+        }
+
+        let lastRecorded = await recorder.last()
+        let recorded = try XCTUnwrap(lastRecorded)
+        let chatBody = recorded.foundationObject
+        XCTAssertEqual(chatBody["stream"] as? Bool, false)
+        XCTAssertEqual(chatBody["max_tokens"] as? Int, 32)
+        let messages = try XCTUnwrap(chatBody["messages"] as? [[String: Any]])
+        let parts = try XCTUnwrap(messages.last?["content"] as? [[String: Any]])
+        XCTAssertEqual(parts.last?["type"] as? String, "image_url")
+        let imageURL = try XCTUnwrap(parts.last?["image_url"] as? [String: Any])
+        XCTAssertEqual(imageURL["url"] as? String, "data:image/png;base64,ZmFrZQ==")
+    }
+
+    func testStreamingResponseEmitsOrderedResponsesLifecycle() async throws {
+        try register(content: "hello")
+        let body = #"{"model":"test-model","input":"Say hello.","stream":true}"#
+
+        try await post(body) { response in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertEqual(response.headers.contentType?.type, "text")
+            XCTAssertEqual(response.headers.contentType?.subType, "event-stream")
+            let types = Self.ssePayloads(response.body.string).compactMap { payload -> String? in
+                guard payload != "[DONE]",
+                      let data = payload.data(using: .utf8),
+                      let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    return nil
+                }
+                return object["type"] as? String
+            }
+            XCTAssertEqual(types.first, "response.created")
+            XCTAssertEqual(types.last, "response.completed")
+            XCTAssertLessThan(
+                try XCTUnwrap(types.firstIndex(of: "response.output_item.added")),
+                try XCTUnwrap(types.firstIndex(of: "response.output_item.done"))
+            )
+            XCTAssertLessThan(
+                try XCTUnwrap(types.firstIndex(of: "response.output_text.delta")),
+                try XCTUnwrap(types.firstIndex(of: "response.completed"))
+            )
+            XCTAssertTrue(response.body.string.hasSuffix("data: [DONE]\n\n"))
+        }
+    }
+
+    func testPreviousResponseIDRestoresPriorConversation() async throws {
+        let recorder = ResponsesChatRecorder()
+        try register(recorder: recorder, content: "Ada")
+
+        var firstID = ""
+        try await post(#"{"input":"My name is Ada. Remember it."}"#) { response in
+            let json = try Self.json(response.body.string)
+            firstID = try XCTUnwrap(json["id"] as? String)
+        }
+        try await post(#"{"input":"What is my name?","previous_response_id":"\#(firstID)"}"#) { response in
+            XCTAssertEqual(response.status, .ok)
+        }
+
+        let requests = (await recorder.all()).map(\.foundationObject)
+        XCTAssertEqual(requests.count, 2)
+        let messages = try XCTUnwrap(requests.last?["messages"] as? [[String: Any]])
+        XCTAssertEqual(messages.count, 3)
+        XCTAssertEqual(messages[0]["content"] as? String, "My name is Ada. Remember it.")
+        XCTAssertEqual(messages[1]["role"] as? String, "assistant")
+        XCTAssertEqual(messages[1]["content"] as? String, "Ada")
+        XCTAssertEqual(messages[2]["content"] as? String, "What is my name?")
+    }
+
+    func testBackgroundResponseReturnsInProgressImmediately() async throws {
+        try register(content: "hi")
+        try await post(#"{"input":"Say hi.","background":true}"#) { response in
+            XCTAssertEqual(response.status, .accepted)
+            let json = try Self.json(response.body.string)
+            XCTAssertEqual(json["status"] as? String, "in_progress")
+            XCTAssertEqual(json["background"] as? Bool, true)
+            XCTAssertNotNil(json["id"] as? String)
+        }
+    }
+
+    private func register(
+        recorder: ResponsesChatRecorder = ResponsesChatRecorder(),
+        content: String
+    ) throws {
+        try app.register(collection: ResponsesController(defaultModelID: "test-model") { request in
+            if let body = request.body.data {
+                await recorder.record(Data(buffer: body))
+            }
+            let escaped = content.replacingOccurrences(of: "\"", with: "\\\"")
+            let response = Response(status: .ok)
+            response.headers.contentType = .json
+            response.body = .init(string: #"{"id":"chatcmpl_test","object":"chat.completion","created":1,"model":"test-model","choices":[{"index":0,"message":{"role":"assistant","content":"\#(escaped)"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":5,"total_tokens":12}}"#)
+            return response
+        })
+    }
+
+    private func post(
+        _ body: String,
+        afterResponse: @escaping (XCTHTTPResponse) throws -> Void
+    ) async throws {
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/responses",
+            headers: headers,
+            body: ByteBuffer(string: body)
+        ) { response async in
+            do {
+                try afterResponse(response)
+            } catch {
+                XCTFail("Response assertion failed: \(error)")
+            }
+        }
+    }
+
+    private static func json(_ string: String) throws -> [String: Any] {
+        try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(string.utf8)) as? [String: Any]
+        )
+    }
+
+    private static func ssePayloads(_ string: String) -> [String] {
+        string.components(separatedBy: "\n\n").compactMap { frame in
+            frame.split(separator: "\n")
+                .first(where: { $0.hasPrefix("data: ") })
+                .map { String($0.dropFirst(6)) }
+        }
+    }
+}
+
+private actor ResponsesChatRecorder {
+    private var requests: [[String: AnySendableJSON]] = []
+
+    func record(_ data: Data) {
+        guard let decoded = try? JSONDecoder().decode([String: AnySendableJSON].self, from: data) else {
+            return
+        }
+        requests.append(decoded)
+    }
+
+    func last() -> [String: AnySendableJSON]? { requests.last }
+
+    func all() -> [[String: AnySendableJSON]] { requests }
+}
+
+private enum AnySendableJSON: Codable, Sendable {
+    case object([String: AnySendableJSON])
+    case array([AnySendableJSON])
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() { self = .null }
+        else if let value = try? container.decode(Bool.self) { self = .bool(value) }
+        else if let value = try? container.decode(Double.self) { self = .number(value) }
+        else if let value = try? container.decode(String.self) { self = .string(value) }
+        else if let value = try? container.decode([AnySendableJSON].self) { self = .array(value) }
+        else { self = .object(try container.decode([String: AnySendableJSON].self)) }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .object(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .string(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
+        case .bool(let value): try container.encode(value)
+        case .null: try container.encodeNil()
+        }
+    }
+
+    var foundationObject: Any {
+        switch self {
+        case .object(let value): return value.foundationObject
+        case .array(let value): return value.map(\.foundationObject)
+        case .string(let value): return value
+        case .number(let value): return value.rounded() == value ? Int(value) : value
+        case .bool(let value): return value
+        case .null: return NSNull()
+        }
+    }
+}
+
+private extension Dictionary where Key == String, Value == AnySendableJSON {
+    var foundationObject: [String: Any] { mapValues(\.foundationObject) }
+}

--- a/Tests/MacLocalAPITests/ResponsesControllerTests.swift
+++ b/Tests/MacLocalAPITests/ResponsesControllerTests.swift
@@ -109,6 +109,43 @@ final class ResponsesControllerTests: XCTestCase {
         XCTAssertEqual(messages[2]["content"] as? String, "What is my name?")
     }
 
+    func testStoreFalseResponseCannotBeRetrieved() async throws {
+        try register(content: "not retained")
+
+        var responseID = ""
+        try await post(#"{"input":"private request","store":false}"#) { response in
+            XCTAssertEqual(response.status, .ok)
+            responseID = try XCTUnwrap(Self.json(response.body.string)["id"] as? String)
+        }
+
+        try await app.testable(method: .running(port: 0)).test(
+            .GET,
+            "/v1/responses/\(responseID)"
+        ) { response async in
+            XCTAssertEqual(response.status, .notFound)
+        }
+    }
+
+    func testPreviousResponseDoesNotCarryPriorInstructions() async throws {
+        let recorder = ResponsesChatRecorder()
+        try register(recorder: recorder, content: "answer")
+
+        var firstID = ""
+        try await post(#"{"input":"first","instructions":"old instruction"}"#) { response in
+            firstID = try XCTUnwrap(Self.json(response.body.string)["id"] as? String)
+        }
+        try await post(#"{"input":"second","instructions":"new instruction","previous_response_id":"\#(firstID)"}"#) { response in
+            XCTAssertEqual(response.status, .ok)
+        }
+
+        let requests = (await recorder.all()).map(\.foundationObject)
+        let messages = try XCTUnwrap(requests.last?["messages"] as? [[String: Any]])
+        let systemMessages = messages.filter { ($0["role"] as? String) == "system" }
+        XCTAssertEqual(systemMessages.count, 1)
+        XCTAssertEqual(systemMessages.first?["content"] as? String, "new instruction")
+        XCTAssertFalse(messages.contains { ($0["content"] as? String) == "old instruction" })
+    }
+
     func testBackgroundResponseReturnsInProgressImmediately() async throws {
         try register(content: "hi")
         try await post(#"{"input":"Say hi.","background":true}"#) { response in

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -118,6 +118,53 @@ struct TokenizeAndOpenAPITests {
         #expect(types.contains("content_block_stop"))
     }
 
+    @Test("Messages adapter translates Anthropic tools, tool history, and base64 images")
+    func messagesAdapterToolAndVisionTranslation() throws {
+        let request = try MessagesController.makeChatRequest(
+            object: [
+                "tools": .array([.object([
+                    "name": .string("weather"), "description": .string("Forecast"),
+                    "input_schema": .object(["type": .string("object")])
+                ])]),
+                "tool_choice": .object(["type": .string("tool"), "name": .string("weather")])
+            ],
+            sourceMessages: [
+                .object(["role": .string("assistant"), "content": .array([.object([
+                    "type": .string("tool_use"), "id": .string("call_1"), "name": .string("weather"),
+                    "input": .object(["city": .string("Toronto")])
+                ])])]),
+                .object(["role": .string("user"), "content": .array([
+                    .object(["type": .string("tool_result"), "tool_use_id": .string("call_1"), "content": .string("sunny")]),
+                    .object(["type": .string("image"), "source": .object([
+                        "type": .string("base64"), "media_type": .string("image/png"), "data": .string("AAAA")
+                    ])])
+                ])])
+            ],
+            maxTokens: 12,
+            defaultModel: "test-model"
+        )
+        #expect(request["tools"]?.arrayValue?.first?["function"]?["parameters"]?["type"]?.stringValue == "object")
+        #expect(request["tool_choice"]?["function"]?["name"]?.stringValue == "weather")
+        let messages = request["messages"]?.arrayValue ?? []
+        #expect(messages.contains { $0["tool_calls"]?.arrayValue?.first?["id"]?.stringValue == "call_1" })
+        #expect(messages.contains { $0["role"]?.stringValue == "tool" && $0["tool_call_id"]?.stringValue == "call_1" })
+        #expect(messages.contains { $0["content"]?.arrayValue?.contains { $0["image_url"]?["url"]?.stringValue == "data:image/png;base64,AAAA" } == true })
+
+        let response = try MessagesController.makeMessage(
+            chat: .object(["choices": .array([.object([
+                "finish_reason": .string("tool_calls"), "message": .object(["tool_calls": .array([.object([
+                    "id": .string("call_2"), "function": .object(["name": .string("weather"), "arguments": .string(#"{"city":"Toronto"}"#)])
+                ])])])
+            ])])]),
+            request: [:], defaultModel: "test-model"
+        )
+        #expect(response["stop_reason"]?.stringValue == "tool_use")
+        #expect(response["content"]?.arrayValue?.first?["type"]?.stringValue == "tool_use")
+        let events = MessagesController.streamingEvents(for: response)
+        #expect(events.contains { $0["content_block"]?["type"]?.stringValue == "tool_use" })
+        #expect(events.contains { $0["delta"]?["type"]?.stringValue == "input_json_delta" })
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // MARK: - T1.7 — OpenAPI spec integrity
     // ═══════════════════════════════════════════════════════════════════

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -67,6 +67,23 @@ struct TokenizeAndOpenAPITests {
         #expect(json.contains("\"model\":\"m\""))
     }
 
+    @Test("Messages count-tokens accepts Anthropic string and block content")
+    func messagesCountRequestDecoding() throws {
+        let json = #"""
+        {
+          "model": "m",
+          "system": [{"type":"text","text":"Be concise."}],
+          "messages": [
+            {"role":"user","content":"Hello"},
+            {"role":"assistant","content":[{"type":"thinking","text":"Plan"},{"type":"text","text":"Hi"}]}
+          ]
+        }
+        """#
+        let request = try JSONDecoder().decode(MessagesCountTokensRequest.self, from: Data(json.utf8))
+        #expect(request.model == "m")
+        #expect(request.effectiveText == "Be concise.\nHello\nPlan\nHi")
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // MARK: - T1.7 — OpenAPI spec integrity
     // ═══════════════════════════════════════════════════════════════════
@@ -91,6 +108,7 @@ struct TokenizeAndOpenAPITests {
             "/v1/chat/completions/{id}/cancel",
             "/v1/tokenize",
             "/v1/count_tokens",
+            "/v1/messages/count_tokens",
             "/v1/embeddings",
             "/v1/audio/transcriptions",
             "/v1/audio/speech",
@@ -167,6 +185,30 @@ final class TokenizeControllerIntegrationTests: XCTestCase {
             body: body
         ) { response async in
             XCTAssertEqual(response.status, .unprocessableEntity)
+        }
+    }
+
+    func testMessagesCountTokensAcceptsConversationShape() async throws {
+        try TokenizeController(
+            mlxModelID: "test/model",
+            tokenizer: FixedTokenizer(tokens: [1, 2, 3, 4]),
+            contextWindow: 8_192
+        ).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"""
+        {"model":"test/model","messages":[{"role":"user","content":"hello"}]}
+        """#)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/messages/count_tokens",
+            headers: headers,
+            body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertContains(response.body.string, #""input_tokens":4"#)
         }
     }
 }

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -75,7 +75,7 @@ struct TokenizeAndOpenAPITests {
           "system": [{"type":"text","text":"Be concise."}],
           "messages": [
             {"role":"user","content":"Hello"},
-            {"role":"assistant","content":[{"type":"thinking","text":"Plan"},{"type":"text","text":"Hi"}]}
+            {"role":"assistant","content":[{"type":"thinking","thinking":"Plan"},{"type":"text","text":"Hi"}]}
           ]
         }
         """#
@@ -114,13 +114,20 @@ struct TokenizeAndOpenAPITests {
             request: [:],
             defaultModel: "test-model"
         )
-        let types = MessagesController.streamingEvents(for: message).compactMap { $0["type"]?.stringValue }
+        let events = MessagesController.streamingEvents(for: message)
+        let types = events.compactMap { $0["type"]?.stringValue }
         #expect(message["stop_reason"]?.stringValue == "stop_sequence")
         #expect(message["stop_sequence"]?.stringValue == "END")
         #expect(types.first == "message_start")
         #expect(types.last == "message_stop")
         #expect(types.contains("content_block_start"))
         #expect(types.contains("content_block_stop"))
+        #expect(events.first?["message"]?["content"]?.arrayValue?.isEmpty == true)
+        #expect(events.first?["message"]?["stop_reason"] == .null)
+        #expect(events.first?["message"]?["usage"]?["output_tokens"]?.intValue == 0)
+        let delta = events.first { $0["type"]?.stringValue == "message_delta" }
+        #expect(delta?["usage"]?["input_tokens"] == nil)
+        #expect(delta?["usage"]?["output_tokens"]?.intValue == 1)
     }
 
     @Test("Messages adapter translates Anthropic tools, tool history, and base64 images")
@@ -134,10 +141,13 @@ struct TokenizeAndOpenAPITests {
                 "tool_choice": .object(["type": .string("tool"), "name": .string("weather")])
             ],
             sourceMessages: [
-                .object(["role": .string("assistant"), "content": .array([.object([
-                    "type": .string("tool_use"), "id": .string("call_1"), "name": .string("weather"),
-                    "input": .object(["city": .string("Toronto")])
-                ])])]),
+                .object(["role": .string("assistant"), "content": .array([
+                    .object(["type": .string("text"), "text": .string("Checking.")]),
+                    .object([
+                        "type": .string("tool_use"), "id": .string("call_1"), "name": .string("weather"),
+                        "input": .object(["city": .string("Toronto")])
+                    ])
+                ])]),
                 .object(["role": .string("user"), "content": .array([
                     .object(["type": .string("tool_result"), "tool_use_id": .string("call_1"), "content": .string("sunny")]),
                     .object(["type": .string("image"), "source": .object([
@@ -151,9 +161,11 @@ struct TokenizeAndOpenAPITests {
         #expect(request["tools"]?.arrayValue?.first?["function"]?["parameters"]?["type"]?.stringValue == "object")
         #expect(request["tool_choice"]?["function"]?["name"]?.stringValue == "weather")
         let messages = request["messages"]?.arrayValue ?? []
-        #expect(messages.contains { $0["tool_calls"]?.arrayValue?.first?["id"]?.stringValue == "call_1" })
-        #expect(messages.contains { $0["role"]?.stringValue == "tool" && $0["tool_call_id"]?.stringValue == "call_1" })
-        #expect(messages.contains { $0["content"]?.arrayValue?.contains { $0["image_url"]?["url"]?.stringValue == "data:image/png;base64,AAAA" } == true })
+        #expect(messages.map { $0["role"]?.stringValue } == ["assistant", "tool", "user"])
+        #expect(messages[0]["content"]?.stringValue == "Checking.")
+        #expect(messages[0]["tool_calls"]?.arrayValue?.first?["id"]?.stringValue == "call_1")
+        #expect(messages[1]["tool_call_id"]?.stringValue == "call_1")
+        #expect(messages[2]["content"]?.arrayValue?.contains { $0["image_url"]?["url"]?.stringValue == "data:image/png;base64,AAAA" } == true)
 
         let response = try MessagesController.makeMessage(
             chat: .object(["choices": .array([.object([
@@ -193,6 +205,21 @@ struct TokenizeAndOpenAPITests {
         #expect(messages.last?["role"]?.stringValue == "user")
         #expect(messages.last?["content"]?.stringValue?.contains("exact continuation") == true)
         #expect(messages.last?["content"]?.stringValue?.contains("The city is Par") == true)
+
+        let response = try MessagesController.makeMessage(
+            chat: .object([
+                "choices": .array([.object([
+                    "finish_reason": .string("stop"),
+                    "message": .object(["content": .string("is.")])
+                ])])
+            ]),
+            request: ["messages": .array([
+                .object(["role": .string("user"), "content": .string("Capital of France?")]),
+                .object(["role": .string("assistant"), "content": .string("Sure. The city is Par")])
+            ])],
+            defaultModel: "test-model"
+        )
+        #expect(response["content"]?.arrayValue?.first?["text"]?.stringValue == "is.")
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -344,6 +371,31 @@ final class TokenizeControllerIntegrationTests: XCTestCase {
             XCTAssertEqual(response.status, .badRequest)
             XCTAssertContains(response.body.string, #""type":"error""#)
             XCTAssertContains(response.body.string, #""invalid_request_error""#)
+        }
+    }
+
+    func testMessagesPreservesChatBackendErrorStatusAndMessage() async throws {
+        try MessagesController(model: "test-model", chatHandler: { _ in
+            let response = Response(status: .serviceUnavailable)
+            response.headers.contentType = .json
+            response.body = .init(string: #"{"error":{"message":"model unavailable","type":"server_error"}}"#)
+            return response
+        }).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"model":"test-model","max_tokens":8,"messages":[{"role":"user","content":"hello"}]}"#)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/messages",
+            headers: headers,
+            body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .serviceUnavailable)
+            XCTAssertContains(response.body.string, "model unavailable")
+            XCTAssertContains(response.body.string, #""type":"error""#)
+            XCTAssertContains(response.body.string, #""type":"api_error""#)
         }
     }
 }

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -105,6 +105,8 @@ struct TokenizeAndOpenAPITests {
         let expected = [
             "/v1/chat/completions",
             "/v1/completions",
+            "/v1/responses",
+            "/v1/responses/{response_id}",
             "/v1/chat/completions/{id}/cancel",
             "/v1/tokenize",
             "/v1/count_tokens",

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -170,6 +170,31 @@ struct TokenizeAndOpenAPITests {
         #expect(events.contains { $0["delta"]?["type"]?.stringValue == "input_json_delta" })
     }
 
+    @Test("Messages adapter honors disable_parallel_tool_use and final assistant prefills")
+    func messagesAdapterParallelToolsAndPrefill() throws {
+        let request = try MessagesController.makeChatRequest(
+            object: [
+                "tool_choice": .object([
+                    "type": .string("any"),
+                    "disable_parallel_tool_use": .bool(true)
+                ])
+            ],
+            sourceMessages: [
+                .object(["role": .string("user"), "content": .string("Capital of France?")]),
+                .object(["role": .string("assistant"), "content": .string("Sure. The city is Par")])
+            ],
+            maxTokens: 12,
+            defaultModel: "test-model"
+        )
+        #expect(request["tool_choice"]?.stringValue == "required")
+        #expect(request["parallel_tool_calls"]?.boolValue == false)
+        let messages = request["messages"]?.arrayValue ?? []
+        #expect(messages.count == 2)
+        #expect(messages.last?["role"]?.stringValue == "user")
+        #expect(messages.last?["content"]?.stringValue?.contains("exact continuation") == true)
+        #expect(messages.last?["content"]?.stringValue?.contains("The city is Par") == true)
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // MARK: - T1.7 — OpenAPI spec integrity
     // ═══════════════════════════════════════════════════════════════════

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -89,7 +89,8 @@ struct TokenizeAndOpenAPITests {
         let request = try MessagesController.makeChatRequest(
             object: [
                 "system": .array([.object(["type": .string("text"), "text": .string("Be concise.")])]),
-                "stop_sequences": .array([.string("END")])
+                "stop_sequences": .array([.string("END")]),
+                "thinking": .object(["type": .string("enabled"), "budget_tokens": .number(256)])
             ],
             sourceMessages: [.object([
                 "role": .string("user"),
@@ -101,10 +102,12 @@ struct TokenizeAndOpenAPITests {
         #expect(request["messages"]?.arrayValue?.count == 2)
         #expect(request["messages"]?.arrayValue?[1]["content"]?.stringValue == "Say hi")
         #expect(request["stop"]?.arrayValue?.first?.stringValue == "END")
+        #expect(request["reasoning_effort"]?.stringValue == "low")
 
         let message = try MessagesController.makeMessage(
             chat: .object([
                 "model": .string("test-model"),
+                "_afm_matched_stop": .string("END"),
                 "choices": .array([.object(["finish_reason": .string("stop"), "message": .object(["content": .string("hello")])])]),
                 "usage": .object(["prompt_tokens": .number(3), "completion_tokens": .number(1)])
             ]),
@@ -112,6 +115,8 @@ struct TokenizeAndOpenAPITests {
             defaultModel: "test-model"
         )
         let types = MessagesController.streamingEvents(for: message).compactMap { $0["type"]?.stringValue }
+        #expect(message["stop_reason"]?.stringValue == "stop_sequence")
+        #expect(message["stop_sequence"]?.stringValue == "END")
         #expect(types.first == "message_start")
         #expect(types.last == "message_stop")
         #expect(types.contains("content_block_start"))

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -84,6 +84,40 @@ struct TokenizeAndOpenAPITests {
         #expect(request.effectiveText == "Be concise.\nHello\nPlan\nHi")
     }
 
+    @Test("Messages adapter forwards block text and preserves Anthropic SSE lifecycle")
+    func messagesAdapterTranslation() throws {
+        let request = try MessagesController.makeChatRequest(
+            object: [
+                "system": .array([.object(["type": .string("text"), "text": .string("Be concise.")])]),
+                "stop_sequences": .array([.string("END")])
+            ],
+            sourceMessages: [.object([
+                "role": .string("user"),
+                "content": .array([.object(["type": .string("text"), "text": .string("Say hi")])])
+            ])],
+            maxTokens: 12,
+            defaultModel: "test-model"
+        )
+        #expect(request["messages"]?.arrayValue?.count == 2)
+        #expect(request["messages"]?.arrayValue?[1]["content"]?.stringValue == "Say hi")
+        #expect(request["stop"]?.arrayValue?.first?.stringValue == "END")
+
+        let message = try MessagesController.makeMessage(
+            chat: .object([
+                "model": .string("test-model"),
+                "choices": .array([.object(["finish_reason": .string("stop"), "message": .object(["content": .string("hello")])])]),
+                "usage": .object(["prompt_tokens": .number(3), "completion_tokens": .number(1)])
+            ]),
+            request: [:],
+            defaultModel: "test-model"
+        )
+        let types = MessagesController.streamingEvents(for: message).compactMap { $0["type"]?.stringValue }
+        #expect(types.first == "message_start")
+        #expect(types.last == "message_stop")
+        #expect(types.contains("content_block_start"))
+        #expect(types.contains("content_block_stop"))
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // MARK: - T1.7 — OpenAPI spec integrity
     // ═══════════════════════════════════════════════════════════════════
@@ -111,6 +145,7 @@ struct TokenizeAndOpenAPITests {
             "/v1/tokenize",
             "/v1/count_tokens",
             "/v1/messages/count_tokens",
+            "/v1/messages",
             "/v1/embeddings",
             "/v1/audio/transcriptions",
             "/v1/audio/speech",
@@ -211,6 +246,27 @@ final class TokenizeControllerIntegrationTests: XCTestCase {
         ) { response async in
             XCTAssertEqual(response.status, .ok)
             XCTAssertContains(response.body.string, #""input_tokens":4"#)
+        }
+    }
+
+    func testMessagesRequiresMaxTokensWithAnthropicErrorEnvelope() async throws {
+        try MessagesController(model: "test-model", chatHandler: { _ in
+            throw Abort(.notImplemented)
+        }).boot(routes: app)
+
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"model":"test-model","messages":[{"role":"user","content":"hello"}]}"#)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/messages",
+            headers: headers,
+            body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            XCTAssertContains(response.body.string, #""type":"error""#)
+            XCTAssertContains(response.body.string, #""invalid_request_error""#)
         }
     }
 }


### PR DESCRIPTION
## Problem

AFM lacked the OpenAI Responses and Anthropic Messages transport surfaces required by modern clients and llmprobe extended conformance.

## Approach

- add OpenAI-compatible `/v1/responses`, including streaming, tools, structured output, image input, background responses, and response chaining
- add Anthropic-compatible `/v1/messages` and `/v1/messages/count_tokens`, including streaming, tools, vision blocks, stops, thinking fields, and assistant prefill
- add multi-choice chat generation, rate-limit headers, bare-string stops, and extended transport compatibility
- document the new routes in OpenAPI and add focused controller coverage

## Validation

- release build succeeded against the companion AFMKit crash/cache branch
- maclocal-api release tests passed: 143 Swift Testing/XCTest cases
- llmprobe v0.5.0 full release run: 264/264 engine assertions (100%)
- model capability: 100%
- engine fidelity: 100%
- Qwen3.8-27B image understanding passed on Chat, Responses, and Messages
- AFM remained healthy throughout the 58,522-token run

The standalone HTML report is attached to the PR as generated evidence and is intentionally not committed.

## Companion AFMKit work

The recurrent-cache replay and MLX error-handling changes live on [AFMKit `fix/llmprobe-crash-handler-staging`](https://github.com/scouzi1966/AFMKit/tree/fix/llmprobe-crash-handler-staging). A Qwen recurrent restore previously replayed a rank-one suffix into a model path requiring `[batch, sequence]`; the companion fix restores the correct shape and prompt boundary.

## Summary by Sourcery

Expand AFM’s HTTP compatibility layer with OpenAI Responses and Anthropic Messages APIs while strengthening chat transport behavior and request controls.

New Features:
- Add OpenAI Responses API support with streaming, multimodal input, tools, structured output, background execution, storage, and response chaining.
- Add Anthropic Messages API support with streaming, vision and tool blocks, thinking fields, assistant prefills, stop sequences, and token counting.

Bug Fixes:
- Improve transport compatibility by accepting bare-string stop values and reporting matched stop sequences.

Enhancements:
- Support multiple non-streaming chat choices with aggregated results and usage.
- Add configurable per-client rate limiting for chat-shaped routes with standard quota headers and errors.
- Expose the new compatibility routes and capabilities through the OpenAPI specification.

Tests:
- Add focused coverage for Responses and Messages translation, streaming lifecycles, chaining, background responses, tools, vision, prefills, token counting, multiple choices, stop handling, and rate limiting.