### PR TITLE
Fix AI judge scoring for expected empty response contracts

### DIFF
--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -1697,6 +1697,39 @@ fi  # end of: if [ -z "$REANALYSE_FILE" ]
 
 if $SMART_ANALYSIS; then
   SMART_TIMESTAMP="$(date -u +%Y%m%d_%H%M%S)"
+  # Shared by batch, per-test, and the AFM judge fallback. Intent takes
+  # precedence over generic text-quality heuristics in every judge mode.
+  JUDGE_RESPONSE_RULES="$(cat <<'JUDGE_RESPONSE_RULES_END'
+RESPONSE CONTRACT PRECEDENCE (applies before generic scoring heuristics):
+- status=FAIL remains score 1; an expected output shape never overrides a failed assertion.
+- Resolve the applicable intent first. For is_baseline=true, ignore the enclosing
+  variant's TEST SPEC/expectations and judge only the result's own prompt.
+- Inspect content, content_preview, reasoning_content, tool_calls, finish_reason,
+  and available executable expectations/assertion results together, not text alone.
+- EXPECTED TOOL-ONLY RESPONSE: When the applicable intent calls for a tool, valid
+  tool_calls with the expected function names/arguments and finish_reason="tool_calls"
+  are the response. Empty content/reasoning_content is normal and carries no automatic
+  penalty or score-3 cap. Judge the actual tool contract; malformed, missing, wrong,
+  or unexpected calls are not exempt and are not automatically successful.
+- EXPECTED IMMEDIATE STOP: When the applicable test explicitly asserts empty output
+  (for example content_equals="") with finish_reason="stop", evaluate that contract.
+  A matching empty response carries no automatic penalty or score-3 cap. An ordinary
+  finish_reason="stop" alone does not establish that empty output was expected.
+- Explicit applicable output contracts take precedence over generic formatting rules,
+  including tests that intentionally stop inside JSON and expect truncated invalid JSON.
+- UNEXPECTED EMPTY OUTPUT: If there is no visible text, reasoning, or valid expected
+  tool response and the test does not explicitly expect emptiness, report the unmet
+  expectation or insufficient evidence. status=OK or completion_tokens>0 alone proves
+  neither successful behavior nor a harness capture bug. Do not automatically score 3;
+  score against the available intent/evidence and state unknown quality when appropriate.
+  Keep the cause unattributed unless evidence establishes a model, engine, or harness fault.
+- REASONING-ONLY OUTPUT: If the intended final answer is absent but reasoning_content
+  is present near the token limit, note possible budget exhaustion and assess the unmet
+  final-answer contract (typically 2-3). Token counts alone do not prove why it occurred
+  or that the engine/model was functioning correctly. Expected tool-only/stop outcomes
+  above take precedence over this heuristic.
+JUDGE_RESPONSE_RULES_END
+)"
   ANALYSIS_PROMPT="$(cat <<'ANALYSIS_PROMPT_END'
 You are a QA engineer for AFM (Apple Foundation Models), an OpenAI-compatible local
 inference server for Apple Silicon. Your job is to review automated test results from
@@ -1745,7 +1778,11 @@ Produce a concise markdown report covering:
    with specific reasons. Separate into:
    - "Likely AFM bug" (model works elsewhere, fails here)
    - "Model quality issue" (model itself is poor)
+   - "Unattributed" (observed issue, evidence does not establish its cause)
    - "Working well" (no action needed)
+
+Attribute a failure to AFM, the model, or the harness only when supported by evidence;
+otherwise retain it as unattributed and identify the evidence needed to investigate.
 
 WORKFLOW CONTEXT: This analysis is part of an iterative debug loop. A developer
 or AI coding agent runs tests, reads your analysis, fixes the issues, then re-runs
@@ -1772,14 +1809,6 @@ Do not score metadata records or capability-aware records whose status is SKIP:
 
 IMPORTANT scoring notes:
 - Base your score on "content", "content_preview", AND "reasoning_content" fields.
-- THINKING-BUDGET EXHAUSTION: If "content" is empty but "reasoning_content" is non-empty
-  and completion_tokens is close to max_tokens, the model spent its entire token budget
-  reasoning and never emitted a response. This is NOT a harness failure or empty response —
-  it means the max_tokens was too low for a thinking model. Score based on the quality of
-  the reasoning content (typically 2-3, since no actual response was produced, but the model
-  was functioning correctly). Flag this pattern explicitly in your anomalies section.
-- If BOTH "content" AND "reasoning_content" are empty but status=OK and completion_tokens > 0,
-  the test harness failed to capture output — score 3 (unknown quality) NOT 1.
 - Only score 1 for actual failures (status=FAIL).
 - A response that works but has minor formatting issues is still a 4 or 5.
 - Repetitive/looping text is a 2. Completely off-topic or garbled is a 2.
