### PR TITLE
Add OpenAI-compatible image endpoints

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -231,6 +231,7 @@ let package = Package(
             dependencies: [
                 "AFMKit",
                 .product(name: "AFMKitMLX", package: "AFMKit"),
+                .product(name: "AFMKitMLXImage", package: "AFMKit"),
                 .product(name: "AFMKitServices", package: "AFMKit"),
                 .product(name: "Vapor", package: "vapor")
             ],
@@ -356,6 +357,7 @@ let package = Package(
                 "AFMTerminalUI",
                 .product(name: "AFMKitCore", package: "AFMKit"),
                 .product(name: "AFMKitMLX", package: "AFMKit"),
+                .product(name: "AFMKitMLXImage", package: "AFMKit"),
                 .product(name: "AFMKitServices", package: "AFMKit"),
                 .product(name: "Jinja", package: "swift-jinja"),
                 .product(name: "XCTVapor", package: "vapor"),

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ afm mlx -m Qwen3-Coder-Next-4bit --openclaw-config
 | `POST` | `/v1/vision/ocr` | OCR, tables, barcodes, classification, saliency, and PDFs |
 | `POST` | `/v1/audio/transcriptions` | On-device speech-to-text |
 | `POST` | `/v1/audio/speech` | Text-to-speech using installed Apple voices |
+| `POST` | `/v1/images/generations` | FLUX.2 Klein text-to-image with base64 PNG output |
+| `POST` | `/v1/images/edits` | Multipart FLUX.2 Klein reference-image editing |
 | `POST` | `/v1/tokenize` | vLLM-compatible tokens and counts for the loaded MLX model |
 | `POST` | `/v1/count_tokens` | Anthropic-style input token count |
 | `POST` | `/v1/batch/completions` | Multiplex up to 64 completions over SSE |
@@ -395,6 +397,7 @@ Small 0.6B–4B quantized models are the easiest way to confirm a setup. Large 3
 - [MLX tool calling](docs/mlx-tool-calling.md)
 - [Vision OCR API](docs/vision-ocr-api.md)
 - [Embeddings API](docs/embeddings-api.md)
+- [Images API](docs/images-api.md)
 - [Apple-native endpoints](docs/apple-native-endpoints.md)
 - [Model path resolution](docs/model-path-resolution.md)
 - [Decode optimizations](docs/decode-optimizations.md)

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -12,6 +12,11 @@
 #   MACAFM_MLX_MODEL_CACHE=/Volumes/edata/models/vesta-test-cache \
 #     .build/release/afm mlx -m mlx-community/Qwen3-0.6B-4bit -p 9998 &
 #   ./Scripts/test-assertions.sh --tier smoke --model mlx-community/Qwen3-0.6B-4bit --port 9998
+#
+# Real FLUX integration smoke test (loads the 23.7 GB image model):
+#   AFM_RUN_FLUX_INTEGRATION=1 \
+#   MACAFM_MLX_MODEL_CACHE=/Volumes/Crucial4TB/models/vesta-test-cache \
+#     ./Scripts/test-assertions.sh --tier unit
 
 set -euo pipefail
 
@@ -35,6 +40,33 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 REPORT_DIR="${AFM_ASSERTIONS_REPORT_DIR:-$PROJECT_ROOT/test-reports}"
 REQUEST_TIMEOUT="${AFM_ASSERTIONS_REQUEST_TIMEOUT:-60}"
 
+usage() {
+  cat <<'EOF'
+Usage: ./Scripts/test-assertions.sh [options]
+
+Options:
+  --tier unit|smoke|standard|full
+  --model MODEL
+  --port PORT
+  --bin BIN
+  --section SECTION
+  --grammar-constraints
+  --help
+
+Optional real FLUX image integration test:
+  AFM_RUN_FLUX_INTEGRATION=1 enables the generation-and-edit smoke test that
+  loads the 23.7 GB FLUX model. This variable enables only the expensive test;
+  it is not required for normal /v1/images API operation.
+
+  Set MACAFM_MLX_MODEL_CACHE to the cache containing
+  mlx-community/FLUX.2-klein-4B-bf16, then run:
+
+    AFM_RUN_FLUX_INTEGRATION=1 \
+    MACAFM_MLX_MODEL_CACHE=/Volumes/Crucial4TB/models/vesta-test-cache \
+      ./Scripts/test-assertions.sh --tier unit
+EOF
+}
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     --tier) TIER="$2"; shift 2 ;;
@@ -43,6 +75,7 @@ while [[ $# -gt 0 ]]; do
     --bin) BIN="$2"; shift 2 ;;
     --section) SECTION="$2"; shift 2 ;;
     --grammar-constraints) GRAMMAR_CONSTRAINTS=true; shift ;;
+    --help|-h) usage; exit 0 ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done

--- a/Scripts/tests/test-assertion-harness-fixtures.sh
+++ b/Scripts/tests/test-assertion-harness-fixtures.sh
@@ -14,6 +14,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
+help_output="$($ROOT_DIR/Scripts/test-assertions.sh --help)"
+grep -q "AFM_RUN_FLUX_INTEGRATION=1" <<<"$help_output" || {
+    echo "assertion harness help does not document the FLUX integration opt-in" >&2
+    exit 1
+}
+grep -q "not required for normal /v1/images API operation" <<<"$help_output" || {
+    echo "assertion harness help does not distinguish the test flag from runtime enablement" >&2
+    exit 1
+}
+
 python3 - "$ROOT_DIR/Scripts/test-assertions.sh" <<'PY'
 import json
 import re

--- a/Sources/AFMServer/Controllers/ImagesAPIController.swift
+++ b/Sources/AFMServer/Controllers/ImagesAPIController.swift
@@ -5,13 +5,25 @@ import Vapor
 public struct ImageGenerationRequestBody: Content {
     public var model: String?
     public var prompt: String
+    public var background: String?
+    public var moderation: String?
     public var n: Int?
+    public var outputCompression: Int?
+    public var outputFormat: String?
+    public var partialImages: Int?
+    public var quality: String?
     public var size: String?
     public var responseFormat: String?
     public var seed: UInt64?
+    public var stream: Bool?
+    public var style: String?
+    public var user: String?
 
     enum CodingKeys: String, CodingKey {
-        case model, prompt, n, size, seed
+        case model, prompt, background, moderation, n, quality, size, seed, stream, style, user
+        case outputCompression = "output_compression"
+        case outputFormat = "output_format"
+        case partialImages = "partial_images"
         case responseFormat = "response_format"
     }
 }
@@ -20,13 +32,27 @@ private struct ImageEditForm: Content {
     var model: String?
     var prompt: String
     var image: File
+    var background: String?
+    var inputFidelity: String?
+    var mask: File?
+    var moderation: String?
     var n: Int?
+    var outputCompression: Int?
+    var outputFormat: String?
+    var partialImages: Int?
+    var quality: String?
     var size: String?
     var responseFormat: String?
     var seed: UInt64?
+    var stream: Bool?
+    var user: String?
 
     enum CodingKeys: String, CodingKey {
-        case model, prompt, image, n, size, seed
+        case model, prompt, image, background, mask, moderation, n, quality, size, seed, stream, user
+        case inputFidelity = "input_fidelity"
+        case outputCompression = "output_compression"
+        case outputFormat = "output_format"
+        case partialImages = "partial_images"
         case responseFormat = "response_format"
     }
 }
