### PR TITLE
Update AFMKit to 0.1.15

### DIFF
--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.14"
+        exact: "0.1.15"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "c3c1a47f740eb08be8ee3dbeda8e8fc6fa88f04a",
-        "version" : "0.1.14"
+        "revision" : "65c0e56f084fdebf1b28d0ae4a9c8b72e757a64d",
+        "version" : "0.1.15"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.14"
+        exact: "0.1.15"
     )
 }
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -145,8 +145,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.14":
-        fail(f"{identity} must resolve the exact 0.1.14 release")
+    if pin["state"].get("version") != "0.1.15":
+        fail(f"{identity} must resolve the exact 0.1.15 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -289,7 +289,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.14"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.15"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.14",
+    "afmkit": "0.1.15",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -61,13 +61,13 @@ cat > "$fake_public_git" <<'SH'
 #!/usr/bin/env bash
 arguments=" $* "
 for ref in \
-  refs/tags/0.1.14 \
-  'refs/tags/0.1.14^{}' \
-  refs/tags/v0.1.14 \
-  'refs/tags/v0.1.14^{}'; do
+  refs/tags/0.1.15 \
+  'refs/tags/0.1.15^{}' \
+  refs/tags/v0.1.15 \
+  'refs/tags/v0.1.15^{}'; do
   [[ "$arguments" == *" $ref "* ]] || exit 2
 done
-printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.14^{}'
+printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.15^{}'
 SH
 chmod 700 "$fake_public_git"
 if ! EXPECTED_AFMKIT_REVISION="$expected_afmkit_revision" \
@@ -87,7 +87,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.14'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.15'
   }
   probe_public_source() {
     return 1
@@ -111,14 +111,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.14" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.14"
+[[ "$release_version" == "0.1.15" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.15"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.14'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.15'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -137,7 +137,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.14'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.15'
   }
   probe_public_source() {
     return 0

--- a/docs/afmkit-url-consumption.md
+++ b/docs/afmkit-url-consumption.md
@@ -6,7 +6,7 @@ one exact release and selects every provider product from it:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.14"
+    exact: "0.1.15"
 )
 ```
 
@@ -14,7 +14,7 @@ Do not use a branch or revision requirement for release builds.
 
 ## Production Blocker
 
-AFMKit is public and exposes `0.1.14`. AFM release publication remains
+AFMKit is public and exposes `0.1.15`. AFM release publication remains
 fail-closed unless AFMKit and every dependency in its root graph are
 anonymously readable and the tracked lock resolves that exact tag.
 
@@ -38,7 +38,7 @@ surface publishable.
 
 ## Dependency Resolution
 
-AFMKit 0.1.14 is public, so normal resolution requires no GitHub credential:
+AFMKit 0.1.15 is public, so normal resolution requires no GitHub credential:
 
 ```bash
 Scripts/resolve-release-dependencies.sh
@@ -55,7 +55,7 @@ The normal graph is independent of maclocal-api's dirty vendor worktrees:
 
 | Dependency | Requirement | Purpose |
 | --- | --- | --- |
-| `AFMKit` | exact `0.1.14` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
+| `AFMKit` | exact `0.1.15` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
 
 The MLX, mlx-c, Swift bindings, and mlx-swift-lm sources are snapshots inside
 AFMKit's `vendor/MLX` tree. They are not separate SwiftPM dependencies of

--- a/docs/vesta-integration.md
+++ b/docs/vesta-integration.md
@@ -11,7 +11,7 @@ Use the current exact public AFMKit release:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.14"
+    exact: "0.1.15"
 )
 ```
 


### PR DESCRIPTION
## Problem

maclocal-api still pins AFMKit 0.1.14 and therefore cannot consume the reviewed Qwen Next NAX attention routing and qualification changes released in 0.1.15.

## Approach

- Pin the single AFMKit dependency and lockfile to exact public release 0.1.15.
- Update the independent consumer example, release gates, tooling fixtures, and dependency documentation to the same exact version.
- Keep provider implementation entirely inside AFMKit.

## Validation

- `Scripts/swiftpm-reliable.sh build -c release --product afm` (clean remote dependency graph)
- `Scripts/check-afmkit-consumer-boundary.sh`
- `Scripts/tests/test-release-tooling.sh`
- `Scripts/check-public-release-eligibility.sh`
- `git diff --check`

AFMKit 0.1.15 resolves anonymously to merge commit `65c0e56f084fdebf1b28d0ae4a9c8b72e757a64d`.

## Summary by Sourcery

Adopt AFMKit 0.1.15 across dependencies, release validation, consumer examples, tooling, and documentation.

Enhancements:
- Upgrade the project and independent consumer integrations to the exact public AFMKit 0.1.15 release.

Documentation:
- Update AFMKit dependency guidance and release documentation to reference version 0.1.15.

Tests:
- Update consumer-boundary, public-release eligibility, and release-tooling checks for AFMKit 0.1.15.

Chores:
- Refresh the Swift package lockfile to resolve AFMKit 0.1.15.