### PR TITLE
Honor recorded assertion failures in comprehensive exit status

### DIFF
--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -2208,11 +2208,35 @@ else
   echo "  JSONL: $RESULTS_FILE"
 fi
 
+# ── Final recorded outcome gate (also used when reanalysing retained JSONL) ──
 if [ -f "$RESULTS_FILE" ]; then
-  RECORDED_FAILURES=$(python3 - "$RESULTS_FILE" <<'PYEOF'
+  if RECORDED_COUNTS=$(python3 - "$RESULTS_FILE" <<'PYEOF'
 import json, sys
 
-failures = 0
+passed = failures = skipped = 0
+
+def outcome(record):
+    fields = {key: str(record.get(key, '')).strip().lower() for key in
+              ('status', 'transport_status', 'assertion_status', 'overall_status')}
+    # A successful HTTP response or summary field must never hide a failed
+    # executable assertion, transport error, or explicit error evidence.
+    if (any(value in ('fail', 'failed', 'error') for value in fields.values())
+            or record.get('assertion_failures') or record.get('error')):
+        return 'fail'
+    allowed = {
+        'status': {'ok', 'skip'},
+        'transport_status': {'', 'pass', 'not_run'},
+        'assertion_status': {'', 'pass', 'not_configured', 'not_run'},
+        'overall_status': {'', 'pass', 'skip'},
+    }
+    if any(value not in allowed[key] for key, value in fields.items()):
+        return 'fail'
+    if fields['status'] == 'skip' or fields['overall_status'] == 'skip':
+        return 'skip'
+    if fields['transport_status'] == 'not_run' or fields['assertion_status'] == 'not_run':
+        return 'fail'
+    return 'pass'
+
 with open(sys.argv[1]) as handle:
     for line in handle:
         line = line.strip()
@@ -2223,15 +2247,31 @@ with open(sys.argv[1]) as handle:
         except json.JSONDecodeError:
             failures += 1
             continue
-        if not record.get('_meta') and record.get('status') != 'OK':
+        if not isinstance(record, dict):
             failures += 1
-print(failures)
+            continue
+        if record.get('_meta'):
+            continue
+        result = outcome(record)
+        passed += result == 'pass'
+        failures += result == 'fail'
+        skipped += result == 'skip'
+print(passed, failures, skipped)
 PYEOF
-  )
-  if [ "$RECORDED_FAILURES" -gt 0 ]; then
-    echo "=== FAILED: $RECORDED_FAILURES result record(s) did not pass ===" >&2
+  ); then
+    read -r RECORDED_PASSES RECORDED_FAILURES RECORDED_SKIPS <<< "$RECORDED_COUNTS"
+    echo "=== Recorded outcomes: $RECORDED_PASSES passed, $RECORDED_FAILURES failed, $RECORDED_SKIPS skipped (not executed; not passes) ==="
+    if [ "$RECORDED_FAILURES" -gt 0 ]; then
+      echo "=== FAILED: $RECORDED_FAILURES result record(s) did not pass ===" >&2
+      OVERALL_STATUS=1
+    fi
+  else
+    echo "=== FAILED: could not evaluate recorded outcomes ===" >&2
     OVERALL_STATUS=1
   fi
+else
+  echo "=== FAILED: results file is missing: $RESULTS_FILE ===" >&2
+  OVERALL_STATUS=1
 fi
 
 exit "$OVERALL_STATUS"

