### PR TITLE
Fix Promptfoo CLI speculation and model ownership

### DIFF
--- a/Scripts/feature-promptfoo-agentic/README.md
+++ b/Scripts/feature-promptfoo-agentic/README.md
@@ -84,11 +84,13 @@ The configs expect these environment variables:
 Optional runner and CLI structured-output settings:
 
 - `AFM_MTP_MODEL`: optional existing local MTP-head directory, passed as one
-  quoted `--mtp-model` argument to every server profile. Requires `AFM_MTP=1`.
+  quoted `--mtp-model` argument to every server profile and CLI guided-json
+  invocation. Requires `AFM_MTP=1`.
   Use this to pin the exact cached Qwen 27B head during release qualification.
 - `AFM_DSPARK_SUPPORT`
   Existing support GGUF path for DwarfStar speculative server profiles. Passed
-  as one quoted `--dspark-support` argument; unset leaves speculation off.
+  as one quoted `--dspark-support` argument to servers and CLI guided-json
+  invocations; unset leaves speculation off.
   Native MLX profiles instead use `AFM_MTP=1`. Request features may still require
   target fallback, so requested flags alone do not prove active speculation.
 - `AFM_PROMPTFOO_LOAD_TIMEOUT_SECONDS`
@@ -163,6 +165,13 @@ AFM_PROMPTFOO_OUT_DIR=/your/custom/output/path \
 ```
 
 That wrapper:
+- runs each structured suite in separate API and CLI phases, stopping the
+  server before its single-prompt CLI cases load the model; each case executes
+  once, serially. Reports use `structured-{api,cli}-MODEL.json` and
+  `structured-stress-{api,cli}-MODEL.json`, both included in the summary.
+- forwards `AFM_MTP=1`, the optional MTP head, and DSpark support to CLI cases
+  as well as server profiles. Requested speculation can still fall back for
+  unsupported request features.
 - runs the structured core suite once against the default AFM profile
 - runs the structured stress suite once against the default AFM profile
 - runs the tool-calling core suite three times:

--- a/Scripts/feature-promptfoo-agentic/providers/afm_provider.mjs
+++ b/Scripts/feature-promptfoo-agentic/providers/afm_provider.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { statSync } from 'node:fs';
 
 function readEnv(name, fallback = undefined) {
   const value = process.env[name];
@@ -171,6 +172,25 @@ export default class AfmPromptfooProvider {
 
       if (this.config.noThink || readEnv('AFM_NO_THINK') === '1') {
         args.push('--no-think');
+      }
+
+      // Match the runner's server profiles. Argument arrays preserve local
+      // checkpoint paths without interpreting them as shell commands.
+      const mtp = readEnv('AFM_MTP', '0');
+      const mtpModel = readEnv('AFM_MTP_MODEL');
+      const dsparkSupport = readEnv('AFM_DSPARK_SUPPORT');
+      if (mtpModel && (mtp !== '1' || !statSync(mtpModel).isDirectory())) {
+        throw new Error('AFM_MTP_MODEL requires AFM_MTP=1 and an existing local model directory');
+      }
+      if (mtp === '1') {
+        args.push('--mtp');
+        if (mtpModel) args.push('--mtp-model', mtpModel);
+      }
+      if (dsparkSupport) {
+        if (!statSync(dsparkSupport).isFile()) {
+          throw new Error('AFM_DSPARK_SUPPORT must name an existing support GGUF file');
+        }
+        args.push('--dspark-support', dsparkSupport);
       }
 
       const env = { ...process.env };

--- a/Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh
+++ b/Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh
@@ -175,36 +175,50 @@ start_server() {
   fi
 }
 
-run_structured() {
-  local output="${out_dir}/structured-$(print -r -- "$model" | tr '/:' '__').json"
+run_structured_suite() {
+  local suite="$1"
+  local output_prefix="${out_dir}/${suite}"
+  local model_slug="$(print -r -- "$model" | tr '/:' '__')"
+  # The two datasets label their single-prompt cases with this prefix.
+  # Complementary filters execute each case exactly once, without keeping a
+  # server's model resident while the CLI loads its own copy.
+  local cli_pattern='^(?:stress/)?cli guided-json '
+  local api_pattern='^(?!(?:stress/)?cli guided-json )'
   start_server default
   AFM_MODEL="$model" \
   AFM_BASE_URL_DEFAULT="http://127.0.0.1:${port}/v1" \
   AFM_BINARY="$afm_binary" \
   MACAFM_MLX_MODEL_CACHE="${MACAFM_MLX_MODEL_CACHE:-}" \
     promptfoo eval \
-      -c Scripts/feature-promptfoo-agentic/promptfooconfig.structured.yaml \
+      -c "Scripts/feature-promptfoo-agentic/promptfooconfig.${suite}.yaml" \
       -j 1 \
-      -o "$output"
+      --filter-pattern "$api_pattern" \
+      -o "${output_prefix}-api-${model_slug}.json"
   local exit_code=$?
+  (( overall_status |= exit_code ))
+
+  cleanup
+  wait_for_port_free || exit 1
+  AFM_MODEL="$model" \
+  AFM_BASE_URL_DEFAULT="http://127.0.0.1:${port}/v1" \
+  AFM_BINARY="$afm_binary" \
+  MACAFM_MLX_MODEL_CACHE="${MACAFM_MLX_MODEL_CACHE:-}" \
+    promptfoo eval \
+      -c "Scripts/feature-promptfoo-agentic/promptfooconfig.${suite}.yaml" \
+      -j 1 \
+      --filter-pattern "$cli_pattern" \
+      -o "${output_prefix}-cli-${model_slug}.json"
+  exit_code=$?
   (( overall_status |= exit_code ))
   return $exit_code
 }
 
+run_structured() {
+  run_structured_suite structured
+}
+
 run_structured_stress() {
-  local output="${out_dir}/structured-stress-$(print -r -- "$model" | tr '/:' '__').json"
-  start_server default
-  AFM_MODEL="$model" \
-  AFM_BASE_URL_DEFAULT="http://127.0.0.1:${port}/v1" \
-  AFM_BINARY="$afm_binary" \
-  MACAFM_MLX_MODEL_CACHE="${MACAFM_MLX_MODEL_CACHE:-}" \
-    promptfoo eval \
-      -c Scripts/feature-promptfoo-agentic/promptfooconfig.structured-stress.yaml \
-      -j 1 \
-      -o "$output"
-  local exit_code=$?
-  (( overall_status |= exit_code ))
-  return $exit_code
+  run_structured_suite structured-stress
 }
 
 run_toolcall_profile() {

--- a/Scripts/tests/test_promptfoo_cli_phases.py
+++ b/Scripts/tests/test_promptfoo_cli_phases.py
@@ -1,0 +1,151 @@
+"""Exercise the real runner/provider with CPU-only fake AFM and Promptfoo CLIs."""
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FAKE_AFM = r'''#!/usr/bin/env python3
+import json, os, signal, sys
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+marker = Path(os.environ['FIXTURE_SERVER_MARKER'])
+args = sys.argv[1:]
+if '--port' not in args:
+    assert not marker.exists(), 'CLI and server must not own models simultaneously'
+    print(json.dumps({'argv': args}))
+    sys.exit(0)
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_): pass
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'{}')
+server = HTTPServer(('127.0.0.1', int(args[args.index('--port') + 1])), Handler)
+marker.write_text(json.dumps(args))
+def stopped(*_): raise SystemExit(0)
+signal.signal(signal.SIGTERM, stopped)
+try: server.serve_forever()
+finally:
+    marker.unlink(missing_ok=True)
+    server.server_close()
+'''
+FAKE_PROMPTFOO = r'''#!/usr/bin/env python3
+import json, os, re, subprocess, sys
+from pathlib import Path
+args = sys.argv[1:]
+config = Path(args[args.index('-c') + 1])
+dataset = config.parent / ('datasets/quality/structured-stress.yaml'
+                          if 'stress' in config.name else 'datasets/structured-core.yaml')
+pattern = args[args.index('--filter-pattern') + 1]
+cases = re.split(r'(?=^- description:)', dataset.read_text(), flags=re.MULTILINE)
+selected = []
+for case in cases:
+    match = re.match(r'- description: "(.*)"', case)
+    if not match or not re.search(pattern, match[1]): continue
+    cli = 'transport: cli-guided-json' in case
+    marker = Path(os.environ['FIXTURE_SERVER_MARKER'])
+    assert marker.exists() != cli, 'phase does not match actual case provider'
+    assert args[args.index('-j') + 1] == '1'
+    if cli:
+        result = subprocess.run(['node', os.environ['FIXTURE_PROVIDER_SCRIPT']],
+                                text=True, capture_output=True, check=True)
+        invocation = json.loads(result.stdout)
+    else:
+        invocation = json.loads(marker.read_text())
+    selected.append({'testCase': {'description': match[1]}, 'success': True,
+                     'response': {'metadata': {'args': invocation}}})
+assert selected, 'each structured phase must select cases'
+output = Path(args[args.index('-o') + 1])
+output.write_text(json.dumps({'results': {'stats': {'successes': len(selected),
+                                                  'failures': 0, 'errors': 0},
+                                        'results': selected}}))
+if os.environ.get('FIXTURE_FAIL_API') == '1' and 'cli' not in output.name:
+    sys.exit(1)
+'''
+
+
+class PromptfooCLIPhasesTests(unittest.TestCase):
+    def run_fixture(self, suite, mode, fail_api=False):
+        parent = ROOT / '.build' / 'promptfoo-cli-fixtures'
+        parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=parent) as directory:
+            work = Path(directory)
+            fake_bin = work / 'bin'
+            fake_bin.mkdir()
+            for name, content in [('afm', FAKE_AFM), ('promptfoo', FAKE_PROMPTFOO)]:
+                executable = fake_bin / name
+                executable.write_text(content)
+                executable.chmod(0o755)
+            provider_script = work / 'invoke-provider.mjs'
+            provider = ROOT / 'Scripts/feature-promptfoo-agentic/providers/afm_provider.mjs'
+            provider_script.write_text(
+                f'import Provider from {json.dumps(provider.as_uri())};\n'
+                'const result = await new Provider({config: {transport: "cli-guided-json"}})'
+                '.callApi("fixture", {vars: {schema: {type: "object"}}});\n'
+                'process.stdout.write(JSON.stringify(JSON.parse(result.output).argv));\n')
+            head = work / 'mtp head $(no-shell)'
+            head.mkdir()
+            support = work / 'support checkpoint $(no-shell).gguf'
+            support.touch()
+            env = {key: value for key, value in os.environ.items()
+                   if not key.startswith('AFM_')}
+            with socket.socket() as probe:
+                probe.bind(('127.0.0.1', 0))
+                port = probe.getsockname()[1]
+            env.update(PATH=str(fake_bin) + os.pathsep + os.environ['PATH'],
+                       AFM_BINARY=str(fake_bin / 'afm'), AFM_MODEL='fixture/model',
+                       AFM_NO_THINK='1', AFM_PROMPTFOO_PORT=str(port),
+                       AFM_PROMPTFOO_OUT_DIR=str(work / 'reports'),
+                       AFM_PROMPTFOO_LOAD_TIMEOUT_SECONDS='10',
+                       FIXTURE_SERVER_MARKER=str(work / 'server-alive'),
+                       FIXTURE_PROVIDER_SCRIPT=str(provider_script),
+                       FIXTURE_FAIL_API='1' if fail_api else '0')
+            if mode == 'mtp': env.update(AFM_MTP='1', AFM_MTP_MODEL=str(head))
+            if mode == 'dspark': env.update(AFM_DSPARK_SUPPORT=str(support))
+            if mode == 'invalid-head': env.update(AFM_MTP_MODEL=str(head))
+            result = subprocess.run(
+                ['zsh', str(ROOT / 'Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh'), suite],
+                env=env, text=True, capture_output=True, timeout=30)
+            if mode == 'invalid-head':
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn('requires AFM_MTP=1', result.stderr)
+                return
+            self.assertEqual(result.returncode, 1 if fail_api else 0,
+                             result.stdout + result.stderr)
+            reports = work / 'reports'
+            api = json.loads((reports / f'{suite}-api-fixture_model.json').read_text())
+            cli = json.loads((reports / f'{suite}-cli-fixture_model.json').read_text())
+            rows = api['results']['results'] + cli['results']['results']
+            self.assertEqual(len(rows), 4 if suite.endswith('stress') else 6)
+            self.assertEqual(len({row['testCase']['description'] for row in rows}), len(rows))
+            for row in rows:
+                args = row['response']['metadata']['args']
+                self.assertEqual(args.count('--no-think'), 1)
+                self.assertEqual(args.count('--mtp'), int(mode == 'mtp'))
+                self.assertEqual(args.count('--dspark-support'), int(mode == 'dspark'))
+                if mode == 'mtp': self.assertEqual(args[args.index('--mtp-model') + 1], str(head))
+                if mode == 'dspark': self.assertEqual(args[args.index('--dspark-support') + 1], str(support))
+            summary = json.loads((reports / 'promptfoo-summary-fixture_model.json').read_text())
+            category = summary['categories']['nativeProtocolConformance']
+            self.assertEqual(category['cases'], len(rows))
+            self.assertEqual(category['fileCount'], 2)
+            self.assertFalse((work / 'server-alive').exists())
+
+    def test_both_suites_preserve_modes_and_exclusive_model_ownership(self):
+        for suite in ['structured', 'structured-stress']:
+            for mode in ['off', 'mtp', 'dspark']:
+                with self.subTest(suite=suite, mode=mode): self.run_fixture(suite, mode)
+
+    def test_cli_runs_after_api_failure_and_failure_status_is_retained(self):
+        self.run_fixture('structured', 'mtp', fail_api=True)
+
+    def test_invalid_head_is_rejected_before_starting_server(self):
+        self.run_fixture('structured', 'invalid-head')
+
+
+if __name__ == '__main__': unittest.main()


### PR DESCRIPTION
Structured Promptfoo runs kept the API server's model resident while direct CLI cases loaded a second copy. Those CLI cases also omitted the MTP/head/DSpark flags requested for server profiles. Run complementary API and CLI phases serially, stopping the server before CLI execution, and forward the same explicit runtime flags through argument arrays.

Each existing case executes once. Separate `structured-{api,cli}` and `structured-stress-{api,cli}` JSON reports retain both phases in the existing native-conformance summary. API failures remain failures even when the later CLI phase succeeds. Requested speculation may still fall back for unsupported features.

Validation: CPU fixtures exercise both suites with off, native MTP plus explicit head, and DSpark settings; invoke the real provider with a fake AFM executable; reject simultaneous model ownership; verify paths with spaces/shell characters, exact case/summary totals, failure propagation, and invalid-head rejection. Existing runner-argument and categorized-summary regressions, shell/JavaScript syntax, and `git diff --check` passed. No builds or GPU workloads; the in-flight qualification worktree was untouched.

Closes #261.

## Summary by Sourcery

Separate structured Promptfoo API and CLI execution so each case runs once with consistent runtime settings and reliable failure reporting.

Bug Fixes:
- Ensure structured Promptfoo API and CLI cases run in separate phases without simultaneous model ownership.
- Preserve API failures when the subsequent CLI phase succeeds.
- Forward MTP, optional MTP-head, and DSpark runtime settings to CLI guided-json invocations.

Enhancements:
- Generate separate API and CLI reports while retaining both phases in native-protocol summary totals.
- Validate runtime model and support paths before execution and preserve paths safely when invoking the CLI.

Documentation:
- Document CLI propagation of speculation settings and the serial API/CLI structured-suite execution model.

Tests:
- Add CPU-only integration coverage for both structured suites, runtime modes, exclusive model ownership, path handling, failure propagation, report totals, and invalid MTP-head validation.