@@ -1807,6 +1836,9 @@ Rules:
 - Do NOT wrap it in a code block
 ANALYSIS_PROMPT_END
 )"
+  ANALYSIS_PROMPT="$JUDGE_RESPONSE_RULES
+
+$ANALYSIS_PROMPT"
 
   # Include test file contents in the prompt if available (AI-readable comments)
   SMART_TEST_FILE_SECTION=""
@@ -1842,9 +1874,6 @@ Score this result on a 1-5 scale:
 
 Scoring rules:
 - If status=FAIL, score 1.
-- If "content" is empty but "reasoning_content" is non-empty and completion_tokens
-  is close to max_tokens, the model spent its token budget reasoning. Score 2-3.
-- If BOTH content and reasoning_content are empty but status=OK, score 3.
 - Repetitive/looping text is a 2. Off-topic or garbled is a 2.
 - For stop sequence tests: output MUST NOT contain the stop string. If it does, score 2.
 - For seed/determinism tests: flag if paired runs differ (but score the content itself).
@@ -1860,6 +1889,9 @@ Respond with EXACTLY one line of JSON, nothing else:
 {"score": N, "reason": "brief explanation referencing expected outcome"}
 PER_TEST_PROMPT_END
 )"
+  PER_TEST_PROMPT="$JUDGE_RESPONSE_RULES
+
+$PER_TEST_PROMPT"
 
   echo "  Smart analysis mode: $([ "$SMART_BATCH" = "1" ] && echo "per-test (1)" || echo "batch (0)")"
 
@@ -2045,13 +2077,13 @@ Score this result on a 1-5 scale:
 
 Scoring rules:
 - If status=FAIL, score 1.
