### PR TITLE
Track beta release-candidate integration and validation

### DIFF
--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.17"
+        exact: "0.1.18-rc.1"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "891efce3d52ae9b55d4ec615beeab61494e0ba28412a94d1ce5bb8f2fdc7890a",
+  "originHash" : "077ade7950b193dbfdac91bfb01c5a55c6077c089b4a2a4f77480fcee58eb97a",
   "pins" : [
     {
       "identity" : "afmkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "35219dafb903091fe27d441ba6d24de513b323c0",
-        "version" : "0.1.17"
+        "revision" : "03fd2b44965970bb965880381ae46cfdf293bdac",
+        "version" : "0.1.18-rc.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.17"
+        exact: "0.1.18-rc.1"
     )
 }
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -146,8 +146,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.17":
-        fail(f"{identity} must resolve the exact 0.1.17 release")
+    if pin["state"].get("version") != "0.1.18-rc.1":
+        fail(f"{identity} must resolve the exact 0.1.18-rc.1 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -290,7 +290,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.17"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.18-rc.1"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.17",
+    "afmkit": "0.1.18-rc.1",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/feature-promptfoo-agentic/README.md
+++ b/Scripts/feature-promptfoo-agentic/README.md
@@ -83,6 +83,9 @@ The configs expect these environment variables:
 
 Optional runner and CLI structured-output settings:
 
+- `AFM_MTP_MODEL`: optional existing local MTP-head directory, passed as one
+  quoted `--mtp-model` argument to every server profile. Requires `AFM_MTP=1`.
+  Use this to pin the exact cached Qwen 27B head during release qualification.
 - `AFM_DSPARK_SUPPORT`
   Existing support GGUF path for DwarfStar speculative server profiles. Passed
   as one quoted `--dspark-support` argument; unset leaves speculation off.

--- a/Scripts/feature-promptfoo-agentic/README.md
+++ b/Scripts/feature-promptfoo-agentic/README.md
@@ -83,6 +83,15 @@ The configs expect these environment variables:
 
 Optional runner and CLI structured-output settings:
 
+- `AFM_DSPARK_SUPPORT`
+  Existing support GGUF path for DwarfStar speculative server profiles. Passed
+  as one quoted `--dspark-support` argument; unset leaves speculation off.
+  Native MLX profiles instead use `AFM_MTP=1`. Request features may still require
+  target fallback, so requested flags alone do not prove active speculation.
+- `AFM_PROMPTFOO_LOAD_TIMEOUT_SECONDS`
+  Positive startup timeout, default `60`. Use `900` for large-model release
+  qualification; a process exit still fails immediately.
+
 - `AFM_BINARY`
   Path to the `afm` binary. Defaults to `.build/arm64-apple-macosx/release/afm`.
 - `MACAFM_MLX_MODEL_CACHE`

--- a/Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh
+++ b/Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh
@@ -13,6 +13,7 @@ mode="${1:-all}"
 port="${AFM_PROMPTFOO_PORT:-9999}"
 no_think="${AFM_NO_THINK:-0}"
 dspark_support="${AFM_DSPARK_SUPPORT:-}"
+mtp_model="${AFM_MTP_MODEL:-}"
 load_timeout="${AFM_PROMPTFOO_LOAD_TIMEOUT_SECONDS:-60}"
 summary_minimum_mtime_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
 server_pid=""
@@ -29,6 +30,10 @@ if [[ "$load_timeout" != <-> || "$load_timeout" -lt 1 ]]; then
 fi
 if [[ -n "$dspark_support" && ! -f "$dspark_support" ]]; then
   echo "AFM_DSPARK_SUPPORT must name an existing support GGUF file" >&2
+  exit 1
+fi
+if [[ -n "$mtp_model" && ( "${AFM_MTP:-0}" != "1" || ! -d "$mtp_model" ) ]]; then
+  echo "AFM_MTP_MODEL requires AFM_MTP=1 and an existing local model directory" >&2
   exit 1
 fi
 
@@ -141,6 +146,9 @@ start_server() {
   # MTP path without accepting an arbitrary string of shell arguments.
   if [[ "${AFM_MTP:-0}" == "1" ]]; then
     extra_args+=(--mtp)
+    if [[ -n "$mtp_model" ]]; then
+      extra_args+=(--mtp-model "$mtp_model")
+    fi
   fi
   if [[ -n "$dspark_support" ]]; then
     extra_args+=(--dspark-support "$dspark_support")

--- a/Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh
+++ b/Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh
@@ -12,12 +12,23 @@ out_dir="${AFM_PROMPTFOO_OUT_DIR:-/Volumes/edata/promptfoo/data/maclocal-api/cur
 mode="${1:-all}"
 port="${AFM_PROMPTFOO_PORT:-9999}"
 no_think="${AFM_NO_THINK:-0}"
+dspark_support="${AFM_DSPARK_SUPPORT:-}"
+load_timeout="${AFM_PROMPTFOO_LOAD_TIMEOUT_SECONDS:-60}"
 summary_minimum_mtime_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
 server_pid=""
 overall_status=0
 
 if [[ "$no_think" != "0" && "$no_think" != "1" ]]; then
   echo "AFM_NO_THINK must be 0 or 1" >&2
+  exit 1
+fi
+
+if [[ "$load_timeout" != <-> || "$load_timeout" -lt 1 ]]; then
+  echo "AFM_PROMPTFOO_LOAD_TIMEOUT_SECONDS must be a positive integer" >&2
+  exit 1
+fi
+if [[ -n "$dspark_support" && ! -f "$dspark_support" ]]; then
+  echo "AFM_DSPARK_SUPPORT must name an existing support GGUF file" >&2
   exit 1
 fi
 
@@ -55,7 +66,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 wait_for_health() {
-  local attempts=60
+  local attempts="$load_timeout"
   local health_url="http://127.0.0.1:${port}/health"
   local i
 
@@ -131,6 +142,9 @@ start_server() {
   if [[ "${AFM_MTP:-0}" == "1" ]]; then
     extra_args+=(--mtp)
   fi
+  if [[ -n "$dspark_support" ]]; then
+    extra_args+=(--dspark-support "$dspark_support")
+  fi
 
   # Keep reasoning-mode qualification explicit and shell-safe across every
   # Promptfoo profile without accepting an arbitrary string of CLI arguments.
@@ -140,6 +154,8 @@ start_server() {
 
   cleanup
   wait_for_port_free || exit 1
+  printf '%q ' "$afm_binary" mlx -m "$model" --port "$port" "${extra_args[@]}" > "${log_file%.log}.command"
+  printf '\n' >> "${log_file%.log}.command"
   : > "$log_file"
   MACAFM_MLX_MODEL_CACHE="${MACAFM_MLX_MODEL_CACHE:-}" \
     "$afm_binary" mlx -m "$model" --port "$port" "${extra_args[@]}" >"$log_file" 2>&1 &

--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -142,8 +142,6 @@ export MACAFM_MLX_MODEL_CACHE="${MACAFM_MLX_MODEL_CACHE:-/Volumes/edata/models/v
 PORT=9877
 DEFAULT_PROMPT="Explain calculus concepts from limits through multivariable calculus with rigorous mathematical notation"
 RESULTS_FILE="${AFM_RESULTS_FILE:-$(pwd)/mlx-test-results-$(date +%Y%m%d_%H%M%S)-$$.jsonl}"
-TEST_WORK_ROOT="${AFM_TEST_WORK_ROOT:-$(dirname "$RESULTS_FILE")/judge-work}"
-mkdir -p "$TEST_WORK_ROOT"
 SERVER_LOG_DIR="${AFM_SERVER_LOG_DIR:-$(dirname "$RESULTS_FILE")/server-logs}"
 DEFAULT_MAX_TOKENS=5000
 DEFAULT_TEMPERATURE=0.7
@@ -1821,6 +1819,9 @@ $(cat "$PROMPTS_FILE")"
   fi
 
   # Build combined prompt+data for tools that need it in one stream
+  # Reanalysis may select a different results file after CLI parsing.
+  TEST_WORK_ROOT="${AFM_TEST_WORK_ROOT:-$(dirname "$RESULTS_FILE")/judge-work}"
+  mkdir -p "$TEST_WORK_ROOT"
   SMART_INPUT="$(mktemp "$TEST_WORK_ROOT/smart-input-XXXXXX")"
   { echo "$ANALYSIS_PROMPT"; echo "$SMART_TEST_FILE_SECTION"; echo ""; echo "--- JSONL DATA ---"; cat "$RESULTS_FILE"; } > "$SMART_INPUT"
 

--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -104,7 +104,7 @@
 # TIPS FOR LLMs GENERATING TESTS:
 #   - Use temperature: 0.0 for deterministic/regression tests
 #   - Use the @ variant syntax to compare sampling strategies
-#   - Use afm: --verbose to capture debug logs in /tmp/mlx-server-*.log
+#   - Use afm: --verbose to capture debug logs beside the result file
 #   - Keep prompts short for fast iteration; use max_tokens: 200-500
 #   - For tool calling tests, set the system prompt with tool definitions
 #     and use afm: --tool-call-parser to select the right parser
@@ -141,7 +141,9 @@ fi
 export MACAFM_MLX_MODEL_CACHE="${MACAFM_MLX_MODEL_CACHE:-/Volumes/edata/models/vesta-test-cache}"
 PORT=9877
 DEFAULT_PROMPT="Explain calculus concepts from limits through multivariable calculus with rigorous mathematical notation"
-RESULTS_FILE="${AFM_RESULTS_FILE:-/tmp/mlx-test-results-$(date +%Y%m%d_%H%M%S)-$$.jsonl}"
+RESULTS_FILE="${AFM_RESULTS_FILE:-$(pwd)/mlx-test-results-$(date +%Y%m%d_%H%M%S)-$$.jsonl}"
+TEST_WORK_ROOT="${AFM_TEST_WORK_ROOT:-$(dirname "$RESULTS_FILE")/judge-work}"
+mkdir -p "$TEST_WORK_ROOT"
 SERVER_LOG_DIR="${AFM_SERVER_LOG_DIR:-$(dirname "$RESULTS_FILE")/server-logs}"
 DEFAULT_MAX_TOKENS=5000
 DEFAULT_TEMPERATURE=0.7
@@ -1819,7 +1821,7 @@ $(cat "$PROMPTS_FILE")"
   fi
 
   # Build combined prompt+data for tools that need it in one stream
-  SMART_INPUT="$(mktemp /tmp/smart-input-XXXXXX)"
+  SMART_INPUT="$(mktemp "$TEST_WORK_ROOT/smart-input-XXXXXX")"
   { echo "$ANALYSIS_PROMPT"; echo "$SMART_TEST_FILE_SECTION"; echo ""; echo "--- JSONL DATA ---"; cat "$RESULTS_FILE"; } > "$SMART_INPUT"
 
   # ── Per-test prompt (used in SMART_BATCH=1 mode) ─────────────────────────
@@ -1933,19 +1935,19 @@ $jsonl_line"
 
         case "$tool" in
           claude)
-            PERTEST_SCORE=$(echo "$PERTEST_INPUT" | "$tool" -p - 2>/tmp/smart-${tool}-stderr-$$.log)
+            PERTEST_SCORE=$(echo "$PERTEST_INPUT" | "$tool" -p - 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log")
             ;;
           codex)
-            CODEX_TMP="$(mktemp /tmp/smart-codex-pertest-XXXXXX)"
+            CODEX_TMP="$(mktemp "$TEST_WORK_ROOT/smart-codex-pertest-XXXXXX")"
             echo "$PERTEST_INPUT" > "$CODEX_TMP"
-            PERTEST_SCORE=$("$tool" exec --skip-git-repo-check "Read and score the test result in $CODEX_TMP. Output exactly one JSON line: {\"score\": N, \"reason\": \"...\"}" </dev/null 2>/tmp/smart-${tool}-stderr-$$.log)
+            PERTEST_SCORE=$("$tool" exec --skip-git-repo-check "Read and score the test result in $CODEX_TMP. Output exactly one JSON line: {\"score\": N, \"reason\": \"...\"}" </dev/null 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log")
             rm -f "$CODEX_TMP"
             ;;
           afm)
-            PERTEST_SCORE=$("$AFM" -s "$PERTEST_INPUT" 2>/tmp/smart-${tool}-stderr-$$.log)
+            PERTEST_SCORE=$("$AFM" -s "$PERTEST_INPUT" 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log")
             ;;
           *)
-            PERTEST_SCORE=$(echo "$PERTEST_INPUT" | "$tool" 2>/tmp/smart-${tool}-stderr-$$.log)
+            PERTEST_SCORE=$(echo "$PERTEST_INPUT" | "$tool" 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log")
             ;;
         esac
 
@@ -1987,17 +1989,17 @@ print(payload['score'] if payload else '?')
 $SMART_TEST_FILE_SECTION
 
 --- JSONL DATA ---"
-          "$tool" -p "$CLAUDE_PROMPT" < "$RESULTS_FILE" > "$SMART_REPORT" 2>/tmp/smart-${tool}-stderr-$$.log
+          "$tool" -p "$CLAUDE_PROMPT" < "$RESULTS_FILE" > "$SMART_REPORT" 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log"
           ;;
         codex)
           # codex exec: use temp file to avoid ARG_MAX limit on command line
           # (91+ test results with full responses easily exceed OS argument length)
-          "$tool" exec --skip-git-repo-check "Read and follow the analysis instructions in $SMART_INPUT. Score every executed JSONL result, omit metadata and status=SKIP records, and output the AI_SCORES block as specified." </dev/null > "$SMART_REPORT" 2>/tmp/smart-${tool}-stderr-$$.log
+          "$tool" exec --skip-git-repo-check "Read and follow the analysis instructions in $SMART_INPUT. Score every executed JSONL result, omit metadata and status=SKIP records, and output the AI_SCORES block as specified." </dev/null > "$SMART_REPORT" 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log"
           ;;
         afm)
           # afm uses Apple Foundation Models — context window is limited (~4K tokens).
           # Two-pass approach: score each result individually, then summarize.
-          AFM_SCORES_DIR="$(mktemp -d /tmp/smart-afm-XXXXXX)"
+          AFM_SCORES_DIR="$(mktemp -d "$TEST_WORK_ROOT/smart-afm-XXXXXX")"
           total_lines=$(wc -l < "$RESULTS_FILE" | tr -d ' ')
           echo "  Pass 1: Scoring $total_lines results individually..."
 
@@ -2061,7 +2063,7 @@ Test expectation: $afm_spec"
 TEST RESULT:
 $jsonl_line"
 
-            AFM_SCORE=$("$AFM" -s "$AFM_SCORE_PROMPT" 2>/tmp/smart-afm-stderr-$$.log)
+            AFM_SCORE=$("$AFM" -s "$AFM_SCORE_PROMPT" 2>"$TEST_WORK_ROOT/smart-afm-stderr-$$.log")
 
             echo "$AFM_SCORE" > "$AFM_SCORES_DIR/score_${line_idx}.txt"
             score_val=$(echo "$AFM_SCORE" | python3 -c "
@@ -2130,7 +2132,7 @@ Produce a brief markdown report:
 
 $AFM_META_DATA
 SUMMARY_PROMPT_END
-)" 2>/tmp/smart-afm-stderr-$$.log)
+)" 2>"$TEST_WORK_ROOT/smart-afm-stderr-$$.log")
 
           {
             echo "$AFM_SUMMARY"
@@ -2146,7 +2148,7 @@ SUMMARY_PROMPT_END
 $SMART_TEST_FILE_SECTION
 
 --- JSONL DATA ---"
-          "$tool" -p "$GENERIC_PROMPT" < "$RESULTS_FILE" > "$SMART_REPORT" 2>/tmp/smart-${tool}-stderr-$$.log
+          "$tool" -p "$GENERIC_PROMPT" < "$RESULTS_FILE" > "$SMART_REPORT" 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log"
           ;;
       esac
     fi

--- a/Scripts/tests/test-mlx-judge-work-root.sh
+++ b/Scripts/tests/test-mlx-judge-work-root.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+work_parent="${TMPDIR:-$repo_root/.build}"
+mkdir -p "$work_parent"
+work_root="$(mktemp -d "$work_parent/afm-judge-root.XXXXXX")"
+trap 'rm -rf "$work_root"' EXIT
+# Exercise the harness's actual configuration statements without model loading.
+configuration="$(awk '/^RESULTS_FILE=/{copy=1} copy{print} copy && /^mkdir -p/{exit}' "$repo_root/Scripts/mlx-model-test.sh")"
+[[ -n "$configuration" ]]
+(
+  unset AFM_TEST_WORK_ROOT
+  AFM_RESULTS_FILE="$work_root/reports with spaces/results.jsonl"
+  eval "$configuration"
+  [[ "$TEST_WORK_ROOT" == "$work_root/reports with spaces/judge-work" ]]
+  [[ -d "$TEST_WORK_ROOT" ]]
+)
+(
+  AFM_RESULTS_FILE="$work_root/other/results.jsonl"
+  AFM_TEST_WORK_ROOT="$work_root/explicit work"
+  eval "$configuration"
+  [[ "$TEST_WORK_ROOT" == "$AFM_TEST_WORK_ROOT" && -d "$TEST_WORK_ROOT" ]]
+)
+if grep -Eq 'mktemp.* /tmp/|2>/tmp/' "$repo_root/Scripts/mlx-model-test.sh"; then
+  echo 'Judge scratch paths must not bypass the configured work root' >&2
+  exit 1
+fi
+echo 'Comprehensive judge work-root tests passed.'

--- a/Scripts/tests/test-mlx-judge-work-root.sh
+++ b/Scripts/tests/test-mlx-judge-work-root.sh
@@ -6,20 +6,28 @@ mkdir -p "$work_parent"
 work_root="$(mktemp -d "$work_parent/afm-judge-root.XXXXXX")"
 trap 'rm -rf "$work_root"' EXIT
 # Exercise the harness's actual configuration statements without model loading.
-configuration="$(awk '/^RESULTS_FILE=/{copy=1} copy{print} copy && /^mkdir -p/{exit}' "$repo_root/Scripts/mlx-model-test.sh")"
+configuration="$(awk '/^[[:space:]]*TEST_WORK_ROOT=/{copy=1} copy{print} copy && /^[[:space:]]*mkdir -p/{exit}' "$repo_root/Scripts/mlx-model-test.sh")"
 [[ -n "$configuration" ]]
 (
   unset AFM_TEST_WORK_ROOT
-  AFM_RESULTS_FILE="$work_root/reports with spaces/results.jsonl"
+  RESULTS_FILE="$work_root/reports with spaces/results.jsonl"
   eval "$configuration"
   [[ "$TEST_WORK_ROOT" == "$work_root/reports with spaces/judge-work" ]]
   [[ -d "$TEST_WORK_ROOT" ]]
 )
 (
-  AFM_RESULTS_FILE="$work_root/other/results.jsonl"
+  RESULTS_FILE="$work_root/other/results.jsonl"
   AFM_TEST_WORK_ROOT="$work_root/explicit work"
   eval "$configuration"
   [[ "$TEST_WORK_ROOT" == "$AFM_TEST_WORK_ROOT" && -d "$TEST_WORK_ROOT" ]]
+)
+(
+  unset AFM_TEST_WORK_ROOT
+  AFM_RESULTS_FILE="$work_root/original.jsonl"
+  # --reanalyse replaces the provisional result path before judging begins.
+  RESULTS_FILE="$work_root/reanalysis/results.jsonl"
+  eval "$configuration"
+  [[ "$TEST_WORK_ROOT" == "$work_root/reanalysis/judge-work" ]]
 )
 if grep -Eq 'mktemp.* /tmp/|2>/tmp/' "$repo_root/Scripts/mlx-model-test.sh"; then
   echo 'Judge scratch paths must not bypass the configured work root' >&2

--- a/Scripts/tests/test-promptfoo-runner-args.sh
+++ b/Scripts/tests/test-promptfoo-runner-args.sh
@@ -47,6 +47,28 @@ enabled_line="$(trace_launch adaptive-xml AFM_NO_THINK=1 AFM_MTP=1 | server_argv
 [[ "$(print -r -- "$enabled_line" | occurrences --mtp)" == "1" ]]
 [[ "$(print -r -- "$enabled_line" | occurrences afm_adaptive_xml)" == "1" ]]
 
+# Quoting must retain a support checkpoint path containing spaces as one value.
+touch "$work_root/support checkpoint.gguf"
+dspark_line="$(trace_launch default AFM_DSPARK_SUPPORT="$work_root/support checkpoint.gguf" AFM_PROMPTFOO_LOAD_TIMEOUT_SECONDS=900 | server_argv)"
+[[ "$(print -r -- "$dspark_line" | occurrences --dspark-support)" == "1" ]]
+[[ "$dspark_line" == *"support checkpoint.gguf"* ]]
+
+for bad_timeout in 0 -1 invalid; do
+  set +e
+  timeout_output="$(AFM_PROMPTFOO_LOAD_TIMEOUT_SECONDS="$bad_timeout" "$runner" all 2>&1)"
+  timeout_status=$?
+  set -e
+  [[ "$timeout_status" == "1" ]]
+  [[ "$timeout_output" == "AFM_PROMPTFOO_LOAD_TIMEOUT_SECONDS must be a positive integer" ]]
+done
+
+set +e
+missing_output="$(AFM_DSPARK_SUPPORT="$work_root/missing.gguf" "$runner" all 2>&1)"
+missing_status=$?
+set -e
+[[ "$missing_status" == "1" ]]
+[[ "$missing_output" == "AFM_DSPARK_SUPPORT must name an existing support GGUF file" ]]
+
 set +e
 invalid_output="$(AFM_NO_THINK=invalid "$runner" all 2>&1)"
 invalid_status=$?

--- a/Scripts/tests/test-promptfoo-runner-args.sh
+++ b/Scripts/tests/test-promptfoo-runner-args.sh
@@ -53,6 +53,17 @@ dspark_line="$(trace_launch default AFM_DSPARK_SUPPORT="$work_root/support check
 [[ "$(print -r -- "$dspark_line" | occurrences --dspark-support)" == "1" ]]
 [[ "$dspark_line" == *"support checkpoint.gguf"* ]]
 
+mkdir "$work_root/mtp head"
+mtp_line="$(trace_launch default AFM_MTP=1 AFM_MTP_MODEL="$work_root/mtp head" | server_argv)"
+[[ "$(print -r -- "$mtp_line" | occurrences --mtp-model)" == "1" ]]
+[[ "$mtp_line" == *"mtp head"* ]]
+set +e
+mtp_output="$(AFM_MTP=0 AFM_MTP_MODEL="$work_root/mtp head" "$runner" all 2>&1)"
+mtp_status=$?
+set -e
+[[ "$mtp_status" == "1" ]]
+[[ "$mtp_output" == "AFM_MTP_MODEL requires AFM_MTP=1 and an existing local model directory" ]]
+
 for bad_timeout in 0 -1 invalid; do
   set +e
   timeout_output="$(AFM_PROMPTFOO_LOAD_TIMEOUT_SECONDS="$bad_timeout" "$runner" all 2>&1)"

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -62,13 +62,13 @@ cat > "$fake_public_git" <<'SH'
 #!/usr/bin/env bash
 arguments=" $* "
 for ref in \
-  refs/tags/0.1.17 \
-  'refs/tags/0.1.17^{}' \
-  refs/tags/v0.1.17 \
-  'refs/tags/v0.1.17^{}'; do
+  refs/tags/0.1.18-rc.1 \
+  'refs/tags/0.1.18-rc.1^{}' \
+  refs/tags/v0.1.18-rc.1 \
+  'refs/tags/v0.1.18-rc.1^{}'; do
   [[ "$arguments" == *" $ref "* ]] || exit 2
 done
-printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.17^{}'
+printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.18-rc.1^{}'
 SH
 chmod 700 "$fake_public_git"
 if ! EXPECTED_AFMKIT_REVISION="$expected_afmkit_revision" \
@@ -88,7 +88,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.17'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.1'
   }
   probe_public_source() {
     return 1
@@ -112,14 +112,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.17" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.17"
+[[ "$release_version" == "0.1.18-rc.1" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.18-rc.1"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.17'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.1'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -138,7 +138,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.17'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.1'
   }
   probe_public_source() {
     return 0

--- a/docs/RC_MODEL_MATRIX_20260905.md
+++ b/docs/RC_MODEL_MATRIX_20260905.md
@@ -42,3 +42,28 @@ tools, response format, logprobs, stop sequences, or media. The full suite must
 still exercise these feature combinations with MTP requested, but their target
 fallback is intentional compatibility coverage rather than a speculative speed
 measurement. Preserve separate focused greedy runs for actual on/off throughput.
+
+## Pre-package progress (September 5)
+
+These are qualification probes, not completed full-suite RC results:
+
+- AFMKit main at `bfef2313` passed all 16 public API snapshot gates. Its full
+  release validator has progressed through the root tests to downstream
+  consumer builds; final validator success is still pending.
+- DeepSeek candidate `54ed9ea4` passed nine focused architecture/rollback
+  tests. Its paired Release binary measured median counting throughput of
+  30.12 target / 51.04 speculative tok/s and prose throughput of
+  29.78 / 27.32 tok/s. Prose was coherent but not byte-identical. API timing
+  in the speculative path includes prefill, so these are not pure kernel rates.
+- A bounded two-client, repeated two-turn isolated-code probe passed 24/24
+  checks. Target mode recorded B=2 execution and radix hits; speculation
+  remained serialized with cache misses. Do not interpret this as speculative
+  batching/cache support. AFMKit issue #98 records that limitation; issue #97
+  tracks the rollback fix on PR #86, which remains unmerged.
+- Promptfoo DS4 support-path and positive load-timeout argument regression
+  tests passed, including a checkpoint path containing spaces. Real DS4
+  inference qualification is still pending. Changes are on this PR (#252),
+  associated with maclocal-api issue #253.
+
+Raw pre-package evidence is preserved under
+`/Volumes/edata2/afm-benchmarks/rc-20260904/`.

--- a/docs/RC_MODEL_MATRIX_20260905.md
+++ b/docs/RC_MODEL_MATRIX_20260905.md
@@ -47,9 +47,9 @@ measurement. Preserve separate focused greedy runs for actual on/off throughput.
 
 These are qualification probes, not completed full-suite RC results:
 
-- AFMKit main at `bfef2313` passed all 16 public API snapshot gates. Its full
-  release validator has progressed through the root tests to downstream
-  consumer builds; final validator success is still pending.
+- AFMKit main at `03fd2b44` passed full release qualification: all 16 public
+  API gates, root tests, and all 16 downstream consumers. It is published as
+  prerelease `v0.1.18-rc.1` and pinned in the consumer lockfile.
 - DeepSeek candidate `54ed9ea4` passed nine focused architecture/rollback
   tests. Its paired Release binary measured median counting throughput of
   30.12 target / 51.04 speculative tok/s and prose throughput of
@@ -71,5 +71,10 @@ Raw pre-package evidence is preserved under
 The earlier full validator built all sixteen downstream consumers but failed
 its stale terminal expectation of fifteen. AFMKit PR #100 fixes that count by
 using the generated inventory; regression tests accept sixteen and reject an
-incomplete fifteen. The local publisher is now rerunning full qualification
-of `03fd2b44` for `v0.1.18-rc.1`, before any tag/release publication.
+incomplete fifteen. The local publisher then completed full qualification
+of `03fd2b44` and published `v0.1.18-rc.1` only after that success.
+
+Consumer release-tooling regressions, explicit MTP-head runner arguments,
+categorized Promptfoo summaries, and external judge-work paths pass their
+focused checks. Codex execution preflight succeeded. The immutable consumer
+Release build and Swift tests are running; packaged model runs have not begun.

--- a/docs/RC_MODEL_MATRIX_20260905.md
+++ b/docs/RC_MODEL_MATRIX_20260905.md
@@ -59,7 +59,7 @@ These are qualification probes, not completed full-suite RC results:
   checks. Target mode recorded B=2 execution and radix hits; speculation
   remained serialized with cache misses. Do not interpret this as speculative
   batching/cache support. AFMKit issue #98 records that limitation; issue #97
-  tracks the rollback fix on PR #86, which remains unmerged.
+  tracks the rollback fix on PR #86, now merged in `03fd2b44`.
 - Promptfoo DS4 support-path and positive load-timeout argument regression
   tests passed, including a checkpoint path containing spaces. Real DS4
   inference qualification is still pending. Changes are on this PR (#252),
@@ -67,3 +67,9 @@ These are qualification probes, not completed full-suite RC results:
 
 Raw pre-package evidence is preserved under
 `/Volumes/edata2/afm-benchmarks/rc-20260904/`.
+
+The earlier full validator built all sixteen downstream consumers but failed
+its stale terminal expectation of fifteen. AFMKit PR #100 fixes that count by
+using the generated inventory; regression tests accept sixteen and reject an
+incomplete fifteen. The local publisher is now rerunning full qualification
+of `03fd2b44` for `v0.1.18-rc.1`, before any tag/release publication.

--- a/docs/RC_MODEL_MATRIX_20260905.md
+++ b/docs/RC_MODEL_MATRIX_20260905.md
@@ -35,3 +35,10 @@ Codex-only judging for comprehensive reports and preserve all raw results.
 Default requested thinking mode is `--no-think`. The comprehensive prompt file
 uses a 20,000-token default, with deliberate per-test limits retained. Do not
 substitute unrelated checkpoints to improve numbers or hide missing assets.
+
+Current native greedy-speculation eligibility requires temperature zero, no
+repetition/presence penalties, top-k/min-p disabled, normal EOS handling, and no
+tools, response format, logprobs, stop sequences, or media. The full suite must
+still exercise these feature combinations with MTP requested, but their target
+fallback is intentional compatibility coverage rather than a speculative speed
+measurement. Preserve separate focused greedy runs for actual on/off throughput.

--- a/docs/RC_MODEL_MATRIX_20260905.md
+++ b/docs/RC_MODEL_MATRIX_20260905.md
@@ -1,0 +1,37 @@
+# Release-candidate model qualification matrix
+
+Requested September 4: package a candidate first, then run the full suite for
+the three AFM-generated models, Qwen 27B, and DeepSeek DS4, with speculation
+requested both off and on. Run sequentially to avoid GPU contention. Use
+Codex-only judging for comprehensive reports and preserve all raw results.
+
+| Checkpoint | Exact local path | Off | On |
+| --- | --- | --- | --- |
+| AFM DeepSeek 0731 | `/Volumes/edata2/models/afm/DeepSeek-V4-Flash-0731-AFM-MLX-native-v11` | Native target | `--mtp`, requires qualification of AFMKit #86 |
+| AFM GLM 5.3 Flash | `/Volumes/edata2/models/afm/GLM-5.3-Flash-AFM-MLX-4bit` | Native target | Request `--mtp`; checkpoint has zero MTP tensors, record unavailable/fallback, not speculative coverage; AFMKit #94 tracks conversion support |
+| AFM Qwen Next | `/Volumes/edata2/models/afm/Qwen3.8-Flash-Next-AFM-MLX-4bit` | Native target | `--mtp`; embedded weights present |
+| Qwen 3.8 27B 4-bit | `/Volumes/edata2/models/huggingface-cache/hub/models--mlx-community--Qwen3.8-27B-4bit/snapshots/3e6447f082e89cc7f0bc6e5441afd38dfce760ff` | Native target | `--mtp` with cached matching 4-bit head, revision `b643c01b6d3b094e325edb6ebd832e16c486c575` |
+| DeepSeek 0731 DS4 | `/Volumes/edata/models/ds4/DeepSeek-V4-Flash-MXFP4Experts-F16HC-F16Compressor-F16Indexer-Q8Attn-Q8Shared-Q8Out-chat-v2-mxfp4-0731.gguf` | DwarfStar target | DwarfStar `--dspark-support /Volumes/edata/models/ds4/DeepSeek-V4-Flash-DSpark-support-0731.gguf` |
+
+## Required evidence
+
+- Candidate source commits, exact AFMKit dependency, packaged binary hash,
+  displayed version, installed resource checks, Foundation/MLX installation smoke.
+- Full assertion suite, comprehensive prompts with Codex judge, and applicable
+  agentic/structured-output coverage. Keep native conformance, model behavior,
+  forced-parser experiments, and unavailable capabilities separate.
+- Record requested versus actually active speculation. Temperature, penalties,
+  batching or unsupported assets may force target fallback; such runs do not
+  establish speculative performance or correctness.
+- Performance: prefill and decode, first four contexts, raw visible/reasoning
+  output, prompt budget and completion count. Same checkpoint across on/off.
+- Prefix cache, concurrency/batching, streaming, cancellation, stop handling,
+  tool calling and structured output must retain their actual test outcomes.
+- File confirmed engine/harness defects as issues, fix through PRs, rebuild
+  changed code, and rerun affected coverage. Do not erase failed-run evidence.
+- The final report must distinguish completed tests from missing MTP coverage
+  and unresolved release blockers. No blanket release-ready claim from smokes.
+
+Default requested thinking mode is `--no-think`. The comprehensive prompt file
+uses a 20,000-token default, with deliberate per-test limits retained. Do not
+substitute unrelated checkpoints to improve numbers or hide missing assets.

--- a/docs/RELEASE_CANDIDATE_20260904.md
+++ b/docs/RELEASE_CANDIDATE_20260904.md
@@ -13,10 +13,11 @@ This document tracks a candidate, not a completed release qualification.
 | AFMKit #77 | Qwen Next measured parity documentation | Merged; preserved newer causal-prefill medians separately from historical peak-of-three results |
 | AFMKit #86 | DeepSeek embedded speculation and graph optimizations | New non-draft PR; review and qualify MTP on/off, cache, concurrency and exact-checkpoint performance |
 | AFMKit #87 | MLX Swift LM independence feasibility study | Merged after review; not authorization to restructure dependencies |
-| AFMKit #88 | Older long-generation lifetime experiment | New non-draft PR; reconcile newer host-token scheduling and measure cache-evaluation/allocator tradeoffs before inclusion |
-| AFMKit #89 | OpenAI request compatibility plus older prefill error handling | New non-draft PR; separate missing API behavior from potentially superseded execution changes |
-| AFMKit #90 | Older recurrent replay/error-handler branch | New non-draft PR; high overlap with merged scheduler and cache changes; reconcile before inclusion |
-| AFMKit #91 | Earlier GLM compilation experiment | New non-draft PR; compare with merged #81 and avoid restoring superseded graph code |
+| AFMKit #88 | Older long-generation lifetime experiment | Kept open, excluded: per-token cache evaluation and 4x allocator-clear cadence need independent memory/throughput evidence against newer host-token scheduling |
+| AFMKit #89 | OpenAI request compatibility plus older prefill error handling | API portion merged through #92; older runtime portion kept open, excluded pending error-attribution qualification |
+| AFMKit #90 | Older recurrent replay/error-handler branch | Kept open, excluded: worker errors can be attributed to another concurrent request by the proposed global last-handler fallback |
+| AFMKit #91 | Earlier GLM compilation experiment | Closed as superseded by #81 and newer cache-lifecycle fixes; guarded SDPA, compiled FFN and multimodal forwarding are already present |
+| AFMKit #92 | Current-main scalar stop and choice-count decoding | Merged after 5 tests, including malformed stops and all-current-fields round-trip coverage |
 | maclocal-api #251 | Messages assistant continuation disables thinking | Merged after semantic review and 15 passing request-mapping tests, including ordinary-thinking preservation |
 | AFMKit #74 | Experimental MLX GGUF loader | Existing draft; separate prototype, not presumed RC-ready |
 | maclocal-api #89–91, #196 | TurboQuant / DFlash | Previously deferred by user; leave open and untouched |
@@ -51,6 +52,14 @@ prefix replay). Full live MTP equivalence and performance remain pending.
 The API-only portion of #89 is isolated on `fix/rc-request-decoding`; its custom
 decoder preserves newer fields such as `ignore_eos`, with all-field round-trip
 regression coverage. It does not import the older asynchronous prefill changes.
+
+Review findings on #90 also identify a callback-data lifetime hazard: copying
+the global callback/data pair outside its registry lock permits concurrent
+replacement to destroy that data before invocation. These are findings in an
+unmerged proposal, not claims that current main contains that implementation.
+The #89 preparation scope catches synchronous scheduling errors only; it is not
+proof of safe attribution for later GPU-worker errors. Any forward port must
+also retain the newer `.logits` result-state assignment.
 
 1. Land isolated correctness/converter fixes and reconcile documentation.
 2. Review API compatibility separately from old runtime changes. For overlapping

--- a/docs/RELEASE_CANDIDATE_20260904.md
+++ b/docs/RELEASE_CANDIDATE_20260904.md
@@ -11,13 +11,14 @@ This document tracks a candidate, not a completed release qualification.
 | --- | --- | --- |
 | AFMKit #85 | GLM cached-source conversion, bounded checksum memory, FP32 router preservation and repair | Merged after focused review; 29 converter tests, full conversion and live load passed |
 | AFMKit #77 | Qwen Next measured parity documentation | Merged; preserved newer causal-prefill medians separately from historical peak-of-three results |
-| AFMKit #86 | DeepSeek embedded speculation and graph optimizations | New non-draft PR; review and qualify MTP on/off, cache, concurrency and exact-checkpoint performance |
+| AFMKit #86 | DeepSeek embedded speculation and graph optimizations | Merged after rollback, isolation and same-checkpoint probes; opt-in cache/concurrency limitation tracked in #98; full RC model suite pending |
 | AFMKit #87 | MLX Swift LM independence feasibility study | Merged after review; not authorization to restructure dependencies |
 | AFMKit #88 | Older long-generation lifetime experiment | Kept open, excluded: per-token cache evaluation and 4x allocator-clear cadence need independent memory/throughput evidence against newer host-token scheduling |
 | AFMKit #89 | OpenAI request compatibility plus older prefill error handling | API portion merged through #92; older runtime portion kept open, excluded pending error-attribution qualification |
 | AFMKit #90 | Older recurrent replay/error-handler branch | Kept open, excluded: worker errors can be attributed to another concurrent request by the proposed global last-handler fallback |
 | AFMKit #91 | Earlier GLM compilation experiment | Closed as superseded by #81 and newer cache-lifecycle fixes; guarded SDPA, compiled FFN and multimodal forwarding are already present |
 | AFMKit #92 | Current-main scalar stop and choice-count decoding | Merged after 5 tests, including malformed stops and all-current-fields round-trip coverage |
+| AFMKit #93, #96, #100 | API snapshots and downstream product-count gate | Merged; complete provider release qualification passed at `03fd2b44`, published as `v0.1.18-rc.1` |
 | maclocal-api #251 | Messages assistant continuation disables thinking | Merged after semantic review and 15 passing request-mapping tests, including ordinary-thinking preservation |
 | AFMKit #74 | Experimental MLX GGUF loader | Existing draft; separate prototype, not presumed RC-ready |
 | maclocal-api #89–91, #196 | TurboQuant / DFlash | Previously deferred by user; leave open and untouched |

--- a/docs/RELEASE_CANDIDATE_20260904.md
+++ b/docs/RELEASE_CANDIDATE_20260904.md
@@ -1,0 +1,97 @@
+# Beta release-candidate integration audit
+
+Scope: branch-tip activity and PR updates from 2026-08-26 through 2026-09-04,
+including local-only branches. Git patch equivalence was checked against fetched
+`origin/main`; old branch names alone are not evidence of missing implementation.
+This document tracks a candidate, not a completed release qualification.
+
+## Inventory and disposition
+
+| Repository / PR | Work | Disposition |
+| --- | --- | --- |
+| AFMKit #85 | GLM cached-source conversion, bounded checksum memory, FP32 router preservation and repair | Merged after focused review; 29 converter tests, full conversion and live load passed |
+| AFMKit #77 | Qwen Next measured parity documentation | Existing non-draft PR; resolve conflict without replacing newer performance notes; retained raw artifact README matches proposed figures |
+| AFMKit #86 | DeepSeek embedded speculation and graph optimizations | New non-draft PR; review and qualify MTP on/off, cache, concurrency and exact-checkpoint performance |
+| AFMKit #87 | MLX Swift LM independence feasibility study | New non-draft documentation PR; review, not authorization to restructure dependencies |
+| AFMKit #88 | Older long-generation lifetime experiment | New non-draft PR; reconcile newer host-token scheduling and measure cache-evaluation/allocator tradeoffs before inclusion |
+| AFMKit #89 | OpenAI request compatibility plus older prefill error handling | New non-draft PR; separate missing API behavior from potentially superseded execution changes |
+| AFMKit #90 | Older recurrent replay/error-handler branch | New non-draft PR; high overlap with merged scheduler and cache changes; reconcile before inclusion |
+| AFMKit #91 | Earlier GLM compilation experiment | New non-draft PR; compare with merged #81 and avoid restoring superseded graph code |
+| maclocal-api #251 | Messages assistant continuation disables thinking | New non-draft PR; current-main request-mapping tests and semantic review required |
+| AFMKit #74 | Experimental MLX GGUF loader | Existing draft; separate prototype, not presumed RC-ready |
+| maclocal-api #89–91, #196 | TurboQuant / DFlash | Previously deferred by user; leave open and untouched |
+| AFMKit issue #76 | Per-slot continuous batching | Previously assigned to next release; do not silently include |
+
+Recent AFMKit #83, #82, #81, #80, #78, #75 and their consumer dependency bumps
+are already merged. GLM converter fixes were extracted onto current main rather
+than merging the entire `perf/glm53-graph-capture` branch, which also inherits
+DeepSeek work. The uncommitted GLM attention-preparation experiment is not part
+of #85 and is not qualified for this RC.
+
+The old `fix/glm53-kda-throughput` history includes an explicit optimization
+revert; do not restore the reverted change merely because its commit is unique.
+Old dependency-bump branches, the closed Qwen sidecar consumer PR #244, and the
+superseded consumer-owned Qwen patch PR #214 are not new merge work.
+
+`fix/v0.9.18.1-foundationmodels-release` contains an older linker-only guard and
+version changes. Current main already invokes the stronger
+`check-foundation-models-build.sh` capability gate. Do not revert versions or
+replace that gate with the older branch wholesale.
+
+The original maclocal-api workspace contains uncommitted build-script changes,
+`Scripts/codex-spark`, and `voxel-art/`. They are preserved and not implicitly
+included in this release. Other worktrees and uncommitted performance probes
+must likewise remain separate until their ownership and validation are clear.
+
+## Integration order
+
+1. Land isolated correctness/converter fixes and reconcile documentation.
+2. Review API compatibility separately from old runtime changes. For overlapping
+   branches, preserve only demonstrably missing behavior in a current-main PR;
+   link a superseding PR instead of merging obsolete implementations.
+3. Qualify DeepSeek and any retained graph/lifetime changes with both correctness
+   and same-checkpoint performance tests. Consult the user before accepting a
+   performance tradeoff. Do not make an unconditional merge-all claim.
+4. Tag a qualified AFMKit version, then update maclocal-api's single exact package
+   dependency and lockfile. Provider sources stay exclusively in AFMKit.
+5. Build the beta in an isolated consumer worktree through
+   `Scripts/swiftpm-reliable.sh`; test the immutable dependency graph, not a
+   development override. Do not depend on GitHub Actions.
+6. Stage only on the beta/staging distribution channel after package validation;
+   no stable-channel promotion is implied.
+
+## Release-candidate gates
+
+- Build provenance: exact source commits, AFMKit pin, toolchain, executable hash,
+  canonical beta/nightly identifier, packaged MLX resource verification.
+- Installation: Foundation Models compiled capability and live smoke request;
+  MLX model load and live request from the installed artifact.
+- Unit/API suites: request validation, stops, streaming, tool calls, structured
+  output, cancellation, model-switch behavior, prefix/radix cache and concurrency.
+- Model qualification: GLM 5.3 Flash, Qwen Next, Qwen 3.8 27B and DeepSeek 0731,
+  sequential GPU workloads using pinned, documented local checkpoint paths.
+- Performance: separate prefill and decode; first four context sizes; same
+  checkpoint, prompts, token budget, speculation, cache policy and concurrency.
+  Test MTP on/off only where weights and runtime support it. Preserve both raw
+  output and timing. No environment-only tuning may be hidden in a default claim.
+- Quality: inspect actual outputs; use Codex-only judging for comprehensive
+  evaluations as previously requested. Keep protocol conformance, model/agent
+  behavior and forced-parser experiments separate. Unexplained failures remain
+  unattributed until reproduced or evidenced.
+- Preserve the earlier 0.9.16/0.9.17 baseline artifacts; do not recreate them
+  unnecessarily. Qwen Next uses its supported, separately recorded baseline.
+- Store bulky reports outside Git on persistent storage. Final release-report
+  bundles belong on the matching release as optional assets, not in the package.
+
+## GLM evidence carried forward
+
+`scouzi1966/GLM-5.3-Flash-AFM-MLX-4bit` was uploaded successfully at HF revision
+`6739b0ce6b97d4d854fd89806413d37ee943c6d1`; all 197 weight hashes match the local
+conversion manifest. The official source revision is
+`04c4e9e95c5da8862dced7e5056455116f83a7e0`.
+
+Initial repaired-checkpoint inference passed arithmetic/logic checks and produced
+roughly 34 tok/s for the first three synthetic context sizes, 27.4 tok/s for the
+largest. The paired oQ4e reference run stopped on reasoning-only output at a
+256-token budget, so this is **not a completed quality/performance parity result**.
+The AFM conversion excludes MTP; do not qualify it with `--mtp`.

--- a/docs/RELEASE_CANDIDATE_20260904.md
+++ b/docs/RELEASE_CANDIDATE_20260904.md
@@ -99,6 +99,26 @@ also retain the newer `.logits` result-state assignment.
 - Store bulky reports outside Git on persistent storage. Final release-report
   bundles belong on the matching release as optional assets, not in the package.
 
+## DeepSeek candidate evidence
+
+Clean paired build: consumer `25458616e1f27135695a398666daf95270c651a0`,
+provider `6550ad3277a3eb04c94309bee550d27fa84f4423`. Build took 259 seconds.
+Checkpoint: `/Volumes/edata2/models/afm/DeepSeek-V4-Flash-0731-AFM-MLX-native-v11`.
+Three 256-token trials per workload, temperature zero, no thinking, no prefix
+cache or diagnostic tuning variables, sequential MTP-off/on processes:
+
+| Mode | Counting median tok/s | Prose median tok/s |
+| --- | ---: | ---: |
+| Target only | 30.19 | 30.24 |
+| Embedded MTP | 50.36 | 26.72 |
+
+These are API-reported rates. MTP currently reports zero separate prefill time
+and includes that work in generation timing. Arithmetic (`391`), logic (`No`)
+and counting outputs match across modes. Prose remains coherent but differs;
+strict target equivalence is not proven. #86 remains unmerged pending output
+review and the user's performance-tradeoff decision. Raw responses, commands,
+and binary checksum are in `/Volumes/edata2/afm-benchmarks/rc-20260904/deepseek`.
+
 ## GLM evidence carried forward
 
 `scouzi1966/GLM-5.3-Flash-AFM-MLX-4bit` was uploaded successfully at HF revision

--- a/docs/RELEASE_CANDIDATE_20260904.md
+++ b/docs/RELEASE_CANDIDATE_20260904.md
@@ -119,6 +119,19 @@ strict target equivalence is not proven. #86 remains unmerged pending output
 review and the user's performance-tradeoff decision. Raw responses, commands,
 and binary checksum are in `/Volumes/edata2/afm-benchmarks/rc-20260904/deepseek`.
 
+Follow-up: #97 identified incomplete restoration of evicted rotating-window
+entries, including the local window inside compressed caches. Commit `54ed9ea4`
+retains those array views and cursor metadata before verification. Nine
+architecture tests passed, including both new wraparound regressions. The
+consumer rebuilt in 116 seconds. Fresh paired results in `deepseek/after-rollback`
+were 30.12/29.78 tok/s target counting/prose and 51.04/27.32 tok/s MTP. Arithmetic,
+logic and counting remain identical; prose still differs, so the rollback fix
+must not be claimed to establish singleton/batched bitwise equivalence.
+
+AFMKit #96 repaired stale Core and MLX public API snapshots for already-merged
+image and Qwen features. All 16 API gates passed; #96 merged and #95 closed.
+Full immutable release qualification is running again on that main revision.
+
 ## GLM evidence carried forward
 
 `scouzi1966/GLM-5.3-Flash-AFM-MLX-4bit` was uploaded successfully at HF revision

--- a/docs/RELEASE_CANDIDATE_20260904.md
+++ b/docs/RELEASE_CANDIDATE_20260904.md
@@ -10,14 +10,14 @@ This document tracks a candidate, not a completed release qualification.
 | Repository / PR | Work | Disposition |
 | --- | --- | --- |
 | AFMKit #85 | GLM cached-source conversion, bounded checksum memory, FP32 router preservation and repair | Merged after focused review; 29 converter tests, full conversion and live load passed |
-| AFMKit #77 | Qwen Next measured parity documentation | Existing non-draft PR; resolve conflict without replacing newer performance notes; retained raw artifact README matches proposed figures |
+| AFMKit #77 | Qwen Next measured parity documentation | Merged; preserved newer causal-prefill medians separately from historical peak-of-three results |
 | AFMKit #86 | DeepSeek embedded speculation and graph optimizations | New non-draft PR; review and qualify MTP on/off, cache, concurrency and exact-checkpoint performance |
-| AFMKit #87 | MLX Swift LM independence feasibility study | New non-draft documentation PR; review, not authorization to restructure dependencies |
+| AFMKit #87 | MLX Swift LM independence feasibility study | Merged after review; not authorization to restructure dependencies |
 | AFMKit #88 | Older long-generation lifetime experiment | New non-draft PR; reconcile newer host-token scheduling and measure cache-evaluation/allocator tradeoffs before inclusion |
 | AFMKit #89 | OpenAI request compatibility plus older prefill error handling | New non-draft PR; separate missing API behavior from potentially superseded execution changes |
 | AFMKit #90 | Older recurrent replay/error-handler branch | New non-draft PR; high overlap with merged scheduler and cache changes; reconcile before inclusion |
 | AFMKit #91 | Earlier GLM compilation experiment | New non-draft PR; compare with merged #81 and avoid restoring superseded graph code |
-| maclocal-api #251 | Messages assistant continuation disables thinking | New non-draft PR; current-main request-mapping tests and semantic review required |
+| maclocal-api #251 | Messages assistant continuation disables thinking | Merged after semantic review and 15 passing request-mapping tests, including ordinary-thinking preservation |
 | AFMKit #74 | Experimental MLX GGUF loader | Existing draft; separate prototype, not presumed RC-ready |
 | maclocal-api #89–91, #196 | TurboQuant / DFlash | Previously deferred by user; leave open and untouched |
 | AFMKit issue #76 | Per-slot continuous batching | Previously assigned to next release; do not silently include |
@@ -44,6 +44,13 @@ included in this release. Other worktrees and uncommitted performance probes
 must likewise remain separate until their ownership and validation are clear.
 
 ## Integration order
+
+Progress: DeepSeek #86 has been integrated with current main at `4b601745` and
+53 targeted Release tests passed (speculation policy, architecture numerics,
+prefix replay). Full live MTP equivalence and performance remain pending.
+The API-only portion of #89 is isolated on `fix/rc-request-decoding`; its custom
+decoder preserves newer fields such as `ignore_eos`, with all-field round-trip
+regression coverage. It does not import the older asynchronous prefill changes.
 
 1. Land isolated correctness/converter fixes and reconcile documentation.
 2. Review API compatibility separately from old runtime changes. For overlapping

--- a/docs/afmkit-url-consumption.md
+++ b/docs/afmkit-url-consumption.md
@@ -6,7 +6,7 @@ one exact release and selects every provider product from it:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.17"
+    exact: "0.1.18-rc.1"
 )
 ```
 
@@ -14,7 +14,7 @@ Do not use a branch or revision requirement for release builds.
 
 ## Production Blocker
 
-AFMKit is public and exposes `0.1.17`. AFM release publication remains
+AFMKit is public and exposes `0.1.18-rc.1`. AFM release publication remains
 fail-closed unless AFMKit and every dependency in its root graph are
 anonymously readable and the tracked lock resolves that exact tag.
 
@@ -38,7 +38,7 @@ surface publishable.
 
 ## Dependency Resolution
 
-AFMKit 0.1.17 is public, so normal resolution requires no GitHub credential:
+AFMKit 0.1.18-rc.1 is public, so normal resolution requires no GitHub credential:
 
 ```bash
 Scripts/resolve-release-dependencies.sh
@@ -55,7 +55,7 @@ The normal graph is independent of maclocal-api's dirty vendor worktrees:
 
 | Dependency | Requirement | Purpose |
 | --- | --- | --- |
-| `AFMKit` | exact `0.1.17` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
+| `AFMKit` | exact `0.1.18-rc.1` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
 
 The MLX, mlx-c, Swift bindings, and mlx-swift-lm sources are snapshots inside
 AFMKit's `vendor/MLX` tree. They are not separate SwiftPM dependencies of

--- a/docs/vesta-integration.md
+++ b/docs/vesta-integration.md
@@ -11,7 +11,7 @@ Use the current exact public AFMKit release:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.17"
+    exact: "0.1.18-rc.1"
 )
 ```
 


### PR DESCRIPTION
Record the ten-day branch and PR audit, newly opened review PRs, deferred work, dependency merge order, and functionality/performance/installation gates. This is a tracking document, not a claim that the beta is built or qualified. The next candidate dependency update will be a separately reviewed change after AFMKit qualification.

## Summary by Sourcery

Track beta release-candidate integration and qualification readiness while updating consumers and validation tooling to AFMKit 0.1.18-rc.1.

New Features:
- Add release-candidate model qualification guidance covering speculation modes, evidence requirements, performance measurements, and release blockers.
- Add Promptfoo runner support for configurable MTP model heads, DwarfStar support files, and extended model-load timeouts.

Bug Fixes:
- Keep MLX model-test judging artifacts and temporary files under a configurable work root, including reanalysis outputs, instead of using fixed system temporary paths.

Enhancements:
- Pin the main and example consumers to AFMKit 0.1.18-rc.1 and update release eligibility, boundary checks, documentation, and tooling expectations accordingly.
- Improve Promptfoo runner validation, command capture, and argument handling for qualification workflows.

Documentation:
- Document the beta release-candidate integration audit, dependency integration order, deferred work, qualification gates, and current pre-package evidence.

Tests:
- Update release and consumer boundary tests for AFMKit 0.1.18-rc.1 and add coverage for Promptfoo qualification arguments and configurable MLX judge work roots.