### PR TITLE
Retain core SDK checks when logprobs is unavailable

### DIFF
--- a/Scripts/feature-codex-optimize-api/test-openai-compat-evals.py
+++ b/Scripts/feature-codex-optimize-api/test-openai-compat-evals.py
@@ -117,7 +117,30 @@ def http_get_json(url: str) -> dict:
         return json.loads(resp.read().decode("utf-8"))
 
 
-def run_models_probe(base_url: str) -> dict:
+def advertised_capabilities(body: dict, model: str) -> list[str] | None:
+    """Only an unambiguous AFM model entry can establish unsupported features."""
+    entries = body.get("models")
+    if not isinstance(entries, list):
+        return None
+    entries = [item for item in entries if isinstance(item, dict)]
+    matches = [item for item in entries if item.get("model") == model]
+    if not matches:
+        # AFM accepts aliases; resolve only a single non-embedding model.
+        matches = [item for item in entries
+                   if isinstance(item.get("capabilities"), list)
+                   and "embeddings" not in item["capabilities"]]
+    if len(matches) != 1:
+        return None
+    caps = matches[0].get("capabilities")
+    if not isinstance(caps, list) or not all(isinstance(cap, str) for cap in caps):
+        return None
+    # An empty/incomplete generic extension is not evidence of AFM capability.
+    if not {"mlx_runtime", "dwarfstar_runtime"}.intersection(caps):
+        return None
+    return sorted(set(caps))
+
+
+def run_models_probe(base_url: str, model: str = "") -> dict:
     started = time.time()
     body = http_get_json(f"{base_url.rstrip('/')}/models")
     data = body.get("data", [])
@@ -128,6 +151,7 @@ def run_models_probe(base_url: str) -> dict:
         "details": {
             "count": len(data),
             "first_id": data[0].get("id") if data else None,
+            "advertised_capabilities": advertised_capabilities(body, model),
         },
     }
 
@@ -373,11 +397,23 @@ def main() -> int:
                 log("Server failed to become ready")
                 return 1
 
-        results.append(run_models_probe(args.base_url))
+        results.append(run_models_probe(args.base_url, args.model))
         results.append(run_openai_python_nonstream(args.base_url, args.model))
         results.append(run_openai_python_stream(args.base_url, args.model))
-        results.append(run_openai_python_nonstream_logprobs(args.base_url, args.model))
-        results.append(run_openai_python_stream_logprobs(args.base_url, args.model))
+        capabilities = results[0]["details"]["advertised_capabilities"]
+        for check in (run_openai_python_nonstream_logprobs, run_openai_python_stream_logprobs):
+            if capabilities is not None and "logprobs" not in capabilities:
+                results.append({
+                    "name": check.__name__.removeprefix("run_"),
+                    "ok": True,
+                    "status": "SKIP",
+                    "elapsed_s": 0,
+                    "details": {"reason": "Selected engine does not advertise logprobs",
+                                "advertised_capabilities": capabilities},
+                })
+            else:
+                # Unknown metadata is not evidence of an unsupported feature.
+                results.append(check(args.base_url, args.model))
         if __import__("shutil").which("vllm"):
             results.append(run_vllm_bench(args.base_url[:-3] if args.base_url.endswith("/v1") else args.base_url, args.model, args.tokenizer))
         else:
@@ -389,7 +425,7 @@ def main() -> int:
         write_report(results, report_path)
 
         for item in results:
-            status = "PASS" if item["ok"] else "FAIL"
+            status = item.get("status") or ("PASS" if item["ok"] else "FAIL")
             log(f"{status} {item['name']} ({item['elapsed_s']}s)")
         log(f"Report: {report_path}")
         return 0 if ok else 1

