### PR TITLE
Route Promptfoo contracts by advertised engine capabilities

### DIFF
--- a/Scripts/feature-promptfoo-agentic/capability-routing.py
+++ b/Scripts/feature-promptfoo-agentic/capability-routing.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Route qualification contracts using advertised capabilities, never model names."""
+import json
+from pathlib import Path
+import sys
+
+
+def snapshot(payload, model):
+    entries = payload.get('models')
+    entries = [entry for entry in entries if isinstance(entry, dict)] if isinstance(entries, list) else []
+    selected = [entry for entry in entries if entry.get('model') == model]
+    if not selected:
+        selected = [entry for entry in entries if isinstance(entry.get('capabilities'), list)
+                    and 'embeddings' not in entry['capabilities']]
+    caps = selected[0].get('capabilities') if len(selected) == 1 else None
+    known = (isinstance(caps, list) and all(isinstance(cap, str) for cap in caps)
+             and bool({'mlx_runtime', 'dwarfstar_runtime'}.intersection(caps)))
+    return dict(requested_model=model, selected_model=selected[0].get('model') if len(selected) == 1 else None,
+                status='known' if known else 'unknown',
+                capabilities=sorted(set(caps)) if known else None)
+
+
+def missing_capabilities(evidence, required):
+    # Unknown or ambiguous metadata must never manufacture SKIP results.
+    if evidence['status'] != 'known':
+        return []
+    return sorted(set(required) - set(evidence['capabilities']))
+
+
+def main():
+    action, source, *args = sys.argv[1:]
+    payload = json.loads(Path(source).read_text())
+    if action == 'snapshot':
+        print(json.dumps(snapshot(payload, args[0]), indent=2))
+        return 0
+    if action != 'check':
+        raise ValueError(f'Unknown action: {action}')
+    destination, scope, *required = args
+    missing = missing_capabilities(payload, required)
+    if not missing:
+        return 0
+    path = Path(destination)
+    records = json.loads(path.read_text()) if path.exists() else []
+    records.append(dict(scope=scope, status='SKIP', required_capabilities=required,
+                        missing_capabilities=missing, evidence=payload,
+                        reason='Contract requires capabilities not advertised by selected engine; not a conformance pass'))
+    path.write_text(json.dumps(records, indent=2))
+    print(f'SKIP {scope}: missing advertised capabilities {", ".join(missing)} (not a conformance pass)')
+    return 3
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh
+++ b/Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh
@@ -18,6 +18,9 @@ load_timeout="${AFM_PROMPTFOO_LOAD_TIMEOUT_SECONDS:-60}"
 summary_minimum_mtime_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
 server_pid=""
 overall_status=0
+capability_snapshot=""
+discovery_server_ready=0
+capability_timeout=20
 
 if [[ "$no_think" != "0" && "$no_think" != "1" ]]; then
   echo "AFM_NO_THINK must be 0 or 1" >&2
@@ -108,6 +111,14 @@ wait_for_port_free() {
 
 start_server() {
   local profile="$1"
+  # Reuse the first default server loaded solely for capability discovery.
+  # This avoids an extra model load, without changing later profile isolation.
+  if [[ "$discovery_server_ready" == "1" ]]; then
+    discovery_server_ready=0
+    if [[ "$profile" == "default" && -n "$server_pid" ]] && kill -0 "$server_pid" 2>/dev/null; then
+      return 0
+    fi
+  fi
   local -a extra_args=()
   local log_file="${out_dir}/server-${profile}.log"
 
@@ -175,8 +186,43 @@ start_server() {
   fi
 }
 
+require_capabilities() {
+  local scope="$1"
+  shift
+  if [[ -z "$capability_snapshot" ]]; then
+    start_server default
+    local raw="${out_dir}/capability-models.json"
+    capability_snapshot="${out_dir}/capability-snapshot.json"
+    if ! curl -sf --max-time "$capability_timeout" "http://127.0.0.1:${port}/v1/models" > "$raw"; then
+      echo "Capability discovery failed; refusing to classify unavailable engine as SKIP" >&2
+      exit 1
+    fi
+    python3 "$script_dir/capability-routing.py" snapshot "$raw" "$model" > "$capability_snapshot" || exit 1
+    # Start a new invocation's skip inventory; never mix previous runs.
+    print -r -- '[]' > "${out_dir}/capability-skips.json"
+    discovery_server_ready=1
+  fi
+  python3 "$script_dir/capability-routing.py" check "$capability_snapshot" \
+    "${out_dir}/capability-skips.json" "$scope" "$@"
+  local check_status=$?
+  case "$check_status" in
+    0) return 0 ;;
+    3) return 1 ;;
+    *) echo "Capability routing failed" >&2; exit 1 ;;
+  esac
+}
+
+require_tool_profile() {
+  local profile="$1"
+  local -a required=(tools)
+  if [[ "$profile" == *adaptive-xml* ]]; then required+=(mlx_runtime); fi
+  if [[ "$profile" == *grammar* ]]; then required+=(structured); fi
+  require_capabilities "${funcstack[2]}/$profile" "${required[@]}"
+}
+
 run_structured_suite() {
   local suite="$1"
+  require_capabilities "$suite (API and CLI strict schemas)" structured || return 0
   local output_prefix="${out_dir}/${suite}"
   local model_slug="$(print -r -- "$model" | tr '/:' '__')"
   # The two datasets label their single-prompt cases with this prefix.
@@ -223,6 +269,7 @@ run_structured_stress() {
 
 run_toolcall_profile() {
   local profile="$1"
+  require_tool_profile "$profile" || return 0
   local filter_regex="$2"
   local env_name="$3"
   local output="${out_dir}/toolcall-${profile}-$(print -r -- "$model" | tr '/:' '__').json"
@@ -250,6 +297,7 @@ run_toolcall_all() {
 
 run_toolcall_quality_profile() {
   local profile="$1"
+  require_tool_profile "$profile" || return 0
   local filter_regex="$2"
   local env_name="$3"
   local output="${out_dir}/toolcall-quality-${profile}-$(print -r -- "$model" | tr '/:' '__').json"
@@ -277,6 +325,7 @@ run_toolcall_quality_all() {
 
 run_agentic_profile() {
   local profile="$1"
+  require_tool_profile "$profile" || return 0
   local filter_regex="$2"
   local env_name="$3"
   local output="${out_dir}/agentic-${profile}-$(print -r -- "$model" | tr '/:' '__').json"
@@ -304,6 +353,7 @@ run_agentic_all() {
 
 run_frameworks_profile() {
   local profile="$1"
+  require_tool_profile "$profile" || return 0
   local filter_regex="$2"
   local env_name="$3"
   local output="${out_dir}/frameworks-${profile}-$(print -r -- "$model" | tr '/:' '__').json"
@@ -331,6 +381,7 @@ run_frameworks_all() {
 
 run_opencode_profile() {
   local profile="$1"
+  require_tool_profile "$profile" || return 0
   local filter_regex="$2"
   local env_name="$3"
   local output="${out_dir}/opencode-${profile}-$(print -r -- "$model" | tr '/:' '__').json"
@@ -358,6 +409,7 @@ run_opencode_all() {
 
 run_pi_profile() {
   local profile="$1"
+  require_tool_profile "$profile" || return 0
   local filter_regex="$2"
   local env_name="$3"
   local output="${out_dir}/pi-${profile}-$(print -r -- "$model" | tr '/:' '__').json"
@@ -385,6 +437,7 @@ run_pi_all() {
 
 run_openclaw_profile() {
   local profile="$1"
+  require_tool_profile "$profile" || return 0
   local filter_regex="$2"
   local env_name="$3"
   local output="${out_dir}/openclaw-${profile}-$(print -r -- "$model" | tr '/:' '__').json"
@@ -412,6 +465,7 @@ run_openclaw_all() {
 
 run_hermes_profile() {
   local profile="$1"
+  require_tool_profile "$profile" || return 0
   local filter_regex="$2"
   local env_name="$3"
   local output="${out_dir}/hermes-${profile}-$(print -r -- "$model" | tr '/:' '__').json"
@@ -438,6 +492,9 @@ run_hermes_all() {
 }
 
 run_grammar_constraints() {
+  # This bundle asserts MLX grammar enforcement and downgrade/header semantics.
+  # Skipping it on another engine does not assert those negative contracts passed.
+  require_capabilities "grammar-constraints (including downgrade and header contracts)" mlx_runtime structured || return 0
   local base_url="http://127.0.0.1:${port}/v1"
 
   # Phase 1: default server (no --enable-grammar-constraints) — tests downgrade path
@@ -514,6 +571,7 @@ run_grammar_constraints() {
   (( overall_status |= exit_code ))
 
   # Phase 4: grammar-enabled-concurrent — concurrent path grammar
+  if require_capabilities "grammar-constraints/concurrent" batch; then
   start_server grammar-enabled-concurrent
 
   local output_schema_conc="${out_dir}/grammar-schema-concurrent-$(print -r -- "$model" | tr '/:' '__').json"
@@ -540,7 +598,10 @@ run_grammar_constraints() {
   exit_code=$?
   (( overall_status |= exit_code ))
 
+  fi
+
   # Phase 5: grammar-enabled-prefix-cache — prefix caching + grammar interaction
+  if require_capabilities "grammar-constraints/prefix-cache" prefix_cache; then
   start_server grammar-enabled-prefix-cache
 
   local output_schema_cache="${out_dir}/grammar-schema-prefix-cache-$(print -r -- "$model" | tr '/:' '__').json"
@@ -566,6 +627,8 @@ run_grammar_constraints() {
       -o "$output_tools_cache"
   exit_code=$?
   (( overall_status |= exit_code ))
+
+  fi
 
   # Phase 6: mixed strict — json_schema + tool strict in same request
   start_server grammar-enabled

--- a/Scripts/feature-promptfoo-agentic/summarize-results.mjs
+++ b/Scripts/feature-promptfoo-agentic/summarize-results.mjs
@@ -163,7 +163,19 @@ const filenames = fs.readdirSync(outDir)
     fs.statSync(path.join(outDir, filename)).mtimeMs >= minimumMtimeMs)
   .sort();
 
-if (filenames.length === 0) {
+const skipPath = path.join(outDir, 'capability-skips.json');
+let capabilitySkips = [];
+if (fs.existsSync(skipPath) &&
+    (minimumMtimeMs === null || fs.statSync(skipPath).mtimeMs >= minimumMtimeMs)) {
+  capabilitySkips = JSON.parse(fs.readFileSync(skipPath, 'utf8'));
+  if (!Array.isArray(capabilitySkips) || capabilitySkips.some((record) =>
+    record.status !== 'SKIP' || record.evidence?.status !== 'known' ||
+    record.evidence?.requested_model !== model || !record.scope ||
+    !Array.isArray(record.missing_capabilities) || record.missing_capabilities.length === 0)) {
+    throw new Error('invalid current-run capability skip inventory');
+  }
+}
+if (filenames.length === 0 && capabilitySkips.length === 0) {
   throw new Error('no current-run Promptfoo JSON reports found');
 }
 
@@ -220,6 +232,7 @@ function serializableBucket(bucket) {
 }
 
 const summary = {
+  capabilitySkips,
   schemaVersion: 1,
   model,
   generatedAt: new Date().toISOString(),
@@ -259,6 +272,7 @@ const rows = Object.values(summary.categories).map((category) => {
 const markdown = `# Promptfoo result categories\n\n` +
   `- Model: \`${model}\`\n` +
   `- Generated: ${summary.generatedAt}\n\n` +
+  `- Capability-skipped suite/profile scopes: ${capabilitySkips.length} (not executed; not conformance passes; excluded from case totals)\n\n` +
   `These categories are intentionally reported separately. Forced-parser experiments are not part of native protocol conformance, and behavioral preferences are not OpenAI API invariants.\n\n` +
   `| Category | Cases | Pass | Fail | Error | Unique failing cases | Pass rate |\n` +
   `|---|---:|---:|---:|---:|---:|---:|\n` +

--- a/Scripts/tests/test-promptfoo-runner-args.sh
+++ b/Scripts/tests/test-promptfoo-runner-args.sh
@@ -39,13 +39,15 @@ unset_line="$(trace_launch default -u AFM_NO_THINK -u AFM_MTP | server_argv)"
 zero_line="$(trace_launch adaptive-xml-grammar AFM_NO_THINK=0 AFM_MTP=0 | server_argv)"
 [[ "$(print -r -- "$zero_line" | occurrences --no-think)" == "0" ]]
 [[ "$(print -r -- "$zero_line" | occurrences --mtp)" == "0" ]]
-[[ "$(print -r -- "$zero_line" | occurrences afm_adaptive_xml)" == "1" ]]
-[[ "$(print -r -- "$zero_line" | occurrences --enable-grammar-constraints)" == "1" ]]
+# Every requested profile first discovers capabilities using the native profile.
+# The real CPU server fixtures verify supported forced profiles after discovery.
+[[ "$(print -r -- "$zero_line" | occurrences afm_adaptive_xml)" == "0" ]]
+[[ "$(print -r -- "$zero_line" | occurrences --enable-grammar-constraints)" == "0" ]]
 
 enabled_line="$(trace_launch adaptive-xml AFM_NO_THINK=1 AFM_MTP=1 | server_argv)"
 [[ "$(print -r -- "$enabled_line" | occurrences --no-think)" == "1" ]]
 [[ "$(print -r -- "$enabled_line" | occurrences --mtp)" == "1" ]]
-[[ "$(print -r -- "$enabled_line" | occurrences afm_adaptive_xml)" == "1" ]]
+[[ "$(print -r -- "$enabled_line" | occurrences afm_adaptive_xml)" == "0" ]]
 
 # Quoting must retain a support checkpoint path containing spaces as one value.
 touch "$work_root/support checkpoint.gguf"

--- a/Scripts/tests/test_promptfoo_capabilities.py
+++ b/Scripts/tests/test_promptfoo_capabilities.py
@@ -1,0 +1,102 @@
+"""CPU fixture servers exercise real runner capability routing and summaries."""
+import importlib.util
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import tempfile
+import unittest
+
+from test_promptfoo_cli_phases import FAKE_AFM, ROOT
+
+HELPER = ROOT / 'Scripts/feature-promptfoo-agentic/capability-routing.py'
+SPEC = importlib.util.spec_from_file_location('routing', HELPER)
+ROUTING = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ROUTING)
+SERVER = FAKE_AFM.replace('self.send_response(200)',
+    "self.send_response(503 if self.path.endswith('/models') and os.environ.get('FIXTURE_DISCOVERY_FAIL') else 200)")
+SERVER = SERVER.replace("self.wfile.write(b'{}')", "self.wfile.write(os.environ['FIXTURE_MODELS'].encode())")
+PROMPTFOO = r'''#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+args = sys.argv[1:]
+assert Path(os.environ['FIXTURE_SERVER_MARKER']).exists()
+invocation = json.loads(Path(os.environ['FIXTURE_SERVER_MARKER']).read_text())
+Path(args[args.index('-o')+1]).write_text(json.dumps({'results': {
+  'stats': {'successes': 1, 'failures': 0, 'errors': 0},
+  'results': [{'success': True, 'testCase': {'description': 'CPU fixture'},
+               'response': {'metadata': {'argv': invocation}}}]}}))
+'''
+
+
+class PromptfooCapabilitiesTests(unittest.TestCase):
+    def run_fixture(self, mode, caps, discovery_fail=False):
+        parent = ROOT / '.build' / 'promptfoo-capability-fixtures'
+        parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=parent) as directory:
+            work = Path(directory)
+            for name, content in [('afm', SERVER), ('promptfoo', PROMPTFOO)]:
+                path = work / name
+                path.write_text(content)
+                path.chmod(0o755)
+            with socket.socket() as probe:
+                probe.bind(('127.0.0.1', 0))
+                port = probe.getsockname()[1]
+            env = {key: value for key, value in os.environ.items() if not key.startswith('AFM_')}
+            env.update(PATH=str(work) + os.pathsep + os.environ['PATH'],
+                       AFM_BINARY=str(work/'afm'), AFM_MODEL='fixture/model',
+                       AFM_PROMPTFOO_PORT=str(port), AFM_PROMPTFOO_OUT_DIR=str(work/'reports'),
+                       AFM_PROMPTFOO_LOAD_TIMEOUT_SECONDS='10',
+                       FIXTURE_SERVER_MARKER=str(work/'server-alive'),
+                       FIXTURE_MODELS=json.dumps({'models': [{'model': 'fixture/model', 'capabilities': caps}]}))
+            if discovery_fail: env['FIXTURE_DISCOVERY_FAIL'] = '1'
+            result = subprocess.run(['zsh', str(ROOT/'Scripts/feature-promptfoo-agentic/run-promptfoo-agentic.sh'), mode],
+                                    env=env, capture_output=True, text=True, timeout=60)
+            self.assertFalse((work/'server-alive').exists())
+            if discovery_fail:
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse((work/'reports/capability-skips.json').exists())
+                return
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            return {path.name: json.loads(path.read_text()) for path in (work/'reports').glob('*.json')}
+
+    def test_ds4_all_keeps_eight_native_suites_and_no_forced_profiles(self):
+        reports = self.run_fixture('all', ['dwarfstar_runtime', 'tools', 'streaming', 'prefix_cache'])
+        summary = reports['promptfoo-summary-fixture_model.json']
+        self.assertEqual(len(summary['capabilitySkips']), 19)
+        self.assertEqual(sum(item['cases'] for item in summary['categories'].values()), 8)
+        for name, report in reports.items():
+            if 'results' not in report: continue
+            self.assertNotIn('adaptive', name)
+            args = report['results']['results'][0]['response']['metadata']['argv']
+            self.assertNotIn('--tool-call-parser', args)
+            self.assertNotIn('--enable-grammar-constraints', args)
+
+    def test_only_unsupported_suite_has_zero_passes_with_explicit_skip(self):
+        reports = self.run_fixture('structured', ['dwarfstar_runtime', 'tools'])
+        summary = reports['promptfoo-summary-fixture_model.json']
+        self.assertEqual(len(summary['capabilitySkips']), 1)
+        self.assertEqual(sum(item['successes'] for item in summary['categories'].values()), 0)
+
+    def test_mlx_forced_profile_remains_enabled(self):
+        reports = self.run_fixture('adaptive-xml-grammar', ['mlx_runtime', 'tools', 'structured'])
+        row = reports['toolcall-adaptive-xml-grammar-fixture_model.json']['results']['results'][0]
+        self.assertIn('afm_adaptive_xml', row['response']['metadata']['argv'])
+        self.assertEqual(reports['capability-skips.json'], [])
+
+    def test_discovery_transport_failure_never_becomes_skip(self):
+        self.run_fixture('all', [], discovery_fail=True)
+
+    def test_unknown_or_ambiguous_metadata_never_skips(self):
+        for payload in ({}, {'models': [{'model': 'fixture', 'capabilities': []}]},
+                        {'models': [{'model': 'a', 'capabilities': ['dwarfstar_runtime']},
+                                    {'model': 'b', 'capabilities': ['mlx_runtime']}]},
+                        {'models': [{'model': 'fixture', 'capabilities': [None]}]}):
+            evidence = ROUTING.snapshot(payload, 'fixture')
+            self.assertEqual(evidence['status'], 'unknown')
+            self.assertEqual(ROUTING.missing_capabilities(evidence, ['structured']), [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #270.

## Changes

- Discover selected-engine capabilities on the native profile before forced profiles; retain raw `/models`, selection, and per-scope skip evidence.
- Preserve native/default toolcall, quality, agentic, frameworks, OpenCode, Pi, OpenClaw, and Hermes coverage when `tools` is advertised.
- Gate strict schema/CLI-guided JSON, forced parser, grammar/header, and optional concurrency/cache scopes on their applicable capability contracts.
- Missing/ambiguous/unknown metadata does not manufacture skips; discovery transport/parse failures abort.
- Summaries include explicit capability-skipped scopes, excluded from executed case/pass totals. An entirely unsupported requested suite produces zero passes plus its skip evidence, not a missing-report error.
- Reuse the initial discovery server for the first default suite, avoiding an additional model load. Existing CLI/server exclusive ownership and mode arguments remain unchanged.

## Validation

- Five new CPU tests exercise the real runner against fake servers/Promptfoo, including eight retained DS4-native suite families plus 19 skipped incompatible scopes; supported MLX forced profile; zero-pass all-skipped suite; transport failure; unknown/ambiguous metadata.
- Existing CLI/provider phase fixtures and shell argument/summary regressions rerun.
- Shell syntax and diff checks.
- No GPU, real model inference, provider, binary, or active release-worktree changes. Independent review required before integration.

Capability skips describe suite/profile scopes, not an invented count of unexecuted dataset cases. MLX-specific negative grammar/header expectations are explicitly unexecuted on DS4, not conformance passes.

## Summary by Sourcery

Route Promptfoo qualification scopes by verified engine capabilities and report incompatible scopes explicitly.

New Features:
- Route Promptfoo suites and profiles using advertised engine capabilities discovered from the native model endpoint.
- Record capability-skipped scopes and include them in result summaries without counting them as executed cases or passes.

Bug Fixes:
- Abort capability discovery failures instead of incorrectly classifying unavailable engines as skipped.
- Handle unsupported or entirely skipped suites without producing missing-report errors or false conformance passes.

Enhancements:
- Reuse the initial native discovery server for the first default suite while preserving profile isolation and existing invocation arguments.
- Retain compatible native and forced-profile coverage while gating structured output, tool, grammar, concurrency, and cache contracts by their required capabilities.

Tests:
- Add CPU fixture coverage for native and forced-profile routing, skipped suites, discovery failures, and unknown or ambiguous metadata.
- Update runner argument regression tests for capability discovery before forced profiles.