### PR TITLE
Update release candidate to qualified AFMKit RC2

### DIFF
--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.18-rc.1"
+        exact: "0.1.18-rc.2"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "077ade7950b193dbfdac91bfb01c5a55c6077c089b4a2a4f77480fcee58eb97a",
+  "originHash" : "ca033e73413d8289719bc4d7a815b843b875134d610c45b4d4b99f726265bed8",
   "pins" : [
     {
       "identity" : "afmkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "03fd2b44965970bb965880381ae46cfdf293bdac",
-        "version" : "0.1.18-rc.1"
+        "revision" : "6a8c25ab948237e822547c576c13a95d926086b1",
+        "version" : "0.1.18-rc.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.18-rc.1"
+        exact: "0.1.18-rc.2"
     )
 }
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -146,8 +146,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.18-rc.1":
-        fail(f"{identity} must resolve the exact 0.1.18-rc.1 release")
+    if pin["state"].get("version") != "0.1.18-rc.2":
+        fail(f"{identity} must resolve the exact 0.1.18-rc.2 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -290,7 +290,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.18-rc.1"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.18-rc.2"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.18-rc.1",
+    "afmkit": "0.1.18-rc.2",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -62,13 +62,13 @@ cat > "$fake_public_git" <<'SH'
 #!/usr/bin/env bash
 arguments=" $* "
 for ref in \
-  refs/tags/0.1.18-rc.1 \
-  'refs/tags/0.1.18-rc.1^{}' \
-  refs/tags/v0.1.18-rc.1 \
-  'refs/tags/v0.1.18-rc.1^{}'; do
+  refs/tags/0.1.18-rc.2 \
+  'refs/tags/0.1.18-rc.2^{}' \
+  refs/tags/v0.1.18-rc.2 \
+  'refs/tags/v0.1.18-rc.2^{}'; do
   [[ "$arguments" == *" $ref "* ]] || exit 2
 done
-printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.18-rc.1^{}'
+printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.18-rc.2^{}'
 SH
 chmod 700 "$fake_public_git"
 if ! EXPECTED_AFMKIT_REVISION="$expected_afmkit_revision" \
@@ -88,7 +88,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.1'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.2'
   }
   probe_public_source() {
     return 1
@@ -112,14 +112,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.18-rc.1" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.18-rc.1"
+[[ "$release_version" == "0.1.18-rc.2" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.18-rc.2"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.1'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.2'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -138,7 +138,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.1'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.2'
   }
   probe_public_source() {
     return 0

--- a/docs/RC_MODEL_MATRIX_20260905.md
+++ b/docs/RC_MODEL_MATRIX_20260905.md
@@ -43,7 +43,50 @@ still exercise these feature combinations with MTP requested, but their target
 fallback is intentional compatibility coverage rather than a speculative speed
 measurement. Preserve separate focused greedy runs for actual on/off throughput.
 
-## Pre-package progress (September 5)
+## RC1 live qualification and corrective follow-up
+
+Installed candidate `v0.9.18-next.20260905.4f6d449` passed Foundation and MLX
+installation requests. Its build passed 332 XCTest cases (two skipped) and
+145 Swift Testing cases, with zero failures. These are not full model results.
+
+The first full Qwen Next MTP-off assertion run crashed in QSA decode when
+2,049 visible tokens contained only 512 complete blocks. AFMKit #104 fixes
+issue #103 by retaining the existing visible-mask path until the complete
+block count exceeds the selection budget; optimized selection resumes at
+2,052 tokens. Four focused tests passed, including real indexer evaluation
+at batch sizes one and two. Same-checkpoint full model requalification is
+required after rebuilding with this change.
+
+maclocal-api #256 fixes transport-loss cascades and preserves partial HTML
+and JSONL reports (issue #255; twelve fixtures passed). Outcomes after the
+RC1 server crash must not be counted as valid model failures, successes or
+unsupported-capability skips. PR #258 separately fixes buffered-stream TTFT
+measurement (issue #257; seven delayed-stream fixtures passed). Earlier
+assertion-suite TTFT passes do not establish measured first-token latency.
+
+RC2 preparation also incorporates AFMKit #102, which accepts indexed
+per-expert DeepSeek MTP layouts without changing the stacked native-v11
+checkpoint selected here. AFMKit `v0.1.18-rc.2` was published at
+`6a8c25ab948237e822547c576c13a95d926086b1` after full local release validation:
+all sixteen API baselines, root tests and sixteen exact-tag downstream
+consumers passed. The exact consumer pin advances to `0.1.18-rc.2`;
+installed-artifact identity and full matrix completion must still be verified
+independently, not inferred from this dependency update.
+
+Failed RC1 evidence remains in `matrix/next-off-rc1` under the external report
+root. Its comprehensive stage did not run inference because the client SDK
+was missing; a dedicated qualification environment is now provisioned.
+No completed comprehensive or Promptfoo result is claimed for that run.
+
+Follow-up on the paired corrected build: Qwen Next completed the assertion
+harness with 116 passes, zero failures and two skips. Separate MTP-off/on API
+canaries passed the former crash request, repeated-prefix reuse, a 4,016-token
+prompt and two concurrent requests. These are pre-package regression evidence,
+not clean throughput measurements (release compilation was still active).
+A one-case comprehensive pipeline preflight completed with Codex score 5/5;
+it verifies judge/report wiring only, not comprehensive model quality.
+
+## Historical pre-package progress (September 5)
 
 These are qualification probes, not completed full-suite RC results:
 

--- a/docs/afmkit-url-consumption.md
+++ b/docs/afmkit-url-consumption.md
@@ -6,7 +6,7 @@ one exact release and selects every provider product from it:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.18-rc.1"
+    exact: "0.1.18-rc.2"
 )
 ```
 
@@ -14,7 +14,7 @@ Do not use a branch or revision requirement for release builds.
 
 ## Production Blocker
 
-AFMKit is public and exposes `0.1.18-rc.1`. AFM release publication remains
+AFMKit is public and exposes `0.1.18-rc.2`. AFM release publication remains
 fail-closed unless AFMKit and every dependency in its root graph are
 anonymously readable and the tracked lock resolves that exact tag.
 
@@ -38,7 +38,7 @@ surface publishable.
 
 ## Dependency Resolution
 
-AFMKit 0.1.18-rc.1 is public, so normal resolution requires no GitHub credential:
+AFMKit 0.1.18-rc.2 is public, so normal resolution requires no GitHub credential:
 
 ```bash
 Scripts/resolve-release-dependencies.sh
@@ -55,7 +55,7 @@ The normal graph is independent of maclocal-api's dirty vendor worktrees:
 
 | Dependency | Requirement | Purpose |
 | --- | --- | --- |
-| `AFMKit` | exact `0.1.18-rc.1` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
+| `AFMKit` | exact `0.1.18-rc.2` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
 
 The MLX, mlx-c, Swift bindings, and mlx-swift-lm sources are snapshots inside
 AFMKit's `vendor/MLX` tree. They are not separate SwiftPM dependencies of

--- a/docs/vesta-integration.md
+++ b/docs/vesta-integration.md
@@ -11,7 +11,7 @@ Use the current exact public AFMKit release:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.18-rc.1"
+    exact: "0.1.18-rc.2"
 )
 ```
 


### PR DESCRIPTION
## Problem

The first installed RC1 full Qwen Next assertion run exposed an engine crash
at the sparse-block decode boundary. The provider fix and harness corrections
must be included in a new, exactly pinned staging candidate before continuing
the requested model matrix.

## Changes

- Pin published AFMKit `0.1.18-rc.2` at
  `6a8c25ab948237e822547c576c13a95d926086b1` in the manifest and lockfile.
- Keep the core-only example, release guards and release-tooling fixtures in
  agreement. No unrelated package revision changes.
- Document RC1's failed qualification separately from completed installation,
  unit-test and corrected paired-build probes.

Provider changes include AFMKit #104 (QSA visible-block boundary, issue #103)
and #102 (DeepSeek per-expert MTP metadata compatibility). Consumer main already
contains #256 (stop on transport loss, preserve reports) and #258 (live TTFT).

## Validation

- Provider full local release qualification passed: all 16 public API baselines,
  root tests and all 16 exact-tag downstream consumers; no Actions dependency.
- Independent read-only review verified the complete pin/docs diff and live
  annotated tag. No findings.
- Corrected paired Qwen Next: 116 assertion passes, zero failures, two skips.
  MTP-off/on API boundary canaries passed original-trigger, cached, longer-context
  and concurrent cases. These were not clean performance measurements.
- Codex one-case comprehensive preflight passed with per-test score and report.
- Immutable consumer XCTest: 332 cases, two skipped, zero failures. Swift Testing:
  145 cases, zero failures. Release-tooling and consumer boundary checks passed.
  Installed RC2 full model matrix remains pending.

No stable release promotion or blanket model qualification is claimed.

## Summary by Sourcery

Pin the project to AFMKit 0.1.18-rc.2 and align release validation and qualification documentation for continued model testing.

Bug Fixes:
- Advance the AFMKit dependency from RC1 to the qualified public 0.1.18-rc.2 release, incorporating provider fixes for sparse-block decode boundaries and DeepSeek MTP metadata compatibility.

Enhancements:
- Keep release manifests, lockfiles, consumer examples, eligibility checks, and integration guidance aligned with the exact RC2 dependency pin.
- Document RC1 qualification failures and distinguish corrected regression evidence from completed release and model qualification.

Documentation:
- Update release and AFMKit consumption documentation with the RC2 version and immutable revision details.

Tests:
- Update release-tooling and consumer-boundary fixtures to validate the exact RC2 release.