--- a/Scripts/tests/test_comprehensive_final_status.py
+++ b/Scripts/tests/test_comprehensive_final_status.py
@@ -1,0 +1,86 @@
+"""Execute the production final shell gate against CPU-only JSONL fixtures."""
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = (ROOT/'Scripts/mlx-model-test.sh').read_text()
+MARKER = '# ── Final recorded outcome gate'
+GATE = SOURCE[SOURCE.index(MARKER):]
+
+
+class FinalStatusTests(unittest.TestCase):
+    def run_gate(self, records, initial_status=0):
+        parent = ROOT/'.build/comprehensive-status-fixtures'
+        parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=parent) as directory:
+            path = Path(directory)/'results.jsonl'
+            if records is not None:
+                path.write_text(records if isinstance(records, str) else
+                                '\n'.join(json.dumps(record) for record in records) + '\n')
+                before = hashlib.sha256(path.read_bytes()).hexdigest()
+            result = subprocess.run(['bash', '-u', '-o', 'pipefail', '-c', GATE],
+                                    env=dict(os.environ, RESULTS_FILE=str(path), OVERALL_STATUS=str(initial_status)),
+                                    text=True, capture_output=True, timeout=10)
+            if records is not None:
+                self.assertEqual(hashlib.sha256(path.read_bytes()).hexdigest(), before)
+            return result
+
+    def test_transport_ok_does_not_hide_failed_assertions(self):
+        result = self.run_gate([{'status': 'OK', 'assertion_status': 'fail', 'overall_status': 'fail'}])
+        self.assertEqual(result.returncode, 1)
+        self.assertIn('0 passed, 1 failed, 0 skipped', result.stdout)
+
+    def test_each_failure_signal_overrides_success_and_skip(self):
+        for field, value in [('status', 'FAIL'), ('transport_status', 'error'),
+                             ('assertion_status', 'FAIL'), ('overall_status', ' fail '),
+                             ('assertion_failures', ['wrong arguments']), ('error', 'connection lost')]:
+            for status in ('OK', 'SKIP'):
+                with self.subTest(field=field, status=status):
+                    record = {'status': status, 'overall_status': 'pass', field: value}
+                    self.assertEqual(self.run_gate([record]).returncode, 1)
+
+    def test_legacy_success_and_normalized_success_pass(self):
+        result = self.run_gate([{'status': 'OK'}, {'status': ' ok ', 'transport_status': 'PASS',
+                                                'assertion_status': 'not_configured', 'overall_status': 'PASS'}])
+        self.assertEqual(result.returncode, 0)
+        self.assertIn('2 passed, 0 failed, 0 skipped', result.stdout)
+
+    def test_capability_skip_is_not_a_pass_or_failure(self):
+        result = self.run_gate([{'status': 'SKIP', 'transport_status': 'not_run',
+                                'assertion_status': 'not_run', 'overall_status': 'skip'},
+                               {'status': 'skip'}])
+        self.assertEqual(result.returncode, 0)
+        self.assertIn('0 passed, 0 failed, 2 skipped (not executed; not passes)', result.stdout)
+
+    def test_metadata_excluded_and_mixed_results_counted_once(self):
+        result = self.run_gate([{'_meta': True}, {'status': 'OK'}, {'status': 'SKIP'},
+                               {'status': 'FAIL', 'overall_status': 'fail', 'error': 'load failed'}])
+        self.assertEqual(result.returncode, 1)
+        self.assertIn('1 passed, 1 failed, 1 skipped', result.stdout)
+
+    def test_invalid_records_and_unknown_status_fail_closed(self):
+        for record in (None, [], 'text', {}, {'status': 'unknown'},
+                       {'status': 'OK', 'assertion_status': 'unknown'},
+                       {'status': 'OK', 'transport_status': 'not_run'}):
+            with self.subTest(record=record):
+                self.assertEqual(self.run_gate([record]).returncode, 1)
+
+    def test_prior_failure_is_not_erased_by_passing_results(self):
+        self.assertEqual(self.run_gate([{'status': 'OK'}], initial_status=7).returncode, 7)
+
+    def test_missing_results_fail_closed(self):
+        self.assertEqual(self.run_gate(None).returncode, 1)
+
+    def test_malformed_json_does_not_hide_following_records(self):
+        result = self.run_gate('{broken json}\n{"status":"OK"}\n')
+        self.assertEqual(result.returncode, 1)
+        self.assertIn('1 passed, 1 failed, 0 skipped', result.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #278.

## Changes

- Final recorded-result gate now honors normalized transport, assertion, overall, and error evidence before success or skip.
- Legacy status=OK records remain supported. Explicit capability skips are unexecuted, not passes or failures.
- Unknown/malformed records and missing/unreadable results fail closed; prior nonzero harness status remains nonzero.
- Print pass/fail/skip counts from the final gate without altering raw results or AI scores.

## Validation

- Nine CPU fixture tests execute the actual production final shell block, covering precedence conflicts, status normalization, legacy records, metadata, skips, malformed/missing evidence, and prior failure preservation. Each fixture verifies raw JSONL remains unchanged.
- Read-only execution on retained Next OFF RC2 `comprehensive.jsonl`: **89 passed, 2 failed, 0 skipped; exit 1**. SHA-256 remained `be03ab83ab7cc43590474ad7816e27aca978ab46bb81b65fa240afe057338d5b` before/after.
- `bash -n Scripts/mlx-model-test.sh` and `git diff --check` passed.
- No GPU, model regeneration, active-worktree edits, or result rewrites. Independent review requested.

## Summary by Sourcery

Make comprehensive test exit status reflect the final recorded outcomes, including assertion failures and invalid evidence.

Bug Fixes:
- Ensure recorded assertion, transport, overall, and error failures determine comprehensive test exit status instead of being hidden by successful transport or legacy status fields.
- Fail closed for missing, malformed, unknown, or unreadable result records while preserving any prior nonzero harness status.

Enhancements:
- Classify recorded results as passed, failed, or explicitly skipped and report the final counts without modifying result files or scoring data.

Tests:
- Add CPU-only fixture coverage for final-status precedence, status normalization, legacy successes, capability skips, metadata, malformed and missing results, and prior failure preservation.