### PR TITLE
Expose optional Qwen n-gram sidecar mapping

### DIFF
--- a/Sources/AFMCLI/ModelEvaluationRunner.swift
+++ b/Sources/AFMCLI/ModelEvaluationRunner.swift
@@ -154,6 +154,7 @@ extension MlxCommand {
                 kvBits: kvBits,
                 enablePrefixCaching: enablePrefixCaching,
                 mlxKernels: mlxKernels,
+                qwenNGramMmapEnabled: qwenNGramMmap,
                 mtpEnabled: mtp,
                 mtpDepth: mtpDepth,
                 mtpModelID: mtpModel,
@@ -430,6 +431,7 @@ extension MlxCommand {
         if vlm { args.append("--vlm") }
         if let kvBits { args += ["--kv-bits", String(kvBits)] }
         if enablePrefixCaching { args.append("--enable-prefix-caching") }
+        if qwenNGramMmap { args.append("--qwen-ngram-mmap") }
         if mlxKernels != "native" { args += ["--mlx-kernels", shellQuote(mlxKernels)] }
         if let temperature { args += ["--temperature", String(temperature)] }
         if maxTokens != 8_192 { args += ["--max-tokens", String(maxTokens)] }

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -274,6 +274,7 @@ struct MlxCommand: ParsableCommand {
           --gguf-file: Exact GGUF path inside a Hugging Face repository; otherwise AFM selects the largest model artifact that fits memory
           --enable-prefix-caching / --no-enable-prefix-caching: KV cache reuse across requests
           --mtp: Enable serial MTP self-speculative decoding for compatible Qwen models
+          --qwen-ngram-mmap: Opt in to a checkpoint-declared, disk-backed Qwen Next n-gram table
           --mtp-depth: MTP draft depth compatibility setting
           --mtp-model: Override the automatic MTP head with a Hugging Face repo, local directory, or .safetensors file
           --dspark-support: DwarfStar DSpark support GGUF for speculative decoding
@@ -514,6 +515,9 @@ struct MlxCommand: ParsableCommand {
 
     @Flag(name: .long, help: "Enable radix tree prefix caching for KV cache reuse across requests")
     var enablePrefixCaching: Bool = false
+
+    @Flag(name: .customLong("qwen-ngram-mmap"), help: "Opt in to a checkpoint-declared, disk-backed Qwen Next n-gram table. Disabled by default and independent from --mtp.")
+    var qwenNGramMmap: Bool = false
 
     @Flag(name: .long, help: "Enable MTP self-speculative decoding. Qwen 3.8 automatically downloads and uses the matching quantized MTP head; concurrent and batch requests safely use autoregressive decoding.")
     var mtp: Bool = false
@@ -837,6 +841,7 @@ struct MlxCommand: ParsableCommand {
             kvBits: kvBits,
             enablePrefixCaching: enablePrefixCaching,
             kernelEngine: kernelEngine,
+            qwenNGramMmapEnabled: qwenNGramMmap,
             mtpEnabled: mtp,
             mtpDepth: mtpDepth,
             mtpModelID: mtpModel,
@@ -879,6 +884,7 @@ struct MlxCommand: ParsableCommand {
                 kvBits: kvBits,
                 enablePrefixCaching: enablePrefixCaching,
                 mlxKernels: kernelEngine.rawValue,
+                qwenNGramMmapEnabled: qwenNGramMmap,
                 mtpEnabled: mtp,
                 mtpDepth: mtpDepth,
                 mtpModelID: mtpModel,
@@ -1407,6 +1413,7 @@ struct MlxCommand: ParsableCommand {
                     kvBits: self.kvBits,
                     enablePrefixCaching: self.enablePrefixCaching,
                     mlxKernels: self.mlxKernels,
+                    qwenNGramMmapEnabled: self.qwenNGramMmap,
                     mtpEnabled: self.mtp,
                     mtpDepth: self.mtpDepth,
                     mtpModelID: self.mtpModel,

--- a/Sources/AFMKit/AFMEngine.swift
+++ b/Sources/AFMKit/AFMEngine.swift
@@ -30,6 +30,7 @@ public struct EngineConfig: Sendable {
     public var kvBits: Int?
     public var enablePrefixCaching: Bool
     public var mlxKernels: String
+    public var qwenNGramMmapEnabled: Bool
     public var mtpEnabled: Bool
     public var mtpDepth: Int
     public var mtpModelID: String?
@@ -56,6 +57,7 @@ public struct EngineConfig: Sendable {
         kvBits: Int? = nil,
         enablePrefixCaching: Bool = false,
         mlxKernels: String = "native",
+        qwenNGramMmapEnabled: Bool = false,
         mtpEnabled: Bool = false,
         mtpDepth: Int = 3,
         mtpModelID: String? = nil,
@@ -81,6 +83,7 @@ public struct EngineConfig: Sendable {
         self.kvBits = kvBits
         self.enablePrefixCaching = enablePrefixCaching
         self.mlxKernels = mlxKernels
+        self.qwenNGramMmapEnabled = qwenNGramMmapEnabled
         self.mtpEnabled = mtpEnabled
         self.mtpDepth = mtpDepth
         self.mtpModelID = mtpModelID
@@ -106,6 +109,7 @@ private extension EngineConfig {
         var values: [String: AFMJSONValue] = [
             "enablePrefixCaching": .bool(enablePrefixCaching),
             "mlxKernels": .string(mlxKernels),
+            "qwenNGramMmapEnabled": .bool(qwenNGramMmapEnabled),
             "mtpEnabled": .bool(mtpEnabled),
             "mtpDepth": .integer(mtpDepth),
             "enableGrammarConstraints": .bool(enableGrammarConstraints),

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -467,7 +467,7 @@ public class Server: @unchecked Sendable {
     ]
     private static let mlxWebFlagOptions: Set<String> = [
         "--verbose", "--very-verbose", "--vv", "--no-streaming", "--raw", "--vlm",
-        "--trust-remote-code", "--fix-tool-args", "--enable-prefix-caching", "--mtp",
+        "--trust-remote-code", "--fix-tool-args", "--enable-prefix-caching", "--qwen-ngram-mmap", "--mtp",
         "--dspark-strict", "--enable-grammar-constraints", "--no-think", "--gpu-profile",
         "--gpu-profile-bw"
     ]

--- a/Tests/MacLocalAPITests/WebRuntimeControlTests.swift
+++ b/Tests/MacLocalAPITests/WebRuntimeControlTests.swift
@@ -53,7 +53,7 @@ final class WebRuntimeControlTests: XCTestCase {
                 "--gguf-file": "model-q4.gguf",
                 "--mtp-model": "mlx-community/example-mtp"
             ],
-            flags: ["--mtp", "--no-think"],
+            flags: ["--qwen-ngram-mmap", "--mtp", "--no-think"],
             dryRun: false
         )
 
@@ -61,6 +61,7 @@ final class WebRuntimeControlTests: XCTestCase {
         XCTAssertEqual(Array(arguments.prefix(3)), ["mlx", "--model", "mlx-community/example"])
         XCTAssertTrue(arguments.contains("--gguf-file"))
         XCTAssertTrue(arguments.contains("--mtp-model"))
+        XCTAssertTrue(arguments.contains("--qwen-ngram-mmap"))
         XCTAssertTrue(arguments.contains("--mtp"))
         XCTAssertEqual(Array(arguments.suffix(5)), ["--hostname", "127.0.0.1", "--port", "10001", "--webui"])
     }


### PR DESCRIPTION
## Problem

The AFM CLI needs an explicit way to request disk-backed n-gram sidecar loading for compatible Qwen Next checkpoints without changing existing model behavior.

## Approach

- add `--qwen-ngram-mmap` as an opt-in MLX flag
- keep the flag disabled by default and independent from `--mtp`
- propagate the setting through direct runs, evaluation/reproduction commands, engine configuration, and server launch
- allowlist the flag in loopback Web runtime command validation

Provider support is implemented in AFMKit PR scouzi1966/AFMKit#63. This consumer PR should merge with the AFMKit release/version bump that contains that provider change.

## Validation

- paired release build against the AFMKit feature branch completed successfully
- `WebRuntimeControlTests`: 6 passed, 0 failed
- CLI help identifies the option as disabled by default and independent from MTP
- exact local checkpoint completed a 128-token generation run with the option enabled
- `git diff --check`: clean

## Summary by Sourcery

Expose optional Qwen Next n-gram mmap loading across CLI, engine, evaluation, and server execution paths.

New Features:
- Add an opt-in `--qwen-ngram-mmap` MLX CLI flag for checkpoint-declared, disk-backed Qwen Next n-gram tables.

Enhancements:
- Propagate the Qwen n-gram mmap setting through engine configuration, evaluation and reproduction commands, direct runs, and server launches while keeping it disabled by default and independent of MTP.
- Allow the new flag in loopback Web runtime command validation and cover its propagation with runtime control tests.

Tests:
- Extend Web runtime control coverage to verify forwarding of the Qwen n-gram mmap option.