### PR TITLE
Fix advertised tools in read-first framework fixture

### DIFF
--- a/Scripts/feature-promptfoo-agentic/datasets/agentic/framework-tool-schemas.yaml
+++ b/Scripts/feature-promptfoo-agentic/datasets/agentic/framework-tool-schemas.yaml
@@ -153,7 +153,7 @@
     framework: Pi
   vars:
     prompt: "Change the README to document the new promptfoo toolcall-quality suite."
-    system_prompt: "You are a Pi-style coding agent with only read, write, edit, and bash. Inspect before editing."
+    system_prompt: "You are a Pi-style coding agent with only read, write, and edit. Inspect before editing."
     tools:
       - type: function
         function:

--- a/Scripts/tests/test_promptfoo_framework_fixture.py
+++ b/Scripts/tests/test_promptfoo_framework_fixture.py
@@ -1,0 +1,50 @@
+"""CPU-only contract checks for the read-before-edit framework fixture.
+
+Uses the dataset's explicit indentation convention, without requiring PyYAML
+or invoking Promptfoo, a server, or a model.
+"""
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DATASET = ROOT / 'Scripts/feature-promptfoo-agentic/datasets/agentic/framework-tool-schemas.yaml'
+DESCRIPTION = 'pi: prefer read before edit for existing file changes'
+
+
+def fixture_block():
+    blocks = re.split(r'(?=^- description:)', DATASET.read_text(), flags=re.MULTILINE)
+    return next(block for block in blocks
+                if block.startswith(f'- description: "{DESCRIPTION}"'))
+
+
+def tool_contract(block):
+    system = re.search(r'^    system_prompt: "([^"]+)"$', block, re.MULTILINE).group(1)
+    advertised = re.search(r'with only (.+?)\.', system).group(1)
+    names = {name.strip() for name in re.split(r',|\band\b', advertised) if name.strip()}
+    tools = set(re.findall(r'^          name: (\w+)$', block, re.MULTILINE))
+    return names, tools
+
+
+class PromptfooFrameworkFixtureTests(unittest.TestCase):
+    def test_advertised_tools_equal_supplied_tools(self):
+        advertised, supplied = tool_contract(fixture_block())
+        self.assertEqual(supplied, {'read', 'write', 'edit'})
+        self.assertEqual(advertised, supplied)
+
+    def test_contract_detects_original_unavailable_bash_advertisement(self):
+        original = fixture_block().replace('read, write, and edit.',
+                                           'read, write, edit, and bash.')
+        advertised, supplied = tool_contract(original)
+        self.assertEqual(advertised - supplied, {'bash'})
+
+    def test_read_first_requirement_and_assertion_are_preserved(self):
+        block = fixture_block()
+        self.assertIn('Inspect before editing.', block)
+        self.assertIn('parsed.tool_calls.length === 1', block)
+        self.assertIn("parsed.tool_calls[0].function.name === 'read'", block)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #276.

The Pi read-before-edit fixture advertised bash in its system prompt but supplied no bash tool. Remove that misleading advertisement; keep all schemas, the inspect-before-edit instruction, and the exactly-one-read assertion unchanged.

Add three CPU-only stdlib tests checking exact advertised/supplied agreement, detection of the original contradiction, and preservation of the read-first requirement/assertion.

Validation: python3 -B Scripts/tests/test_promptfoo_framework_fixture.py passes 3/3; git diff --check passes. No server, model, GPU, or Swift build invoked. Existing RC benchmark results and judgments are unchanged. This corrects a fixture contradiction, not a claim that every observed bash call was solely caused by the fixture.

## Summary by Sourcery

Align the Pi read-first framework fixture’s advertised tools with its available tools and add regression coverage for the contract.

Bug Fixes:
- Remove the unavailable bash tool from the Pi fixture’s advertised tool set to align its prompt with the supplied tools.

Tests:
- Add CPU-only contract tests covering advertised/supplied tool agreement, regression detection for the bash contradiction, and preservation of the read-before-edit requirement.