### PR TITLE
Fix collection of multiple completed tool calls

### DIFF
--- a/Sources/AFMServer/Controllers/AFMChatServing.swift
+++ b/Sources/AFMServer/Controllers/AFMChatServing.swift
@@ -71,6 +71,8 @@ struct AFMServerResolvedLogprob: Sendable {
 struct AFMServerStreamChunk: Sendable {
     let text: String
     let logprobs: [AFMServerResolvedLogprob]?
+    /// Completed per-call snapshots; consumers accumulate across chunks and
+    /// replace repeated indices. Argument fragments live in toolCallDeltas.
     let toolCalls: [ResponseToolCall]?
     let toolCallDeltas: [StreamDeltaToolCall]?
     let promptTokens: Int?

--- a/Sources/AFMServer/Controllers/CompletedToolCallAccumulator.swift
+++ b/Sources/AFMServer/Controllers/CompletedToolCallAccumulator.swift
@@ -1,0 +1,28 @@
+import AFMOpenAICompat
+
+/// Completed tool-call chunks are per-call snapshots, not a cumulative list.
+/// Preserve first-seen order and replace repeated snapshots without concatenating
+/// arguments (only toolCallDeltas contain argument fragments).
+struct CompletedToolCallAccumulator {
+    private enum Key: Hashable {
+        case index(Int)
+        case id(String)
+    }
+
+    private var positions: [Key: Int] = [:]
+    private var calls: [ResponseToolCall] = []
+
+    mutating func consume(_ completed: [ResponseToolCall]) {
+        for call in completed {
+            let key = call.index.map(Key.index) ?? .id(call.id)
+            if let position = positions[key] {
+                calls[position] = call
+            } else {
+                positions[key] = calls.count
+                calls.append(call)
+            }
+        }
+    }
+
+    var toolCalls: [ResponseToolCall]? { calls.isEmpty ? nil : calls }
+}

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -578,7 +578,7 @@ struct MLXChatCompletionsController: RouteCollection {
                 // Collect stream into complete response
                 var fullText = ""
                 var allLogprobs: [AFMServerResolvedLogprob] = []
-                var finalToolCalls: [ResponseToolCall]? = nil
+                var completedToolCalls = CompletedToolCallAccumulator()
                 var promptTokens = streamResult.promptTokens
                 var completionTokens = 0
                 var cachedTokens = 0
@@ -589,7 +589,7 @@ struct MLXChatCompletionsController: RouteCollection {
                 for try await chunk in streamResult.stream {
                     fullText += chunk.text
                     if let lp = chunk.logprobs { allLogprobs.append(contentsOf: lp) }
-                    if let tc = chunk.toolCalls { finalToolCalls = tc }
+                    if let tc = chunk.toolCalls { completedToolCalls.consume(tc) }
                     if let pt = chunk.promptTokens { promptTokens = pt }
                     if let ct = chunk.completionTokens { completionTokens = ct }
                     if let cached = chunk.cachedTokens { cachedTokens = cached }
@@ -598,6 +598,7 @@ struct MLXChatCompletionsController: RouteCollection {
                     if let sbs = chunk.stoppedBySequence { stoppedBySequence = sbs }
                 }
 
+                var finalToolCalls = completedToolCalls.toolCalls
                 // FIX: Vendor ToolCallProcessor can append XML tag remnants to tool names
                 // for zero-parameter calls (e.g. "todoread</function"). Strip them.
                 // See: opencode promptfoo test #20/#33 — todoread</function bug.

--- a/Sources/AFMServer/Controllers/StreamCollector.swift
+++ b/Sources/AFMServer/Controllers/StreamCollector.swift
@@ -75,7 +75,7 @@ enum StreamCollector {
     ) async throws -> CollectedResult {
         var fullText = ""
         var allLogprobs: [AFMServerResolvedLogprob] = []
-        var toolCalls: [ResponseToolCall]? = nil
+        var completedToolCalls = CompletedToolCallAccumulator()
         var promptTokens = streamResult.promptTokens
         var completionTokens = 0
         var cachedTokens = 0
@@ -86,7 +86,7 @@ enum StreamCollector {
         for try await chunk in streamResult.stream {
             fullText += chunk.text
             if let lp = chunk.logprobs { allLogprobs.append(contentsOf: lp) }
-            if let tc = chunk.toolCalls { toolCalls = tc }
+            if let tc = chunk.toolCalls { completedToolCalls.consume(tc) }
             if let pt = chunk.promptTokens { promptTokens = pt }
             if let ct = chunk.completionTokens { completionTokens = ct }
             if let cached = chunk.cachedTokens { cachedTokens = cached }
@@ -95,6 +95,7 @@ enum StreamCollector {
             if let sbs = chunk.stoppedBySequence { stoppedBySequence = sbs }
         }
 
+        let toolCalls = completedToolCalls.toolCalls
         // Determine finish reason
         let finishReason: String
         if let tc = toolCalls, !tc.isEmpty {

--- a/Tests/MacLocalAPITests/CompletedToolCallAccumulatorTests.swift
+++ b/Tests/MacLocalAPITests/CompletedToolCallAccumulatorTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+import AFMOpenAICompat
+@testable import AFMServer
+
+final class CompletedToolCallAccumulatorTests: XCTestCase {
+    private func call(_ index: Int?, id: String, arguments: String = "{}") -> ResponseToolCall {
+        ResponseToolCall(index: index, id: id, type: "function",
+                         function: .init(name: "get_weather", arguments: arguments))
+    }
+
+    func testSingletonChunksPreserveBothCallsAndOrder() {
+        var accumulator = CompletedToolCallAccumulator()
+        accumulator.consume([call(0, id: "first")])
+        accumulator.consume([call(1, id: "second")])
+        XCTAssertEqual(accumulator.toolCalls?.map(\.id), ["first", "second"])
+    }
+
+    func testRepeatedIndexReplacesSnapshotWithoutDuplicatingOrConcatenatingArguments() {
+        var accumulator = CompletedToolCallAccumulator()
+        accumulator.consume([call(0, id: "first"), call(1, id: "second")])
+        let updated = call(0, id: "first", arguments: #"{"location":"Berlin"}"#)
+        accumulator.consume([updated])
+        accumulator.consume([updated, call(1, id: "second")])
+        XCTAssertEqual(accumulator.toolCalls?.map(\.id), ["first", "second"])
+        XCTAssertEqual(accumulator.toolCalls?.first?.function.arguments, updated.function.arguments)
+    }
+
+    func testUnindexedCallsUseIdentityAndEmptyChunksDoNotClearCalls() {
+        var accumulator = CompletedToolCallAccumulator()
+        XCTAssertNil(accumulator.toolCalls)
+        accumulator.consume([])
+        XCTAssertNil(accumulator.toolCalls)
+        accumulator.consume([call(nil, id: "first"), call(nil, id: "second")])
+        accumulator.consume([call(nil, id: "first", arguments: #"{"location":"Paris"}"#)])
+        accumulator.consume([])
+        XCTAssertEqual(accumulator.toolCalls?.map(\.id), ["first", "second"])
+        XCTAssertEqual(accumulator.toolCalls?.first?.function.arguments, #"{"location":"Paris"}"#)
+    }
+
+    func testStreamCollectorPreservesCompletedCallsAcrossUsageAndRepeatedSnapshots() async throws {
+        let first = call(0, id: "first", arguments: #"{"location":"Berlin"}"#)
+        let second = call(1, id: "second")
+        let stream = AsyncThrowingStream<AFMServerStreamChunk, Error> { continuation in
+            continuation.yield(.init(text: "", toolCalls: [first]))
+            continuation.yield(.init(text: "", toolCalls: [second]))
+            continuation.yield(.init(text: "", toolCalls: [first]))
+            continuation.yield(.init(text: "", promptTokens: 10, completionTokens: 71))
+            continuation.finish()
+        }
+        let result: AFMChatStreamingResult = ("fixture", stream, 10, nil, nil, nil, nil)
+        let collected = try await StreamCollector.collect(from: result, extractThinking: false)
+        XCTAssertEqual(collected.toolCalls?.map(\.id), ["first", "second"])
+        XCTAssertEqual(collected.finishReason, "tool_calls")
+        XCTAssertEqual(collected.completionTokens, 71)
+    }
+}

--- a/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
+++ b/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
@@ -296,7 +296,7 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
             .POST, "/v1/chat/completions", headers: requestHeaders(for: body), body: body
         ) { response async in
             XCTAssertEqual(response.status, .ok)
-            let object = try JSONSerialization.jsonObject(with: Data(buffer: response.body)) as? [String: Any]
+            let object = (try? JSONSerialization.jsonObject(with: Data(buffer: response.body))) as? [String: Any]
             let choices = object?["choices"] as? [[String: Any]]
             let message = choices?.first?["message"] as? [String: Any]
             let calls = message?["tool_calls"] as? [[String: Any]]

--- a/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
+++ b/Tests/MacLocalAPITests/MLXChatCompletionsControllerStreamingTests.swift
@@ -275,6 +275,37 @@ final class MLXChatCompletionsControllerStreamingTests: XCTestCase {
         }
     }
 
+    func testNonStreamingConcurrentControllerPreservesSingletonToolCallChunks() async throws {
+        let weather = ResponseToolCall(index: 0, id: "call_weather", type: "function",
+            function: .init(name: "get_weather", arguments: #"{"location":"Berlin"}"#))
+        let time = ResponseToolCall(index: 1, id: "call_time", type: "function",
+            function: .init(name: "get_time", arguments: #"{"timezone":"Europe/Berlin"}"#))
+        let service = FakeMLXChatService(
+            maxConcurrent: 2,
+            streamingResult: makeStreamingResult(chunks: [
+                .init(text: "", toolCalls: [weather]),
+                .init(text: "", toolCalls: [time]),
+                .init(text: "", toolCalls: [time]),
+                .init(text: "", promptTokens: 359, completionTokens: 71),
+            ])
+        )
+        try MLXChatCompletionsController(modelID: "test-model", service: service,
+            temperature: nil, repetitionPenalty: nil).boot(routes: app)
+        let body = try requestBody(stream: false)
+        try await app.testable(method: .running(port: 0)).test(
+            .POST, "/v1/chat/completions", headers: requestHeaders(for: body), body: body
+        ) { response async in
+            XCTAssertEqual(response.status, .ok)
+            let object = try JSONSerialization.jsonObject(with: Data(buffer: response.body)) as? [String: Any]
+            let choices = object?["choices"] as? [[String: Any]]
+            let message = choices?.first?["message"] as? [String: Any]
+            let calls = message?["tool_calls"] as? [[String: Any]]
+            XCTAssertEqual(calls?.compactMap { $0["id"] as? String }, ["call_weather", "call_time"])
+            XCTAssertEqual(calls?.compactMap { $0["index"] as? Int }, [0, 1])
+            XCTAssertEqual(choices?.first?["finish_reason"] as? String, "tool_calls")
+        }
+    }
+
     func testStreamingControllerSerializesProviderToolCallsIntoSSEToolCalls() async throws {
         let toolCall = ResponseToolCall(
             index: 0,


### PR DESCRIPTION
## Summary
Fixes #272.

Both nonstreaming collectors previously replaced their collected calls whenever a completed-call chunk arrived. The typed serving adapter emits singleton completed snapshots, so only the final call survived. This affected concurrent-path chat completions and the shared batch collector.

Use a shared ordered accumulator with constant-time indexed lookup, ID fallback for unindexed calls, and replacement of repeated snapshots. Full argument snapshots are never concatenated or reparsed. Streaming delta handling is unchanged.

## Regression coverage
- Singleton completed calls at indices 0 then 1 preserve both calls.
- Same-index updated snapshots and repeated cumulative snapshots do not duplicate calls or arguments.
- Unindexed identities remain distinct; empty chunks do not erase calls.
- Shared StreamCollector preserves calls across usage and repeated snapshots.
- Nonstreaming HTTP fixture with maxConcurrent=2 preserves weather and time calls.

## Validation
- git diff --check passed.
- Five CPU-only tests added; execution pending the coordinated build window. No GPU or model workload launched.
- RC2 raw response and source inspection establish the defect; this fix is not present in RC2. Release rebuild and scoped replay remain required before qualification.

No provider sources, resolved checkouts, or benchmark artifacts modified.

## Summary by Sourcery

Preserve multiple completed tool calls across nonstreaming collection paths while safely updating repeated snapshots.

Bug Fixes:
- Preserve all completed tool calls in nonstreaming chat and shared stream collection instead of retaining only the latest snapshot.
- Handle repeated and unindexed tool-call snapshots without duplicating calls or concatenating arguments.

Enhancements:
- Centralize ordered completed tool-call accumulation for consistent collection behavior across serving paths.

Tests:
- Add regression coverage for multiple, repeated, unindexed, and usage-interleaved completed tool-call snapshots, including concurrent nonstreaming HTTP responses.