### PR TITLE
Fix batch failure attribution and preserve raw evidence

### DIFF
--- a/Scripts/feature-mlx-concurrent-batch/batch_validation_report.py
+++ b/Scripts/feature-mlx-concurrent-batch/batch_validation_report.py
@@ -1,0 +1,22 @@
+"""Opt-in snapshots of batch validation evidence, outside the request path."""
+import json
+import os
+from pathlib import Path
+import uuid
+
+
+class BatchReport:
+    def __init__(self, suite, model, endpoint):
+        root = os.environ.get('AFM_REPORT_DIR')
+        self.path = Path(root) / f'{suite}-{uuid.uuid4().hex}.json' if root else None
+        self.metadata = dict(suite=suite, model=model, endpoint=endpoint,
+                             failure_attribution='unattributed')
+
+    def save(self, batches):
+        if self.path is None:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_suffix('.partial')
+        temporary.write_text(json.dumps(dict(self.metadata, batches=batches), indent=2))
+        temporary.replace(self.path)
+        print(f'  Raw evidence: {self.path}')

--- a/Scripts/feature-mlx-concurrent-batch/validate_mixed_workload.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_mixed_workload.py
@@ -3,6 +3,7 @@
 
 Reports pp (prompt processing), tg (token generation), TTFT, total tokens,
 and GPU metrics via mactop. Designed for A/B comparison between code versions.
+Set AFM_REPORT_DIR to retain JSON evidence after each completed batch size.
 
 Usage:
     python3 validate_mixed_workload.py              # test B=1,2,4,8
@@ -10,6 +11,7 @@ Usage:
     python3 validate_mixed_workload.py --label "overlap-v2" 1 2 4 8
 """
 import asyncio, aiohttp, json, time, sys, subprocess, threading, os
+from batch_validation_report import BatchReport
 
 URL = os.environ.get("AFM_CHAT_COMPLETIONS_URL", "http://localhost:9999/v1/chat/completions")
 MODEL = os.environ.get("AFM_MODEL", "mlx-community/Qwen3.5-35B-A3B-4bit")
@@ -227,6 +229,7 @@ async def send_request(session, prompt, max_tokens=4096):
     start = time.monotonic()
 
     async with session.post(URL, json=payload) as resp:
+        resp.raise_for_status()
         async for line in resp.content:
             line = line.decode().strip()
             if not line.startswith("data: "):
@@ -361,6 +364,8 @@ async def main():
     total_passed = 0
     total_failed = 0
     all_batch_results = {}
+    report = BatchReport('batch-mixed', MODEL, URL)
+    report_batches = {}
 
     for bs in batch_sizes:
         print(f"\n{'='*100}")
@@ -429,6 +434,9 @@ async def main():
             "passed": p, "failed": f, "results": completed_results,
             "gpu": gpu_stats, "workload_wall_s": workload_wall,
         }
+        # Keep exceptions and failed output checks, not just metric-bearing rows.
+        report_batches[bs] = dict(all_batch_results[bs], results=results)
+        report.save(report_batches)
         await asyncio.sleep(1)
 
     # ─── Final summary table ──────────────────────────────────────────────
@@ -476,8 +484,7 @@ async def main():
 
     print(f"{'='*120}")
     print(f"  TOTAL: {total_passed}/{total_passed+total_failed} passed across {len(batch_sizes)} batch sizes")
-    if total_failed > 0:
-        print(f"  ({total_failed} failures: model answer mismatches, not code bugs)")
+    print_failure_summary(total_failed)
     print(f"{'='*120}")
 
     acceptance_failed = False
@@ -519,4 +526,11 @@ async def main():
     return 1 if total_failed else 0
 
 
-raise SystemExit(asyncio.run(main()))
+def print_failure_summary(failed):
+    if failed:
+        print(f"  ({failed} failed checks; cause remains unattributed. "
+              "Review request errors and output checks before assigning ownership.)")
+
+
+if __name__ == '__main__':
+    raise SystemExit(asyncio.run(main()))

--- a/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
@@ -5,7 +5,9 @@ Simulates realistic agent/chatbot usage:
   - Shared long system prompts across turns (prefix cache hits)
   - Multi-turn conversations (growing context)
   - Concurrent users with different system prompts
-  - Measures cached_tokens, pp, tg, TTFT
+- Measures cached_tokens, pp, tg, TTFT
+
+Set AFM_REPORT_DIR to retain JSON evidence after each completed batch size.
 
 Usage:
     python3 validate_multiturn_prefix.py              # test B=1,2,4,8
@@ -13,6 +15,7 @@ Usage:
     python3 validate_multiturn_prefix.py --label "overlap+prefix" 1 2 4 8
 """
 import asyncio, aiohttp, json, time, sys, os