@@ -46,6 +72,18 @@ public struct OpenAIImagesResponse: Content {
 
 public struct ImagesAPIController: RouteCollection, Sendable {
     private static let maximumBodySize: ByteCount = "100mb"
+    private static let compatibilityHeader = HTTPHeaders.Name("X-AFM-Compatibility")
+    private static let emulatedParametersHeader = HTTPHeaders.Name("X-AFM-Emulated-Parameters")
+    private static let generationParameters: Set<String> = [
+        "model", "prompt", "background", "moderation", "n", "output_compression",
+        "output_format", "partial_images", "quality", "size", "response_format",
+        "seed", "stream", "style", "user",
+    ]
+    private static let editParameters: Set<String> = [
+        "model", "prompt", "image", "image[]", "background", "input_fidelity", "mask",
+        "moderation", "n", "output_compression", "output_format", "partial_images",
+        "quality", "size", "response_format", "seed", "stream", "user",
+    ]
     private let generator: any AFMImageGenerating
 
     public init(generator: any AFMImageGenerating) {
@@ -58,45 +96,116 @@ public struct ImagesAPIController: RouteCollection, Sendable {
         images.on(.POST, "edits", body: .collect(maxSize: Self.maximumBodySize), use: edit)
         images.on(.OPTIONS, "generations", use: options)
         images.on(.OPTIONS, "edits", use: options)
+        for method in [HTTPMethod.GET, .PUT, .PATCH, .DELETE] {
+            images.on(method, "generations", use: unsupportedMethod)
+            images.on(method, "edits", use: unsupportedMethod)
+        }
     }
 
     private func generate(req: Request) async throws -> Response {
+        guard Self.isJSON(req.headers.contentType) else {
+            return try Self.errorResponse(
+                request: req,
+                status: .unsupportedMediaType,
+                message: "Content-Type must be application/json",
+                code: "unsupported_media_type"
+            )
+        }
+        if let parameter = Self.unknownJSONParameter(in: req, allowed: Self.generationParameters) {
+            return try Self.errorResponse(
+                request: req,
+                status: .badRequest,
+                message: "Unknown parameter: \(parameter)",
+                code: "unknown_parameter",
+                param: parameter
+            )
+        }
         let body: ImageGenerationRequestBody
         do {
             body = try req.content.decode(ImageGenerationRequestBody.self)
         } catch {
-            throw Abort(.badRequest, reason: "Invalid image generation request: \(error.localizedDescription)")
+            return try Self.errorResponse(
+                request: req,
+                status: .badRequest,
+                message: "Invalid image generation request: \(error.localizedDescription)",
+                code: "invalid_request_error"
+            )
         }
-        let dimensions = try Self.dimensions(body.size, defaultValue: (1024, 1024))
-        try Self.validateResponseFormat(body.responseFormat)
-        let results = try await generator.generateImages(for: AFMImageGenerationRequest(
-            prompt: try Self.validPrompt(body.prompt),
-            width: dimensions.width,
-            height: dimensions.height,
-            count: try Self.validCount(body.n),
-            seed: body.seed
-        ))
-        return try Self.response(for: results)
+        do {
+            try Self.validateGenerationControls(body)
+            let dimensions = try Self.dimensions(body.size, defaultValue: (1024, 1024))
+            let results = try await generator.generateImages(for: AFMImageGenerationRequest(
+                prompt: try Self.validPrompt(body.prompt),
+                width: dimensions.width,
+                height: dimensions.height,
+                count: try Self.validCount(body.n),
+                seed: body.seed
+            ))
+            return try Self.response(
+                for: results,
+                emulatedParameters: body.model == nil ? [] : ["model"]
+            )
+        } catch let error as ImageAPIRequestError {
+            return try Self.errorResponse(request: req, error: error)
+        }
     }
 
     private func edit(req: Request) async throws -> Response {
+        guard Self.isMultipartForm(req.headers.contentType) else {
+            return try Self.errorResponse(
+                request: req,
+                status: .unsupportedMediaType,
+                message: "Content-Type must be multipart/form-data",
+                code: "unsupported_media_type"
+            )
+        }
+        if let parameter = Self.unknownMultipartParameter(in: req, allowed: Self.editParameters) {
+            return try Self.errorResponse(
+                request: req,
+                status: .badRequest,
+                message: "Unknown parameter: \(parameter)",
+                code: "unknown_parameter",
+                param: parameter
+            )
+        }
+        if Self.multipartParameterNames(in: req).contains("image[]") {
+            return try Self.errorResponse(
+                request: req,
+                status: .badRequest,
+                message: "Multiple image inputs are not supported; send one file using the image field",
+                code: "unsupported_parameter",
+                param: "image"
+            )
+        }
         let form: ImageEditForm
         do {
             form = try req.content.decode(ImageEditForm.self)
         } catch {
-            throw Abort(.badRequest, reason: "Invalid multipart image edit request: \(error.localizedDescription)")
+            return try Self.errorResponse(
+                request: req,
+                status: .badRequest,
+                message: "Invalid multipart image edit request: \(error.localizedDescription)",
+                code: "invalid_request_error"
+            )
         }
-        let dimensions = try Self.dimensions(form.size, defaultValue: (1024, 1024))
-        try Self.validateResponseFormat(form.responseFormat)
-        let results = try await generator.editImages(for: AFMImageEditRequest(
-            prompt: try Self.validPrompt(form.prompt),
-            images: [Data(buffer: form.image.data)],
-            width: dimensions.width,
-            height: dimensions.height,
-            count: try Self.validCount(form.n),
-            seed: form.seed
-        ))
-        return try Self.response(for: results)
+        do {
+            try Self.validateEditControls(form)
+            let dimensions = try Self.dimensions(form.size, defaultValue: (1024, 1024))
+            let results = try await generator.editImages(for: AFMImageEditRequest(
+                prompt: try Self.validPrompt(form.prompt),
+                images: [Data(buffer: form.image.data)],
+                width: dimensions.width,
+                height: dimensions.height,
+                count: try Self.validCount(form.n),
+                seed: form.seed
+            ))
+            return try Self.response(
+                for: results,
+                emulatedParameters: form.model == nil ? [] : ["model"]
+            )
+        } catch let error as ImageAPIRequestError {
+            return try Self.errorResponse(request: req, error: error)
+        }
     }
 
     private func options(req: Request) async throws -> Response {
@@ -105,15 +214,33 @@ public struct ImagesAPIController: RouteCollection, Sendable {
         return response
     }
 
+    private func unsupportedMethod(req: Request) async throws -> Response {
+        let response = try Self.errorResponse(
+            request: req,
+            status: .methodNotAllowed,
+            message: "Method \(req.method.rawValue) is not allowed for this endpoint",
+            code: "method_not_allowed"
+        )
+        response.headers.replaceOrAdd(name: "Allow", value: "POST, OPTIONS")
+        return response
+    }
+
     private static func validPrompt(_ prompt: String) throws -> String {
         let value = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !value.isEmpty else { throw Abort(.badRequest, reason: "prompt must not be empty") }
+        guard !value.isEmpty else {
+            throw ImageAPIRequestError.invalid("prompt must not be empty", param: "prompt")
+        }
         return value
     }
 
     private static func validCount(_ count: Int?) throws -> Int {
         let value = count ?? 1
-        guard (1...4).contains(value) else { throw Abort(.badRequest, reason: "n must be between 1 and 4") }
+        guard (1...10).contains(value) else {
+            throw ImageAPIRequestError.invalid("n must be between 1 and 10", param: "n")
+        }
+        guard value <= 4 else {
+            throw ImageAPIRequestError.unsupported("AFM image generation currently supports at most 4 images per request", param: "n")
+        }
         return value
     }
 
@@ -124,25 +251,138 @@ public struct ImagesAPIController: RouteCollection, Sendable {
               let width = Int(parts[0]), let height = Int(parts[1]),
               (64...2048).contains(width), (64...2048).contains(height)
         else {
-            throw Abort(.badRequest, reason: "size must be auto or WIDTHxHEIGHT between 64 and 2048")
+            throw ImageAPIRequestError.invalid(
+                "size must be auto or WIDTHxHEIGHT between 64 and 2048",
+                param: "size"
+            )
         }
         return (width, height)
     }
 
+    private static func validateGenerationControls(_ body: ImageGenerationRequestBody) throws {
+        try validateResponseFormat(body.responseFormat)
+        try validatePNGOutputFormat(body.outputFormat)
+        try rejectIfPresent(body.background, param: "background")
+        try rejectIfPresent(body.moderation, param: "moderation")
+        try rejectIfPresent(body.outputCompression, param: "output_compression")
+        try rejectIfPresent(body.partialImages, param: "partial_images")
+        try rejectIfPresent(body.quality, param: "quality")
+        try rejectIfTrue(body.stream, param: "stream")
+        try rejectIfPresent(body.style, param: "style")
+    }
+
+    private static func validateEditControls(_ form: ImageEditForm) throws {
+        try validateResponseFormat(form.responseFormat)
+        try validatePNGOutputFormat(form.outputFormat)
+        try rejectIfPresent(form.background, param: "background")
+        try rejectIfPresent(form.inputFidelity, param: "input_fidelity")
+        try rejectIfPresent(form.mask, param: "mask")
+        try rejectIfPresent(form.moderation, param: "moderation")
+        try rejectIfPresent(form.outputCompression, param: "output_compression")
+        try rejectIfPresent(form.partialImages, param: "partial_images")
+        try rejectIfPresent(form.quality, param: "quality")
+        try rejectIfTrue(form.stream, param: "stream")
+    }
+
     private static func validateResponseFormat(_ format: String?) throws {
-        guard let format else { return }
-        guard format == "b64_json" else {
-            throw Abort(.badRequest, reason: "Only response_format=b64_json is supported")
+        guard let format, format != "b64_json" else { return }
+        throw ImageAPIRequestError.unsupported(
+            "response_format=\(format) is not supported; use b64_json",
+            param: "response_format"
+        )
+    }
+
+    private static func validatePNGOutputFormat(_ format: String?) throws {
+        guard let format, format != "png" else { return }
+        throw ImageAPIRequestError.unsupported(
+            "output_format=\(format) is not supported; use png",
+            param: "output_format"
+        )
+    }
+
+    private static func rejectIfPresent<T>(_ value: T?, param: String) throws {
+        guard value != nil else { return }
+        throw ImageAPIRequestError.unsupported("Parameter '\(param)' is not supported by the configured AFM image model", param: param)
+    }
+
+    private static func rejectIfTrue(_ value: Bool?, param: String) throws {
+        guard value == true else { return }
+        throw ImageAPIRequestError.unsupported("Parameter '\(param)=true' is not supported by the configured AFM image model", param: param)
+    }
+
+    private static func isJSON(_ mediaType: HTTPMediaType?) -> Bool {
+        mediaType?.type == "application" && mediaType?.subType == "json"
+    }
+
+    private static func isMultipartForm(_ mediaType: HTTPMediaType?) -> Bool {
+        mediaType?.type == "multipart" && mediaType?.subType == "form-data"
+    }
+
+    private static func unknownJSONParameter(in request: Request, allowed: Set<String>) -> String? {
+        guard let buffer = request.body.data,
+              let object = try? JSONSerialization.jsonObject(with: Data(buffer: buffer)) as? [String: Any]
+        else { return nil }
+        return object.keys.filter { !allowed.contains($0) }.sorted().first
+    }
+
+    private static func unknownMultipartParameter(in request: Request, allowed: Set<String>) -> String? {
+        multipartParameterNames(in: request).filter { !allowed.contains($0) }.sorted().first
+    }
+
+    private static func multipartParameterNames(in request: Request) -> [String] {
+        guard let buffer = request.body.data else { return [] }
+        let text = String(decoding: Data(buffer: buffer), as: UTF8.self)
+        let pattern = #"Content-Disposition:[^\r\n]*\bname="([^"]+)""#
+        guard let expression = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return []
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return expression.matches(in: text, range: range).compactMap { match -> String? in
+            guard let nameRange = Range(match.range(at: 1), in: text) else { return nil }
+            return String(text[nameRange])
         }
     }
 
-    private static func response(for images: [AFMGeneratedImage]) throws -> Response {
+    private static func errorResponse(request: Request, error: ImageAPIRequestError) throws -> Response {
+        try errorResponse(
+            request: request,
+            status: .badRequest,
+            message: error.message,
+            code: error.code,
+            param: error.param
+        )
+    }
+
+    private static func errorResponse(
+        request: Request,
+        status: HTTPResponseStatus,
+        message: String,
+        code: String,
+        param: String? = nil
+    ) throws -> Response {
+        let response = Response(status: status)
+        try response.content.encode(OpenAIError(
+            message: message,
+            type: "invalid_request_error",
+            code: code,
+            param: param,
+            requestId: request.afmRequestID.isEmpty ? nil : request.afmRequestID
+        ))
+        applyHeaders(to: response)
+        return response
+    }
+
+    private static func response(for images: [AFMGeneratedImage], emulatedParameters: [String]) throws -> Response {
         let body = OpenAIImagesResponse(
             created: Int64(Date().timeIntervalSince1970),
             data: images.map { OpenAIImageData(b64Json: $0.data.base64EncodedString()) }
         )
         let response = Response(status: .ok)
         try response.content.encode(body)
+        if !emulatedParameters.isEmpty {
+            response.headers.replaceOrAdd(name: compatibilityHeader, value: "emulated")
+            response.headers.replaceOrAdd(name: emulatedParametersHeader, value: emulatedParameters.joined(separator: ","))
+        }
         applyHeaders(to: response)
         return response
     }
@@ -151,6 +391,24 @@ public struct ImagesAPIController: RouteCollection, Sendable {
         response.headers.replaceOrAdd(name: .accessControlAllowOrigin, value: "*")
         response.headers.replaceOrAdd(name: .accessControlAllowMethods, value: "POST, OPTIONS")
         response.headers.replaceOrAdd(name: .accessControlAllowHeaders, value: "Authorization, Content-Type")
+        response.headers.replaceOrAdd(
+            name: "Access-Control-Expose-Headers",
+            value: "X-Request-ID, OpenAI-Request-ID, X-AFM-Compatibility, X-AFM-Emulated-Parameters"
+        )
         response.headers.replaceOrAdd(name: .cacheControl, value: "no-store")
+    }
+}
+
+private struct ImageAPIRequestError: Error {
+    let message: String
+    let code: String
+    let param: String
+
+    static func invalid(_ message: String, param: String) -> Self {
+        Self(message: message, code: "invalid_request_error", param: param)
+    }
+
+    static func unsupported(_ message: String, param: String) -> Self {
+        Self(message: message, code: "unsupported_parameter", param: param)
     }
 }

--- a/Sources/AFMServer/Controllers/ImagesAPIController.swift
+++ b/Sources/AFMServer/Controllers/ImagesAPIController.swift
@@ -1,0 +1,156 @@
+import AFMKit
+import Foundation
+import Vapor
+
+public struct ImageGenerationRequestBody: Content {
+    public var model: String?
+    public var prompt: String
+    public var n: Int?
+    public var size: String?
+    public var responseFormat: String?
+    public var seed: UInt64?
+
+    enum CodingKeys: String, CodingKey {
+        case model, prompt, n, size, seed
+        case responseFormat = "response_format"
+    }
+}
+
+private struct ImageEditForm: Content {
+    var model: String?
+    var prompt: String
+    var image: File
+    var n: Int?
+    var size: String?
+    var responseFormat: String?
+    var seed: UInt64?
+
+    enum CodingKeys: String, CodingKey {
+        case model, prompt, image, n, size, seed
+        case responseFormat = "response_format"
+    }
+}
+
+public struct OpenAIImageData: Content {
+    public var b64Json: String
+
+    enum CodingKeys: String, CodingKey {
+        case b64Json = "b64_json"
+    }
+}
+
+public struct OpenAIImagesResponse: Content {
+    public var created: Int64
+    public var data: [OpenAIImageData]
+}
+
+public struct ImagesAPIController: RouteCollection, Sendable {
+    private static let maximumBodySize: ByteCount = "100mb"
+    private let generator: any AFMImageGenerating
+
+    public init(generator: any AFMImageGenerating) {
+        self.generator = generator
+    }
+
+    public func boot(routes: RoutesBuilder) throws {
+        let images = routes.grouped("v1", "images")
+        images.on(.POST, "generations", body: .collect(maxSize: Self.maximumBodySize), use: generate)
+        images.on(.POST, "edits", body: .collect(maxSize: Self.maximumBodySize), use: edit)
+        images.on(.OPTIONS, "generations", use: options)
+        images.on(.OPTIONS, "edits", use: options)
+    }
+
+    private func generate(req: Request) async throws -> Response {
+        let body: ImageGenerationRequestBody
+        do {
+            body = try req.content.decode(ImageGenerationRequestBody.self)
+        } catch {
+            throw Abort(.badRequest, reason: "Invalid image generation request: \(error.localizedDescription)")
+        }
+        let dimensions = try Self.dimensions(body.size, defaultValue: (1024, 1024))
+        try Self.validateResponseFormat(body.responseFormat)
+        let results = try await generator.generateImages(for: AFMImageGenerationRequest(
+            prompt: try Self.validPrompt(body.prompt),
+            width: dimensions.width,
+            height: dimensions.height,
+            count: try Self.validCount(body.n),
+            seed: body.seed
+        ))
+        return try Self.response(for: results)
+    }
+
+    private func edit(req: Request) async throws -> Response {
+        let form: ImageEditForm
+        do {
+            form = try req.content.decode(ImageEditForm.self)
+        } catch {
+            throw Abort(.badRequest, reason: "Invalid multipart image edit request: \(error.localizedDescription)")
+        }
+        let dimensions = try Self.dimensions(form.size, defaultValue: (1024, 1024))
+        try Self.validateResponseFormat(form.responseFormat)
+        let results = try await generator.editImages(for: AFMImageEditRequest(
+            prompt: try Self.validPrompt(form.prompt),
+            images: [Data(buffer: form.image.data)],
+            width: dimensions.width,
+            height: dimensions.height,
+            count: try Self.validCount(form.n),
+            seed: form.seed
+        ))
+        return try Self.response(for: results)
+    }
+
+    private func options(req: Request) async throws -> Response {
+        let response = Response(status: .ok)
+        Self.applyHeaders(to: response)
+        return response
+    }
+
+    private static func validPrompt(_ prompt: String) throws -> String {
+        let value = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { throw Abort(.badRequest, reason: "prompt must not be empty") }
+        return value
+    }
+
+    private static func validCount(_ count: Int?) throws -> Int {
+        let value = count ?? 1
+        guard (1...4).contains(value) else { throw Abort(.badRequest, reason: "n must be between 1 and 4") }
+        return value
+    }
+
+    static func dimensions(_ size: String?, defaultValue: (Int, Int)) throws -> (width: Int, height: Int) {
+        guard let size, size.lowercased() != "auto" else { return defaultValue }
+        let parts = size.lowercased().split(separator: "x", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let width = Int(parts[0]), let height = Int(parts[1]),
+              (64...2048).contains(width), (64...2048).contains(height)
+        else {
+            throw Abort(.badRequest, reason: "size must be auto or WIDTHxHEIGHT between 64 and 2048")
+        }
+        return (width, height)
+    }
+
+    private static func validateResponseFormat(_ format: String?) throws {
+        guard let format else { return }
+        guard format == "b64_json" else {
+            throw Abort(.badRequest, reason: "Only response_format=b64_json is supported")
+        }
+    }
+
+    private static func response(for images: [AFMGeneratedImage]) throws -> Response {
+        let body = OpenAIImagesResponse(
+            created: Int64(Date().timeIntervalSince1970),
+            data: images.map { OpenAIImageData(b64Json: $0.data.base64EncodedString()) }
+        )
+        let response = Response(status: .ok)
+        try response.content.encode(body)
+        applyHeaders(to: response)
+        return response
+    }
+
+    private static func applyHeaders(to response: Response) {
+        response.headers.replaceOrAdd(name: .accessControlAllowOrigin, value: "*")
+        response.headers.replaceOrAdd(name: .accessControlAllowMethods, value: "POST, OPTIONS")
+        response.headers.replaceOrAdd(name: .accessControlAllowHeaders, value: "Authorization, Content-Type")
+        response.headers.replaceOrAdd(name: .cacheControl, value: "no-store")
+    }
+}

--- a/Sources/AFMServer/Controllers/ImagesAPIController.swift
+++ b/Sources/AFMServer/Controllers/ImagesAPIController.swift
@@ -1,4 +1,5 @@
 import AFMKit
+import AFMKitMLXImage
 import Foundation
 import Vapor
 
@@ -31,7 +32,7 @@ public struct ImageGenerationRequestBody: Content {
 private struct ImageEditForm: Content {
     var model: String?
     var prompt: String
-    var image: File
+    var image: File?
     var background: String?
     var inputFidelity: String?
     var mask: File?
@@ -71,7 +72,10 @@ public struct OpenAIImagesResponse: Content {
 }
 
 public struct ImagesAPIController: RouteCollection, Sendable {
-    private static let maximumBodySize: ByteCount = "100mb"
+    private static let maximumGenerationBodySize: ByteCount = "1mb"
+    private static let maximumEditBodySize: ByteCount = "25mb"
+    private static let maximumImageBytes = 20 * 1024 * 1024
+    private static let maximumPromptCharacters = 32_000
     private static let compatibilityHeader = HTTPHeaders.Name("X-AFM-Compatibility")
     private static let emulatedParametersHeader = HTTPHeaders.Name("X-AFM-Emulated-Parameters")
     private static let generationParameters: Set<String> = [
@@ -85,18 +89,26 @@ public struct ImagesAPIController: RouteCollection, Sendable {
         "quality", "size", "response_format", "seed", "stream", "user",
     ]
     private let generator: any AFMImageGenerating
+    private let modelID: String
+    private let modelAliases: Set<String>
 
-    public init(generator: any AFMImageGenerating) {
+    public init(
+        generator: any AFMImageGenerating,
+        modelID: String = "mlx-community/FLUX.2-klein-4B-bf16",
+        modelAliases: Set<String> = []
+    ) {
         self.generator = generator
+        self.modelID = modelID
+        self.modelAliases = modelAliases
     }
 
     public func boot(routes: RoutesBuilder) throws {
         let images = routes.grouped("v1", "images")
-        images.on(.POST, "generations", body: .collect(maxSize: Self.maximumBodySize), use: generate)
-        images.on(.POST, "edits", body: .collect(maxSize: Self.maximumBodySize), use: edit)
+        images.on(.POST, "generations", body: .collect(maxSize: Self.maximumGenerationBodySize), use: generate)
+        images.on(.POST, "edits", body: .collect(maxSize: Self.maximumEditBodySize), use: edit)
         images.on(.OPTIONS, "generations", use: options)
         images.on(.OPTIONS, "edits", use: options)
-        for method in [HTTPMethod.GET, .PUT, .PATCH, .DELETE] {
+        for method in [HTTPMethod.GET, .HEAD, .PUT, .PATCH, .DELETE, .CONNECT, .TRACE] {
             images.on(method, "generations", use: unsupportedMethod)
             images.on(method, "edits", use: unsupportedMethod)
         }
@@ -133,6 +145,7 @@ public struct ImagesAPIController: RouteCollection, Sendable {
         }
         do {
             try Self.validateGenerationControls(body)
+            let emulatesModel = try validateModel(body.model)
             let dimensions = try Self.dimensions(body.size, defaultValue: (1024, 1024))
             let results = try await generator.generateImages(for: AFMImageGenerationRequest(
                 prompt: try Self.validPrompt(body.prompt),
@@ -142,11 +155,14 @@ public struct ImagesAPIController: RouteCollection, Sendable {
                 seed: body.seed
             ))
             return try Self.response(
+                request: req,
                 for: results,
-                emulatedParameters: body.model == nil ? [] : ["model"]
+                emulatedParameters: emulatesModel ? ["model"] : []
             )
         } catch let error as ImageAPIRequestError {
             return try Self.errorResponse(request: req, error: error)
+        } catch {
+            return try Self.providerErrorResponse(request: req, error: error, operation: "generation")
         }
     }
 
@@ -159,22 +175,32 @@ public struct ImagesAPIController: RouteCollection, Sendable {
                 code: "unsupported_media_type"
             )
         }
-        if let parameter = Self.unknownMultipartParameter(in: req, allowed: Self.editParameters) {
+        do {
+            let parameterNames = try Self.multipartParameterNames(in: req)
+            if let parameter = parameterNames.filter({ !Self.editParameters.contains($0) }).sorted().first {
+                return try Self.errorResponse(
+                    request: req,
+                    status: .badRequest,
+                    message: "Unknown parameter: \(parameter)",
+                    code: "unknown_parameter",
+                    param: parameter
+                )
+            }
+            if parameterNames.contains("image[]") {
+                return try Self.errorResponse(
+                    request: req,
+                    status: .badRequest,
+                    message: "Multiple image inputs are not supported; send one file using the image field",
+                    code: "unsupported_parameter",
+                    param: "image"
+                )
+            }
+        } catch {
             return try Self.errorResponse(
                 request: req,
                 status: .badRequest,
-                message: "Unknown parameter: \(parameter)",
-                code: "unknown_parameter",
-                param: parameter
-            )
-        }
-        if Self.multipartParameterNames(in: req).contains("image[]") {
-            return try Self.errorResponse(
-                request: req,
-                status: .badRequest,
-                message: "Multiple image inputs are not supported; send one file using the image field",
-                code: "unsupported_parameter",
-                param: "image"
+                message: "Invalid multipart image edit request",
+                code: "invalid_request_error"
             )
         }
         let form: ImageEditForm
@@ -190,27 +216,35 @@ public struct ImagesAPIController: RouteCollection, Sendable {
         }
         do {
             try Self.validateEditControls(form)
+            let emulatesModel = try validateModel(form.model)
+            guard let image = form.image else {
+                throw ImageAPIRequestError.invalid("image is required", param: "image")
+            }
+            try Self.validateImageFile(image)
             let dimensions = try Self.dimensions(form.size, defaultValue: (1024, 1024))
             let results = try await generator.editImages(for: AFMImageEditRequest(
                 prompt: try Self.validPrompt(form.prompt),
-                images: [Data(buffer: form.image.data)],
+                images: [Data(buffer: image.data)],
                 width: dimensions.width,
                 height: dimensions.height,
                 count: try Self.validCount(form.n),
                 seed: form.seed
             ))
             return try Self.response(
+                request: req,
                 for: results,
-                emulatedParameters: form.model == nil ? [] : ["model"]
+                emulatedParameters: emulatesModel ? ["model"] : []
             )
         } catch let error as ImageAPIRequestError {
             return try Self.errorResponse(request: req, error: error)
+        } catch {
+            return try Self.providerErrorResponse(request: req, error: error, operation: "edit")
         }
     }
 
     private func options(req: Request) async throws -> Response {
         let response = Response(status: .ok)
-        Self.applyHeaders(to: response)
+        Self.applyHeaders(to: response, for: req)
         return response
     }
 
@@ -230,7 +264,40 @@ public struct ImagesAPIController: RouteCollection, Sendable {
         guard !value.isEmpty else {
             throw ImageAPIRequestError.invalid("prompt must not be empty", param: "prompt")
         }
+        guard value.count <= maximumPromptCharacters else {
+            throw ImageAPIRequestError.invalid(
+                "prompt must not exceed \(maximumPromptCharacters) characters",
+                param: "prompt"
+            )
+        }
         return value
+    }
+
+    private func validateModel(_ requestedModel: String?) throws -> Bool {
+        guard let requestedModel else { return false }
+        guard !requestedModel.isEmpty else {
+            throw ImageAPIRequestError.invalid("model must not be empty", param: "model")
+        }
+        if requestedModel == modelID { return false }
+        if modelAliases.contains(requestedModel) { return true }
+        throw ImageAPIRequestError(
+            message: "Model '\(requestedModel)' is not configured for image generation; use '\(modelID)'",
+            code: "unsupported_model",
+            param: "model"
+        )
+    }
+
+    private static func validateImageFile(_ image: File) throws {
+        guard image.data.readableBytes > 0 else {
+            throw ImageAPIRequestError.invalid("image must not be empty", param: "image")
+        }
+        guard image.data.readableBytes <= maximumImageBytes else {
+            throw ImageAPIRequestError.invalid("image must not exceed 20 MB", param: "image")
+        }
+        let supportedExtensions: Set<String> = ["png", "jpg", "jpeg", "webp"]
+        guard let fileExtension = image.extension?.lowercased(), supportedExtensions.contains(fileExtension) else {
+            throw ImageAPIRequestError.invalid("image must be a PNG, JPEG, or WebP file", param: "image")
+        }
     }
 
     private static func validCount(_ count: Int?) throws -> Int {
@@ -249,10 +316,12 @@ public struct ImagesAPIController: RouteCollection, Sendable {
         let parts = size.lowercased().split(separator: "x", omittingEmptySubsequences: false)
         guard parts.count == 2,
               let width = Int(parts[0]), let height = Int(parts[1]),
-              (64...2048).contains(width), (64...2048).contains(height)
+              (64...2048).contains(width), (64...2048).contains(height),
+              width.isMultiple(of: 16), height.isMultiple(of: 16),
+              width <= height * 3, height <= width * 3
         else {
             throw ImageAPIRequestError.invalid(
-                "size must be auto or WIDTHxHEIGHT between 64 and 2048",
+                "size must be auto or WIDTHxHEIGHT between 64 and 2048, divisible by 16, with an aspect ratio from 1:3 through 3:1",
                 param: "size"
             )
         }
@@ -325,22 +394,27 @@ public struct ImagesAPIController: RouteCollection, Sendable {
         return object.keys.filter { !allowed.contains($0) }.sorted().first
     }
 
-    private static func unknownMultipartParameter(in request: Request, allowed: Set<String>) -> String? {
-        multipartParameterNames(in: request).filter { !allowed.contains($0) }.sorted().first
-    }
-
-    private static func multipartParameterNames(in request: Request) -> [String] {
-        guard let buffer = request.body.data else { return [] }
-        let text = String(decoding: Data(buffer: buffer), as: UTF8.self)
-        let pattern = #"Content-Disposition:[^\r\n]*\bname="([^"]+)""#
-        guard let expression = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
-            return []
+    /// Parses only multipart boundaries and headers. Uploaded bytes are never decoded as text
+    /// or copied into a second full-body allocation.
+    private static func multipartParameterNames(in request: Request) throws -> Set<String> {
+        guard let boundary = request.headers.contentType?.parameters["boundary"],
+              let buffer = request.body.data
+        else { return [] }
+        let parser = MultipartParser(boundary: boundary)
+        var headers = HTTPHeaders()
+        var names: Set<String> = []
+        parser.onHeader = { field, value in
+            headers.replaceOrAdd(name: field, value: value)
         }
-        let range = NSRange(text.startIndex..<text.endIndex, in: text)
-        return expression.matches(in: text, range: range).compactMap { match -> String? in
-            guard let nameRange = Range(match.range(at: 1), in: text) else { return nil }
-            return String(text[nameRange])
+        parser.onBody = { _ in }
+        parser.onPartComplete = {
+            if let name = MultipartPart(headers: headers, body: ByteBuffer()).name {
+                names.insert(name)
+            }
+            headers = HTTPHeaders()
         }
+        try parser.execute(buffer)
+        return names
     }
 
     private static func errorResponse(request: Request, error: ImageAPIRequestError) throws -> Response {
@@ -358,21 +432,57 @@ public struct ImagesAPIController: RouteCollection, Sendable {
         status: HTTPResponseStatus,
         message: String,
         code: String,
-        param: String? = nil
+        param: String? = nil,
+        type: String = "invalid_request_error"
     ) throws -> Response {
         let response = Response(status: status)
         try response.content.encode(OpenAIError(
             message: message,
-            type: "invalid_request_error",
+            type: type,
             code: code,
             param: param,
             requestId: request.afmRequestID.isEmpty ? nil : request.afmRequestID
         ))
-        applyHeaders(to: response)
+        applyHeaders(to: response, for: request)
         return response
     }
 
-    private static func response(for images: [AFMGeneratedImage], emulatedParameters: [String]) throws -> Response {
+    private static func providerErrorResponse(request: Request, error: Error, operation: String) throws -> Response {
+        if error is CancellationError { throw error }
+        if let error = error as? FluxKleinImageError {
+            switch error {
+            case .invalidImage:
+                return try errorResponse(
+                    request: request,
+                    status: .badRequest,
+                    message: "The input image could not be decoded",
+                    code: "invalid_image",
+                    param: "image"
+                )
+            case .unreadableSnapshot:
+                request.logger.error("Image model snapshot is unavailable: \(error.localizedDescription)")
+                return try errorResponse(
+                    request: request,
+                    status: .serviceUnavailable,
+                    message: "The configured image model is unavailable",
+                    code: "image_model_unavailable",
+                    type: "server_error"
+                )
+            case .pngEncodingFailed:
+                break
+            }
+        }
+        request.logger.error("Image \(operation) failed: \(String(describing: error))")
+        return try errorResponse(
+            request: request,
+            status: .internalServerError,
+            message: "Image \(operation) failed",
+            code: "image_generation_failed",
+            type: "server_error"
+        )
+    }
+
+    private static func response(request: Request, for images: [AFMGeneratedImage], emulatedParameters: [String]) throws -> Response {
         let body = OpenAIImagesResponse(
             created: Int64(Date().timeIntervalSince1970),
             data: images.map { OpenAIImageData(b64Json: $0.data.base64EncodedString()) }
@@ -383,19 +493,26 @@ public struct ImagesAPIController: RouteCollection, Sendable {
             response.headers.replaceOrAdd(name: compatibilityHeader, value: "emulated")
             response.headers.replaceOrAdd(name: emulatedParametersHeader, value: emulatedParameters.joined(separator: ","))
         }
-        applyHeaders(to: response)
+        applyHeaders(to: response, for: request)
         return response
     }
 
-    private static func applyHeaders(to response: Response) {
+    private static let defaultAllowHeaders = "Authorization, Content-Type, OpenAI-Organization, OpenAI-Project"
+
+    private static func applyHeaders(to response: Response, for request: Request) {
         response.headers.replaceOrAdd(name: .accessControlAllowOrigin, value: "*")
         response.headers.replaceOrAdd(name: .accessControlAllowMethods, value: "POST, OPTIONS")
-        response.headers.replaceOrAdd(name: .accessControlAllowHeaders, value: "Authorization, Content-Type")
+        let requested = request.headers.first(name: "Access-Control-Request-Headers")
+        response.headers.replaceOrAdd(
+            name: .accessControlAllowHeaders,
+            value: requested.flatMap { $0.isEmpty ? nil : $0 } ?? defaultAllowHeaders
+        )
         response.headers.replaceOrAdd(
             name: "Access-Control-Expose-Headers",
             value: "X-Request-ID, OpenAI-Request-ID, X-AFM-Compatibility, X-AFM-Emulated-Parameters"
         )
         response.headers.replaceOrAdd(name: .cacheControl, value: "no-store")
+        response.headers.replaceOrAdd(name: .vary, value: "Access-Control-Request-Headers")
     }
 }
 

--- a/Sources/AFMServer/Controllers/OpenAPIController.swift
+++ b/Sources/AFMServer/Controllers/OpenAPIController.swift
@@ -223,10 +223,19 @@ struct OpenAPIController: RouteCollection {
             "properties": {
               "model": { "type": "string", "description": "Accepted for OpenAI client compatibility; AFM routes image requests to its configured FLUX model." },
               "prompt": { "type": "string" },
+              "background": { "type": "string", "enum": ["transparent", "opaque", "auto"], "x-afm-support": "unsupported" },
+              "moderation": { "type": "string", "enum": ["low", "auto"], "x-afm-support": "unsupported" },
               "n": { "type": "integer", "minimum": 1, "maximum": 4, "default": 1 },
+              "output_compression": { "type": "integer", "minimum": 0, "maximum": 100, "x-afm-support": "unsupported" },
+              "output_format": { "type": "string", "const": "png", "x-afm-support": "exact" },
+              "partial_images": { "type": "integer", "minimum": 0, "maximum": 3, "x-afm-support": "unsupported" },
+              "quality": { "type": "string", "enum": ["auto", "low", "medium", "high", "standard", "hd"], "x-afm-support": "unsupported" },
               "size": { "type": "string", "description": "auto or WIDTHxHEIGHT from 64 through 2048." },
               "response_format": { "type": "string", "const": "b64_json" },
-              "seed": { "type": "integer", "minimum": 0 }
+              "seed": { "type": "integer", "minimum": 0, "description": "AFM extension for deterministic generation." },
+              "stream": { "type": "boolean", "const": false, "x-afm-support": "unsupported-when-true" },
+              "style": { "type": "string", "enum": ["vivid", "natural"], "x-afm-support": "unsupported" },
+              "user": { "type": "string", "description": "Accepted as non-behavioral client metadata." }
             }
           },
           "ImagesResponse": {
@@ -253,6 +262,7 @@ struct OpenAPIController: RouteCollection {
                   "message": { "type": "string" },
                   "type": { "type": "string" },
                   "code": { "type": "string", "nullable": true },
+                  "param": { "type": "string", "nullable": true },
                   "request_id": { "type": "string", "nullable": true }
                 }
               }
@@ -401,7 +411,11 @@ struct OpenAPIController: RouteCollection {
             "tags": ["images"],
             "summary": "Generate images with FLUX.2 Klein",
             "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImageGenerationRequest" } } } },
-            "responses": { "200": { "description": "Base64-encoded PNG images", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImagesResponse" } } } } }
+            "responses": {
+              "200": { "description": "Base64-encoded PNG images", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImagesResponse" } } } },
+              "400": { "description": "Invalid or unsupported request parameter", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
+              "415": { "description": "Request must use application/json", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } }
+            }
           }
         },
         "/v1/images/edits": {
@@ -419,16 +433,30 @@ struct OpenAPIController: RouteCollection {
                       "model": { "type": "string" },
                       "prompt": { "type": "string" },
                       "image": { "type": "string", "format": "binary" },
+                      "background": { "type": "string", "enum": ["transparent", "opaque", "auto"], "x-afm-support": "unsupported" },
+                      "input_fidelity": { "type": "string", "enum": ["high", "low"], "x-afm-support": "unsupported" },
+                      "mask": { "type": "string", "format": "binary", "x-afm-support": "unsupported" },
+                      "moderation": { "type": "string", "enum": ["low", "auto"], "x-afm-support": "unsupported" },
                       "n": { "type": "integer", "minimum": 1, "maximum": 4 },
+                      "output_compression": { "type": "integer", "minimum": 0, "maximum": 100, "x-afm-support": "unsupported" },
+                      "output_format": { "type": "string", "const": "png", "x-afm-support": "exact" },
+                      "partial_images": { "type": "integer", "minimum": 0, "maximum": 3, "x-afm-support": "unsupported" },
+                      "quality": { "type": "string", "enum": ["auto", "low", "medium", "high"], "x-afm-support": "unsupported" },
                       "size": { "type": "string" },
                       "response_format": { "type": "string", "const": "b64_json" },
-                      "seed": { "type": "integer", "minimum": 0 }
+                      "seed": { "type": "integer", "minimum": 0, "description": "AFM extension for deterministic generation." },
+                      "stream": { "type": "boolean", "const": false, "x-afm-support": "unsupported-when-true" },
+                      "user": { "type": "string", "description": "Accepted as non-behavioral client metadata." }
                     }
                   }
                 }
               }
             },
-            "responses": { "200": { "description": "Base64-encoded edited PNG images", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImagesResponse" } } } } }
+            "responses": {
+              "200": { "description": "Base64-encoded edited PNG images", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImagesResponse" } } } },
+              "400": { "description": "Invalid or unsupported request parameter", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
+              "415": { "description": "Request must use multipart/form-data", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } }
+            }
           }
         },
         "/v1/audio/speech": {

--- a/Sources/AFMServer/Controllers/OpenAPIController.swift
+++ b/Sources/AFMServer/Controllers/OpenAPIController.swift
@@ -73,6 +73,7 @@ struct OpenAPIController: RouteCollection {
         { "name": "embeddings", "description": "Text embeddings" },
         { "name": "audio", "description": "Speech transcription and synthesis" },
         { "name": "vision", "description": "Apple Vision OCR" },
+        { "name": "images", "description": "FLUX.2 Klein image generation and editing" },
         { "name": "batch", "description": "Batch completions API" },
         { "name": "tokenize", "description": "Tokenizer access for context-budgeting" },
         { "name": "models", "description": "Model discovery" },
@@ -214,6 +215,33 @@ struct OpenAPIController: RouteCollection {
               "model": { "type": "string" },
               "choices": { "type": "array" },
               "usage": { "type": "object" }
+            }
+          },
+          "ImageGenerationRequest": {
+            "type": "object",
+            "required": ["prompt"],
+            "properties": {
+              "model": { "type": "string", "description": "Accepted for OpenAI client compatibility; AFM routes image requests to its configured FLUX model." },
+              "prompt": { "type": "string" },
+              "n": { "type": "integer", "minimum": 1, "maximum": 4, "default": 1 },
+              "size": { "type": "string", "description": "auto or WIDTHxHEIGHT from 64 through 2048." },
+              "response_format": { "type": "string", "const": "b64_json" },
+              "seed": { "type": "integer", "minimum": 0 }
+            }
+          },
+          "ImagesResponse": {
+            "type": "object",
+            "required": ["created", "data"],
+            "properties": {
+              "created": { "type": "integer" },
+              "data": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["b64_json"],
+                  "properties": { "b64_json": { "type": "string", "contentEncoding": "base64" } }
+                }
+              }
             }
           },
           "OpenAIError": {
@@ -366,6 +394,41 @@ struct OpenAPIController: RouteCollection {
             "summary": "Transcribe audio (Apple Speech)",
             "requestBody": { "required": true, "content": { "multipart/form-data": { "schema": { "type": "object" } } } },
             "responses": { "200": { "description": "Transcription result" } }
+          }
+        },
+        "/v1/images/generations": {
+          "post": {
+            "tags": ["images"],
+            "summary": "Generate images with FLUX.2 Klein",
+            "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImageGenerationRequest" } } } },
+            "responses": { "200": { "description": "Base64-encoded PNG images", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImagesResponse" } } } } }
+          }
+        },
+        "/v1/images/edits": {
+          "post": {
+            "tags": ["images"],
+            "summary": "Edit an image with FLUX.2 Klein",
+            "requestBody": {
+              "required": true,
+              "content": {
+                "multipart/form-data": {
+                  "schema": {
+                    "type": "object",
+                    "required": ["prompt", "image"],
+                    "properties": {
+                      "model": { "type": "string" },
+                      "prompt": { "type": "string" },
+                      "image": { "type": "string", "format": "binary" },
+                      "n": { "type": "integer", "minimum": 1, "maximum": 4 },
+                      "size": { "type": "string" },
+                      "response_format": { "type": "string", "const": "b64_json" },
+                      "seed": { "type": "integer", "minimum": 0 }
+                    }
+                  }
+                }
+              }
+            },
+            "responses": { "200": { "description": "Base64-encoded edited PNG images", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImagesResponse" } } } } }
           }
         },
         "/v1/audio/speech": {

--- a/Sources/AFMServer/Controllers/OpenAPIController.swift
+++ b/Sources/AFMServer/Controllers/OpenAPIController.swift
@@ -93,6 +93,14 @@ struct OpenAPIController: RouteCollection {
           "XRequestID": {
             "description": "Server-assigned or echoed request correlation id.",
             "schema": { "type": "string" }
+          },
+          "XAFMCompatibility": {
+            "description": "Present as `emulated` only when an explicitly configured image-model alias was routed to the local image model.",
+            "schema": { "type": "string", "const": "emulated" }
+          },
+          "XAFMEmulatedParameters": {
+            "description": "Comma-separated request parameters whose behavior was emulated.",
+            "schema": { "type": "string" }
           }
         },
         "schemas": {
@@ -219,10 +227,11 @@ struct OpenAPIController: RouteCollection {
           },
           "ImageGenerationRequest": {
             "type": "object",
+            "additionalProperties": false,
             "required": ["prompt"],
             "properties": {
-              "model": { "type": "string", "description": "Accepted for OpenAI client compatibility; AFM routes image requests to its configured FLUX model." },
-              "prompt": { "type": "string" },
+              "model": { "type": "string", "description": "Must match MACAFM_IMAGE_MODEL or an alias explicitly listed in MACAFM_IMAGE_MODEL_ALIASES." },
+              "prompt": { "type": "string", "minLength": 1, "maxLength": 32000 },
               "background": { "type": "string", "enum": ["transparent", "opaque", "auto"], "x-afm-support": "unsupported" },
               "moderation": { "type": "string", "enum": ["low", "auto"], "x-afm-support": "unsupported" },
               "n": { "type": "integer", "minimum": 1, "maximum": 4, "default": 1 },
@@ -230,7 +239,7 @@ struct OpenAPIController: RouteCollection {
               "output_format": { "type": "string", "const": "png", "x-afm-support": "exact" },
               "partial_images": { "type": "integer", "minimum": 0, "maximum": 3, "x-afm-support": "unsupported" },
               "quality": { "type": "string", "enum": ["auto", "low", "medium", "high", "standard", "hd"], "x-afm-support": "unsupported" },
-              "size": { "type": "string", "description": "auto or WIDTHxHEIGHT from 64 through 2048." },
+              "size": { "type": "string", "description": "auto or WIDTHxHEIGHT from 64 through 2048. Both dimensions must be divisible by 16 and the aspect ratio must be between 1:3 and 3:1." },
               "response_format": { "type": "string", "const": "b64_json" },
               "seed": { "type": "integer", "minimum": 0, "description": "AFM extension for deterministic generation." },
               "stream": { "type": "boolean", "const": false, "x-afm-support": "unsupported-when-true" },
@@ -240,6 +249,7 @@ struct OpenAPIController: RouteCollection {
           },
           "ImagesResponse": {
             "type": "object",
+            "additionalProperties": false,
             "required": ["created", "data"],
             "properties": {
               "created": { "type": "integer" },
@@ -247,6 +257,7 @@ struct OpenAPIController: RouteCollection {
                 "type": "array",
                 "items": {
                   "type": "object",
+                  "additionalProperties": false,
                   "required": ["b64_json"],
                   "properties": { "b64_json": { "type": "string", "contentEncoding": "base64" } }
                 }
@@ -410,11 +421,24 @@ struct OpenAPIController: RouteCollection {
           "post": {
             "tags": ["images"],
             "summary": "Generate images with FLUX.2 Klein",
+            "parameters": [{ "$ref": "#/components/parameters/RequestIdHeader" }],
             "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImageGenerationRequest" } } } },
             "responses": {
-              "200": { "description": "Base64-encoded PNG images", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImagesResponse" } } } },
-              "400": { "description": "Invalid or unsupported request parameter", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
-              "415": { "description": "Request must use application/json", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } }
+              "200": {
+                "description": "Base64-encoded PNG images",
+                "headers": {
+                  "X-Request-ID": { "$ref": "#/components/headers/XRequestID" },
+                  "X-AFM-Compatibility": { "$ref": "#/components/headers/XAFMCompatibility" },
+                  "X-AFM-Emulated-Parameters": { "$ref": "#/components/headers/XAFMEmulatedParameters" }
+                },
+                "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImagesResponse" } } }
+              },
+              "400": { "description": "Invalid or unsupported request parameter", "headers": { "X-Request-ID": { "$ref": "#/components/headers/XRequestID" } }, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
+              "405": { "description": "Method not allowed", "headers": { "X-Request-ID": { "$ref": "#/components/headers/XRequestID" } }, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
+              "413": { "description": "Request body exceeds 1 MB", "headers": { "X-Request-ID": { "$ref": "#/components/headers/XRequestID" } }, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
+              "415": { "description": "Request must use application/json", "headers": { "X-Request-ID": { "$ref": "#/components/headers/XRequestID" } }, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
+              "500": { "description": "Image generation failed", "headers": { "X-Request-ID": { "$ref": "#/components/headers/XRequestID" } }, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
+              "503": { "description": "Configured image model unavailable", "headers": { "X-Request-ID": { "$ref": "#/components/headers/XRequestID" } }, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } }
             }
           }
         },
@@ -422,17 +446,19 @@ struct OpenAPIController: RouteCollection {
           "post": {
             "tags": ["images"],
             "summary": "Edit an image with FLUX.2 Klein",
+            "parameters": [{ "$ref": "#/components/parameters/RequestIdHeader" }],
             "requestBody": {
               "required": true,
               "content": {
                 "multipart/form-data": {
                   "schema": {
                     "type": "object",
+                    "additionalProperties": false,
                     "required": ["prompt", "image"],
                     "properties": {
-                      "model": { "type": "string" },
-                      "prompt": { "type": "string" },
-                      "image": { "type": "string", "format": "binary" },
+                      "model": { "type": "string", "description": "Must match MACAFM_IMAGE_MODEL or an explicitly configured alias." },
+                      "prompt": { "type": "string", "minLength": 1, "maxLength": 32000 },
+                      "image": { "type": "string", "format": "binary", "maxLength": 20971520, "description": "One PNG, JPEG, or WebP image, at most 20 MB." },
                       "background": { "type": "string", "enum": ["transparent", "opaque", "auto"], "x-afm-support": "unsupported" },
                       "input_fidelity": { "type": "string", "enum": ["high", "low"], "x-afm-support": "unsupported" },
                       "mask": { "type": "string", "format": "binary", "x-afm-support": "unsupported" },
@@ -442,7 +468,7 @@ struct OpenAPIController: RouteCollection {
                       "output_format": { "type": "string", "const": "png", "x-afm-support": "exact" },
                       "partial_images": { "type": "integer", "minimum": 0, "maximum": 3, "x-afm-support": "unsupported" },
                       "quality": { "type": "string", "enum": ["auto", "low", "medium", "high"], "x-afm-support": "unsupported" },
-                      "size": { "type": "string" },
+                      "size": { "type": "string", "description": "auto or WIDTHxHEIGHT from 64 through 2048; dimensions divisible by 16; aspect ratio 1:3 through 3:1." },
                       "response_format": { "type": "string", "const": "b64_json" },
                       "seed": { "type": "integer", "minimum": 0, "description": "AFM extension for deterministic generation." },
                       "stream": { "type": "boolean", "const": false, "x-afm-support": "unsupported-when-true" },
@@ -453,9 +479,21 @@ struct OpenAPIController: RouteCollection {
               }
             },
             "responses": {
-              "200": { "description": "Base64-encoded edited PNG images", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImagesResponse" } } } },
-              "400": { "description": "Invalid or unsupported request parameter", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
-              "415": { "description": "Request must use multipart/form-data", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } }
+              "200": {
+                "description": "Base64-encoded edited PNG images",
+                "headers": {
+                  "X-Request-ID": { "$ref": "#/components/headers/XRequestID" },
+                  "X-AFM-Compatibility": { "$ref": "#/components/headers/XAFMCompatibility" },
+                  "X-AFM-Emulated-Parameters": { "$ref": "#/components/headers/XAFMEmulatedParameters" }
+                },
+                "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ImagesResponse" } } }
+              },
+              "400": { "description": "Invalid or unsupported request parameter", "headers": { "X-Request-ID": { "$ref": "#/components/headers/XRequestID" } }, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
+              "405": { "description": "Method not allowed", "headers": { "X-Request-ID": { "$ref": "#/components/headers/XRequestID" } }, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
+              "413": { "description": "Multipart request exceeds 25 MB", "headers": { "X-Request-ID": { "$ref": "#/components/headers/XRequestID" } }, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
+              "415": { "description": "Request must use multipart/form-data", "headers": { "X-Request-ID": { "$ref": "#/components/headers/XRequestID" } }, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
+              "500": { "description": "Image edit failed", "headers": { "X-Request-ID": { "$ref": "#/components/headers/XRequestID" } }, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } },
+              "503": { "description": "Configured image model unavailable", "headers": { "X-Request-ID": { "$ref": "#/components/headers/XRequestID" } }, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/OpenAIError" } } } }
             }
           }
         },

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -116,13 +116,26 @@ struct PayloadTooLargeMiddleware: AsyncMiddleware {
             // Return a JSON error response compatible with OpenAI format
             let reqId = request.afmRequestID
             let errorResponse = OpenAIError(
-                message: "Your conversation is too long. Please start a new conversation.",
+                message: request.url.path.hasPrefix("/v1/images/")
+                    ? "Image request exceeds the maximum allowed size."
+                    : "Request payload exceeds the maximum allowed size.",
                 type: "payload_too_large",
+                code: "payload_too_large",
                 requestId: reqId.isEmpty ? nil : reqId
             )
             let response = Response(status: .payloadTooLarge)
             response.headers.add(name: .contentType, value: "application/json")
             response.headers.add(name: .accessControlAllowOrigin, value: "*")
+            response.headers.add(name: .accessControlAllowMethods, value: "GET, POST, OPTIONS")
+            let requestedHeaders = request.headers.first(name: "Access-Control-Request-Headers")
+            response.headers.add(
+                name: .accessControlAllowHeaders,
+                value: requestedHeaders.flatMap { $0.isEmpty ? nil : $0 }
+                    ?? "Authorization, Content-Type, OpenAI-Organization, OpenAI-Project"
+            )
+            response.headers.add(name: "Access-Control-Expose-Headers", value: "X-Request-ID, OpenAI-Request-ID")
+            response.headers.add(name: .vary, value: "Access-Control-Request-Headers")
+            response.headers.add(name: .cacheControl, value: "no-store")
             try response.content.encode(errorResponse)
             return response
         }
@@ -933,13 +946,24 @@ public class Server: @unchecked Sendable {
 
         try app.register(collection: VisionAPIController())
         try app.register(collection: SpeechAPIController())
+        let imageModelID = ProcessInfo.processInfo.environment["MACAFM_IMAGE_MODEL"]
+            ?? "mlx-community/FLUX.2-klein-4B-bf16"
         let imageService = FluxKleinImageService(configuration: FluxKleinImageConfiguration(
-            modelID: ProcessInfo.processInfo.environment["MACAFM_IMAGE_MODEL"]
-                ?? "mlx-community/FLUX.2-klein-4B-bf16",
+            modelID: imageModelID,
             cacheDirectory: Self.imageModelCacheDirectory(),
             quantization: Self.imageQuantization()
         ))
-        try app.register(collection: ImagesAPIController(generator: imageService))
+        let imageModelAliases = Set(
+            (ProcessInfo.processInfo.environment["MACAFM_IMAGE_MODEL_ALIASES"] ?? "")
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+        )
+        try app.register(collection: ImagesAPIController(
+            generator: imageService,
+            modelID: imageModelID,
+            modelAliases: imageModelAliases
+        ))
         // POST /v1/embeddings on the main server (#132). The Apple NL embedding
         // model is loaded lazily on first request (a chat-only server pays
         // nothing until used) and this path never triggers MLX init. It does NOT

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -1,6 +1,7 @@
 import Vapor
 import AFMKit
 import AFMKitMLX
+import AFMKitMLXImage
 import Foundation
 import Compression
 import Darwin
@@ -355,6 +356,28 @@ public class Server: @unchecked Sendable {
         if #available(macOS 13.0, *) { return true }
         return false
     }()
+
+    private static func imageModelCacheDirectory() -> URL {
+        let environment = ProcessInfo.processInfo.environment
+        if let path = environment["MACAFM_MLX_MODEL_CACHE"], !path.isEmpty {
+            return URL(fileURLWithPath: path, isDirectory: true)
+        }
+        if let path = environment["HUGGINGFACE_HUB_CACHE"] ?? environment["HF_HUB_CACHE"], !path.isEmpty {
+            return URL(fileURLWithPath: path, isDirectory: true)
+        }
+        if let path = environment["HF_HOME"], !path.isEmpty {
+            return URL(fileURLWithPath: path, isDirectory: true).appendingPathComponent("hub", isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Documents/huggingface/models", isDirectory: true)
+    }
+
+    private static func imageQuantization() -> FluxKleinQuantization {
+        guard let value = ProcessInfo.processInfo.environment["MACAFM_IMAGE_QUANT"]?.lowercased() else {
+            return .int4
+        }
+        return FluxKleinQuantization(rawValue: value) ?? .int4
+    }
 
     public init(port: Int, hostname: String, verbose: Bool, veryVerbose: Bool = false, trace: Bool = false, streamingEnabled: Bool, instructions: String, adapter: String? = nil, temperature: Double? = nil, randomness: String? = nil, permissiveGuardrails: Bool = false, stop: String? = nil, webuiEnabled: Bool = false, gatewayEnabled: Bool = false, prewarmEnabled: Bool = true, telegramConfiguration: TelegramConfiguration? = nil, defaultGuidedJsonSchema: ResponseFormat? = nil, defaultChatTemplateKwargs: [String: AnyCodable]? = nil, forceDisableThinking: Bool = false, mlxModelID: String? = nil, mlxModel: AFMMLXModel? = nil, afmModel: AnyAFMModel? = nil, mlxRepetitionPenalty: Double? = nil, mlxTopP: Double? = nil, mlxMaxTokens: Int? = nil, mlxRawOutput: Bool = false, mlxTopK: Int? = nil, mlxMinP: Double? = nil, mlxPresencePenalty: Double? = nil, mlxSeed: Int? = nil, mlxMaxLogprobs: Int? = nil, contextWindow: Int? = nil, telemetry: AFMServerTelemetryAdapter? = nil) async throws {
         self.port = port
@@ -910,6 +933,13 @@ public class Server: @unchecked Sendable {
 
         try app.register(collection: VisionAPIController())
         try app.register(collection: SpeechAPIController())
+        let imageService = FluxKleinImageService(configuration: FluxKleinImageConfiguration(
+            modelID: ProcessInfo.processInfo.environment["MACAFM_IMAGE_MODEL"]
+                ?? "mlx-community/FLUX.2-klein-4B-bf16",
+            cacheDirectory: Self.imageModelCacheDirectory(),
+            quantization: Self.imageQuantization()
+        ))
+        try app.register(collection: ImagesAPIController(generator: imageService))
         // POST /v1/embeddings on the main server (#132). The Apple NL embedding
         // model is loaded lazily on first request (a chat-only server pays
         // nothing until used) and this path never triggers MLX init. It does NOT

--- a/Tests/MacLocalAPITests/ImagesAPIControllerTests.swift
+++ b/Tests/MacLocalAPITests/ImagesAPIControllerTests.swift
@@ -20,7 +20,7 @@ final class ImagesAPIControllerTests: XCTestCase {
 
     func testGenerationReturnsBase64ImagePayload() async throws {
         let generator = FakeImageGenerator()
-        try ImagesAPIController(generator: generator).boot(routes: app)
+        try ImagesAPIController(generator: generator, modelAliases: ["any-model"]).boot(routes: app)
         var headers = HTTPHeaders()
         headers.contentType = .json
         let body = ByteBuffer(string: #"{"model":"any-model","prompt":"a red square","n":1,"size":"256x256"}"#)
@@ -42,7 +42,7 @@ final class ImagesAPIControllerTests: XCTestCase {
 
     func testEditAcceptsMultipartModelFieldAndImage() async throws {
         let generator = FakeImageGenerator()
-        try ImagesAPIController(generator: generator).boot(routes: app)
+        try ImagesAPIController(generator: generator, modelAliases: ["Qwen3.8-27B"]).boot(routes: app)
         let boundary = "afm-image-boundary"
         let png = Data([0x89, 0x50, 0x4e, 0x47])
         var body = Data()
@@ -85,6 +85,97 @@ final class ImagesAPIControllerTests: XCTestCase {
         }
         let request = await generator.generationRequest
         XCTAssertNil(request)
+    }
+
+    func testNonAlignedSizeIsRejectedInsteadOfSilentlyRounded() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/images/generations",
+            headers: headers,
+            body: ByteBuffer(string: #"{"prompt":"test","size":"257x256"}"#)
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["param"] as? String, "size")
+        }
+        let request = await generator.generationRequest
+        XCTAssertNil(request)
+    }
+
+    func testUnknownImageModelIsRejected() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator, modelID: "local-image-model").boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/images/generations",
+            headers: headers,
+            body: ByteBuffer(string: #"{"model":"chat-model","prompt":"test"}"#)
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["code"] as? String, "unsupported_model")
+            XCTAssertEqual(error["param"] as? String, "model")
+        }
+    }
+
+    func testPromptOverOpenAILimitIsRejected() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let data = try JSONSerialization.data(withJSONObject: ["prompt": String(repeating: "a", count: 32_001)])
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/generations", headers: headers, body: ByteBuffer(data: data)
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["param"] as? String, "prompt")
+        }
+    }
+
+    func testOversizedGenerationBodyReturnsRouteAppropriate413() async throws {
+        app.middleware.use(PayloadTooLargeMiddleware())
+        try ImagesAPIController(generator: FakeImageGenerator()).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"prompt":"\#(String(repeating: "a", count: 1_100_000))"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/generations", headers: headers, body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .payloadTooLarge)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["code"] as? String, "payload_too_large")
+            XCTAssertContains(error["message"] as? String ?? "", "Image request")
+            XCTAssertEqual(response.headers.first(name: .cacheControl), "no-store")
+            XCTAssertContains(response.headers.first(name: "Access-Control-Expose-Headers") ?? "", "X-Request-ID")
+        }
+    }
+
+    func testExactImageModelDoesNotReportEmulation() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator, modelID: "local-image-model").boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/images/generations",
+            headers: headers,
+            body: ByteBuffer(string: #"{"model":"local-image-model","prompt":"test"}"#)
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertNil(response.headers.first(name: "X-AFM-Compatibility"))
+        }
     }
 
     func testUnsupportedGenerationControlReturnsParameterSpecificOpenAIError() async throws {
@@ -186,6 +277,104 @@ final class ImagesAPIControllerTests: XCTestCase {
         }
     }
 
+    func testHeadReturns405InsteadOfFallingThroughTo404() async throws {
+        try ImagesAPIController(generator: FakeImageGenerator()).boot(routes: app)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .HEAD, "/v1/images/generations"
+        ) { response async in
+            XCTAssertEqual(response.status, .methodNotAllowed)
+            XCTAssertEqual(response.headers.first(name: "Allow"), "POST, OPTIONS")
+        }
+    }
+
+    func testCORSPreflightReflectsSDKHeadersAndVaries() async throws {
+        try ImagesAPIController(generator: FakeImageGenerator()).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.add(name: "Access-Control-Request-Headers", value: "Content-Type, x-stainless-arch, OpenAI-Project")
+
+        try await app.testable(method: .running(port: 0)).test(
+            .OPTIONS, "/v1/images/generations", headers: headers
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertEqual(
+                response.headers.first(name: .accessControlAllowHeaders),
+                "Content-Type, x-stainless-arch, OpenAI-Project"
+            )
+            XCTAssertEqual(response.headers.first(name: .vary), "Access-Control-Request-Headers")
+        }
+    }
+
+    func testInvalidProviderImageReturnsParameterSpecific400() async throws {
+        let generator = FakeImageGenerator(editFailure: .invalidImage)
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        let request = Self.multipartEditBody(image: Data("not-an-image".utf8), filename: "input.png")
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/edits", headers: request.headers, body: request.body
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["code"] as? String, "invalid_image")
+            XCTAssertEqual(error["param"] as? String, "image")
+        }
+    }
+
+    func testEditRejectsUnsupportedImageFileTypeBeforeProviderCall() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        let request = Self.multipartEditBody(image: Data("image".utf8), filename: "input.gif")
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/edits", headers: request.headers, body: request.body
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["param"] as? String, "image")
+        }
+        let providerRequest = await generator.editRequest
+        XCTAssertNil(providerRequest)
+    }
+
+    func testUnavailableImageSnapshotReturnsRetryable503() async throws {
+        let generator = FakeImageGenerator(generationFailure: .unreadableSnapshot)
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/images/generations",
+            headers: headers,
+            body: ByteBuffer(string: #"{"prompt":"test"}"#)
+        ) { response async in
+            XCTAssertEqual(response.status, .serviceUnavailable)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["type"] as? String, "server_error")
+            XCTAssertEqual(error["code"] as? String, "image_model_unavailable")
+        }
+    }
+
+    func testUnexpectedProviderFailureReturnsShaped500() async throws {
+        let generator = FakeImageGenerator(generationFailure: .unexpected)
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST,
+            "/v1/images/generations",
+            headers: headers,
+            body: ByteBuffer(string: #"{"prompt":"test"}"#)
+        ) { response async in
+            XCTAssertEqual(response.status, .internalServerError)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["type"] as? String, "server_error")
+            XCTAssertEqual(error["code"] as? String, "image_generation_failed")
+            XCTAssertNotNil(error["request_id"] as? String)
+        }
+    }
+
     func testStandardCountBeyondLocalLimitIsUnsupportedRatherThanInvalid() async throws {
         let generator = FakeImageGenerator()
         try ImagesAPIController(generator: generator).boot(routes: app)
@@ -255,6 +444,22 @@ final class ImagesAPIControllerTests: XCTestCase {
         return object["error"] as? [String: Any]
     }
 
+    private static func multipartEditBody(image: Data, filename: String) -> (headers: HTTPHeaders, body: ByteBuffer) {
+        let boundary = "afm-image-test-boundary"
+        var data = Data()
+        data.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nedit it\r\n".utf8))
+        data.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"image\"; filename=\"\(filename)\"\r\nContent-Type: image/png\r\n\r\n".utf8))
+        data.append(image)
+        data.append(Data("\r\n--\(boundary)--\r\n".utf8))
+        var headers = HTTPHeaders()
+        headers.contentType = HTTPMediaType(
+            type: "multipart",
+            subType: "form-data",
+            parameters: ["boundary": boundary]
+        )
+        return (headers, ByteBuffer(data: data))
+    }
+
     func testFluxKleinGenerationAndEditIntegration() async throws {
         guard ProcessInfo.processInfo.environment["AFM_RUN_FLUX_INTEGRATION"] == "1" else {
             throw XCTSkip("Set AFM_RUN_FLUX_INTEGRATION=1 to run the 23.7 GB FLUX model smoke test")
@@ -265,7 +470,7 @@ final class ImagesAPIControllerTests: XCTestCase {
             cacheDirectory: URL(fileURLWithPath: cachePath, isDirectory: true),
             quantization: .int4
         ))
-        try ImagesAPIController(generator: generator).boot(routes: app)
+        try ImagesAPIController(generator: generator, modelAliases: ["Qwen3.8-27B"]).boot(routes: app)
         var headers = HTTPHeaders()
         headers.contentType = .json
         let body = ByteBuffer(string: #"{"model":"Qwen3.8-27B","prompt":"a red square on a white background","n":1,"size":"256x256","response_format":"b64_json","seed":42}"#)
@@ -305,17 +510,45 @@ final class ImagesAPIControllerTests: XCTestCase {
     }
 }
 
+private enum FakeImageFailure: Error, Sendable {
+    case invalidImage
+    case unreadableSnapshot
+    case unexpected
+}
+
 private actor FakeImageGenerator: AFMImageGenerating {
     var generationRequest: AFMImageGenerationRequest?
     var editRequest: AFMImageEditRequest?
+    let generationFailure: FakeImageFailure?
+    let editFailure: FakeImageFailure?
+
+    init(generationFailure: FakeImageFailure? = nil, editFailure: FakeImageFailure? = nil) {
+        self.generationFailure = generationFailure
+        self.editFailure = editFailure
+    }
 
     func generateImages(for request: AFMImageGenerationRequest) async throws -> [AFMGeneratedImage] {
+        try Self.throwFailure(generationFailure)
         generationRequest = request
         return [AFMGeneratedImage(data: Data("png".utf8), width: request.width, height: request.height)]
     }
 
     func editImages(for request: AFMImageEditRequest) async throws -> [AFMGeneratedImage] {
+        try Self.throwFailure(editFailure)
         editRequest = request
         return [AFMGeneratedImage(data: Data("edited".utf8), width: request.width, height: request.height)]
+    }
+
+    private static func throwFailure(_ failure: FakeImageFailure?) throws {
+        switch failure {
+        case .invalidImage:
+            throw FluxKleinImageError.invalidImage
+        case .unreadableSnapshot:
+            throw FluxKleinImageError.unreadableSnapshot("/missing")
+        case .unexpected:
+            throw FakeImageFailure.unexpected
+        case nil:
+            return
+        }
     }
 }

--- a/Tests/MacLocalAPITests/ImagesAPIControllerTests.swift
+++ b/Tests/MacLocalAPITests/ImagesAPIControllerTests.swift
@@ -11,6 +11,7 @@ final class ImagesAPIControllerTests: XCTestCase {
 
     override func setUp() async throws {
         app = try await Application.make(.testing)
+        app.middleware.use(RequestIDMiddleware())
     }
 
     override func tearDown() async throws {
@@ -30,6 +31,8 @@ final class ImagesAPIControllerTests: XCTestCase {
             XCTAssertEqual(response.status, .ok)
             let decoded = try! JSONDecoder().decode(OpenAIImagesResponse.self, from: Data(buffer: response.body))
             XCTAssertEqual(decoded.data.first?.b64Json, Data("png".utf8).base64EncodedString())
+            XCTAssertEqual(response.headers.first(name: "X-AFM-Compatibility"), "emulated")
+            XCTAssertEqual(response.headers.first(name: "X-AFM-Emulated-Parameters"), "model")
         }
         let request = await generator.generationRequest
         XCTAssertEqual(request?.prompt, "a red square")
@@ -73,9 +76,183 @@ final class ImagesAPIControllerTests: XCTestCase {
             .POST, "/v1/images/generations", headers: headers, body: body
         ) { response async in
             XCTAssertEqual(response.status, .badRequest)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["type"] as? String, "invalid_request_error")
+            XCTAssertEqual(error["code"] as? String, "invalid_request_error")
+            XCTAssertEqual(error["param"] as? String, "size")
+            XCTAssertNotNil(error["request_id"] as? String)
+            XCTAssertNotNil(response.headers.first(name: "x-request-id"))
         }
         let request = await generator.generationRequest
         XCTAssertNil(request)
+    }
+
+    func testUnsupportedGenerationControlReturnsParameterSpecificOpenAIError() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"prompt":"test","background":"transparent"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/generations", headers: headers, body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["type"] as? String, "invalid_request_error")
+            XCTAssertEqual(error["code"] as? String, "unsupported_parameter")
+            XCTAssertEqual(error["param"] as? String, "background")
+            XCTAssertContains(error["message"] as? String ?? "", "not supported")
+        }
+        let request = await generator.generationRequest
+        XCTAssertNil(request)
+    }
+
+    func testSupportedExplicitPNGAndNonStreamingControlsAreAccepted() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"prompt":"test","output_format":"png","response_format":"b64_json","stream":false}"#)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/generations", headers: headers, body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertNil(response.headers.first(name: "X-AFM-Compatibility"))
+        }
+    }
+
+    func testStreamingRequestIsRejectedAsNonRetryableClientError() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"prompt":"test","stream":true}"#)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/generations", headers: headers, body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["code"] as? String, "unsupported_parameter")
+            XCTAssertEqual(error["param"] as? String, "stream")
+        }
+    }
+
+    func testWrongGenerationContentTypeReturns415OpenAIError() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .plainText
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/generations", headers: headers, body: ByteBuffer(string: "test")
+        ) { response async in
+            XCTAssertEqual(response.status, .unsupportedMediaType)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["code"] as? String, "unsupported_media_type")
+        }
+    }
+
+    func testUnknownGenerationParameterIsNotSilentlyIgnored() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"prompt":"test","qualitty":"high"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/generations", headers: headers, body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["code"] as? String, "unknown_parameter")
+            XCTAssertEqual(error["param"] as? String, "qualitty")
+        }
+    }
+
+    func testUnsupportedMethodReturns405WithAllowHeader() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .GET, "/v1/images/generations"
+        ) { response async in
+            XCTAssertEqual(response.status, .methodNotAllowed)
+            XCTAssertEqual(response.headers.first(name: "Allow"), "POST, OPTIONS")
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["code"] as? String, "method_not_allowed")
+        }
+    }
+
+    func testStandardCountBeyondLocalLimitIsUnsupportedRatherThanInvalid() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"prompt":"test","n":5}"#)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/generations", headers: headers, body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["code"] as? String, "unsupported_parameter")
+            XCTAssertEqual(error["param"] as? String, "n")
+        }
+    }
+
+    func testUnsupportedEditMaskReturnsParameterSpecificOpenAIError() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        let boundary = "afm-image-mask-boundary"
+        let png = Data([0x89, 0x50, 0x4e, 0x47])
+        var body = Data()
+        body.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nedit it\r\n".utf8))
+        body.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"image\"; filename=\"image.png\"\r\nContent-Type: image/png\r\n\r\n".utf8))
+        body.append(png)
+        body.append(Data("\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"mask\"; filename=\"mask.png\"\r\nContent-Type: image/png\r\n\r\n".utf8))
+        body.append(png)
+        body.append(Data("\r\n--\(boundary)--\r\n".utf8))
+        var headers = HTTPHeaders()
+        headers.contentType = HTTPMediaType(type: "multipart", subType: "form-data", parameters: ["boundary": boundary])
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/edits", headers: headers, body: ByteBuffer(data: body)
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["code"] as? String, "unsupported_parameter")
+            XCTAssertEqual(error["param"] as? String, "mask")
+        }
+    }
+
+    func testEditImageArraySyntaxIsRecognizedAndRejectedExplicitly() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        let boundary = "afm-image-array-boundary"
+        var body = Data()
+        body.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nedit it\r\n".utf8))
+        body.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"image[]\"; filename=\"image.png\"\r\nContent-Type: image/png\r\n\r\nPNG\r\n--\(boundary)--\r\n".utf8))
+        var headers = HTTPHeaders()
+        headers.contentType = HTTPMediaType(type: "multipart", subType: "form-data", parameters: ["boundary": boundary])
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/edits", headers: headers, body: ByteBuffer(data: body)
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+            let error = try! XCTUnwrap(Self.errorDetail(response.body))
+            XCTAssertEqual(error["code"] as? String, "unsupported_parameter")
+            XCTAssertEqual(error["param"] as? String, "image")
+        }
+    }
+
+    private static func errorDetail(_ body: ByteBuffer) -> [String: Any]? {
+        guard let object = try? JSONSerialization.jsonObject(with: Data(buffer: body)) as? [String: Any] else {
+            return nil
+        }
+        return object["error"] as? [String: Any]
     }
 
     func testFluxKleinGenerationAndEditIntegration() async throws {

--- a/Tests/MacLocalAPITests/ImagesAPIControllerTests.swift
+++ b/Tests/MacLocalAPITests/ImagesAPIControllerTests.swift
@@ -1,0 +1,144 @@
+import AFMKitCore
+import AFMKitMLXImage
+import XCTest
+import Vapor
+import XCTVapor
+
+@testable import AFMServer
+
+final class ImagesAPIControllerTests: XCTestCase {
+    private var app: Application!
+
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
+    func testGenerationReturnsBase64ImagePayload() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"model":"any-model","prompt":"a red square","n":1,"size":"256x256"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/generations", headers: headers, body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            let decoded = try! JSONDecoder().decode(OpenAIImagesResponse.self, from: Data(buffer: response.body))
+            XCTAssertEqual(decoded.data.first?.b64Json, Data("png".utf8).base64EncodedString())
+        }
+        let request = await generator.generationRequest
+        XCTAssertEqual(request?.prompt, "a red square")
+        XCTAssertEqual(request?.width, 256)
+        XCTAssertEqual(request?.height, 256)
+    }
+
+    func testEditAcceptsMultipartModelFieldAndImage() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        let boundary = "afm-image-boundary"
+        let png = Data([0x89, 0x50, 0x4e, 0x47])
+        var body = Data()
+        body.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nQwen3.8-27B\r\n".utf8))
+        body.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nmake it blue\r\n".utf8))
+        body.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"image\"; filename=\"image.png\"\r\nContent-Type: image/png\r\n\r\n".utf8))
+        body.append(png)
+        body.append(Data("\r\n--\(boundary)--\r\n".utf8))
+        var headers = HTTPHeaders()
+        headers.contentType = HTTPMediaType(type: "multipart", subType: "form-data", parameters: ["boundary": boundary])
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/edits", headers: headers, body: ByteBuffer(data: body)
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertContains(response.body.string, "b64_json")
+        }
+        let request = await generator.editRequest
+        XCTAssertEqual(request?.prompt, "make it blue")
+        XCTAssertEqual(request?.images, [png])
+    }
+
+    func testInvalidSizeIsRejectedBeforeGeneration() async throws {
+        let generator = FakeImageGenerator()
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"prompt":"test","size":"nope"}"#)
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/generations", headers: headers, body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .badRequest)
+        }
+        let request = await generator.generationRequest
+        XCTAssertNil(request)
+    }
+
+    func testFluxKleinGenerationAndEditIntegration() async throws {
+        guard ProcessInfo.processInfo.environment["AFM_RUN_FLUX_INTEGRATION"] == "1" else {
+            throw XCTSkip("Set AFM_RUN_FLUX_INTEGRATION=1 to run the 23.7 GB FLUX model smoke test")
+        }
+        let cachePath = ProcessInfo.processInfo.environment["MACAFM_MLX_MODEL_CACHE"]
+            ?? "/Volumes/Crucial4TB/models/vesta-test-cache"
+        let generator = FluxKleinImageService(configuration: FluxKleinImageConfiguration(
+            cacheDirectory: URL(fileURLWithPath: cachePath, isDirectory: true),
+            quantization: .int4
+        ))
+        try ImagesAPIController(generator: generator).boot(routes: app)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        let body = ByteBuffer(string: #"{"model":"Qwen3.8-27B","prompt":"a red square on a white background","n":1,"size":"256x256","response_format":"b64_json","seed":42}"#)
+
+        var generatedPNG = Data()
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/generations", headers: headers, body: body
+        ) { response async throws in
+            XCTAssertEqual(response.status, .ok)
+            let decoded = try JSONDecoder().decode(OpenAIImagesResponse.self, from: Data(buffer: response.body))
+            let png = try XCTUnwrap(Data(base64Encoded: try XCTUnwrap(decoded.data.first?.b64Json)))
+            XCTAssertEqual(Array(png.prefix(8)), [137, 80, 78, 71, 13, 10, 26, 10])
+            try png.write(to: URL(fileURLWithPath: "/tmp/afm-flux-klein-smoke.png"), options: .atomic)
+            generatedPNG = png
+        }
+
+        let boundary = "afm-flux-integration-boundary"
+        var editBody = Data()
+        editBody.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nQwen3.8-27B\r\n".utf8))
+        editBody.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nturn the red square into a blue circle on a white background\r\n".utf8))
+        editBody.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"size\"\r\n\r\n256x256\r\n".utf8))
+        editBody.append(Data("--\(boundary)\r\nContent-Disposition: form-data; name=\"image\"; filename=\"generated.png\"\r\nContent-Type: image/png\r\n\r\n".utf8))
+        editBody.append(generatedPNG)
+        editBody.append(Data("\r\n--\(boundary)--\r\n".utf8))
+        var editHeaders = HTTPHeaders()
+        editHeaders.contentType = HTTPMediaType(type: "multipart", subType: "form-data", parameters: ["boundary": boundary])
+
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/images/edits", headers: editHeaders, body: ByteBuffer(data: editBody)
+        ) { response async throws in
+            XCTAssertEqual(response.status, .ok)
+            let decoded = try JSONDecoder().decode(OpenAIImagesResponse.self, from: Data(buffer: response.body))
+            let png = try XCTUnwrap(Data(base64Encoded: try XCTUnwrap(decoded.data.first?.b64Json)))
+            XCTAssertEqual(Array(png.prefix(8)), [137, 80, 78, 71, 13, 10, 26, 10])
+            try png.write(to: URL(fileURLWithPath: "/tmp/afm-flux-klein-edit-smoke.png"), options: .atomic)
+        }
+    }
+}
+
+private actor FakeImageGenerator: AFMImageGenerating {
+    var generationRequest: AFMImageGenerationRequest?
+    var editRequest: AFMImageEditRequest?
+
+    func generateImages(for request: AFMImageGenerationRequest) async throws -> [AFMGeneratedImage] {
+        generationRequest = request
+        return [AFMGeneratedImage(data: Data("png".utf8), width: request.width, height: request.height)]
+    }
+
+    func editImages(for request: AFMImageEditRequest) async throws -> [AFMGeneratedImage] {
+        editRequest = request
+        return [AFMGeneratedImage(data: Data("edited".utf8), width: request.width, height: request.height)]
+    }
+}

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -108,6 +108,29 @@ struct TokenizeAndOpenAPITests {
         }
     }
 
