### PR TITLE
Add explicit diagnostic batch stream evidence capture

### DIFF
--- a/Scripts/feature-mlx-concurrent-batch/STREAM_EVIDENCE.md
+++ b/Scripts/feature-mlx-concurrent-batch/STREAM_EVIDENCE.md
@@ -12,6 +12,8 @@ Each request produces one atomically published JSON file in
 endpoint, HTTP status/headers, base64-encoded bytes consumed by the sender,
 separate visible/reasoning text, finish reasons, observed `[DONE]`, iterator EOF,
 parse errors, and partial evidence on a request exception or cancellation.
+When available, `http_raw_headers_base64` retains ordered name/value byte pairs,
+including duplicate headers; `http_headers` remains a convenience dictionary.
 This is not an independent socket capture: the sender normally stops at `[DONE]`
 without reading the following blank line or exhausting the response iterator.
 Missing finish/DONE evidence must not be interpreted as proof of an engine bug.

--- a/Scripts/feature-mlx-concurrent-batch/STREAM_EVIDENCE.md
+++ b/Scripts/feature-mlx-concurrent-batch/STREAM_EVIDENCE.md
@@ -1,0 +1,50 @@
+# Optional streaming evidence
+
+The known-answer, mixed-workload, and multi-turn prefix validators can retain
+diagnostic stream evidence when **both** `AFM_CAPTURE_STREAM_EVIDENCE=1` and
+`AFM_REPORT_DIR=/path/to/diagnostic-report` are set. Report-directory configuration
+alone keeps the original sender path and existing batch reports; it does not
+enable this capture. Do not enable capture for primary performance comparisons
+without first agreeing to its overhead.
+
+Each request produces one atomically published JSON file in
+`AFM_REPORT_DIR/stream-requests/`. It includes the exact request/history,
+endpoint, HTTP status/headers, base64-encoded bytes consumed by the sender,
+separate visible/reasoning text, finish reasons, observed `[DONE]`, iterator EOF,
+parse errors, and partial evidence on a request exception or cancellation.
+This is not an independent socket capture: the sender normally stops at `[DONE]`
+without reading the following blank line or exhausting the response iterator.
+Missing finish/DONE evidence must not be interpreted as proof of an engine bug.
+
+The original request, parser, merged scoring text, assertions, and timing
+expressions are unchanged. Parse errors from the existing sender and from the
+post-request evidence observer are distinguished. Evidence never repairs the
+scoring input. Lexical-gate concerns remain tracked separately in issue #265;
+new evidence cannot retroactively reclassify responses that were not retained.
+The prefix report's existing Turn 1 “cold” label is also not proof of a cold
+cache: earlier batch sizes may have warmed its prefix. Use actual cache metrics.
+
+## Bounds and performance caveats
+
+Raw retention is capped at `min(16 MiB, 64 KiB + max_tokens * 2048 bytes)` per
+request (about 8.06 MiB at the current 4096-token budget). The sender still
+receives all bytes; overflow sets explicit truncation flags. Derived channel
+text and finish reasons then describe only the retained prefix, while the
+independent DONE observation still covers all consumed lines. Parse-error
+details are capped at 128 records with 512-character messages.
+
+Capture adds byte copying and line bookkeeping during streaming. After the
+sender samples elapsed time/TTFT, a worker thread parses retained SSE and writes
+one JSON document through an atomic rename; there are no per-token filesystem
+writes. Serialization/base64 and decoded text temporarily allocate several
+times the retained byte count, multiplied by concurrent requests. Persistence
+is awaited before the next conversation turn, so it adds between-turn latency
+and can affect aggregate wall time, concurrency overlap, and observed throughput.
+Even individual timings can be indirectly affected by capture overhead. Treat
+these as diagnostic runs, not equivalent performance baselines.
+
+I/O failures warn on stderr and do not change inference scoring. Abrupt process
+termination may leave no evidence (or an unpublished `.partial` file); normal
+request exceptions and cancellation are captured on a best-effort basis.
+Artifacts contain full prompts, responses, and response headers: review them
+before sharing and keep them outside version control.

--- a/Scripts/feature-mlx-concurrent-batch/batch_stream_evidence.py
+++ b/Scripts/feature-mlx-concurrent-batch/batch_stream_evidence.py
@@ -33,6 +33,7 @@ class StreamEvidence:
         self.observed_bytes = self.lines_seen = self.parse_error_count = 0
         self.parse_errors = []
         self.request = self.endpoint = self.http_status = self.http_headers = None
