### PR TITLE
Fix assertion TTFT measurement from live SSE

### DIFF
--- a/Scripts/measure-sse-ttft.py
+++ b/Scripts/measure-sse-ttft.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Measure the first visible/reasoning token while draining an active SSE stream."""
+import argparse
+import json
+import sys
+import time
+
+
+def measure(lines, started_ns, clock=time.monotonic_ns):
+    first_token_ms = None
+    for line in lines:
+        # Timestamp receipt before JSON parsing; role-only and empty deltas do
+        # not constitute a token. Continue draining to preserve curl failures
+        # and avoid creating an artificial broken pipe after the first token.
+        if first_token_ms is not None:
+            continue
+        received_ns = clock()
+        if not line.startswith('data:'):
+            continue
+        try:
+            event = json.loads(line[len('data:'):].strip())
+            for choice in event.get('choices', []):
+                delta = choice.get('delta') or {}
+                if any(isinstance(delta.get(key), str) and delta[key]
+                       for key in ('content', 'reasoning_content')):
+                    first_token_ms = max(0, (received_ns - started_ns) // 1_000_000)
+                    break
+        except (ValueError, AttributeError, TypeError):
+            continue
+    return first_token_ms
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--start-ns', type=int, required=True)
+    args = parser.parse_args()
+    result = measure(sys.stdin, args.start_ns)
+    print(result if result is not None else 'no content or reasoning token received')

--- a/Scripts/test-assertions.sh
+++ b/Scripts/test-assertions.sh
@@ -40,6 +40,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 REPORT_DIR="${AFM_ASSERTIONS_REPORT_DIR:-$PROJECT_ROOT/test-reports}"
 REQUEST_TIMEOUT="${AFM_ASSERTIONS_REQUEST_TIMEOUT:-60}"
 TRANSPORT_HEALTH_TIMEOUT=5
+TTFT_LIMIT_MS=5000
 
 usage() {
   cat <<'EOF'
@@ -2668,29 +2669,14 @@ if should_run_section 9 && min_tier full; then
 
   # Test: TTFT < 5s (first token — content or reasoning_content)
   t0=$(now_ms)
-  stream_resp=$(api_stream '{"messages":[{"role":"user","content":"Hello"}],"max_tokens":50,"stream":true,"temperature":0}')
-  first_data_ms=$(echo "$stream_resp" | python3 -c "
-import sys, time, json
-start = time.time()
-for line in sys.stdin:
-    line = line.strip()
-    if line.startswith('data: {'):
-        try:
-            d = json.loads(line[6:])
-            delta = d.get('choices', [{}])[0].get('delta', {})
-            c = delta.get('content', '') or delta.get('reasoning_content', '')
-            if c:
-                print(int((time.time() - start) * 1000))
-                break
-        except: pass
-else:
-    print('99999')
-" 2>/dev/null || echo "99999")
+  request_started_ns=$(python3 -c 'import time; print(time.monotonic_ns())')
+  first_data_ms=$(api_stream '{"messages":[{"role":"user","content":"Hello"}],"max_tokens":50,"stream":true,"temperature":0}' |
+    python3 "$SCRIPT_DIR/measure-sse-ttft.py" --start-ns "$request_started_ns")
   dur=$(( $(now_ms) - t0 ))
-  if [ "$first_data_ms" -lt 5000 ] 2>/dev/null; then
-    run_test "Perf" "TTFT < 5s" "<5000ms" "PASS" "$dur"
+  if [[ "$first_data_ms" =~ ^[0-9]+$ ]] && [ "$first_data_ms" -lt "$TTFT_LIMIT_MS" ]; then
+    run_test "Perf" "TTFT < 5s (${first_data_ms}ms)" "<${TTFT_LIMIT_MS}ms" "PASS" "$dur"
   else
-    run_test "Perf" "TTFT < 5s" "<5000ms" "FAIL: ${first_data_ms}ms" "$dur"
+    run_test "Perf" "TTFT < 5s" "<${TTFT_LIMIT_MS}ms" "FAIL: $first_data_ms" "$dur"
   fi
 
   # Test: tok/s > 1 (bare minimum)

--- a/Scripts/tests/test_assertion_ttft.py
+++ b/Scripts/tests/test_assertion_ttft.py
@@ -1,0 +1,154 @@
+"""Deterministic clock checks and delayed HTTP/SSE fixtures; no model required."""
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+ROOT = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location('ttft', ROOT / 'Scripts/measure-sse-ttft.py')
+ttft = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ttft)
+
+
+class ClockTests(unittest.TestCase):
+    def test_role_empty_and_malformed_events_do_not_start_clock(self):
+        lines = ['data: {"choices":[{"delta":{"role":"assistant"}}]}\n',
+                 'data: not json\n',
+                 'data: {"choices":[{"delta":{"content":""}}]}\n',
+                 'data: {"choices":[{"delta":{"reasoning_content":"hmm"}}]}\n',
+                 'data: {"choices":[{"delta":{"content":"answer"}}]}\n',
+                 'data: [DONE]\n']
+        times = iter([2, 3, 4, 7, 9, 12])
+        self.assertEqual(ttft.measure(iter(lines), 1_000_000,
+                                     lambda: next(times) * 1_000_000), 6)
+        self.assertEqual(list(times), [9, 12])  # Stop timing after first token.
+
+    def test_empty_stream_does_not_report_zero_ttft(self):
+        self.assertIsNone(ttft.measure(['data: [DONE]\n'], 0, lambda: 1))
+
+
+class DelayedSSETests(unittest.TestCase):
+    def run_fixture(self, mode, token_delay=0.2, tail_delay=0.3, request_timeout=10):
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *_):
+                pass
+
+            def send_json(self, body):
+                data = json.dumps(body).encode()
+                self.send_response(200)
+                self.send_header('Content-Type', 'application/json')
+                self.send_header('Content-Length', str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            def do_GET(self):
+                self.send_json({'data': [{'id': 'fixture'}], 'models': []})
+
+            def do_POST(self):
+                body = json.loads(self.rfile.read(int(self.headers['Content-Length'])))
+                if not body.get('stream'):
+                    self.send_json({'choices': [{'message': {'content': 'OK'}}],
+                                    'usage': {'completion_tokens': 50}})
+                    return
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/event-stream')
+                self.send_header('Transfer-Encoding', 'chunked')
+                self.end_headers()
+
+                def event(payload):
+                    data = ('data: ' + payload + '\n\n').encode()
+                    self.wfile.write(f'{len(data):x}\r\n'.encode() + data + b'\r\n')
+                    self.wfile.flush()
+
+                try:
+                    event('{"choices":[{"delta":{"role":"assistant"}}]}')
+                    time.sleep(token_delay)
+                    if mode != 'role-only':
+                        key = 'reasoning_content' if mode == 'reasoning' else 'content'
+                        event(json.dumps({'choices': [{'delta': {key: 'first'}}]}))
+                    if mode == 'disconnect':
+                        self.close_connection = True
+                        return  # Missing final chunk: transport failure after first token.
+                    time.sleep(tail_delay)
+                    event('[DONE]')
+                    self.wfile.write(b'0\r\n\r\n')
+                    self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+        server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        parent = ROOT / '.build' / 'assertion-ttft-fixtures'
+        parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with tempfile.TemporaryDirectory(dir=parent) as directory:
+                env = dict(os.environ, MACAFM_SWIFT_TEST_SKIP='1',
+                           AFM_ASSERTIONS_REPORT_DIR=directory,
+                           AFM_ASSERTIONS_WORK_ROOT=directory + '/work',
+                           AFM_ASSERTIONS_REQUEST_TIMEOUT=str(request_timeout))
+                result = subprocess.run(
+                    ['bash', str(ROOT / 'Scripts/test-assertions.sh'), '--model', 'fixture',
+                     '--bin', '/usr/bin/true', '--section', '9', '--tier', 'full',
+                     '--port', str(server.server_port)],
+                    cwd=ROOT, env=env, capture_output=True, text=True, timeout=20)
+                reports = list(Path(directory).glob('*.jsonl'))
+                self.assertEqual(len(reports), 1, result.stdout + result.stderr)
+                rows = [json.loads(line) for line in reports[0].read_text().splitlines()]
+                return result, rows
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_delay_is_measured_live_and_tail_is_excluded(self):
+        for mode in ['content', 'reasoning']:
+            with self.subTest(mode=mode):
+                result, rows = self.run_fixture(mode)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                row = next(row for row in rows if row['name'].startswith('TTFT'))
+                elapsed = int(re.search(r'\((\d+)ms\)', row['name'])[1])
+                self.assertGreaterEqual(elapsed, 190)  # Immediate role event is ignored.
+                self.assertGreaterEqual(row['duration_ms'] - elapsed, 250)
+
+    def test_delayed_first_token_fails_five_second_threshold(self):
+        result, rows = self.run_fixture('content', token_delay=5.1, tail_delay=0)
+        self.assertNotEqual(result.returncode, 0)
+        row = next(row for row in rows if row['name'].startswith('TTFT'))
+        self.assertEqual(row['status'], 'FAIL')
+        self.assertGreaterEqual(int(row['actual'].removeprefix('FAIL: ')), 5000)
+
+    def test_role_only_stream_fails_without_claiming_first_token(self):
+        result, rows = self.run_fixture('role-only', token_delay=0, tail_delay=0)
+        self.assertNotEqual(result.returncode, 0)
+        row = next(row for row in rows if row['name'].startswith('TTFT'))
+        self.assertEqual(row['status'], 'FAIL')
+        self.assertIn('no content or reasoning token', row['actual'])
+
+    def test_disconnect_after_first_token_retains_transport_failure(self):
+        result, rows = self.run_fixture('disconnect', token_delay=0)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(rows[-1]['status'], 'FAIL')
+        self.assertIn('engine unavailable', rows[-1]['actual'])
+        self.assertEqual(len(rows), 3)
+
+    def test_live_timeout_after_first_token_is_not_a_ttft_pass(self):
+        result, rows = self.run_fixture('content', token_delay=0, tail_delay=1.2,
+                                        request_timeout=1)
+        self.assertNotEqual(result.returncode, 0)
+        row = next(row for row in rows if row['name'].startswith('TTFT'))
+        self.assertEqual(row['status'], 'FAIL')
+        self.assertIn('request timeout', row['actual'])
+        self.assertEqual(len(rows), 6)  # A live server can continue other assertions.
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The full-tier TTFT check previously timed parsing after the complete SSE response had already been buffered, allowing a slow first token to pass. Measure monotonic time from request start to the first nonempty content or reasoning delta as the stream arrives, and include the measured milliseconds in the assertion record.

Role-only and empty events do not count. The reader drains the stream after the first token so the existing transport failure handling still catches a disconnect or timeout. The existing request timeout remains in force, and the change sends no additional inference requests.

Validation: seven CPU clock/delayed-HTTP fixture tests passed, including a real 5.1-second first-token delay, a delayed stream tail, reasoning tokens, role-only output, disconnect after the first token, and a live-server timeout. All twelve transport fixtures, shell syntax, and `git diff --check` also passed. No GPU workloads.

Closes #257.

## Summary by Sourcery

Correct live SSE TTFT assertions to measure the actual time to the first visible or reasoning token while preserving stream failure detection.

Bug Fixes:
- Measure full-tier TTFT from request start to the first nonempty content or reasoning token received from the live SSE stream, preventing delayed first tokens from passing the threshold.

Enhancements:
- Continue draining the SSE stream after the first token so transport disconnects and timeouts remain detectable, while reporting the measured TTFT in assertion records.

Tests:
- Add deterministic clock and delayed SSE fixture coverage for token timing, reasoning output, ignored role-only or empty events, delayed stream tails, disconnects, and timeouts.