+    @Test("T1.7 image schemas declare strict controls and operational errors")
+    func openAPIImagesContract() throws {
+        let data = Data(OpenAPIController.specJSON.utf8)
+        let parsed = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let components = try #require(parsed["components"] as? [String: Any])
+        let schemas = try #require(components["schemas"] as? [String: Any])
+        let generation = try #require(schemas["ImageGenerationRequest"] as? [String: Any])
+        #expect(generation["additionalProperties"] as? Bool == false)
+        let generationProperties = try #require(generation["properties"] as? [String: Any])
+        let prompt = try #require(generationProperties["prompt"] as? [String: Any])
+        #expect(prompt["maxLength"] as? Int == 32_000)
+
+        let paths = try #require(parsed["paths"] as? [String: Any])
+        for path in ["/v1/images/generations", "/v1/images/edits"] {
+            let pathItem = try #require(paths[path] as? [String: Any])
+            let post = try #require(pathItem["post"] as? [String: Any])
+            let responses = try #require(post["responses"] as? [String: Any])
+            for status in ["200", "400", "405", "413", "415", "500", "503"] {
+                #expect(responses[status] != nil, "missing image response status \(status) for \(path)")
+            }
+        }
+    }
+
     @Test("T1.7 docs page references /openapi.json on same origin")
     func docsHTMLReferencesSpec() {
         let html = OpenAPIController.docsHTML

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -94,6 +94,8 @@ struct TokenizeAndOpenAPITests {
             "/v1/embeddings",
             "/v1/audio/transcriptions",
             "/v1/audio/speech",
+            "/v1/images/generations",
+            "/v1/images/edits",
             "/v1/ocr",
             "/v1/batch/completions",
             "/v1/files",

--- a/docs/images-api.md
+++ b/docs/images-api.md
@@ -117,3 +117,20 @@ correlated OpenAI-shaped HTTP 500.
 
 The current endpoint returns PNG data through `b64_json`. URL-hosted output,
 streaming partial images, masks, and variations are not implemented.
+
+## Testing
+
+The normal unit suite exercises the Images HTTP contract with a lightweight
+fake provider. The real generation-and-edit smoke test is opt-in because it
+loads the 23.7 GB FLUX snapshot:
+
+```bash
+AFM_RUN_FLUX_INTEGRATION=1 \
+MACAFM_MLX_MODEL_CACHE=/Volumes/Crucial4TB/models/vesta-test-cache \
+  ./Scripts/test-assertions.sh --tier unit
+```
+
+`AFM_RUN_FLUX_INTEGRATION=1` enables only this expensive test. It is not
+required to start AFM or use `/v1/images/generations` and `/v1/images/edits`.
+Without it, the harness reports the real-model test as skipped while continuing
+to run all controller and OpenAPI contract tests.

--- a/docs/images-api.md
+++ b/docs/images-api.md
@@ -22,6 +22,12 @@ snapshot. Set `MACAFM_IMAGE_QUANT=bf16`, `int8`, or `int4` to select the memory
 tier. Set `MACAFM_IMAGE_MODEL` to use a different compatible cache-relative
 model ID.
 
+Requests must omit `model` or name that configured image model exactly. To
+support a client that cannot select a separate image model, set
+`MACAFM_IMAGE_MODEL_ALIASES` to an explicit comma-separated allowlist, for
+example `Qwen3.8-27B,dall-e-3`. Unknown model IDs are rejected with
+`code=unsupported_model`; AFM never silently reroutes them.
+
 ## Generate an image
 
 ```bash
@@ -54,11 +60,10 @@ curl http://127.0.0.1:9999/v1/images/edits \
   -F 'response_format=b64_json'
 ```
 
-`model` remains accepted when an OpenAI client sends its active chat model ID;
-AFM routes these image-only endpoints to `MACAFM_IMAGE_MODEL`. This lets one
-server expose chat and image surfaces without requiring the client to manage a
-second base URL. Because that routing emulates rather than exactly honors the
-requested `model`, successful responses include:
+When an OpenAI client sends an alias explicitly listed in
+`MACAFM_IMAGE_MODEL_ALIASES`, AFM routes the request to `MACAFM_IMAGE_MODEL`.
+Because that opt-in routing emulates rather than exactly honors the requested
+`model`, successful responses include:
 
 ```text
 X-AFM-Compatibility: emulated
@@ -91,10 +96,20 @@ silently. Unsupported HTTP methods return 405 and `Allow: POST, OPTIONS`.
 Permanent capability gaps are deliberately reported as non-retryable client
 errors rather than 501 server errors.
 
+Generation JSON is limited to 1 MB. Edit multipart requests are limited to 25
+MB, with one non-empty PNG, JPEG, or WebP input of at most 20 MB. Prompts are
+limited to 32,000 characters. Explicit sizes must be 64–2048 pixels in each
+dimension, divisible by 16, and between 1:3 and 3:1 aspect ratio. These checks
+prevent the provider from silently rounding dimensions or failing after model
+loading. A missing model snapshot returns retryable HTTP 503; invalid image
+bytes return HTTP 400 with `param=image`; unexpected provider failures return a
+correlated OpenAI-shaped HTTP 500.
+
 | Control | AFM behavior |
 | --- | --- |
 | `prompt`, `size`, `n` (1-4), `response_format=b64_json`, `output_format=png`, `seed` | Exact |
-| `model` | Emulated routing with response headers |
+| exact configured `model` | Exact |
+| alias listed in `MACAFM_IMAGE_MODEL_ALIASES` | Emulated routing with response headers |
 | `stream=false`, `user` | Accepted compatibility values |
 | `background`, `moderation`, `output_compression`, `partial_images`, `quality`, `style` | Rejected with `unsupported_parameter` |
 | edit `input_fidelity`, `mask`, and `image[]` multi-input syntax | Rejected with `unsupported_parameter` |

--- a/docs/images-api.md
+++ b/docs/images-api.md
@@ -1,0 +1,63 @@
+# Images API
+
+AFM exposes OpenAI-compatible image generation and image editing backed by
+FLUX.2 Klein on the same pinned MLX runtime used for text inference. The image
+model loads lazily on the first image request, so normal chat startup and
+memory use are unchanged.
+
+## Model setup
+
+Place the Hugging Face snapshot below the configured MLX model cache:
+
+```text
+$MACAFM_MLX_MODEL_CACHE/mlx-community/FLUX.2-klein-4B-bf16/
+├── transformer/
+├── text_encoder/
+├── tokenizer/
+└── vae/
+```
+
+The default runtime quantizes the transformer to int4 after loading the bf16
+snapshot. Set `MACAFM_IMAGE_QUANT=bf16`, `int8`, or `int4` to select the memory
+tier. Set `MACAFM_IMAGE_MODEL` to use a different compatible cache-relative
+model ID.
+
+## Generate an image
+
+```bash
+curl http://127.0.0.1:9999/v1/images/generations \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "mlx-community/FLUX.2-klein-4B-bf16",
+    "prompt": "a red fox reading beside a campfire",
+    "n": 1,
+    "size": "1024x1024",
+    "response_format": "b64_json",
+    "seed": 42
+  }'
+```
+
+The response follows the OpenAI Images shape:
+
+```json
+{"created": 1788091200, "data": [{"b64_json": "iVBORw0KGgo..."}]}
+```
+
+## Edit an image
+
+```bash
+curl http://127.0.0.1:9999/v1/images/edits \
+  -F 'model=mlx-community/FLUX.2-klein-4B-bf16' \
+  -F 'prompt=turn the daytime scene into moonlight' \
+  -F 'image=@input.png;type=image/png' \
+  -F 'size=1024x1024' \
+  -F 'response_format=b64_json'
+```
+
+`model` remains accepted when an OpenAI client sends its active chat model ID;
+AFM routes these image-only endpoints to `MACAFM_IMAGE_MODEL`. This lets one
+server expose chat and image surfaces without requiring the client to manage a
+second base URL.
+
+The current endpoint returns PNG data through `b64_json`. URL-hosted output,
+streaming partial images, masks, and variations are not implemented.

--- a/docs/images-api.md
+++ b/docs/images-api.md
@@ -57,7 +57,48 @@ curl http://127.0.0.1:9999/v1/images/edits \
 `model` remains accepted when an OpenAI client sends its active chat model ID;
 AFM routes these image-only endpoints to `MACAFM_IMAGE_MODEL`. This lets one
 server expose chat and image surfaces without requiring the client to manage a
-second base URL.
+second base URL. Because that routing emulates rather than exactly honors the
+requested `model`, successful responses include:
+
+```text
+X-AFM-Compatibility: emulated
+X-AFM-Emulated-Parameters: model
+```
+
+## Compatibility and errors
+
+AFM does not silently ignore behavior-changing OpenAI Images controls. A known
+but unavailable control returns HTTP 400 with an OpenAI-compatible,
+parameter-specific error:
+
+```json
+{
+  "error": {
+    "message": "Parameter 'background' is not supported by the configured AFM image model",
+    "type": "invalid_request_error",
+    "code": "unsupported_parameter",
+    "param": "background",
+    "request_id": "req_..."
+  }
+}
+```
+
+The same request ID is returned in `X-Request-ID` and `OpenAI-Request-ID`.
+Malformed values use `code=invalid_request_error`; an incorrect request media
+type returns HTTP 415 with `code=unsupported_media_type`; unknown fields are
+rejected with `code=unknown_parameter` so misspelled controls cannot disappear
+silently. Unsupported HTTP methods return 405 and `Allow: POST, OPTIONS`.
+Permanent capability gaps are deliberately reported as non-retryable client
+errors rather than 501 server errors.
+
+| Control | AFM behavior |
+| --- | --- |
+| `prompt`, `size`, `n` (1-4), `response_format=b64_json`, `output_format=png`, `seed` | Exact |
+| `model` | Emulated routing with response headers |
+| `stream=false`, `user` | Accepted compatibility values |
+| `background`, `moderation`, `output_compression`, `partial_images`, `quality`, `style` | Rejected with `unsupported_parameter` |
+| edit `input_fidelity`, `mask`, and `image[]` multi-input syntax | Rejected with `unsupported_parameter` |
+| `stream=true`, `response_format=url`, `output_format=jpeg/webp`, `n` 5-10 | Rejected with `unsupported_parameter` |
 
 The current endpoint returns PNG data through `b64_json`. URL-hosted output,
 streaming partial images, masks, and variations are not implemented.


### PR DESCRIPTION
## Problem

llmprobe reports `/v1/images/generations` and `/v1/images/edits` as missing. AFM currently has no OpenAI-compatible image HTTP surface. OpenAI clients may also send controls that FLUX.2 Klein cannot honor; silently ignoring those controls would report false compatibility.

## Approach

- add POST `/v1/images/generations` JSON handling
- add POST `/v1/images/edits` multipart handling
- return OpenAI-compatible `created` and `data[].b64_json` payloads
- lazily route both endpoints to FLUX.2 Klein through `AFMKitMLXImage`
- require the configured image model ID by default and support only aliases explicitly allowlisted through `MACAFM_IMAGE_MODEL_ALIASES`
- add OpenAPI schemas/routes, CORS/no-store headers, tests, and setup documentation
- reject recognized but unavailable controls with HTTP 400 and an OpenAI-shaped `invalid_request_error`
- include stable `code`, exact `param`, and correlated `request_id` fields
- reject unknown fields rather than silently ignoring misspelled controls
- return 415 for incorrect request media types and 405 plus `Allow` for unsupported methods
- disclose model-routing emulation through `X-AFM-Compatibility` and `X-AFM-Emulated-Parameters`
- expose request and compatibility headers to browser clients through CORS

The compatibility behavior follows the current official OpenAI Images contracts:

- https://developers.openai.com/api/reference/resources/images/methods/generate
- https://developers.openai.com/api/reference/resources/images/methods/edit

## Capability policy

| Request | Behavior |
| --- | --- |
| Exact local controls | 200 |
| Emulated `model` routing | 200 with compatibility headers |
| Known but unsupported control | 400 `unsupported_parameter` with `param` |
| Invalid value | 400 `invalid_request_error` with `param` |
| Unknown field | 400 `unknown_parameter` with `param` |
| Incorrect media type | 415 `unsupported_media_type` |
| Unsupported HTTP method | 405 `method_not_allowed`, `Allow: POST, OPTIONS` |

Permanent capability gaps deliberately use a non-retryable 4xx response rather than 501, which OpenAI SDKs classify as an internal server error.

## Review fixes

- map invalid images to 400, missing snapshots to 503, and unexpected provider failures to OpenAI-shaped 500 responses
- replace whole-binary UTF-8 multipart scanning with boundary-aware header parsing
- reject dimensions the provider would otherwise round and enforce prompt, image, and request size limits
- reject unknown image models unless an administrator explicitly configures an alias
- reflect browser SDK preflight headers and cover HEAD plus other unsupported methods with 405
- expand the OpenAPI contract with strict schemas, operational errors, and response headers

## Validation

- focused Images controller tests: 24 executed, 23 passed, 1 opt-in real-model test skipped, 0 failures
- OpenAPI tests: 10 passed, 0 failures
- complete release Swift test suite passed with 0 failures; Swift Testing reported 140 tests across 17 suites
- AFMKit consumer boundary check passed
- `git diff --check` passed
- earlier real FLUX generation + edit endpoint test: 1 passed, 0 failures (12.435 seconds)
- earlier paired optimized `afm` release build passed in 272.46 seconds
- generation output: valid 256x256 PNG of a red square
- edit output: valid 256x256 PNG transforming it to a blue circle
- model snapshot: all 24 tracked files checksum-verified at `/Volumes/Crucial4TB/models/vesta-test-cache/mlx-community/FLUX.2-klein-4B-bf16`

## Dependency

Depends on scouzi1966/AFMKit#60. This PR remains draft until that provider is merged, released as an exact AFMKit version, and this branch updates the single exact package pin. Local paired validation used the supported `MACLOCAL_AFMKIT_PATH` workflow; it does not introduce a branch or revision dependency.

## Summary by Sourcery

Expose strict OpenAI-compatible image generation and editing APIs backed by lazily loaded FLUX.2 Klein.

New Features:
- Add OpenAI-compatible image generation and editing endpoints backed by FLUX.2 Klein with base64-encoded PNG responses.
- Support configurable image-model selection with explicitly allowlisted aliases and compatibility disclosures for emulated routing.

Bug Fixes:
- Prevent unsupported, invalid, or unknown image request controls from being silently ignored by returning parameter-specific OpenAI-shaped errors.
- Return appropriate media-type, method, payload-size, provider, and model-availability errors with request correlation details.

Enhancements:
- Add CORS, cache-control, method handling, request-size limits, input validation, and strict multipart parsing for image requests.
- Expose image endpoint contracts, compatibility headers, and operational errors through OpenAPI.

Build:
- Add the AFMKitMLXImage product dependency.

CI:
- Extend the assertion harness with help output and an opt-in real FLUX integration test workflow.

Documentation:
- Document image model setup, configuration, endpoint usage, compatibility behavior, limits, errors, and testing.

Tests:
- Add controller coverage for image generation and editing behavior, validation, compatibility, errors, CORS, methods, and provider failures.
- Add OpenAPI contract tests for image routes, schemas, headers, and response statuses.