+        self.http_raw_headers_base64 = None
         self.done_observed = self.iterator_eof = False
 
     def parse_error(self, error, origin):
@@ -85,6 +86,7 @@ class StreamEvidence:
         truncated = self.observed_bytes > len(self.raw)
         return dict(request=self.request, endpoint=self.endpoint, started_at_unix=self.started_at_unix,
                     http_status=self.http_status, http_headers=self.http_headers,
+                    http_raw_headers_base64=self.http_raw_headers_base64,
                     raw_sse_base64=base64.b64encode(self.raw).decode('ascii'),
                     raw_encoding='base64 (exact bytes consumed by the sender, not an independent socket capture)',
                     observed_bytes=self.observed_bytes, retained_bytes=len(self.raw),
@@ -128,6 +130,12 @@ class _Post:
         response = await self.manager.__aenter__()
         self.capture.http_status = getattr(response, 'status', None)
         self.capture.http_headers = dict(getattr(response, 'headers', {}))
+        raw_headers = getattr(response, 'raw_headers', None)
+        if raw_headers is not None:
+            self.capture.http_raw_headers_base64 = [
+                [base64.b64encode(name).decode('ascii'), base64.b64encode(value).decode('ascii')]
+                for name, value in raw_headers
+            ]
         return _Response(response, self.capture)
 
     async def __aexit__(self, *args):

--- a/Scripts/feature-mlx-concurrent-batch/batch_stream_evidence.py
+++ b/Scripts/feature-mlx-concurrent-batch/batch_stream_evidence.py
@@ -1,0 +1,174 @@
+"""Opt-in, bounded wire evidence; never feeds the validators' scoring paths."""
+import asyncio
+import base64
+from contextvars import ContextVar
+from functools import wraps
+import json
+import os
+from pathlib import Path
+import sys
+import time
+import uuid
+
+BYTES_PER_REQUEST_TOKEN = 2048
+STREAM_OVERHEAD_BYTES = 64 * 1024
+MAX_CAPTURE_BYTES = 16 * 1024 * 1024
+MAX_PARSE_ERRORS = 128
+MAX_ERROR_MESSAGE_CHARS = 512
+_active = ContextVar('batch_stream_evidence', default=None)
+
+
+def record_stream_parse_error():
+    capture = _active.get()
+    if capture is not None:
+        capture.parse_error(sys.exc_info()[1], 'sender')
+
+
+class StreamEvidence:
+    def __init__(self, root, suite):
+        self.path = Path(root)/'stream-requests'/f'{suite}-{uuid.uuid4().hex}.json'
+        self.started_at_unix = time.time()
+        self.raw = bytearray()
+        self.limit = STREAM_OVERHEAD_BYTES
+        self.observed_bytes = self.lines_seen = self.parse_error_count = 0
+        self.parse_errors = []
+        self.request = self.endpoint = self.http_status = self.http_headers = None
+        self.done_observed = self.iterator_eof = False
+
+    def parse_error(self, error, origin):
+        self.parse_error_count += 1
+        if len(self.parse_errors) < MAX_PARSE_ERRORS:
+            self.parse_errors.append(dict(origin=origin, line=self.lines_seen if origin == 'sender' else None,
+                                          type=type(error).__name__, message=str(error)[:MAX_ERROR_MESSAGE_CHARS]))
+
+    async def lines(self, source):
+        async for line in source:
+            self.lines_seen += 1
+            self.observed_bytes += len(line)
+            remaining = max(0, self.limit-len(self.raw))
+            if remaining:
+                self.raw.extend(line[:remaining])
+            if line.startswith(b'data:') and line[5:].strip() == b'[DONE]':
+                self.done_observed = True
+            yield line
+        self.iterator_eof = True
+
+    def document(self, error):
+        visible, reasoning, finish_reasons = [], [], []
+        # Parse retained bytes after timing has been sampled. This observer
+        # never replaces or repairs the sender's existing parser or text.
+        event_data = []
+        def event():
+            if not event_data:
+                return
+            data = b'\n'.join(event_data)
+            event_data.clear()
+            if data.strip() == b'[DONE]':
+                return
+            try:
+                chunk = json.loads(data)
+                choices = chunk.get('choices') or []
+                if choices:
+                    choice = choices[0]
+                    delta = choice.get('delta') or {}
+                    if isinstance(delta.get('content'), str): visible.append(delta['content'])
+                    if isinstance(delta.get('reasoning_content'), str): reasoning.append(delta['reasoning_content'])
+                    if choice.get('finish_reason') is not None: finish_reasons.append(choice['finish_reason'])
+            except Exception as parse_error:
+                self.parse_error(parse_error, 'retained_sse_observer')
+        for line in bytes(self.raw).splitlines():
+            if not line:
+                event()
+            elif line.startswith(b'data:'):
+                event_data.append(line[5:].lstrip(b' '))
+        event()
+        truncated = self.observed_bytes > len(self.raw)
+        return dict(request=self.request, endpoint=self.endpoint, started_at_unix=self.started_at_unix,
+                    http_status=self.http_status, http_headers=self.http_headers,
+                    raw_sse_base64=base64.b64encode(self.raw).decode('ascii'),
+                    raw_encoding='base64 (exact bytes consumed by the sender, not an independent socket capture)',
+                    observed_bytes=self.observed_bytes, retained_bytes=len(self.raw),
+                    byte_limit=self.limit, raw_truncated=truncated,
+                    visible_content=''.join(visible), reasoning_content=''.join(reasoning),
+                    finish_reason=finish_reasons[-1] if finish_reasons else None,
+                    finish_reasons=finish_reasons, derived_channels_may_be_truncated=truncated,
+                    done_observed=self.done_observed, iterator_eof=self.iterator_eof,
+                    parse_errors=self.parse_errors, parse_error_count=self.parse_error_count,
+                    parse_errors_truncated=self.parse_error_count > len(self.parse_errors),
+                    request_error=None if error is None else dict(type=type(error).__name__, message=str(error)),
+                    scoring_note='Observability only; original sender text and predicates are unchanged')
+
+    def publish(self, error):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_suffix('.partial')
+        try:
+            temporary.write_text(json.dumps(self.document(error), ensure_ascii=False, indent=2))
+            temporary.replace(self.path)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+
+class _Response:
+    def __init__(self, response, capture):
+        self.response, self.capture = response, capture
+
+    @property
+    def content(self):
+        return self.capture.lines(self.response.content)
+
+    def __getattr__(self, name):
+        return getattr(self.response, name)
+
+
+class _Post:
+    def __init__(self, manager, capture):
+        self.manager, self.capture = manager, capture
+
+    async def __aenter__(self):
+        response = await self.manager.__aenter__()
+        self.capture.http_status = getattr(response, 'status', None)
+        self.capture.http_headers = dict(getattr(response, 'headers', {}))
+        return _Response(response, self.capture)
+
+    async def __aexit__(self, *args):
+        return await self.manager.__aexit__(*args)
+
+
+class _Session:
+    def __init__(self, session, capture):
+        self.session, self.capture = session, capture
+
+    def post(self, endpoint, **kwargs):
+        self.capture.endpoint = endpoint
+        self.capture.request = kwargs.get('json')
+        tokens = int((self.capture.request or {}).get('max_tokens') or 0)
+        self.capture.limit = min(MAX_CAPTURE_BYTES, STREAM_OVERHEAD_BYTES + max(0, tokens)*BYTES_PER_REQUEST_TOKEN)
+        return _Post(self.session.post(endpoint, **kwargs), self.capture)
+
+
+def capture_stream_evidence(suite):
+    def decorate(sender):
+        @wraps(sender)
+        async def wrapped(session, *args, **kwargs):
+            root = os.environ.get('AFM_REPORT_DIR')
+            if os.environ.get('AFM_CAPTURE_STREAM_EVIDENCE') != '1' or not root:
+                return await sender(session, *args, **kwargs)
+            capture = StreamEvidence(root, suite)
+            token = _active.set(capture)
+            error = None
+            try:
+                return await sender(_Session(session, capture), *args, **kwargs)
+            except BaseException as caught:
+                error = caught
+                raise
+            finally:
+                _active.reset(token)
+                try:
+                    # Serialize once off the event loop, after sender timing;
+                    # await persistence so later conversation mutation is safe.
+                    await asyncio.to_thread(capture.publish, error)
+                except Exception as write_error:
+                    # Evidence I/O must not change existing inference scoring.
+                    print(f'WARNING: stream evidence not saved to {capture.path}: {write_error}', file=sys.stderr)
+        return wrapped
+    return decorate

--- a/Scripts/feature-mlx-concurrent-batch/validate_mixed_workload.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_mixed_workload.py
@@ -12,6 +12,7 @@ Usage:
 """
 import asyncio, aiohttp, json, time, sys, subprocess, threading, os
 from batch_validation_report import BatchReport
+from batch_stream_evidence import capture_stream_evidence, record_stream_parse_error
 
 URL = os.environ.get("AFM_CHAT_COMPLETIONS_URL", "http://localhost:9999/v1/chat/completions")
 MODEL = os.environ.get("AFM_MODEL", "mlx-community/Qwen3.5-35B-A3B-4bit")
@@ -211,6 +212,7 @@ class MactopSampler:
 
 # ─── request sender ──────────────────────────────────────────────────────────
 
+@capture_stream_evidence("batch-mixed")
 async def send_request(session, prompt, max_tokens=4096):
     """Send streaming request, return full stats dict from server."""
     if MAX_TOKENS_CAP > 0:
@@ -252,6 +254,7 @@ async def send_request(session, prompt, max_tokens=4096):
                         ttft = time.monotonic() - start
                     text += content
             except Exception:
+                record_stream_parse_error()
                 pass
 
     elapsed = time.monotonic() - start

--- a/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
@@ -16,6 +16,7 @@ Usage:
 """
 import asyncio, aiohttp, json, time, sys, os
 from batch_validation_report import BatchReport
+from batch_stream_evidence import capture_stream_evidence, record_stream_parse_error
 
 URL = os.environ.get("AFM_CHAT_COMPLETIONS_URL", "http://localhost:9999/v1/chat/completions")
 MODEL = os.environ.get("AFM_MODEL", "mlx-community/Qwen3.5-35B-A3B-4bit")
@@ -224,6 +225,7 @@ CONVERSATIONS = [
 
 # ─── Request sender ───────────────────────────────────────────────────────────
 
+@capture_stream_evidence("batch-prefix")
 async def send_request(session, messages, max_tokens=1024):
     """Send streaming request, return full stats dict."""
     payload = {
@@ -261,6 +263,7 @@ async def send_request(session, messages, max_tokens=1024):
                         ttft = time.monotonic() - start
                     text += content
             except Exception:
+                record_stream_parse_error()
                 pass
 
     elapsed = time.monotonic() - start

--- a/Scripts/feature-mlx-concurrent-batch/validate_responses.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_responses.py
@@ -17,6 +17,7 @@ Set AFM_REPORT_DIR to retain JSON evidence after each completed batch size.
 """
 import asyncio, aiohttp, json, time, sys, re, os, unicodedata
 from batch_validation_report import BatchReport
+from batch_stream_evidence import capture_stream_evidence, record_stream_parse_error
 
 URL = os.environ.get("AFM_CHAT_COMPLETIONS_URL", "http://localhost:9999/v1/chat/completions")
 MODEL = os.environ.get("AFM_MODEL", "mlx-community/Qwen3.5-35B-A3B-4bit")
@@ -67,6 +68,7 @@ VALIDATIONS = [
 ]
 
 
+@capture_stream_evidence("batch-known-answers")
 async def send_request(session, prompt, max_tokens=200):
     """Send a streaming request, return full text."""
     payload = {
@@ -95,6 +97,7 @@ async def send_request(session, prompt, max_tokens=200):
                 if content:
                     text += content
             except:
+                record_stream_parse_error()
                 pass
 
     elapsed = time.monotonic() - start

--- a/Scripts/tests/test_batch_stream_evidence.py
+++ b/Scripts/tests/test_batch_stream_evidence.py
@@ -90,6 +90,63 @@ class EvidenceTests(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(any(error['origin'] == 'sender' for error in doc['parse_errors']))
             self.assertEqual(doc['visible_content'], 'ok')
 
+    async def test_interleaved_requests_keep_histories_channels_errors_and_headers_isolated(self):
+        turns = [asyncio.Event(), asyncio.Event()]
+        turns[0].set()
+        interleaving = []
+        bodies = []
+        histories = []
+        responses = []
+
+        class InterleavedResponse(Response):
+            @property
+            def content(self):
+                async def lines():
+                    for line in self.body.splitlines(keepends=True):
+                        await turns[self.index].wait()
+                        turns[self.index].clear()
+                        interleaving.append(self.index)
+                        yield line
+                        turns[1-self.index].set()
+                    raise self.error
+                return lines()
+
+        for index in range(2):
+            body = (frame({'choices': [{'delta': {'content': f'visible-{index}',
+                                                   'reasoning_content': f'reasoning-{index}'}}]})
+                    + b'data: {broken' + str(index).encode() + b'}\n\n')
+            bodies.append(body)
+            histories.append([{'role': 'system', 'content': f'system-{index}'},
+                              {'role': 'user', 'content': f'history-{index}'}])
+            response = InterleavedResponse(body, RuntimeError(f'connection-{index}'))
+            response.index = index
+            response.headers = {'X-Request-ID': f'request-{index}', 'X-Repeat': 'second'}
+            response.raw_headers = ((b'X-Request-ID', f'request-{index}'.encode()),
+                                    (b'X-Repeat', b'first'), (b'X-Repeat', b'second\xff'))
+            responses.append(response)
+
+        with patch.dict(os.environ, {'AFM_REPORT_DIR': str(self.root), 'AFM_CAPTURE_STREAM_EVIDENCE': '1'}):
+            results = await asyncio.wait_for(asyncio.gather(*[
+                MODULES[2].send_request(SimpleNamespace(post=Mock(return_value=responses[index])),
+                                        histories[index], max_tokens=8)
+                for index in range(2)
+            ], return_exceptions=True), timeout=5)
+        self.assertEqual(interleaving, [0, 1]*4)
+        self.assertEqual([str(result) for result in results], ['connection-0', 'connection-1'])
+        docs = self.documents()
+        self.assertEqual(len(docs), 2)
+        by_id = {doc['http_headers']['X-Request-ID']: doc for doc in docs}
+        for index in range(2):
+            doc = by_id[f'request-{index}']
+            self.assertEqual(doc['request']['messages'], histories[index])
+            self.assertEqual(base64.b64decode(doc['raw_sse_base64']), bodies[index])
+            self.assertEqual(doc['visible_content'], f'visible-{index}')
+            self.assertEqual(doc['reasoning_content'], f'reasoning-{index}')
+            self.assertEqual(doc['request_error']['message'], f'connection-{index}')
+            self.assertEqual(sum(error['origin'] == 'sender' for error in doc['parse_errors']), 1)
+            self.assertEqual([tuple(base64.b64decode(part) for part in pair)
+                              for pair in doc['http_raw_headers_base64']], list(responses[index].raw_headers))
+
     async def test_eof_without_done_is_not_invented_as_clean_done(self):
         await self.send(MODULES[0], Response(frame({'choices': [{'delta': {'content': 'partial'}}]})))
         doc = self.documents()[0]

--- a/Scripts/tests/test_batch_stream_evidence.py
+++ b/Scripts/tests/test_batch_stream_evidence.py
@@ -1,0 +1,156 @@
+"""CPU-only wire-evidence tests against all three real streaming senders."""
+import asyncio
+import base64
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from test_batch_failure_reporting import load, ROOT
+from batch_stream_evidence import StreamEvidence, MAX_CAPTURE_BYTES
+
+MODULES = [load(name) for name in ('validate_responses', 'validate_mixed_workload', 'validate_multiturn_prefix')]
+
+
+def frame(payload):
+    return ('data: ' + json.dumps(payload, ensure_ascii=False) + '\n\n').encode()
+
+
+class Response:
+    status = 200
+    headers = {'X-Request-ID': 'fixture-request'}
+    def __init__(self, body, error=None): self.body, self.error = body, error
+    def raise_for_status(self): pass
+    @property
+    def content(self):
+        async def lines():
+            for line in self.body.splitlines(keepends=True):
+                yield line
+            if self.error is not None: raise self.error
+        return lines()
+    async def __aenter__(self): return self
+    async def __aexit__(self, *_): return False
+
+
+class EvidenceTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        parent = ROOT.parents[1]/'.build/batch-stream-fixtures'
+        parent.mkdir(parents=True, exist_ok=True)
+        self.directory = tempfile.TemporaryDirectory(dir=parent)
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+
+    async def send(self, module, response, enabled=True):
+        post = Mock(return_value=response)
+        session = SimpleNamespace(post=post)
+        argument = [{'role': 'user', 'content': 'fixture history'}] if module.__name__.endswith('prefix') else 'fixture'
+        with patch.dict(os.environ, {'AFM_REPORT_DIR': str(self.root),
+                                    'AFM_CAPTURE_STREAM_EVIDENCE': '1' if enabled else ''}), \
+             patch.object(module, 'time', SimpleNamespace(monotonic=Mock(side_effect=[100, 100.25, 101]))):
+            result = await module.send_request(session, argument, max_tokens=8)
+        return result, post.call_args
+
+    def documents(self):
+        self.assertFalse(list(self.root.rglob('*.partial')))
+        return [json.loads(path.read_text()) for path in self.root.rglob('*.json')]
+
+    async def test_all_senders_preserve_payload_scoring_text_and_timing_values(self):
+        body = (frame({'choices': [{'delta': {'content': 'héllo', 'reasoning_content': 'private reasoning'}}]})
+                + frame({'choices': [{'delta': {}, 'finish_reason': 'stop'}]})
+                + b'data: [DONE]\n\n')
+        for module in MODULES:
+            baseline, request = await self.send(module, Response(body), enabled=False)
+            observed, captured_request = await self.send(module, Response(body))
+            self.assertEqual(observed, baseline)
+            self.assertEqual(captured_request, request)
+        docs = self.documents()
+        self.assertEqual(len(docs), 3)
+        for doc in docs:
+            self.assertEqual(base64.b64decode(doc['raw_sse_base64']), body[:-1])
+            self.assertEqual(doc['visible_content'], 'héllo')
+            self.assertEqual(doc['reasoning_content'], 'private reasoning')
+            self.assertEqual(doc['finish_reason'], 'stop')
+            self.assertTrue(doc['done_observed'])
+            self.assertFalse(doc['iterator_eof'])  # Sender stops at DONE; no claim of socket EOF.
+            self.assertEqual(doc['http_status'], 200)
+            self.assertEqual(doc['http_headers']['X-Request-ID'], 'fixture-request')
+
+    async def test_malformed_events_are_retained_without_changing_sender_result(self):
+        body = b'data: {broken}\n\n' + frame({'choices': [{'delta': {'content': 'ok'}}]}) + b'data: [DONE]\n\n'
+        for module in MODULES:
+            baseline, _ = await self.send(module, Response(body), enabled=False)
+            observed, _ = await self.send(module, Response(body))
+            self.assertEqual(observed, baseline)
+        for doc in self.documents():
+            self.assertTrue(any(error['origin'] == 'sender' for error in doc['parse_errors']))
+            self.assertEqual(doc['visible_content'], 'ok')
+
+    async def test_eof_without_done_is_not_invented_as_clean_done(self):
+        await self.send(MODULES[0], Response(frame({'choices': [{'delta': {'content': 'partial'}}]})))
+        doc = self.documents()[0]
+        self.assertFalse(doc['done_observed'])
+        self.assertTrue(doc['iterator_eof'])
+        self.assertIsNone(doc['finish_reason'])
+
+    async def test_transport_failure_and_cancellation_preserve_partial_wire(self):
+        body = frame({'choices': [{'delta': {'content': 'partial'}}]})
+        for error in (RuntimeError('connection lost'), asyncio.CancelledError('fixture cancellation')):
+            with self.assertRaises(type(error)):
+                await self.send(MODULES[0], Response(body, error))
+        docs = self.documents()
+        self.assertEqual(len(docs), 2)
+        for doc in docs:
+            self.assertEqual(base64.b64decode(doc['raw_sse_base64']), body)
+            self.assertEqual(doc['visible_content'], 'partial')
+            self.assertIsNotNone(doc['request_error'])
+            self.assertFalse(doc['iterator_eof'])
+
+    async def test_http_rejection_does_not_read_body_or_become_empty_success(self):
+        class Unavailable(Response):
+            status = 503
+            def raise_for_status(self): raise RuntimeError('HTTP 503')
+            @property
+            def content(self): raise AssertionError('must not read failed response')
+        with self.assertRaisesRegex(RuntimeError, 'HTTP 503'):
+            await self.send(MODULES[0], Unavailable(b''))
+        self.assertEqual(self.documents()[0]['http_status'], 503)
+
+    async def test_capture_limit_never_truncates_the_senders_input(self):
+        body = frame({'choices': [{'delta': {'content': 'x'*100_000}}]}) + b'data: [DONE]\n\n'
+        result, _ = await self.send(MODULES[0], Response(body))
+        self.assertEqual(len(result[0]), 100_000)
+        doc = self.documents()[0]
+        self.assertTrue(doc['raw_truncated'])
+        self.assertEqual(doc['retained_bytes'], doc['byte_limit'])
+        self.assertLessEqual(doc['retained_bytes'], MAX_CAPTURE_BYTES)
+        self.assertTrue(doc['done_observed'])
+        self.assertTrue(doc['derived_channels_may_be_truncated'])
+
+    async def test_evidence_write_failure_warns_without_changing_score_input(self):
+        body = frame({'choices': [{'delta': {'content': 'ok'}}]})
+        with patch.object(StreamEvidence, 'publish', side_effect=OSError('fixture disk full')), \
+             contextlib.redirect_stderr(io.StringIO()) as log:
+            result, _ = await self.send(MODULES[0], Response(body))
+        self.assertEqual(result[0], 'ok')
+        self.assertIn('stream evidence not saved', log.getvalue())
+
+    async def test_report_directory_alone_preserves_original_session_and_creates_no_raw_artifact(self):
+        for module in MODULES:
+            with patch('batch_stream_evidence.StreamEvidence', side_effect=AssertionError('capture must be bypassed')):
+                await self.send(module, Response(b''), enabled=False)
+        self.assertEqual(self.documents(), [])
+
+    async def test_capture_requires_report_directory(self):
+        sender = MODULES[0].send_request
+        with patch.dict(os.environ, {'AFM_REPORT_DIR': '', 'AFM_CAPTURE_STREAM_EVIDENCE': '1'}), \
+             patch('batch_stream_evidence.StreamEvidence', side_effect=AssertionError('capture must be bypassed')):
+            await sender(SimpleNamespace(post=Mock(return_value=Response(b''))), 'fixture')
+        self.assertEqual(self.documents(), [])
+
+
+if __name__ == '__main__': unittest.main()


### PR DESCRIPTION
Closes #280.

Adds shared, bounded observability around the three existing batch streaming senders. Per-request atomic JSON preserves request history, consumed raw SSE (base64), separate visible/reasoning channels, finish reasons, DONE/EOF observations, HTTP metadata, parse errors, and partial exception/cancellation evidence. Original request parameters, merged scoring text, lexical assertions, and sender timing expressions are unchanged. #265 remains separate; no past failures are retroactively reclassified.

Capture requires BOTH AFM_CAPTURE_STREAM_EVIDENCE=1 and AFM_REPORT_DIR. Existing report-directory-only benchmarks take the original sender path. No active matrix runner was edited or instrumented. Capture is diagnostic-only: bounded byte copying during streaming and awaited worker-thread serialization after sender timing add between-turn/aggregate overhead and transient allocations. Raw cap is min(16 MiB, 64 KiB + 2048 bytes per max_tokens); truncation explicit and original sender still receives all bytes. No per-token filesystem writes. Documentation also warns that the unchanged Turn 1 cold label does not prove an unwarmed cache.

Validation: 17 CPU tests passed (9 new stream-evidence fixtures plus 8 existing batch-reporting fixtures), covering actual senders, request/result/timing-value parity, opt-out with report directory set, malformed SSE, EOF without DONE, transport/cancellation, HTTP rejection, retention cap, and disk failure. git diff --check passed. No builds, GPU workloads, or model requests. Independent review requested before integration; runtime performance overhead is disclosed, not benchmarked.

## Summary by Sourcery

Provide opt-in diagnostic evidence capture for batch streaming requests without changing validation results or the default sender path.

New Features:
- Add opt-in, bounded per-request streaming evidence capture for the three batch validation senders.
- Record request metadata, consumed SSE bytes, response channels, completion state, parse errors, and partial failures in atomically published diagnostic reports.

Enhancements:
- Keep evidence collection isolated from validation scoring and preserve the original sender behavior when capture is disabled.
- Bound retained data and document diagnostic overhead, truncation semantics, and cache-label interpretation.

Documentation:
- Document configuration, evidence contents, retention limits, performance caveats, and artifact handling.

Tests:
- Add CPU-only coverage for sender parity, malformed and incomplete SSE, concurrent request isolation, transport and cancellation failures, HTTP rejection, retention limits, and persistence failures.