### PR TITLE
Document experimental MLX model status

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ can display local images inline; Terminal.app uses an explicit `/image` Quick Lo
 | **DwarfStar** | Compatible fixed-schedule Metal checkpoints | `afm mlx -m <owner/repo>` (auto-resolved) or `afm mlx -m <checkpoint.gguf> --mlx-runtime dwarfstar` |
 | **Gateway** | One model list for Ollama, LM Studio, Jan, and other local servers | `afm --gateway` |
 
-Model IDs without an organization default to `mlx-community`, so `Qwen3-0.6B-4bit` and `mlx-community/Qwen3-0.6B-4bit` both work.
+Model IDs without an organization default to `mlx-community`, so `Qwen3-0.6B-4bit` and `mlx-community/Qwen3-0.6B-4bit` both work. For stable, general-purpose MLX models, use `mlx-community`; experimental [`scouzi1966`](https://huggingface.co/scouzi1966) MLX artifacts require an unreleased maclocal-api version and are described in [Experimental `scouzi1966` MLX models](docs/experimental-mlx-models.md).
 
 ## Evaluate a local model
 

--- a/docs/experimental-mlx-models.md
+++ b/docs/experimental-mlx-models.md
@@ -1,0 +1,23 @@
+# Experimental `scouzi1966` MLX models
+
+MLX model repositories published under the
+[`scouzi1966`](https://huggingface.co/scouzi1966) Hugging Face account are
+experimental. They are intended for use with a later version of
+[maclocal-api](https://github.com/scouzi1966/maclocal-api) that is still in
+development and has not yet been released.
+
+These artifacts are not stable MLX model distributions. They may use conversion,
+quantization, architecture, speculative-decoding, or serving behavior that is not
+supported by current public releases of maclocal-api, MLX, LM Studio,
+llama.cpp, or other runtimes. File layouts, behavior, performance, memory use,
+output quality, and compatibility may change. Repositories may also be replaced
+or removed without notice.
+
+For normal use, choose models from
+[`mlx-community`](https://huggingface.co/mlx-community) instead. The
+`mlx-community` organization is the supported source for general-purpose MLX
+models in maclocal-api.
+
+If you download a `scouzi1966` MLX model, use it only for testing unreleased
+software and experimental model artifacts. Do not use it as a substitute for an
+official or community-maintained production model.


### PR DESCRIPTION
Adds a prominent README warning and a dedicated documentation page explaining that `scouzi1966` Hugging Face MLX artifacts are experimental, target an unreleased maclocal-api version, and should not replace stable `mlx-community` models for normal use.

## Summary by Sourcery

Document the experimental status and limited compatibility of `scouzi1966` MLX models while guiding users toward stable `mlx-community` alternatives.

Enhancements:
- Clarify that `scouzi1966` Hugging Face MLX artifacts are experimental and require an unreleased maclocal-api version.
- Direct users to `mlx-community` for stable, general-purpose MLX models and document the compatibility and production-use limitations of experimental artifacts.

Documentation:
- Add documentation describing the status, risks, compatibility limitations, and intended use of experimental `scouzi1966` MLX models.