### PR TITLE
Prevent degraded Foundation Models builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,28 +1,19 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.4
 import PackageDescription
 import Foundation
 
 // Strip absolute build paths from __FILE__ macros in C++ warnings (privacy: don't leak dev machine paths)
 let packageDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
-let foundationModelsDependencies: [Target.Dependency]
-let foundationModels27Dependencies: [Target.Dependency]
-let dwarfStarFoundationModelsDependencies: [Target.Dependency]
-#if compiler(>=6.4)
-foundationModelsDependencies = [
+let foundationModelsDependencies: [Target.Dependency] = [
     .product(name: "AFMKitApple", package: "AFMKit")
 ]
-foundationModels27Dependencies = [
+let foundationModels27Dependencies: [Target.Dependency] = [
     .product(name: "AFMKitApple", package: "AFMKit"),
     .product(name: "AFMKitFoundationModelsMLX", package: "AFMKit")
 ]
-dwarfStarFoundationModelsDependencies = [
+let dwarfStarFoundationModelsDependencies: [Target.Dependency] = [
     .product(name: "AFMKitFoundationModelsDwarfStar", package: "AFMKit")
 ]
-#else
-foundationModelsDependencies = []
-foundationModels27Dependencies = []
-dwarfStarFoundationModelsDependencies = []
-#endif
 let afmKitDependency: Package.Dependency
 if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WORKSPACE_PATH"],
    !localAFMKitPath.isEmpty {

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -31,8 +31,9 @@ facade_files=(Sources/AFMKitFoundationModels/*.swift)
   fail "AFMKitFoundationModels must contain only its compatibility facade"
 grep -Fqx '@_exported import AFMKitApple' "${facade_files[0]}" || \
   fail "AFMKitFoundationModels must re-export the AFMKitApple product"
-grep -Fqx '#if compiler(>=6.4)' "${facade_files[0]}" || \
-  fail "AFMKitFoundationModels must compile to an empty compatibility surface on Xcode 26"
+if grep -Fq '#if compiler' "${facade_files[0]}"; then
+  fail "AFMKitFoundationModels must not silently compile to an empty compatibility surface"
+fi
 if grep -Eq '\b(class|struct|enum|protocol|actor|func)[[:space:]]+' "${facade_files[0]}"; then
   fail "AFMKitFoundationModels facade contains a local implementation"
 fi
@@ -297,8 +298,25 @@ for project in pyproject.toml pyproject-next.toml; do
     fail "$project does not package nested Xcode 27 provider resources"
 done
 
+grep -Fq '// swift-tools-version: 6.4' Package.swift || \
+  fail "Package.swift must reject compilers that cannot build Apple Foundation Models"
 grep -Fq '.macOS("26.0")' Package.swift || \
   fail "Package.swift no longer preserves the macOS 26 deployment boundary"
+
+for artifact_gate in \
+  build.sh \
+  Scripts/build-native-wheel.sh \
+  Scripts/build-nightly-wheel.sh \
+  Scripts/create-tarball.sh \
+  Scripts/publish-next.sh \
+  Scripts/publish-stable.sh \
+  Scripts/verify-native-wheel.sh \
+  Scripts/verify-release-archive.sh; do
+  grep -Fq 'check-macos26-compatibility.sh' "$artifact_gate" || \
+    fail "$artifact_gate bypasses release binary compatibility checks"
+done
+grep -Fq 'check-foundation-models-build.sh' Scripts/check-macos26-compatibility.sh || \
+  fail "release binary compatibility does not verify compiled Foundation Models support"
 
 if grep -ERn \
   '\b(MLXModelService|BatchScheduler|RequestSlot|RadixTreeCache|ToolCallStreamingRuntime)\b' \

--- a/Scripts/check-foundation-models-build.sh
+++ b/Scripts/check-foundation-models-build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Reject binaries that were compiled without the real Apple Foundation Models
+# provider. Version/help smoke tests alone cannot distinguish those binaries
+# from a complete build because MLX remains functional.
+set -euo pipefail
+
+BINARY="${1:-}"
+if [[ -z "$BINARY" || ! -x "$BINARY" ]]; then
+  echo "[foundation-build] Missing executable: ${BINARY:-<not provided>}" >&2
+  exit 2
+fi
+
+if ! CAPABILITIES_JSON="$("$BINARY" --help-json 2>/dev/null)"; then
+  echo "[foundation-build] Could not read build capabilities from $BINARY" >&2
+  exit 1
+fi
+
+if ! AFM_CAPABILITIES_JSON="$CAPABILITIES_JSON" python3 - <<'PY'
+import json
+import os
+
+try:
+    document = json.loads(os.environ["AFM_CAPABILITIES_JSON"])
+except (KeyError, json.JSONDecodeError) as error:
+    raise SystemExit(f"invalid --help-json output: {error}")
+
+capabilities = document.get("build_capabilities")
+if not isinstance(capabilities, dict):
+    raise SystemExit("build_capabilities is missing")
+if capabilities.get("foundation_models_compiled") is not True:
+    raise SystemExit("foundation_models_compiled is not true")
+if capabilities.get("minimum_swift_compiler") != "6.4":
+    raise SystemExit("minimum_swift_compiler is not 6.4")
+PY
+then
+  echo "[foundation-build] $BINARY does not contain the required Apple Foundation Models provider." >&2
+  echo "[foundation-build] Rebuild with Swift 6.4 or newer; refusing to package a degraded MLX-only executable." >&2
+  exit 1
+fi
+
+echo "[foundation-build] Apple Foundation Models provider is compiled into $BINARY"

--- a/Scripts/check-macos26-compatibility.sh
+++ b/Scripts/check-macos26-compatibility.sh
@@ -24,6 +24,8 @@ if [ ! -x "$BINARY" ]; then
   exit 1
 fi
 
+"$ROOT_DIR/Scripts/check-foundation-models-build.sh" "$BINARY"
+
 if [ -z "$METALLIB" ]; then
   METALLIB="$($ROOT_DIR/Scripts/resolve-afmkit-resource.sh --metallib "$(dirname "$BINARY")" 2>/dev/null || true)"
 fi

--- a/Scripts/swiftpm-reliable.sh
+++ b/Scripts/swiftpm-reliable.sh
@@ -18,6 +18,29 @@ if [[ "$SUBCOMMAND" != "build" && "$SUBCOMMAND" != "test" ]]; then
 fi
 shift
 
+SWIFT_VERSION_OUTPUT="$(swift --version 2>&1)" || {
+    echo "[swiftpm-reliable] Unable to run the selected Swift compiler." >&2
+    exit 1
+}
+if ! SWIFT_VERSION_OUTPUT="$SWIFT_VERSION_OUTPUT" python3 - <<'PY'
+import os
+import re
+
+output = os.environ["SWIFT_VERSION_OUTPUT"]
+match = re.search(r"Swift version\s+(\d+)\.(\d+)", output, re.IGNORECASE)
+if match is None:
+    raise SystemExit(1)
+version = tuple(map(int, match.groups()))
+raise SystemExit(0 if version >= (6, 4) else 1)
+PY
+then
+    echo "[swiftpm-reliable] Apple Foundation Models require Swift 6.4 or newer." >&2
+    echo "[swiftpm-reliable] Selected compiler: ${SWIFT_VERSION_OUTPUT%%$'\n'*}" >&2
+    echo "[swiftpm-reliable] Refusing to produce a degraded MLX-only build." >&2
+    exit 1
+fi
+echo "[swiftpm-reliable] Foundation-capable compiler: ${SWIFT_VERSION_OUTPUT%%$'\n'*}" >&2
+
 LOCAL_PACKAGE_ROOT=""
 if [[ -n "${MACLOCAL_AFMKIT_WORKSPACE_PATH:-}" ]]; then
     echo "[swiftpm-reliable] MACLOCAL_AFMKIT_WORKSPACE_PATH is reserved for the generated workspace." >&2

--- a/Scripts/tests/test-foundation-build-gate.sh
+++ b/Scripts/tests/test-foundation-build-gate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK_ROOT="$ROOT_DIR/.build/foundation-build-gate-tests"
+rm -rf "$WORK_ROOT"
+mkdir -p "$WORK_ROOT"
+
+make_fixture() {
+  local path="$1"
+  local payload="$2"
+  printf '#!/usr/bin/env bash\nprintf '\''%%s\\n'\'' '\''%s'\''\n' "$payload" > "$path"
+  chmod 700 "$path"
+}
+
+make_fixture "$WORK_ROOT/complete-afm" \
+  '{"build_capabilities":{"foundation_models_compiled":true,"minimum_swift_compiler":"6.4"}}'
+make_fixture "$WORK_ROOT/degraded-afm" \
+  '{"build_capabilities":{"foundation_models_compiled":false,"minimum_swift_compiler":"6.4"}}'
+make_fixture "$WORK_ROOT/legacy-afm" \
+  '{"version":"v0.9.18"}'
+
+"$ROOT_DIR/Scripts/check-foundation-models-build.sh" "$WORK_ROOT/complete-afm" >/dev/null
+
+for rejected in "$WORK_ROOT/degraded-afm" "$WORK_ROOT/legacy-afm"; do
+  if "$ROOT_DIR/Scripts/check-foundation-models-build.sh" "$rejected" >"$WORK_ROOT/rejected.log" 2>&1; then
+    echo "[foundation-build-test] accepted incomplete fixture: $rejected" >&2
+    exit 1
+  fi
+  grep -Fq 'refusing to package a degraded MLX-only executable' "$WORK_ROOT/rejected.log" || {
+    echo "[foundation-build-test] rejection was not actionable: $rejected" >&2
+    exit 1
+  }
+done
+
+cat > "$WORK_ROOT/swift" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'Apple Swift version 6.3 (swiftlang-6.3.0 clang-1700.0.0.0)'
+SH
+chmod 700 "$WORK_ROOT/swift"
+
+if PATH="$WORK_ROOT:$PATH" \
+   "$ROOT_DIR/Scripts/swiftpm-reliable.sh" build \
+   >"$WORK_ROOT/old-compiler.log" 2>&1; then
+  echo "[foundation-build-test] Swift 6.3 unexpectedly reached SwiftPM" >&2
+  exit 1
+fi
+grep -Fq 'Apple Foundation Models require Swift 6.4 or newer' "$WORK_ROOT/old-compiler.log" || {
+  echo "[foundation-build-test] old-compiler rejection was not actionable" >&2
+  exit 1
+}
+grep -Fq 'Refusing to produce a degraded MLX-only build' "$WORK_ROOT/old-compiler.log" || {
+  echo "[foundation-build-test] old compiler did not reject degraded output" >&2
+  exit 1
+}
+
+echo "[foundation-build-test] complete build accepted; degraded binaries and Swift 6.3 rejected"

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -12,6 +12,7 @@ fail() {
 }
 
 "$ROOT_DIR/Scripts/check-afmkit-consumer-boundary.sh"
+"$ROOT_DIR/Scripts/tests/test-foundation-build-gate.sh"
 
 codeql_workflow="$ROOT_DIR/.github/workflows/codeql-analysis.yml"
 if grep -Eq 'AFMKIT_READ_TOKEN|private-dependency-notice|while AFMKit is private' "$codeql_workflow"; then

--- a/Sources/AFMCLI/main.swift
+++ b/Sources/AFMCLI/main.swift
@@ -1910,6 +1910,11 @@ func printHelpJson(command: String) {
     }
     flushL1()
 
+    root["build_capabilities"] = [
+        "foundation_models_compiled": BuildInfo.foundationModelsCompiled,
+        "minimum_swift_compiler": "6.4",
+    ]
+
     if let jsonData = try? JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys]),
        let jsonString = String(data: jsonData, encoding: .utf8) {
         print(jsonString)

--- a/Sources/AFMKit/BuildInfo.swift
+++ b/Sources/AFMKit/BuildInfo.swift
@@ -7,6 +7,16 @@ public struct BuildInfo {
     public static let version: String? = "v0.9.18"
     static let commit: String? = nil
 
+    /// True only when the executable was compiled with the toolchain required
+    /// to include the real Apple Foundation Models provider.
+    public static var foundationModelsCompiled: Bool {
+#if compiler(>=6.4) && canImport(AFMKitFoundationModels)
+        true
+#else
+        false
+#endif
+    }
+
     public static var fullVersion: String {
         resolvedVersion(
             override: ProcessInfo.processInfo.environment["AFM_BUILD_VERSION"]

--- a/Sources/AFMKitFoundationModels/AFMKitFoundationModelsExports.swift
+++ b/Sources/AFMKitFoundationModels/AFMKitFoundationModelsExports.swift
@@ -1,5 +1,3 @@
 // Compatibility facade for applications that imported maclocal-api's original
 // Foundation Models product. AFMKit owns the implementation.
-#if compiler(>=6.4)
 @_exported import AFMKitApple
-#endif

--- a/Sources/AFMKitFoundationModels27/AFMKitFoundationModels27Exports.swift
+++ b/Sources/AFMKitFoundationModels27/AFMKitFoundationModels27Exports.swift
@@ -1,6 +1,4 @@
 // Compatibility facade for applications that adopted the original maclocal-api
 // macOS 27 product before AFMKit became an independent package.
-#if compiler(>=6.4)
 @_exported import AFMKitApple
 @_exported import AFMKitFoundationModelsMLX
-#endif

--- a/Tests/MacLocalAPITests/BuildInfoTests.swift
+++ b/Tests/MacLocalAPITests/BuildInfoTests.swift
@@ -2,6 +2,10 @@
 import XCTest
 
 final class BuildInfoTests: XCTestCase {
+    func testReleaseCompilerIncludesFoundationModels() {
+        XCTAssertTrue(BuildInfo.foundationModelsCompiled)
+    }
+
     func testBaseVersionIsNextRelease() {
         XCTAssertEqual(BuildInfo.resolvedVersion(override: nil), "v0.9.18")
     }


### PR DESCRIPTION
Closes #248.

## Problem

A pre-Swift-6.4 toolchain could successfully produce an MLX-capable `afm` binary while compiler guards silently removed the real Apple Foundation Models provider. Version and help smoke tests could not distinguish that degraded artifact from a complete release.

## Fix

- require Swift tools 6.4 and make Foundation provider dependencies unconditional
- fail early in the reliable SwiftPM wrapper when the selected compiler is older than 6.4
- expose a compiled-provider attestation in `--help-json`
- reject incomplete or legacy binaries from all centralized archive, wheel, and publication compatibility gates
- add regression fixtures for complete, degraded, legacy, and Swift 6.3 builds

## Validation

- release `afm` build passed with Swift 6.4
- binary Foundation capability and macOS/Metal compatibility gates passed
- real Foundation generation returned `FOUNDATION_BUILD_OK`
- 5 focused `BuildInfoTests` passed
- release-tooling suite passed
- release archive verified and its relocated executable passed the new gate
- degraded/legacy binary fixtures and Swift 6.3 were rejected

No inference path was changed; these checks affect build and packaging only.

## Summary by Sourcery

Require Swift 6.4 and attest to compiled Foundation Models support to prevent degraded binaries from being built or released.

New Features:
- Expose compiled Foundation Models support and the minimum required Swift compiler through `--help-json`.
- Add centralized validation that rejects binaries lacking the real Foundation Models provider.

Bug Fixes:
- Prevent older Swift toolchains from producing degraded MLX-only executables that appear otherwise valid.

Enhancements:
- Make Swift 6.4 the package requirement and keep Foundation Models dependencies unconditional.
- Apply Foundation Models compatibility checks across build, archive, wheel, verification, and publication workflows.

Tests:
- Add regression coverage for complete, degraded, legacy, and Swift 6.3 build artifacts.