### PR TITLE
Fix assertion reports after server transport loss

### DIFF
--- a/Scripts/assertion-report.sh
+++ b/Scripts/assertion-report.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# Shared report renderer; sourced by test-assertions.sh for normal and aborted runs.
+generate_assertion_report() {
+TEST_END_TIME=$(date +%s)
+TOTAL_SECS=$((TEST_END_TIME - TEST_START_TIME))
+
+EFFECTIVE_TOTAL=$((TOTAL - SKIP))
+if [ $EFFECTIVE_TOTAL -gt 0 ]; then
+  PCT=$(( PASS * 100 / EFFECTIVE_TOTAL ))
+else
+  PCT=0
+fi
+
+if [ $FAIL -eq 0 ]; then
+  BAR_COLOR="#3fb950"
+else
+  BAR_COLOR="#f85149"
+fi
+
+DATE_STR=$(date '+%Y-%m-%d %H:%M:%S')
+
+cat > "$REPORT_FILE" <<'HTMLHEAD'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AFM Assertion Test Report</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'SF Pro', system-ui, sans-serif; background: #0d1117; color: #e6edf3; padding: 2rem; }
+  .header { text-align: center; margin-bottom: 2rem; padding: 2rem; background: linear-gradient(135deg, #1a1f2e 0%, #0d1117 100%); border: 1px solid #30363d; border-radius: 12px; }
+  .header h1 { font-size: 1.8rem; margin-bottom: 0.5rem; background: linear-gradient(90deg, #58a6ff, #bc8cff); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+  .header .meta { color: #8b949e; font-size: 0.9rem; line-height: 1.6; }
+  .summary { display: flex; gap: 1rem; justify-content: center; margin: 1.5rem 0; flex-wrap: wrap; }
+  .stat { background: #161b22; border: 1px solid #30363d; border-radius: 10px; padding: 1rem 1.5rem; text-align: center; min-width: 120px; }
+  .stat .value { font-size: 2rem; font-weight: 700; }
+  .stat .label { color: #8b949e; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; margin-top: 0.25rem; }
+  .stat.pass .value { color: #3fb950; }
+  .stat.fail .value { color: #f85149; }
+  .stat.skip .value { color: #d29922; }
+  .stat.time .value { color: #58a6ff; }
+  .stat.pct .value { color: #d2a8ff; }
+  .progress-bar { width: 100%; height: 8px; background: #21262d; border-radius: 4px; margin: 1rem auto; max-width: 400px; overflow: hidden; }
+  .progress-fill { height: 100%; border-radius: 4px; }
+  table { width: 100%; border-collapse: collapse; margin-top: 1.5rem; }
+  th { background: #161b22; color: #8b949e; font-weight: 600; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.05em; padding: 0.75rem 1rem; text-align: left; border-bottom: 1px solid #30363d; }
+  td { padding: 0.75rem 1rem; border-bottom: 1px solid #21262d; vertical-align: top; }
+  tr:hover { background: #161b22; }
+  .badge { display: inline-block; padding: 0.15rem 0.6rem; border-radius: 12px; font-size: 0.75rem; font-weight: 600; }
+  .badge.pass { background: #0d2818; color: #3fb950; border: 1px solid #238636; }
+  .badge.fail { background: #2d1215; color: #f85149; border: 1px solid #da3633; }
+  .badge.skip { background: #2d2400; color: #d29922; border: 1px solid #9e6a03; }
+  .group-badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 6px; font-size: 0.7rem; font-weight: 500; background: #1a1f2e; color: #8b949e; border: 1px solid #30363d; }
+  .group-badge.Preflight { color: #8b949e; border-color: #484f58; }
+  .group-badge.Lifecycle { color: #3fb950; border-color: #238636; }
+  .group-badge.Stop { color: #f85149; border-color: #da3633; }
+  .group-badge.Logprobs { color: #58a6ff; border-color: #1f6feb; }
+  .group-badge.Think { color: #d2a8ff; border-color: #8957e5; }
+  .group-badge.Tools { color: #ffa657; border-color: #d18616; }
+  .group-badge.XMLTools { color: #f0883e; border-color: #bd561d; }
+  .group-badge.Cache { color: #79c0ff; border-color: #388bfd; }
+  .group-badge.Concurrent { color: #f778ba; border-color: #db61a2; }
+  .group-badge.Error { color: #ff7b72; border-color: #da3633; }
+  .group-badge.Kwargs { color: #a5d6ff; border-color: #58a6ff; }
+  .group-badge.Perf { color: #3fb950; border-color: #238636; }
+  .group-badge.Structured { color: #d2a8ff; border-color: #8957e5; }
+  .group-badge.AdaptiveXML { color: #f0883e; border-color: #bd561d; }
+  .group-badge.Grammar { color: #d2a8ff; border-color: #8957e5; }
+  .group-badge.XMLParsing { color: #f0883e; border-color: #bd561d; }
+  .group-badge.NullableSchema { color: #79c0ff; border-color: #388bfd; }
+  .group-badge.UnitTest { color: #a5d6ff; border-color: #58a6ff; }
+  .group-badge.Batch { color: #7ee787; border-color: #3fb950; }
+  .tier-row td { background: #161b22; padding: 0.6rem 1rem; font-weight: 700; font-size: 0.9rem; border-bottom: 2px solid #30363d; border-top: 2px solid #30363d; }
+  .tier-badge { display: inline-block; padding: 0.2rem 0.6rem; border-radius: 6px; font-size: 0.7rem; font-weight: 600; }
+  .tier-badge.unit { background: #1a1a2e; color: #a5d6ff; border: 1px solid #58a6ff; }
+  .tier-badge.smoke { background: #0d2818; color: #3fb950; border: 1px solid #238636; }
+  .tier-badge.standard { background: #0d1a30; color: #58a6ff; border: 1px solid #1f6feb; }
+  .tier-badge.full { background: #2d1f00; color: #d29922; border: 1px solid #9e6a03; }
+  .detail { font-family: 'SF Mono', 'Menlo', monospace; font-size: 0.8rem; color: #8b949e; white-space: pre-wrap; word-break: break-word; max-height: 100px; overflow-y: auto; background: #0d1117; padding: 0.5rem; border-radius: 6px; border: 1px solid #21262d; margin-top: 0.25rem; }
+  .duration { color: #8b949e; font-family: 'SF Mono', monospace; font-size: 0.85rem; }
+  .test-idx { color: #8b949e; font-family: 'SF Mono', monospace; font-size: 0.85rem; }
+  .footer { text-align: center; margin-top: 2rem; color: #484f58; font-size: 0.8rem; }
+</style>
+</head>
+<body>
+HTMLHEAD
+
+if [ -s "$TRANSPORT_FAILURE_FILE" ]; then
+  printf '%s\n' '<p role="alert">Partial run: engine unavailable to an assertion request. Remaining assertions were not executed.</p>' >> "$REPORT_FILE"
+fi
+
+cat >> "$REPORT_FILE" <<EOF
+<div class="header">
+  <h1>AFM Assertion Test Report</h1>
+  <div class="meta">
+    Model: <strong>$MODEL</strong> &middot; Tier: <strong>$TIER</strong> &middot; Grammar: <strong>$GRAMMAR_CONSTRAINTS</strong><br>
+    Server: <code>$BASE_URL</code><br>
+    Date: $DATE_STR
+  </div>
+</div>
+<div class="summary">
+  <div class="stat pass"><div class="value">$PASS</div><div class="label">Passed</div></div>
+  <div class="stat fail"><div class="value">$FAIL</div><div class="label">Failed</div></div>
+  <div class="stat skip"><div class="value">$SKIP</div><div class="label">Skipped</div></div>
+  <div class="stat pct"><div class="value">${PCT}%</div><div class="label">Pass Rate</div></div>
+  <div class="stat time"><div class="value">${TOTAL_SECS}s</div><div class="label">Total Time</div></div>
+</div>
+<div class="progress-bar"><div class="progress-fill" style="width:${PCT}%;background:${BAR_COLOR};"></div></div>
+<table>
+<thead>
+<tr><th>#</th><th>Test</th><th>Group</th><th>Coverage</th><th>Status</th><th>Classification</th><th>Duration</th><th>Details</th></tr>
+</thead>
+<tbody>
+EOF
+
+# Emit all rows in execution order with coverage tier badges
+for entry in "${RESULTS[@]}"; do
+  IFS='|' read -r status group name expected actual duration tier test_idx classification <<< "$entry"
+  tier="${tier:-smoke}"
+  test_idx="${test_idx:-0}"
+  classification="${classification:-needs triage}"
+
+  if [ "$status" = "PASS" ]; then
+    badge='<span class="badge pass">PASS</span>'
+    detail_text="$expected"
+  elif [ "$status" = "SKIP" ]; then
+    badge='<span class="badge skip">SKIP</span>'
+    detail_text="$expected"
+  else
+    badge='<span class="badge fail">FAIL</span>'
+    detail_text="Expected: $expected\nActual: $actual"
+  fi
+  detail_text=$(echo "$detail_text" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+  name_esc=$(echo "$name" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+  classification_esc=$(echo "$classification" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+
+  dur_s=""
+  if [ -n "$duration" ] && [ "$duration" -gt 0 ] 2>/dev/null; then
+    dur_s=$(python3 -c "print(f'{$duration/1000:.1f}s')" 2>/dev/null || echo "${duration}ms")
+  fi
+
+  # Coverage badges: show which tiers include this test
+  # smoke tests run in smoke+standard+full, standard in standard+full, full in full only
+  tier_badges=""
+  case "$tier" in
+    unit)     tier_badges='<span class="tier-badge unit">unit</span> <span class="tier-badge smoke">smoke</span> <span class="tier-badge standard">standard</span> <span class="tier-badge full">full</span>' ;;
+    smoke)    tier_badges='<span class="tier-badge smoke">smoke</span> <span class="tier-badge standard">standard</span> <span class="tier-badge full">full</span>' ;;
+    standard) tier_badges='<span class="tier-badge standard">standard</span> <span class="tier-badge full">full</span>' ;;
+    full)     tier_badges='<span class="tier-badge full">full</span>' ;;
+  esac
+
+  cat >> "$REPORT_FILE" <<EOF
+<tr>
+  <td><span class="test-idx">${test_idx}</span></td>
+  <td>$name_esc</td>
+  <td><span class="group-badge $group">$group</span></td>
+  <td>${tier_badges}</td>
+  <td>$badge</td>
+  <td>${classification_esc}</td>
+  <td><span class="duration">$dur_s</span></td>
+  <td><div class="detail">$detail_text</div></td>
+</tr>
+EOF
+done
+
+cat >> "$REPORT_FILE" <<EOF
+</tbody>
+</table>
+<div class="footer">
+  Generated by Scripts/test-assertions.sh (tier: $TIER) &mdash; $(date '+%Y-%m-%d %H:%M:%S')
+</div>
+</body>
+</html>
+EOF
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Results: $PASS/$EFFECTIVE_TOTAL passed ($PCT%) | $SKIP skipped"
+if [ $FAIL -gt 0 ]; then
+  echo "  ❌ $FAIL FAILED"
+fi
+echo "  Report: $REPORT_FILE"
+echo "  JSONL:  $JSONL_FILE"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+}

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -39,6 +39,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 REPORT_DIR="${AFM_ASSERTIONS_REPORT_DIR:-$PROJECT_ROOT/test-reports}"
 REQUEST_TIMEOUT="${AFM_ASSERTIONS_REQUEST_TIMEOUT:-60}"
+TRANSPORT_HEALTH_TIMEOUT=5
 
 usage() {
   cat <<'EOF'
@@ -96,6 +97,9 @@ JSONL_FILE="$REPORT_DIR/assertions-report-${TIMESTAMP}.jsonl"
 mkdir -p "$REPORT_DIR"
 WORK_ROOT="${AFM_ASSERTIONS_WORK_ROOT:-$REPORT_DIR/work}"
 mkdir -p "$WORK_ROOT"
+TRANSPORT_FAILURE_FILE=$(mktemp "$WORK_ROOT/transport-failure.XXXXXX")
+REQUEST_FAILURE_FILE="${TRANSPORT_FAILURE_FILE}.request"
+TRANSPORT_FAILURE_RECORDED=false
 
 # ─── Test infrastructure ─────────────────────────────────────────────────────
 PASS=0
@@ -145,6 +149,18 @@ run_test() {
   local actual="$4"
   local duration="${5:-0}"
 
+  # Command substitutions and background requests share this marker.
+  # Never classify an absent response as PASS or an unavailable capability.
+  local abort_transport=false
+  if [ -s "$TRANSPORT_FAILURE_FILE" ] && ! $TRANSPORT_FAILURE_RECORDED; then
+    actual="FAIL: engine unavailable to assertion request: $(< "$TRANSPORT_FAILURE_FILE")"
+    TRANSPORT_FAILURE_RECORDED=true
+    abort_transport=true
+  elif [ -s "$REQUEST_FAILURE_FILE" ]; then
+    actual="FAIL: $(< "$REQUEST_FAILURE_FILE")"
+    rm -f "$REQUEST_FAILURE_FILE"
+  fi
+
   TOTAL=$((TOTAL + 1))
   if [ "$actual" = "PASS" ]; then
     PASS=$((PASS + 1))
@@ -168,7 +184,7 @@ run_test() {
   RESULTS+=("${actual}|${group}|${name}|${esc_expected}|${esc_actual}|${duration}|${CURRENT_TIER}|${TOTAL}|${category}")
 
   # JSONL record
-  _GROUP="$group" _NAME="$name" _STATUS="$status_val" _DUR="$duration" _TIER="$CURRENT_TIER" _IDX="$TOTAL" _CATEGORY="$category" python3 -c "
+  _EXPECTED="$expected" _ACTUAL="$actual" _GROUP="$group" _NAME="$name" _STATUS="$status_val" _DUR="$duration" _TIER="$CURRENT_TIER" _IDX="$TOTAL" _CATEGORY="$category" python3 -c "
 import json, os
 print(json.dumps({
     'index': int(os.environ['_IDX']),
@@ -177,10 +193,57 @@ print(json.dumps({
     'status': os.environ['_STATUS'],
     'duration_ms': int(os.environ['_DUR']),
     'tier': os.environ['_TIER'],
-    'classification': os.environ['_CATEGORY']
+    'classification': os.environ['_CATEGORY'],
+    'expected': os.environ['_EXPECTED'],
+    'actual': os.environ['_ACTUAL']
 }))
 " >> "$JSONL_FILE"
+  if $abort_transport; then
+    echo "FATAL: transport failure; stopping with partial results." >&2
+    exit 1
+  fi
 }
+
+
+# All shell HTTP requests use this boundary, including command substitutions
+# and concurrent requests. HTTP error responses (curl 22) remain assertions.
+# A failed transport is not evidence of model capability or successful headers.
+curl() {
+  local code=0
+  [ ! -s "$TRANSPORT_FAILURE_FILE" ] || return 7
+  command curl "$@" || code=$?
+  if [ "$code" -ne 0 ] && [ "$code" -ne 22 ]; then
+    # A live server can time out a costly request. Fail that assertion, but
+    # abort only when the bounded, non-inference availability check also fails.
+    if [ "$code" -eq 28 ] && command curl -sf --max-time "$TRANSPORT_HEALTH_TIMEOUT" \
+        "$BASE_URL/v1/models" >/dev/null 2>&1; then
+      printf 'request timeout (curl exit 28); server still reachable\n' > "$REQUEST_FAILURE_FILE"
+    else
+      printf 'curl exit %s at %s\n' "$code" "$BASE_URL" > "$TRANSPORT_FAILURE_FILE"
+    fi
+  fi
+  return "$code"
+}
+
+source "$SCRIPT_DIR/assertion-report.sh"
+finish_assertions() {
+  local exit_code=$?
+  trap - EXIT
+  if [ -s "$TRANSPORT_FAILURE_FILE" ] && ! $TRANSPORT_FAILURE_RECORDED; then
+    TRANSPORT_FAILURE_RECORDED=true
+    run_test "Lifecycle" "Engine unavailable; run aborted" "reachable server" \
+      "FAIL: engine unavailable to assertion request: $(< "$TRANSPORT_FAILURE_FILE")" 0
+    exit_code=1
+  elif [ -s "$REQUEST_FAILURE_FILE" ]; then
+    run_test "Lifecycle" "Request transport failed; run aborted" "complete response" \
+      "FAIL: $(< "$REQUEST_FAILURE_FILE")" 0
+    exit_code=1
+  fi
+  generate_assertion_report
+  rm -f "$TRANSPORT_FAILURE_FILE" "$REQUEST_FAILURE_FILE"
+  exit "$exit_code"
+}
+trap finish_assertions EXIT
 
 # Helper: call API and return full JSON response
 api_call() {
@@ -422,14 +485,19 @@ if [ -z "$MODEL" ]; then
 fi
 echo "  Model: $MODEL"
 
-capability_lines=$(python3 - "$MODEL" "$PORT" <<'PY' 2>/dev/null || true
+capability_payload=$(curl -sf --max-time "$TRANSPORT_HEALTH_TIMEOUT" "$BASE_URL/v1/models") || {
+  capability_status=$?
+  run_test "Preflight" "Read model capabilities" "successful models response" \
+    "FAIL: HTTP capability discovery failed (curl exit $capability_status)" 0
+  exit 1
+}
+capability_lines=$(CAPABILITY_PAYLOAD="$capability_payload" python3 - "$MODEL" <<'PY' 2>/dev/null || true
 import json
 import sys
-import urllib.request
+import os
 
-model, port = sys.argv[1:]
-with urllib.request.urlopen(f"http://127.0.0.1:{port}/v1/models", timeout=5) as response:
-    payload = json.load(response)
+model = sys.argv[1]
+payload = json.loads(os.environ["CAPABILITY_PAYLOAD"])
 details = payload.get("models") or []
 selected = next((item for item in details if item.get("model") == model), None)
 if selected is None:
@@ -2643,7 +2711,7 @@ print(f'{tps:.1f}')
     run_test "Perf" "tok/s > 1 ($tps tok/s)" ">1" "FAIL: $tps tok/s" "$dur_ms"
   fi
 
-  # Test: long context (2048 tokens) no crash
+  # Test: repeated-word prompt (500 repetitions) no crash
   t0=$(now_ms)
   long_prompt=$(python3 -c "print('word ' * 500)")
   resp=$(api_call "{\"messages\":[{\"role\":\"user\",\"content\":\"Summarize this text: $long_prompt\"}],\"max_tokens\":500,\"stream\":false,\"temperature\":0}")
@@ -2660,12 +2728,12 @@ except Exception as e:
     print(f'FAIL: {e}')
 " 2>/dev/null || echo "FAIL: parse error")
   if [ "$long_ok" = "PASS" ]; then
-    run_test "Perf" "Long context (~2K tokens) no crash" "valid response" "PASS" "$dur"
+    run_test "Perf" "Repeated-word prompt (500 repetitions) no crash" "valid response" "PASS" "$dur"
   else
-    run_test "Perf" "Long context (~2K tokens) no crash" "valid response" "$long_ok" "$dur"
+    run_test "Perf" "Repeated-word prompt (500 repetitions) no crash" "valid response" "$long_ok" "$dur"
   fi
 
-  # Test: very long context (4096 tokens) no NaN/garbage
+  # Test: repeated-sentence prompt (200 repetitions) no NaN/garbage
   t0=$(now_ms)
   very_long_prompt=$(python3 -c "print('The quick brown fox jumps over the lazy dog. ' * 200)")
   resp=$(api_call "{\"messages\":[{\"role\":\"user\",\"content\":\"Summarize: $very_long_prompt\"}],\"max_tokens\":500,\"stream\":false,\"temperature\":0}")
@@ -2688,9 +2756,9 @@ except Exception as e:
     print(f'FAIL: {e}')
 " 2>/dev/null || echo "FAIL: parse error")
   if [ "$vlong_ok" = "PASS" ]; then
-    run_test "Perf" "Very long context (~4K tokens) no NaN/garbage" "clean output" "PASS" "$dur"
+    run_test "Perf" "Repeated-sentence prompt (200 repetitions) no NaN/garbage" "clean output" "PASS" "$dur"
   else
-    run_test "Perf" "Very long context (~4K tokens) no NaN/garbage" "clean output" "$vlong_ok" "$dur"
+    run_test "Perf" "Repeated-sentence prompt (200 repetitions) no NaN/garbage" "clean output" "$vlong_ok" "$dur"
   fi
 fi
 
@@ -4542,183 +4610,4 @@ fi
 # ═══════════════════════════════════════════════════════════════════════════════
 # Generate HTML Report
 # ═══════════════════════════════════════════════════════════════════════════════
-TEST_END_TIME=$(date +%s)
-TOTAL_SECS=$((TEST_END_TIME - TEST_START_TIME))
-
-EFFECTIVE_TOTAL=$((TOTAL - SKIP))
-if [ $EFFECTIVE_TOTAL -gt 0 ]; then
-  PCT=$(( PASS * 100 / EFFECTIVE_TOTAL ))
-else
-  PCT=0
-fi
-
-if [ $FAIL -eq 0 ]; then
-  BAR_COLOR="#3fb950"
-else
-  BAR_COLOR="#f85149"
-fi
-
-DATE_STR=$(date '+%Y-%m-%d %H:%M:%S')
-
-cat > "$REPORT_FILE" <<'HTMLHEAD'
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>AFM Assertion Test Report</title>
-<style>
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: -apple-system, BlinkMacSystemFont, 'SF Pro', system-ui, sans-serif; background: #0d1117; color: #e6edf3; padding: 2rem; }
-  .header { text-align: center; margin-bottom: 2rem; padding: 2rem; background: linear-gradient(135deg, #1a1f2e 0%, #0d1117 100%); border: 1px solid #30363d; border-radius: 12px; }
-  .header h1 { font-size: 1.8rem; margin-bottom: 0.5rem; background: linear-gradient(90deg, #58a6ff, #bc8cff); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
-  .header .meta { color: #8b949e; font-size: 0.9rem; line-height: 1.6; }
-  .summary { display: flex; gap: 1rem; justify-content: center; margin: 1.5rem 0; flex-wrap: wrap; }
-  .stat { background: #161b22; border: 1px solid #30363d; border-radius: 10px; padding: 1rem 1.5rem; text-align: center; min-width: 120px; }
-  .stat .value { font-size: 2rem; font-weight: 700; }
-  .stat .label { color: #8b949e; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; margin-top: 0.25rem; }
-  .stat.pass .value { color: #3fb950; }
-  .stat.fail .value { color: #f85149; }
-  .stat.skip .value { color: #d29922; }
-  .stat.time .value { color: #58a6ff; }
-  .stat.pct .value { color: #d2a8ff; }
-  .progress-bar { width: 100%; height: 8px; background: #21262d; border-radius: 4px; margin: 1rem auto; max-width: 400px; overflow: hidden; }
-  .progress-fill { height: 100%; border-radius: 4px; }
-  table { width: 100%; border-collapse: collapse; margin-top: 1.5rem; }
-  th { background: #161b22; color: #8b949e; font-weight: 600; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.05em; padding: 0.75rem 1rem; text-align: left; border-bottom: 1px solid #30363d; }
-  td { padding: 0.75rem 1rem; border-bottom: 1px solid #21262d; vertical-align: top; }
-  tr:hover { background: #161b22; }
-  .badge { display: inline-block; padding: 0.15rem 0.6rem; border-radius: 12px; font-size: 0.75rem; font-weight: 600; }
-  .badge.pass { background: #0d2818; color: #3fb950; border: 1px solid #238636; }
-  .badge.fail { background: #2d1215; color: #f85149; border: 1px solid #da3633; }
-  .badge.skip { background: #2d2400; color: #d29922; border: 1px solid #9e6a03; }
-  .group-badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 6px; font-size: 0.7rem; font-weight: 500; background: #1a1f2e; color: #8b949e; border: 1px solid #30363d; }
-  .group-badge.Preflight { color: #8b949e; border-color: #484f58; }
-  .group-badge.Lifecycle { color: #3fb950; border-color: #238636; }
-  .group-badge.Stop { color: #f85149; border-color: #da3633; }
-  .group-badge.Logprobs { color: #58a6ff; border-color: #1f6feb; }
-  .group-badge.Think { color: #d2a8ff; border-color: #8957e5; }
-  .group-badge.Tools { color: #ffa657; border-color: #d18616; }
-  .group-badge.XMLTools { color: #f0883e; border-color: #bd561d; }
-  .group-badge.Cache { color: #79c0ff; border-color: #388bfd; }
-  .group-badge.Concurrent { color: #f778ba; border-color: #db61a2; }
-  .group-badge.Error { color: #ff7b72; border-color: #da3633; }
-  .group-badge.Kwargs { color: #a5d6ff; border-color: #58a6ff; }
-  .group-badge.Perf { color: #3fb950; border-color: #238636; }
-  .group-badge.Structured { color: #d2a8ff; border-color: #8957e5; }
-  .group-badge.AdaptiveXML { color: #f0883e; border-color: #bd561d; }
-  .group-badge.Grammar { color: #d2a8ff; border-color: #8957e5; }
-  .group-badge.XMLParsing { color: #f0883e; border-color: #bd561d; }
-  .group-badge.NullableSchema { color: #79c0ff; border-color: #388bfd; }
-  .group-badge.UnitTest { color: #a5d6ff; border-color: #58a6ff; }
-  .group-badge.Batch { color: #7ee787; border-color: #3fb950; }
-  .tier-row td { background: #161b22; padding: 0.6rem 1rem; font-weight: 700; font-size: 0.9rem; border-bottom: 2px solid #30363d; border-top: 2px solid #30363d; }
-  .tier-badge { display: inline-block; padding: 0.2rem 0.6rem; border-radius: 6px; font-size: 0.7rem; font-weight: 600; }
-  .tier-badge.unit { background: #1a1a2e; color: #a5d6ff; border: 1px solid #58a6ff; }
-  .tier-badge.smoke { background: #0d2818; color: #3fb950; border: 1px solid #238636; }
-  .tier-badge.standard { background: #0d1a30; color: #58a6ff; border: 1px solid #1f6feb; }
-  .tier-badge.full { background: #2d1f00; color: #d29922; border: 1px solid #9e6a03; }
-  .detail { font-family: 'SF Mono', 'Menlo', monospace; font-size: 0.8rem; color: #8b949e; white-space: pre-wrap; word-break: break-word; max-height: 100px; overflow-y: auto; background: #0d1117; padding: 0.5rem; border-radius: 6px; border: 1px solid #21262d; margin-top: 0.25rem; }
-  .duration { color: #8b949e; font-family: 'SF Mono', monospace; font-size: 0.85rem; }
-  .test-idx { color: #8b949e; font-family: 'SF Mono', monospace; font-size: 0.85rem; }
-  .footer { text-align: center; margin-top: 2rem; color: #484f58; font-size: 0.8rem; }
-</style>
-</head>
-<body>
-HTMLHEAD
-
-cat >> "$REPORT_FILE" <<EOF
-<div class="header">
-  <h1>AFM Assertion Test Report</h1>
-  <div class="meta">
-    Model: <strong>$MODEL</strong> &middot; Tier: <strong>$TIER</strong> &middot; Grammar: <strong>$GRAMMAR_CONSTRAINTS</strong><br>
-    Server: <code>$BASE_URL</code><br>
-    Date: $DATE_STR
-  </div>
-</div>
-<div class="summary">
-  <div class="stat pass"><div class="value">$PASS</div><div class="label">Passed</div></div>
-  <div class="stat fail"><div class="value">$FAIL</div><div class="label">Failed</div></div>
-  <div class="stat skip"><div class="value">$SKIP</div><div class="label">Skipped</div></div>
-  <div class="stat pct"><div class="value">${PCT}%</div><div class="label">Pass Rate</div></div>
-  <div class="stat time"><div class="value">${TOTAL_SECS}s</div><div class="label">Total Time</div></div>
-</div>
-<div class="progress-bar"><div class="progress-fill" style="width:${PCT}%;background:${BAR_COLOR};"></div></div>
-<table>
-<thead>
-<tr><th>#</th><th>Test</th><th>Group</th><th>Coverage</th><th>Status</th><th>Classification</th><th>Duration</th><th>Details</th></tr>
-</thead>
-<tbody>
-EOF
-
-# Emit all rows in execution order with coverage tier badges
-for entry in "${RESULTS[@]}"; do
-  IFS='|' read -r status group name expected actual duration tier test_idx classification <<< "$entry"
-  tier="${tier:-smoke}"
-  test_idx="${test_idx:-0}"
-  classification="${classification:-needs triage}"
-
-  if [ "$status" = "PASS" ]; then
-    badge='<span class="badge pass">PASS</span>'
-    detail_text="$expected"
-  elif [ "$status" = "SKIP" ]; then
-    badge='<span class="badge skip">SKIP</span>'
-    detail_text="$expected"
-  else
-    badge='<span class="badge fail">FAIL</span>'
-    detail_text="Expected: $expected\nActual: $actual"
-  fi
-  detail_text=$(echo "$detail_text" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
-  name_esc=$(echo "$name" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
-  classification_esc=$(echo "$classification" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
-
-  dur_s=""
-  if [ -n "$duration" ] && [ "$duration" -gt 0 ] 2>/dev/null; then
-    dur_s=$(python3 -c "print(f'{$duration/1000:.1f}s')" 2>/dev/null || echo "${duration}ms")
-  fi
-
-  # Coverage badges: show which tiers include this test
-  # smoke tests run in smoke+standard+full, standard in standard+full, full in full only
-  tier_badges=""
-  case "$tier" in
-    unit)     tier_badges='<span class="tier-badge unit">unit</span> <span class="tier-badge smoke">smoke</span> <span class="tier-badge standard">standard</span> <span class="tier-badge full">full</span>' ;;
-    smoke)    tier_badges='<span class="tier-badge smoke">smoke</span> <span class="tier-badge standard">standard</span> <span class="tier-badge full">full</span>' ;;
-    standard) tier_badges='<span class="tier-badge standard">standard</span> <span class="tier-badge full">full</span>' ;;
-    full)     tier_badges='<span class="tier-badge full">full</span>' ;;
-  esac
-
-  cat >> "$REPORT_FILE" <<EOF
-<tr>
-  <td><span class="test-idx">${test_idx}</span></td>
-  <td>$name_esc</td>
-  <td><span class="group-badge $group">$group</span></td>
-  <td>${tier_badges}</td>
-  <td>$badge</td>
-  <td>${classification_esc}</td>
-  <td><span class="duration">$dur_s</span></td>
-  <td><div class="detail">$detail_text</div></td>
-</tr>
-EOF
-done
-
-cat >> "$REPORT_FILE" <<EOF
-</tbody>
-</table>
-<div class="footer">
-  Generated by Scripts/test-assertions.sh (tier: $TIER) &mdash; $(date '+%Y-%m-%d %H:%M:%S')
-</div>
-</body>
-</html>
-EOF
-
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  Results: $PASS/$EFFECTIVE_TOTAL passed ($PCT%) | $SKIP skipped"
-if [ $FAIL -gt 0 ]; then
-  echo "  ❌ $FAIL FAILED"
-fi
-echo "  Report: $REPORT_FILE"
-echo "  JSONL:  $JSONL_FILE"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-
-exit $FAIL
+exit "$FAIL"

--- a/Scripts/tests/test_assertion_transport.py
+++ b/Scripts/tests/test_assertion_transport.py
@@ -1,0 +1,152 @@
+"""CPU-only end-to-end assertion runner tests using a fake curl executable."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FAKE_CURL = r'''#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+args = sys.argv[1:]
+log = Path(os.environ['FIXTURE_CALL_LOG'])
+with log.open('a') as handle:
+    handle.write(json.dumps(args) + '\n')
+mode = os.environ['FIXTURE_MODE']
+is_models = any(arg.endswith('/v1/models') for arg in args)
+calls = log.read_text().splitlines()
+if mode == 'preflight' or (mode == 'capabilities' and len(calls) == 2):
+    sys.exit(7)
+if mode == 'capabilities-http-error' and len(calls) == 2:
+    sys.exit(22)
+if mode == 'timeout-dead' and is_models and len(calls) > 2:
+    sys.exit(7)
+if is_models:
+    print(json.dumps({'data': [{'id': 'fixture'}], 'models': []}))
+    sys.exit(0)
+if mode == 'http-error':
+    sys.exit(22)
+if mode == 'drop' or (mode == 'stream-drop' and '-N' in args):
+    sys.exit(52)
+if mode in ('timeout', 'timeout-dead'):
+    sys.exit(28)
+print(json.dumps({'choices': [{'message': {'content': 'AFM_PREFIX'},
+                              'finish_reason': 'stop'}]}))
+'''
+
+
+class AssertionTransportTests(unittest.TestCase):
+    def run_fixture(self, mode, section='1', tier='smoke'):
+        parent = ROOT / '.build' / 'assertion-transport-fixtures'
+        parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=parent) as directory:
+            work = Path(directory)
+            fake_bin = work / 'bin'
+            fake_bin.mkdir()
+            curl = fake_bin / 'curl'
+            curl.write_text(FAKE_CURL)
+            curl.chmod(0o755)
+            log = work / 'calls.jsonl'
+            reports = work / 'reports'
+            env = dict(os.environ, PATH=str(fake_bin) + os.pathsep + os.environ['PATH'],
+                       MACAFM_SWIFT_TEST_SKIP='1', AFM_ASSERTIONS_REPORT_DIR=str(reports),
+                       AFM_ASSERTIONS_WORK_ROOT=str(work / 'scratch'),
+                       FIXTURE_MODE=mode, FIXTURE_CALL_LOG=str(log))
+            result = subprocess.run(
+                ['bash', str(ROOT / 'Scripts/test-assertions.sh'), '--model', 'fixture',
+                 '--bin', '/usr/bin/true', '--section', section, '--tier', tier,
+                 '--grammar-constraints'],
+                cwd=ROOT, env=env, capture_output=True, text=True, timeout=60)
+            jsonl = list(reports.glob('*.jsonl'))
+            html = list(reports.glob('*.html'))
+            self.assertEqual(len(jsonl), 1, result.stdout + result.stderr)
+            self.assertEqual(len(html), 1, result.stdout + result.stderr)
+            rows = [json.loads(line) for line in jsonl[0].read_text().splitlines()]
+            self.assertIn('</html>', html[0].read_text())
+            calls = [json.loads(line) for line in log.read_text().splitlines()]
+            return result, rows, calls
+
+    def assert_aborted(self, mode, section='1', tier='smoke'):
+        result, rows, calls = self.run_fixture(mode, section, tier)
+        self.assertNotEqual(result.returncode, 0)
+        failures = [row for row in rows if 'engine unavailable' in row['actual']]
+        self.assertEqual(len(failures), 1, result.stdout + result.stderr)
+        self.assertEqual(rows[-1], failures[0])
+        self.assertEqual(rows[-1]['status'], 'FAIL')
+        self.assertEqual(rows[-1]['classification'], 'engine/runtime likely')
+        self.assertNotEqual(rows[0]['status'], 'FAIL')  # Retain completed evidence.
+        return rows, calls
+
+    def test_json_transport_loss_preserves_partial_report_and_stops(self):
+        rows, calls = self.assert_aborted('drop')
+        self.assertEqual(len(calls), 4)
+        self.assertEqual([row['status'] for row in rows], ['PASS'] * 3 + ['FAIL'])
+
+    def test_header_transport_loss_cannot_pass_absent_header(self):
+        rows, calls = self.assert_aborted('drop', '14')
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(len(rows), 3)
+
+    def test_failed_thinking_probe_cannot_be_capability_skip(self):
+        rows, calls = self.assert_aborted('drop', '4')
+        self.assertFalse(any(row['status'] == 'SKIP' for row in rows))
+        self.assertEqual(len(calls), 3)
+
+    def test_stream_transport_loss_stops_at_failed_stream(self):
+        _, calls = self.assert_aborted('stream-drop', '2', 'standard')
+        self.assertIn('-N', calls[-1])
+        self.assertEqual(sum('-N' in call for call in calls), 1)
+
+    def test_direct_http_status_request_preserves_report_on_errexit(self):
+        _, calls = self.assert_aborted('drop', '8')
+        self.assertEqual(len(calls), 3)
+
+    def test_concurrent_requests_share_transport_failure(self):
+        _, calls = self.assert_aborted('drop', '7', 'standard')
+        self.assertLessEqual(len(calls), 4)
+
+    def test_preflight_and_capability_fetch_fail_closed(self):
+        for mode in ['preflight', 'capabilities']:
+            with self.subTest(mode=mode):
+                self.assert_aborted(mode)
+
+    def test_timeout_is_failed_transport_not_capability(self):
+        rows, _ = self.assert_aborted('timeout-dead', '4')
+        self.assertIn('curl exit 28', rows[-1]['actual'])
+
+    def test_live_timeout_fails_assertion_without_claiming_server_death(self):
+        result, rows, calls = self.run_fixture('timeout', '4')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(rows[-1]['status'], 'FAIL')
+        self.assertIn('server still reachable', rows[-1]['actual'])
+        self.assertNotIn('engine unavailable', rows[-1]['actual'])
+        self.assertTrue(any(arg.endswith('/v1/models') for arg in calls[-1]))
+
+    def test_http_error_response_remains_an_assertion_failure(self):
+        result, rows, calls = self.run_fixture('http-error')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(any('engine unavailable' in row['actual'] for row in rows))
+        self.assertEqual(len(calls), 4)
+
+    def test_failed_capability_endpoint_is_not_unsupported_model(self):
+        result, rows, calls = self.run_fixture('capabilities-http-error')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(rows[-1]['status'], 'FAIL')
+        self.assertIn('HTTP capability discovery failed', rows[-1]['actual'])
+        self.assertFalse(any(row['status'] == 'SKIP' for row in rows))
+        self.assertEqual(len(calls), 2)
+
+    def test_success_adds_no_health_or_inference_requests(self):
+        result, rows, calls = self.run_fixture('success')
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(all(row['status'] == 'PASS' for row in rows))
+        self.assertEqual(len(calls), 4)
+        self.assertEqual(sum(any(arg.endswith('/v1/chat/completions') for arg in call)
+                             for call in calls), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When the assertion server disconnects, failed curl output can satisfy absent-header checks or masquerade as unsupported model capabilities. Stop on transport loss, record the failed assertion, and render partial HTML and JSONL through the exit handler. A timed-out request receives one bounded models-endpoint check; a reachable server retains the existing failed-assertion behavior. Successful requests add no health or inference calls.

The existing HTML renderer is moved to a sourced helper so normal and aborted runs share it. JSONL now retains expected/actual evidence. Repeated-context labels state prompt repetitions instead of unmeasured 2K/4K token claims.

Validation: 12 CPU end-to-end transport fixtures passed, covering JSON, header, streaming, capability discovery, direct curl, concurrency, dead/live timeouts, expected HTTP errors, and unchanged successful request counts. Existing assertion-harness fixtures passed, including six recorded live-server timeouts. Shell syntax and `git diff --check` passed. Independent read-only review found no blocker. No GPU workloads or provider changes.

Closes #255.

## Summary by Sourcery

Make assertion reporting fail closed on server transport loss while preserving partial results and distinguishing unavailable engines from live-server request failures.

Bug Fixes:
- Fail assertion runs closed on curl transport loss instead of misclassifying missing responses as successful checks or unsupported capabilities.
- Preserve the failed assertion and completed evidence while stopping execution and generating partial HTML and JSONL reports after engine unavailability.
- Handle timed-out requests with a bounded models-endpoint reachability check so live-server timeouts remain assertion failures.

Enhancements:
- Share report rendering between normal and aborted runs and retain expected and actual evidence in JSONL output.
- Clarify repeated-context assertion labels to describe prompt repetitions rather than estimated token counts.

Tests:
- Add CPU-only end-to-end transport fixtures covering transport drops, streaming, capability discovery, timeouts, HTTP errors, concurrency, and unchanged successful request behavior.