### PR TITLE
Fix assistant prefill reasoning in Messages requests

### DIFF
--- a/Sources/AFMServer/Controllers/MessagesController.swift
+++ b/Sources/AFMServer/Controllers/MessagesController.swift
@@ -125,6 +125,15 @@ struct MessagesController: RouteCollection {
         if object["thinking"]?["type"]?.stringValue == "enabled" {
             request["reasoning_effort"] = .string("low")
         }
+        if assistantPrefill != nil {
+            // A final assistant turn is continuation text, not a new reasoning
+            // turn. Thinking models can otherwise spend the entire response
+            // budget on a hidden scratchpad before emitting the few characters
+            // that complete the prefix.
+            request["chat_template_kwargs"] = .object([
+                "enable_thinking": .bool(false)
+            ])
+        }
         if let tools = object["tools"]?.arrayValue {
             request["tools"] = .array(tools.compactMap { tool in
                 guard let tool = tool.objectValue, let name = tool["name"] else { return nil }

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -223,6 +223,18 @@ struct TokenizeAndOpenAPITests {
         #expect(response["content"]?.arrayValue?.first?["text"]?.stringValue == "is.")
     }
 
+    @Test("Messages without assistant prefill retain requested thinking")
+    func messagesWithoutPrefillRetainThinking() throws {
+        let request = try MessagesController.makeChatRequest(
+            object: ["thinking": .object(["type": .string("enabled")])],
+            sourceMessages: [.object(["role": .string("user"), "content": .string("Explain your answer.")])],
+            maxTokens: 128,
+            defaultModel: "test-model"
+        )
+        #expect(request["reasoning_effort"]?.stringValue == "low")
+        #expect(request["chat_template_kwargs"] == nil)
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // MARK: - T1.7 — OpenAPI spec integrity
     // ═══════════════════════════════════════════════════════════════════

--- a/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
+++ b/Tests/MacLocalAPITests/TokenizeAndOpenAPITests.swift
@@ -205,6 +205,7 @@ struct TokenizeAndOpenAPITests {
         #expect(messages.last?["role"]?.stringValue == "user")
         #expect(messages.last?["content"]?.stringValue?.contains("exact continuation") == true)
         #expect(messages.last?["content"]?.stringValue?.contains("The city is Par") == true)
+        #expect(request["chat_template_kwargs"]?["enable_thinking"]?.boolValue == false)
 
         let response = try MessagesController.makeMessage(
             chat: .object([


### PR DESCRIPTION
Expose the recent unsubmitted Messages assistant-prefill fix. Requests non-thinking template behavior for assistant continuation text and adds a mapping assertion. Requires current-main review and API tests before merge. No provider implementation is added to the consumer.

## Summary by Sourcery

Fix Messages assistant-prefill requests so continuation text is generated without thinking while preserving reasoning for normal requests.

Bug Fixes:
- Prevent assistant-prefill continuation requests from entering a new reasoning turn, ensuring the response can complete the supplied assistant text.

Tests:
- Add API coverage confirming assistant-prefill disables thinking and requests without prefill preserve the requested reasoning behavior.