-- If \"content\" is empty but \"reasoning_content\" is non-empty and completion_tokens
-  is close to max_tokens, the model spent its token budget reasoning. Score 2-3.
-- If BOTH content and reasoning_content are empty but status=OK, score 3.
 - Repetitive/looping text is a 2. Off-topic or garbled is a 2.
 
 Respond with EXACTLY one line of JSON, nothing else:
 {\"score\": N, \"reason\": \"brief explanation\"}"
+            AFM_SCORE_PROMPT="$JUDGE_RESPONSE_RULES
+
+$AFM_SCORE_PROMPT"
 
             if [ -n "$afm_spec" ]; then
               AFM_SCORE_PROMPT="$AFM_SCORE_PROMPT

--- a/Scripts/tests/test-mlx-judge-response-rules.py
+++ b/Scripts/tests/test-mlx-judge-response-rules.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""CPU prompt-contract fixtures; no model invocation or inferred judge scores."""
+from pathlib import Path
+import re
+import subprocess
+import unittest
+
+
+SOURCE = (Path(__file__).resolve().parents[1] / "mlx-model-test.sh").read_text()
+
+
+def heredoc_assignment(name):
+    match = re.search(
+        rf"^ +{name}=\"\$\(cat <<'{name}_END'\n.*?^{name}_END\n\)\"",
+        SOURCE, re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        raise AssertionError(f"Missing production assignment: {name}")
+    return match.group()
+
+
+def assembled_prompt(name):
+    shared = heredoc_assignment("JUDGE_RESPONSE_RULES")
+    if name == "AFM_SCORE_PROMPT":
+        # Include only the production literal assignment, not the model invocation.
+        start = SOURCE.index('            AFM_SCORE_PROMPT="You are')
+        end = SOURCE.index('\n            AFM_SCORE_PROMPT="$JUDGE_RESPONSE_RULES', start)
+        assignment = SOURCE[start:end]
+    else:
+        assignment = heredoc_assignment(name)
+    prepend = re.search(
+        rf'^ +{name}="\$JUDGE_RESPONSE_RULES\n\n\${name}"$',
+        SOURCE, re.MULTILINE,
+    )
+    if not prepend:
+        raise AssertionError(f"Shared policy not wired into {name}")
+    script = shared + "\n" + assignment + "\n" + prepend.group()
+    script += f'\nprintf "%s" "${name}"\n'
+    return subprocess.check_output(["bash", "-eu", "-c", script], text=True)
+
+
+class JudgeResponseRulesTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.prompts = {name: assembled_prompt(name) for name in (
+            "ANALYSIS_PROMPT", "PER_TEST_PROMPT", "AFM_SCORE_PROMPT",
+        )}
+
+    def check_all(self, *clauses):
+        for name, prompt in self.prompts.items():
+            with self.subTest(mode=name):
+                for clause in clauses:
+                    self.assertIn(clause, prompt)
+
+    def test_all_modes_prepend_identical_policy(self):
+        policies = []
+        for prompt in self.prompts.values():
+            self.assertTrue(prompt.startswith("RESPONSE CONTRACT PRECEDENCE"))
+            policies.append(prompt.split("\n\nYou are", 1)[0])
+        self.assertEqual(len(set(policies)), 1)
+
+    def test_tool_only_contract_requires_valid_expected_calls(self):
+        self.check_all('finish_reason="tool_calls"', "expected function names/arguments",
+                       "penalty or score-3 cap", "or unexpected calls are not exempt")
+
+    def test_immediate_stop_requires_explicit_empty_expectation(self):
+        self.check_all('content_equals=""', 'with finish_reason="stop"',
+                       'finish_reason="stop" alone does not establish')
+
+    def test_failure_and_baseline_guards_apply_before_exceptions(self):
+        self.check_all("status=FAIL remains score 1", "never overrides a failed assertion",
+                       "For is_baseline=true, ignore the enclosing",
+                       "judge only the result's own prompt")
+        for prompt in self.prompts.values():
+            self.assertLess(prompt.index("For is_baseline=true"),
+                            prompt.index("EXPECTED TOOL-ONLY RESPONSE"))
+
+    def test_unexpected_empty_stays_evidence_based(self):
+        self.check_all("Do not automatically score 3", "state unknown quality",
+                       "Keep the cause unattributed unless evidence establishes",
+                       "neither successful behavior nor a harness capture bug")
+        self.assertNotIn("the test harness failed to capture output", SOURCE)
+        self.assertNotIn("If BOTH content and reasoning_content", SOURCE)
+
+    def test_reasoning_only_does_not_prove_budget_or_engine_health(self):
+        self.check_all("possible budget exhaustion", "Token counts alone do not prove",
+                       "above take precedence over this heuristic")
+        self.assertNotIn("it means the max_tokens was too low", SOURCE)
+
+    def test_intent_can_explicitly_require_truncated_json(self):
+        self.check_all("output contracts take precedence over generic formatting rules",
+                       "expect truncated invalid JSON")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #266.

## Changes

- Share one response-contract precedence policy across batch analysis, per-test analysis, and the AFM judge fallback.
- Evaluate valid expected tool-only calls and explicitly asserted immediate-stop emptiness against the actual intent, without an automatic empty-text penalty or score-3 cap.
- Preserve status=FAIL and baseline-routing precedence; malformed/unexpected calls and ordinary unanticipated empty answers receive no blanket exception.
- Remove unsupported capture-bug and definitive reasoning-budget attribution. Report unknown quality/unattributed causes when evidence is insufficient.
- Explicit expected truncation contracts precede generic JSON-format heuristics.

## Validation

- `python3 Scripts/tests/test-mlx-judge-response-rules.py`: 7 CPU fixtures passed, executing the actual production shell prompt assignments for all three modes.
- Existing judge work-root regression passed with scratch under this external worktree's `.build`.
- `bash -n Scripts/mlx-model-test.sh` and `git diff --check` passed.
- No GPU/model invocation, inference regeneration, or changes to active RC results. Fixtures validate prompt policy/wiring, not AI compliance; retained outputs still require independent rejudging after review.

Scope is script/prompt reporting only; no provider or packaged binary changes. Independent review requested before integration.

## Summary by Sourcery

Align AI judge response evaluation with explicit test contracts so expected empty and tool-only results are scored against their intended behavior.

Bug Fixes:
- Correct AI judge scoring for expected tool-only responses and explicitly expected empty stop responses without applying automatic empty-output penalties or score caps.

Enhancements:
- Apply a shared response-contract precedence policy across batch analysis, per-test analysis, and AFM fallback judging.
- Preserve failure and baseline intent precedence while making unexpected empty and reasoning-only outputs evidence-based and avoiding unsupported fault attribution.
- Honor explicit output contracts, including intentionally truncated JSON, before generic formatting heuristics.

Tests:
- Add CPU prompt-contract fixtures covering policy consistency and precedence across all three judge modes.