+from batch_validation_report import BatchReport
 
 URL = os.environ.get("AFM_CHAT_COMPLETIONS_URL", "http://localhost:9999/v1/chat/completions")
 MODEL = os.environ.get("AFM_MODEL", "mlx-community/Qwen3.5-35B-A3B-4bit")
@@ -318,6 +321,7 @@ async def run_conversation(session, conv):
         r["turn"] = i + 1
         r["name"] = f"{conv['name']}/t{i+1}"
         r["ok"] = check["ok"]
+        r["is_garbage"] = check["is_garbage"]
         r["missing"] = check["missing"]
         r["min_tokens"] = turn.get("min_tokens", 0)
 
@@ -345,6 +349,8 @@ async def run_batch(batch_size, conversations):
                 if isinstance(outcome, Exception):
                     failed += len(conv["turns"])
                     print(f"  FAIL  {conv['name']}: exception {outcome}")
+                    all_results.append(dict(name=conv['name'], status='EXCEPTION',
+                                            error=repr(outcome), affected_turns=len(conv['turns'])))
                     continue
 
                 for r in outcome:
@@ -364,7 +370,9 @@ async def run_batch(batch_size, conversations):
                             failed += 1
                             passed -= 1
                             print(f"  FAIL  {r['name']:30s}  TOO SHORT ({ct} tok)")
+                            r['status'] = 'TOO_SHORT'
                         else:
+                            r['status'] = 'OK'
                             print(f"  OK    {r['name']:30s}  "
                                   f"pp={pt:5d} ({cached:4d} cached {cache_pct:4.0f}%) {pp:7.1f} t/s  "
                                   f"tg={ct:4d} tok {tg:6.1f} t/s  "
@@ -372,8 +380,10 @@ async def run_batch(batch_size, conversations):
                     else:
                         failed += 1
                         if r.get("is_garbage"):
+                            r['status'] = 'GARBAGE'
                             print(f"  FAIL  {r['name']:30s}  GARBAGE")
                         else:
+                            r['status'] = 'MISSING'
                             print(f"  FAIL  {r['name']:30s}  missing {r['missing']}")
 
     return passed, failed, all_results
@@ -393,6 +403,8 @@ async def main():
     total_passed = 0
     total_failed = 0
     all_batch_summaries = {}
+    report = BatchReport('batch-prefix', MODEL, URL)
+    report_batches = {}
 
     # Warm up: first request primes the prefix cache
     print("Warming up prefix cache...")
@@ -467,6 +479,8 @@ async def main():
         print(f"{'='*120}")
 
         all_batch_summaries[bs] = {"passed": p, "failed": f, "results": ok if ok else []}
+        report_batches[bs] = dict(passed=p, failed=f, results=results)
+        report.save(report_batches)
         await asyncio.sleep(1)
 
     # ─── Summary table ────────────────────────────────────────────────────
@@ -513,4 +527,5 @@ async def main():
     return 1 if total_failed else 0
 
 
-raise SystemExit(asyncio.run(main()))
+if __name__ == '__main__':
+    raise SystemExit(asyncio.run(main()))

--- a/Scripts/feature-mlx-concurrent-batch/validate_responses.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_responses.py
@@ -12,8 +12,11 @@ Usage:
 Prerequisites:
     pip install aiohttp
     Server running on port 9999
+
+Set AFM_REPORT_DIR to retain JSON evidence after each completed batch size.
 """
 import asyncio, aiohttp, json, time, sys, re, os, unicodedata
+from batch_validation_report import BatchReport
 
 URL = os.environ.get("AFM_CHAT_COMPLETIONS_URL", "http://localhost:9999/v1/chat/completions")
 MODEL = os.environ.get("AFM_MODEL", "mlx-community/Qwen3.5-35B-A3B-4bit")
@@ -77,6 +80,7 @@ async def send_request(session, prompt, max_tokens=200):
     start = time.monotonic()
 
     async with session.post(URL, json=payload) as resp:
+        resp.raise_for_status()
         async for line in resp.content:
             line = line.decode().strip()
             if not line.startswith("data: "):
@@ -106,7 +110,7 @@ def check_response(text, expected_substrings):
     return False, None
 
 
-async def run_validation(batch_size):
+async def run_validation(batch_size, records=None):
     """Run all validations at the given concurrency level."""
     print(f"\n{'='*70}")
     print(f"  Validating B={batch_size}")
@@ -115,6 +119,7 @@ async def run_validation(batch_size):
     passed = 0
     failed = 0
     errors = []
+    records = [] if records is None else records
 
     async with aiohttp.ClientSession() as session:
         # Send batch_size requests concurrently, cycling through validations
@@ -128,12 +133,17 @@ async def run_validation(batch_size):
                     failed += 1
                     errors.append((desc, f"EXCEPTION: {result}"))
                     print(f"  FAIL  {desc}: exception {result}")
+                    records.append(dict(name=desc, prompt=prompt, expected=expected,
+                                        status='EXCEPTION', error=repr(result)))
                     continue
 
                 text, elapsed = result
                 ok, matched = check_response(text, expected)
                 # Also check for obvious garbage
                 is_garbage = not text.strip() or text.count('\ufffd') > 5
+                records.append(dict(name=desc, prompt=prompt, expected=expected,
+                                    text=text, wall_s=elapsed, matched=matched,
+                                    status='GARBAGE' if is_garbage else ('OK' if ok else 'MISSING')))
 
                 if is_garbage:
                     failed += 1
@@ -166,9 +176,14 @@ async def main():
 
     total_passed = 0
     total_failed = 0
+    report = BatchReport('batch-known-answers', MODEL, URL)
+    report_batches = {}
 
     for bs in batch_sizes:
-        p, f = await run_validation(bs)
+        records = []
+        p, f = await run_validation(bs, records)
+        report_batches[bs] = dict(passed=p, failed=f, results=records)
+        report.save(report_batches)
         total_passed += p
         total_failed += f
         await asyncio.sleep(0.5)
@@ -183,4 +198,5 @@ async def main():
 
     return 1 if total_failed else 0
 
-raise SystemExit(asyncio.run(main()))
+if __name__ == '__main__':
+    raise SystemExit(asyncio.run(main()))

--- a/Scripts/tests/test_batch_failure_reporting.py
+++ b/Scripts/tests/test_batch_failure_reporting.py
@@ -1,0 +1,169 @@
+"""CPU-only checks for batch failure diagnostics; no server or GPU required."""
+import contextlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+import sys
+import tempfile
+from unittest.mock import AsyncMock, patch
+
+
+ROOT = Path(__file__).resolve().parents[1] / 'feature-mlx-concurrent-batch'
+sys.path.insert(0, str(ROOT))
+from batch_validation_report import BatchReport
+
+
+def load(name):
+    spec = importlib.util.spec_from_file_location(name, ROOT / f'{name}.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mixed = load('validate_mixed_workload')
+responses = load('validate_responses')
+prefix = load('validate_multiturn_prefix')
+
+
+class AsyncContext:
+    def __init__(self, value): self.value = value
+    async def __aenter__(self): return self.value
+    async def __aexit__(self, *_): return False
+
+
+def response(text):
+    return dict(text=text, completion_tokens=10, prompt_tokens=10, cached_tokens=0,
+                pp_tok_s=10, tg_tok_s=10, ttft=0.1, wall_s=1)
+
+
+class FailureReportingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_http_errors_surface_before_output_judgment(self):
+        class HTTPErrorResponse:
+            def raise_for_status(self): raise RuntimeError('HTTP 503 unavailable')
+            @property
+            def content(self): raise AssertionError('HTTP error must not become empty output')
+        session = SimpleNamespace(post=lambda *_args, **_kwargs: AsyncContext(HTTPErrorResponse()))
+        for module in [responses, mixed, prefix]:
+            with self.subTest(module=module.__name__):
+                with self.assertRaisesRegex(RuntimeError, 'HTTP 503'):
+                    await module.send_request(session, 'fixture')
+
+    async def test_mixed_failures_retain_distinct_evidence_without_blame(self):
+        tests = [dict(name=name, prompt='fixture', expected=['needle'], min_tokens=min_tokens)
+                 for name, min_tokens in [('timeout', 0), ('garbage', 0), ('short', 20),
+                                          ('missing', 0), ('success', 0)]]
+        outcomes = [TimeoutError('fixture timeout'), response(''), response('ok'),
+                    response('other answer'), response('needle')]
+        output = io.StringIO()
+        with patch.object(mixed.aiohttp, 'ClientSession', return_value=AsyncContext(object())), \
+             patch.object(mixed, 'send_request', AsyncMock(side_effect=outcomes)), \
+             contextlib.redirect_stdout(output):
+            passed, failed, rows, _ = await mixed.run_batch(5, tests)
+            mixed.print_failure_summary(failed)
+        self.assertEqual((passed, failed), (1, 4))
+        self.assertEqual([row['status'] for row in rows],
+                         ['EXCEPTION', 'GARBAGE', 'TOO_SHORT', 'MISSING', 'OK'])
+        self.assertIn('fixture timeout', rows[0]['error'])
+        self.assertIn('4 failed checks; cause remains unattributed', output.getvalue())
+        self.assertNotIn('not code bugs', output.getvalue())
+        self.assertNotIn('model answer mismatches', output.getvalue())
+
+    async def test_multiturn_garbage_is_not_reported_as_missing_empty_list(self):
+        conversation = dict(name='fixture', system='system',
+                            turns=[dict(user='hi', expected=[])])
+        output = io.StringIO()
+        with patch.object(prefix.aiohttp, 'ClientSession', return_value=AsyncContext(object())), \
+             patch.object(prefix, 'send_request', AsyncMock(return_value=response(''))), \
+             contextlib.redirect_stdout(output):
+            passed, failed, rows = await prefix.run_batch(1, [conversation])
+        self.assertEqual((passed, failed), (0, 1))
+        self.assertTrue(rows[0]['is_garbage'])
+        self.assertIn('GARBAGE', output.getvalue())
+        self.assertNotIn('missing []', output.getvalue())
+
+    async def test_legitimate_missing_answer_keeps_specific_diagnostic(self):
+        conversation = dict(name='fixture', system='system',
+                            turns=[dict(user='hi', expected=['needle'])])
+        output = io.StringIO()
+        with patch.object(prefix.aiohttp, 'ClientSession', return_value=AsyncContext(object())), \
+             patch.object(prefix, 'send_request', AsyncMock(return_value=response('other'))), \
+             contextlib.redirect_stdout(output):
+            passed, failed, rows = await prefix.run_batch(1, [conversation])
+        self.assertEqual((passed, failed), (0, 1))
+        self.assertFalse(rows[0]['is_garbage'])
+        self.assertIn("missing ['needle']", output.getvalue())
+
+    def test_success_summary_does_not_emit_failure_warning(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output): mixed.print_failure_summary(0)
+        self.assertEqual(output.getvalue(), '')
+
+    def test_raw_report_opt_in_preserves_full_text_errors_and_metrics(self):
+        parent = ROOT.parents[1] / '.build' / 'batch-report-fixtures'
+        parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=parent) as directory:
+            with patch.dict(os.environ, {'AFM_REPORT_DIR': directory}):
+                report = BatchReport('fixture', 'model', 'endpoint')
+                records = [dict(response('full output ' * 100), status='MISSING'),
+                           dict(status='EXCEPTION', error='TimeoutError()')]
+                batches = {1: dict(passed=0, failed=2, results=records)}
+                with contextlib.redirect_stdout(io.StringIO()):
+                    report.save(batches)
+                    batches[2] = dict(passed=1, failed=0, results=[response('answer')])
+                    report.save(batches)
+                saved = json.loads(report.path.read_text())
+                self.assertEqual(saved['batches']['1']['results'], records)
+                self.assertEqual(saved['batches']['2']['results'][0]['text'], 'answer')
+                self.assertEqual(len(list(Path(directory).glob('*.json'))), 1)
+                self.assertFalse(list(Path(directory).glob('*.partial')))
+                self.assertNotEqual(BatchReport('fixture', 'model', 'endpoint').path, report.path)
+
+    def test_unset_report_directory_keeps_console_only_behavior(self):
+        with patch.dict(os.environ):
+            os.environ.pop('AFM_REPORT_DIR', None)
+            report = BatchReport('fixture', 'model', 'endpoint')
+            self.assertIsNone(report.path)
+            report.save({'unserializable': object()})  # No serialization/file writes.
+
+    async def test_each_validator_main_saves_exception_records(self):
+        parent = ROOT.parents[1] / '.build' / 'batch-report-fixtures'
+        parent.mkdir(parents=True, exist_ok=True)
+        error = dict(name='fixture', status='EXCEPTION', error='HTTP 503 unavailable')
+
+        async def known_batch(_size, records):
+            records.append(error)
+            return 0, 1
+
+        with tempfile.TemporaryDirectory(dir=parent) as directory:
+            for module, function, result in [
+                (responses, 'run_validation', None),
+                (mixed, 'run_batch', (0, 1, [error], 1)),
+                (prefix, 'run_batch', (0, 1, [error])),
+            ]:
+                with self.subTest(module=module.__name__), \
+                     patch.dict(os.environ, {'AFM_REPORT_DIR': directory}), \
+                     patch.object(sys, 'argv', ['fixture', '1']), \
+                     patch.object(module.aiohttp, 'ClientSession', return_value=AsyncContext(object())), \
+                     patch.object(module, 'send_request', AsyncMock(return_value=response('warmup'))), \
+                     patch.object(module.asyncio, 'sleep', AsyncMock()), \
+                     contextlib.redirect_stdout(io.StringIO()), \
+                     contextlib.ExitStack() as stack:
+                    if module is mixed:
+                        sampler = stack.enter_context(patch.object(mixed, 'MactopSampler'))
+                        sampler.return_value.summary.return_value = None
+                        stack.enter_context(patch.object(mixed, 'ASSERT_ACCEPTANCE', False))
+                    operation = AsyncMock(side_effect=known_batch) if module is responses else AsyncMock(return_value=result)
+                    stack.enter_context(patch.object(module, function, operation))
+                    self.assertEqual(await module.main(), 1)
+            reports = list(Path(directory).glob('*.json'))
+            self.assertEqual(len(reports), 3)
+            for path in reports:
+                saved = json.loads(path.read_text())
+                self.assertEqual(saved['batches']['1']['results'], [error])
+
+
+if __name__ == '__main__': unittest.main()


### PR DESCRIPTION
Mixed-batch summaries attributed every failure to model answers even when requests timed out or returned garbage. Leave causes unattributed, surface HTTP errors before output judgment, and preserve the multi-turn garbage flag so its diagnostic does not become `missing []`.

When `AFM_REPORT_DIR` is set, all three validators save unique JSON evidence files after each completed batch size, atomically retaining prior batches plus available full text, errors, statuses, and metrics. Failed records are preserved alongside successful ones. Without the environment variable, output remains console-only. Request content, concurrency, timing thresholds, and performance calculations are unchanged.

Validation: eight CPU-only tests passed using the qualification environment, covering HTTP errors across all validators; timeout/garbage/short/missing outcomes; multi-turn diagnostics; opt-in/default reporting; full text and metrics; and all three main report paths. `git diff --check` passed. No server, GPU workload, or mactop process was launched; the active qualification worktree was untouched.

Closes #263.

## Summary by Sourcery

Improve batch validation diagnostics and preserve opt-in raw evidence across completed batch sizes.

New Features:
- Add opt-in JSON evidence snapshots for all batch validators, retaining completed batches and full validation records.

Bug Fixes:
- Preserve accurate failure diagnostics by surfacing HTTP errors before output checks, retaining failed records, and distinguishing garbage responses from missing answers.
- Avoid attributing mixed-batch failures to model responses when the underlying cause is unknown.

Enhancements:
- Preserve multi-turn garbage indicators and structured statuses in validation results.
- Make validator modules import-safe by guarding command-line execution.

Documentation:
- Document the AFM_REPORT_DIR option for retaining batch validation evidence.

Tests:
- Add CPU-only coverage for HTTP errors, failure classifications, multi-turn diagnostics, and opt-in report persistence.