--- a/Scripts/tests/test-openai-sdk-capabilities.py
+++ b/Scripts/tests/test-openai-sdk-capabilities.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""CPU-only SDK dispatch fixtures; no server or inference subprocess."""
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+PATH = Path(__file__).resolve().parents[1] / "feature-codex-optimize-api/test-openai-compat-evals.py"
+SPEC = importlib.util.spec_from_file_location("sdk_eval", PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def models(caps, name="exact-checkpoint"):
+    return {"data": [{"id": name}], "models": [{"model": name, "capabilities": caps}]}
+
+
+class CapabilityTests(unittest.TestCase):
+    def run_suite(self, payload):
+        reports = []
+        checks = ("run_openai_python_nonstream", "run_openai_python_stream",
+                  "run_openai_python_nonstream_logprobs", "run_openai_python_stream_logprobs")
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            stack.enter_context(patch("sys.argv", [str(PATH), "--model", "exact-checkpoint"]))
+            stack.enter_context(patch.object(MODULE, "http_get_json", return_value=payload))
+            stack.enter_context(patch("shutil.which", return_value=None))
+            stack.enter_context(patch.object(MODULE, "log"))
+            stack.enter_context(patch.object(MODULE, "write_report", side_effect=lambda results, path: reports.extend(results)))
+            mocks = []
+            for name in checks:
+                mock = stack.enter_context(patch.object(MODULE, name, return_value={
+                    "name": name.removeprefix("run_"), "ok": True, "elapsed_s": 0,
+                }))
+                mock.__name__ = name
+                mocks.append(mock)
+            self.assertEqual(MODULE.main(), 0)
+            return reports, [mock.call_count for mock in mocks]
+
+    def test_dwarfstar_runs_core_sdk_and_records_two_skips(self):
+        reports, calls = self.run_suite(models(["dwarfstar_runtime", "text", "streaming"]))
+        self.assertEqual(calls, [1, 1, 0, 0])
+        self.assertEqual([r["status"] for r in reports if "status" in r], ["SKIP", "SKIP"])
+        self.assertEqual(len(reports), 5)
+
+    def test_mlx_logprobs_runs_all_checks(self):
+        reports, calls = self.run_suite(models(["mlx_runtime", "text", "logprobs"]))
+        self.assertEqual(calls, [1, 1, 1, 1])
+        self.assertFalse(any(r.get("status") == "SKIP" for r in reports))
+
+    def test_capabilities_not_engine_name_determine_skip(self):
+        _, calls = self.run_suite(models(["mlx_runtime", "text"]))
+        self.assertEqual(calls, [1, 1, 0, 0])
+        _, calls = self.run_suite(models(["dwarfstar_runtime", "logprobs"]))
+        self.assertEqual(calls, [1, 1, 1, 1])
+
+    def test_unknown_missing_and_malformed_metadata_do_not_skip(self):
+        for payload in ({"data": [{"id": "plain-openai"}]}, models([]),
+                        models("dwarfstar_runtime"), models([None]),
+                        models(["third_party_runtime"])):
+            with self.subTest(payload=payload):
+                _, calls = self.run_suite(payload)
+                self.assertEqual(calls, [1, 1, 1, 1])
+
+    def test_exact_model_precedes_unrelated_capabilities(self):
+        payload = models(["mlx_runtime", "logprobs"])
+        payload["models"].append({"model": "other", "capabilities": ["dwarfstar_runtime"]})
+        _, calls = self.run_suite(payload)
+        self.assertEqual(calls, [1, 1, 1, 1])
+
+    def test_alias_only_resolves_unambiguous_model(self):
+        payload = models(["dwarfstar_runtime"], name="canonical-name")
+        self.assertEqual(MODULE.advertised_capabilities(payload, "alias"), ["dwarfstar_runtime"])
+        payload["models"].append({"model": "other", "capabilities": ["mlx_runtime"]})
+        self.assertIsNone(MODULE.advertised_capabilities(payload, "alias"))
+
+    def test_transport_failure_is_not_capability_skip(self):
+        with patch.object(MODULE, "http_get_json", side_effect=OSError("connection refused")):
+            with self.assertRaises(OSError):
+                MODULE.run_models_probe("http://fixture/v1", "exact-checkpoint")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #268.

## Changes

- Always retain the `/models`, ordinary nonstreaming, and ordinary streaming SDK checks.
- Gate only the two logprobs checks using the selected engine's advertised capabilities; record each unavailable check as `status: SKIP` with its capability evidence and print SKIP rather than PASS.
- Exact model metadata wins. Alias fallback requires a single non-embedding engine. Missing, malformed, generic third-party, or ambiguous metadata does not imply unsupported functionality.
- No model-name heuristic; a DwarfStar engine advertising logprobs would run both checks, and an MLX engine lacking logprobs would explicitly skip them.

## Validation

`python3 Scripts/tests/test-openai-sdk-capabilities.py`: 7 CPU fixtures passed (core dispatch, supported/unsupported capabilities, metadata ambiguity, exact matching, aliases, and transport errors). `git diff --check` passed. No GPU or model invocation.

The external release runner still needs to invoke this SDK stage for all engines rather than blanket-skipping DS4. This PR changes no active run, packaged binary, or provider implementation. Independent review requested before integration.

## Summary by Sourcery

Retain core SDK compatibility coverage while making logprobs evaluation capability-aware.

Bug Fixes:
- Preserve the core SDK compatibility checks while selectively skipping logprobs checks when the selected engine explicitly lacks that capability.

Enhancements:
- Resolve model capabilities from exact metadata or unambiguous aliases, avoiding engine-name heuristics and treating unknown or ambiguous metadata as insufficient evidence to skip checks.
- Record skipped checks with capability evidence and report their explicit SKIP status.

Tests:
- Add CPU-only coverage for capability dispatch, metadata matching and ambiguity, alias handling, engine-independent behavior, and transport failures.