### PR TITLE
Fail closed on incomplete smart judge results

### DIFF
--- a/Scripts/assemble_smart_report.py
+++ b/Scripts/assemble_smart_report.py
@@ -46,8 +46,24 @@ def assemble_per_test_report(scores_dir: str | Path, results_file: str | Path) -
             payload = None
             if score_file.exists():
                 payload = extract_score_payload(score_file.read_text(encoding="utf-8").strip())
-            score_value = payload["score"] if payload else 3
-            reason = str(payload.get("reason", "")) if payload else ""
+            if payload is None:
+                raise ValueError(
+                    f"Result {result_idx} ({name}) has no genuine judge payload; "
+                    "refusing to synthesize a fallback score"
+                )
+
+            score_value = payload.get("score")
+            if type(score_value) is not int or not 1 <= score_value <= 5:
+                raise ValueError(
+                    f"Result {result_idx} ({name}) has invalid judge score: {score_value!r}"
+                )
+
+            reason = payload.get("reason", "")
+            if not isinstance(reason, str) or not reason.strip():
+                raise ValueError(
+                    f"Result {result_idx} ({name}) has no genuine judge reason; "
+                    "refusing to publish its score"
+                )
             scores.append({"i": result_idx, "s": score_value})
 
             tokens_per_second = result.get("tokens_per_sec", 0) or 0

--- a/Scripts/check_pr_reviews.py
+++ b/Scripts/check_pr_reviews.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Inspect automatic PR reviews before treating a change as review-ready."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+GRAPHQL_URL = "https://api.github.com/graphql"
+PR_PATTERN = re.compile(r"^(?P<owner>[^/]+)/(?P<name>[^#]+)#(?P<number>[0-9]+)$")
+RATE_LIMIT_MARKERS = (
+    "review budget",
+    "rate limit hit",
+    "used your own review budget",
+)
+
+QUERY = """
+query ReviewState($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      number
+      title
+      url
+      state
+      merged
+      mergeable
+      reviewDecision
+      comments(first: 100) {
+        nodes {
+          databaseId
+          createdAt
+          author { login }
+          body
+          url
+        }
+      }
+      reviews(first: 100) {
+        nodes {
+          databaseId
+          submittedAt
+          author { login }
+          state
+          body
+          url
+        }
+      }
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first: 100) {
+            nodes {
+              databaseId
+              createdAt
+              author { login }
+              body
+              path
+              line
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def parse_pr(value: str) -> tuple[str, str, int]:
+    match = PR_PATTERN.fullmatch(value.strip())
+    if match is None:
+        raise ValueError("PR must be specified as owner/repository#number")
+    return match.group("owner"), match.group("name"), int(match.group("number"))
+
+
+def github_token() -> str | None:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        return token
+    executable = os.environ.get("GH_EXECUTABLE", "gh")
+    try:
+        completed = subprocess.run(
+            [executable, "auth", "token"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    token = completed.stdout.strip()
+    return token or None
+
+
+def fetch_pr_review_state(
+    owner: str,
+    repository: str,
+    number: int,
+    token: str | None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    if not token:
+        raise RuntimeError(
+            "GitHub GraphQL authentication is required; set GITHUB_TOKEN or log in with gh"
+        )
+    payload = json.dumps(
+        {
+            "query": QUERY,
+            "variables": {"owner": owner, "name": repository, "number": number},
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        GRAPHQL_URL,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "maclocal-api-review-check",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            document = json.load(response)
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub API HTTP {error.code}: {detail}") from error
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"GitHub API request failed: {error}") from error
+
+    if document.get("errors"):
+        messages = "; ".join(
+            str(item.get("message", item)) for item in document["errors"]
+        )
+        raise RuntimeError(f"GitHub GraphQL errors: {messages}")
+    pull_request = document.get("data", {}).get("repository", {}).get("pullRequest")
+    if pull_request is None:
+        raise RuntimeError("GitHub API returned no pull request")
+    return pull_request
+
+
+def author_login(node: dict[str, Any]) -> str:
+    return str((node.get("author") or {}).get("login") or "")
+
+
+def is_selected_bot(node: dict[str, Any], bots: set[str]) -> bool:
+    return author_login(node).lower() in bots
+
+
+def normalize_state(
+    pull_request: dict[str, Any],
+    bots: set[str],
+) -> dict[str, Any]:
+    comments = pull_request.get("comments", {}).get("nodes", [])
+    reviews = pull_request.get("reviews", {}).get("nodes", [])
+    threads = pull_request.get("reviewThreads", {}).get("nodes", [])
+    automatic_comments = [item for item in comments if is_selected_bot(item, bots)]
+    automatic_reviews = [item for item in reviews if is_selected_bot(item, bots)]
+    automatic_threads = []
+    for thread in threads:
+        thread_comments = thread.get("comments", {}).get("nodes", [])
+        if any(is_selected_bot(item, bots) for item in thread_comments):
+            automatic_threads.append(
+                {
+                    **thread,
+                    "url": next(
+                        (item.get("url") for item in thread_comments if item.get("url")),
+                        None,
+                    ),
+                }
+            )
+
+    automatic_text = " ".join(
+        str(item.get("body") or "")
+        for item in automatic_comments + automatic_reviews
+    ).lower()
+    rate_limited = any(marker in automatic_text for marker in RATE_LIMIT_MARKERS)
+    changes_requested = any(
+        str(item.get("state") or "").upper() == "CHANGES_REQUESTED"
+        for item in automatic_reviews
+    )
+
+    return {
+        "pr": {
+            "number": pull_request.get("number"),
+            "title": pull_request.get("title"),
+            "url": pull_request.get("url"),
+            "state": pull_request.get("state"),
+            "merged": pull_request.get("merged"),
+            "mergeable": pull_request.get("mergeable"),
+            "review_decision": pull_request.get("reviewDecision"),
+        },
+        "selected_bots": sorted(bots),
+        "automatic_comment_count": len(automatic_comments),
+        "automatic_review_count": len(automatic_reviews),
+        "automatic_review_states": sorted(
+            {str(item.get("state") or "UNKNOWN") for item in automatic_reviews}
+        ),
+        "automatic_threads": [
+            {
+                "url": thread.get("url"),
+                "resolved": bool(thread.get("isResolved")),
+                "outdated": bool(thread.get("isOutdated")),
+                "comments": thread.get("comments", {}).get("nodes", []),
+            }
+            for thread in automatic_threads
+        ],
+        "rate_limited": rate_limited,
+        "changes_requested": changes_requested,
+    }
+
+
+def evaluate_state(
+    state: dict[str, Any],
+    *,
+    require_review: bool = False,
+    allow_outdated: bool = False,
+) -> tuple[str, list[str]]:
+    findings: list[str] = []
+    if state["changes_requested"]:
+        findings.append("Selected automatic reviewer requested changes")
+
+    unresolved = []
+    for thread in state["automatic_threads"]:
+        if thread["resolved"]:
+            continue
+        if allow_outdated and thread["outdated"]:
+            continue
+        unresolved.append(thread)
+    if unresolved:
+        findings.append(
+            f"Selected automatic reviewer has {len(unresolved)} unresolved thread(s)"
+        )
+
+    observed = bool(state["automatic_comment_count"] or state["automatic_review_count"])
+    if require_review and not observed:
+        findings.append("No selected automatic review or guide comment was observed")
+    if require_review and state["rate_limited"]:
+        findings.append(
+            "Selected automatic review was rate-limited; request a completed review"
+        )
+
+    return ("FAIL" if findings else "PASS"), findings
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("pr", help="Pull request as owner/repository#number")
+    parser.add_argument(
+        "--bot",
+        action="append",
+        default=["sourcery-ai"],
+        help="Automatic reviewer login; repeatable (default: sourcery-ai)",
+    )
+    parser.add_argument(
+        "--require-review",
+        action="store_true",
+        help="Fail when no selected review was observed or the review was rate-limited",
+    )
+    parser.add_argument(
+        "--allow-outdated",
+        action="store_true",
+        help="Do not fail for unresolved threads marked outdated",
+    )
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="GitHub API timeout in seconds (default: 30)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        owner, repository, number = parse_pr(args.pr)
+        state = normalize_state(
+            fetch_pr_review_state(
+                owner,
+                repository,
+                number,
+                github_token(),
+                timeout=args.timeout,
+            ),
+            {bot.lower() for bot in args.bot},
+        )
+        outcome, findings = evaluate_state(
+            state,
+            require_review=args.require_review,
+            allow_outdated=args.allow_outdated,
+        )
+        state["outcome"] = outcome
+        state["findings"] = findings
+        if args.json:
+            print(json.dumps(state, indent=2, sort_keys=True))
+        else:
+            print(f"PR: {state['pr']['url']}")
+            print(f"Automatic comments: {state['automatic_comment_count']}")
+            print(f"Automatic reviews: {state['automatic_review_count']}")
+            print(f"Automatic threads: {len(state['automatic_threads'])}")
+            print(f"Rate limited: {state['rate_limited']}")
+            print(f"Outcome: {outcome}")
+            for finding in findings:
+                print(f"- {finding}")
+        return 0 if outcome == "PASS" else 1
+    except (ValueError, RuntimeError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -471,8 +471,8 @@ HELPEOF
   i=$((i + 1))
 done
 
-# Validate openai SDK prerequisite
-if ! python3 -c "import openai" 2>/dev/null; then
+# Generation needs the OpenAI SDK; CPU-only reanalysis must not require it.
+if [ -z "$REANALYSE_FILE" ] && ! python3 -c "import openai" 2>/dev/null; then
   echo "Error: OpenAI Python SDK not found. Install with: pip3 install openai" >&2
   exit 1
 fi
@@ -1969,29 +1969,57 @@ $jsonl_line"
         case "$tool" in
           claude)
             PERTEST_SCORE=$(echo "$PERTEST_INPUT" | "$tool" -p - 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log")
+            judge_status=$?
             ;;
           codex)
             CODEX_TMP="$(mktemp "$TEST_WORK_ROOT/smart-codex-pertest-XXXXXX")"
             echo "$PERTEST_INPUT" > "$CODEX_TMP"
             PERTEST_SCORE=$("$tool" exec --skip-git-repo-check "Read and score the test result in $CODEX_TMP. Output exactly one JSON line: {\"score\": N, \"reason\": \"...\"}" </dev/null 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log")
+            judge_status=$?
             rm -f "$CODEX_TMP"
             ;;
           afm)
             PERTEST_SCORE=$("$AFM" -s "$PERTEST_INPUT" 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log")
+            judge_status=$?
             ;;
           *)
             PERTEST_SCORE=$(echo "$PERTEST_INPUT" | "$tool" 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log")
+            judge_status=$?
             ;;
         esac
 
         echo "$PERTEST_SCORE" > "$PERTEST_SCORES_DIR/score_${line_idx}.txt"
+        if [ "$judge_status" -ne 0 ]; then
+          echo "" >&2
+          echo "Error: $tool judge exited with status $judge_status for result $line_idx" >&2
+          echo "Preserved raw judge output: $PERTEST_SCORES_DIR/score_${line_idx}.txt" >&2
+          echo "Check stderr: $TEST_WORK_ROOT/smart-${tool}-stderr-$$.log" >&2
+          exit "$judge_status"
+        fi
+
         score_val=$(echo "$PERTEST_SCORE" | PYTHONPATH="$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -c "
 import sys
 from mlx_model_test_oracle import extract_score_payload
 text = sys.stdin.read().strip()
 payload = extract_score_payload(text)
-print(payload['score'] if payload else '?')
+reason = payload.get('reason', '') if payload else ''
+valid = (
+    payload is not None
+    and type(payload.get('score')) is int
+    and 1 <= payload['score'] <= 5
+    and isinstance(reason, str)
+    and bool(reason.strip())
+)
+print(payload['score'] if valid else '?')
 " 2>/dev/null)
+        if [ "$score_val" != "?" ] && [ "$score_val" != "" ]; then
+          :
+        else
+          echo "" >&2
+          echo "Error: $tool judge returned no valid score payload for result $line_idx" >&2
+          echo "Preserved raw judge output: $PERTEST_SCORES_DIR/score_${line_idx}.txt" >&2
+          exit 1
+        fi
         echo "score=$score_val"
         line_idx=$((line_idx + 1))
       done < "$RESULTS_FILE"

--- a/Scripts/test_mlx_model_test_oracle.py
+++ b/Scripts/test_mlx_model_test_oracle.py
@@ -248,6 +248,34 @@ class ModelTestOracleTests(unittest.TestCase):
         self.assertIn("> meets intent", report)
         self.assertIn('<!-- AI_SCORES [{"i": 1, "s": 5}] -->', report)
 
+    def test_per_test_report_assembler_rejects_fallback_scores(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            results = root / "results.jsonl"
+            scores = root / "scores"
+            scores.mkdir()
+            results.write_text(
+                json.dumps({"model": "model/a", "label": "working", "status": "OK"})
+                + "\n",
+                encoding="utf-8",
+            )
+
+            cases = {
+                "missing": None,
+                "empty": "",
+                "unparseable": "judge unavailable",
+                "no-reason": '{"score":5}',
+                "blank-reason": '{"score":5,"reason":"   "}',
+                "non-string-reason": '{"score":5,"reason":["looks genuine"]}',
+                "out-of-range": '{"score":6,"reason":"invalid range"}',
+            }
+            for name, payload in cases.items():
+                with self.subTest(case=name):
+                    score_file = scores / "score_0.txt"
+                    score_file.write_text(payload or "", encoding="utf-8")
+                    with self.assertRaisesRegex(ValueError, "refusing|invalid judge score"):
+                        assemble_per_test_report(scores, results)
+
     def test_evaluation_lane_distinguishes_native_and_cross_family_parser_use(self):
         self.assertEqual(
             evaluation_lane(

--- a/Scripts/tests/test_check_pr_reviews.py
+++ b/Scripts/tests/test_check_pr_reviews.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Offline fixtures for automatic-review inspection; no network or tokens."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "check_pr_reviews.py"
+SPEC = importlib.util.spec_from_file_location("check_pr_reviews", MODULE_PATH)
+check_pr_reviews = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(check_pr_reviews)
+sys.modules[check_pr_reviews.__name__] = check_pr_reviews
+
+
+def state(
+    *,
+    comments=(),
+    reviews=(),
+    threads=(),
+):
+    return check_pr_reviews.normalize_state(
+        {
+            "number": 283,
+            "title": "Fixture",
+            "url": "https://example.invalid/pr/283",
+            "state": "OPEN",
+            "merged": False,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "comments": {"nodes": list(comments)},
+            "reviews": {"nodes": list(reviews)},
+            "reviewThreads": {"nodes": list(threads)},
+        },
+        {"sourcery-ai"},
+    )
+
+
+def thread(resolved=False, outdated=False):
+    return {
+        "url": "https://example.invalid/thread",
+        "isResolved": resolved,
+        "isOutdated": outdated,
+        "comments": {
+            "nodes": [
+                {
+                    "author": {"login": "sourcery-ai"},
+                    "body": "fixture finding",
+                    "path": "README.md",
+                    "line": 1,
+                }
+            ]
+        },
+    }
+
+
+class CheckPrReviewsTests(unittest.TestCase):
+    def test_parses_and_rejects_pr_references(self):
+        self.assertEqual(
+            check_pr_reviews.parse_pr("scouzi1966/maclocal-api#283"),
+            ("scouzi1966", "maclocal-api", 283),
+        )
+        with self.assertRaisesRegex(ValueError, "owner/repository#number"):
+            check_pr_reviews.parse_pr("scouzi1966/maclocal-api")
+
+    def test_rate_limited_guide_is_visible_but_not_a_finding(self):
+        review_state = state(
+            comments=[{"author": {"login": "sourcery-ai"}, "body": "Reviewer guide"}],
+            reviews=[
+                {
+                    "author": {"login": "sourcery-ai"},
+                    "state": "COMMENTED",
+                    "body": "Sorry, you've used your own review budget.",
+                }
+            ],
+        )
+
+        outcome, findings = check_pr_reviews.evaluate_state(review_state)
+
+        self.assertTrue(review_state["rate_limited"])
+        self.assertEqual(review_state["automatic_comment_count"], 1)
+        self.assertEqual(review_state["automatic_review_count"], 1)
+        self.assertEqual((outcome, findings), ("PASS", []))
+
+    def test_unresolved_and_changes_requested_reviews_fail(self):
+        review_state = state(
+            reviews=[
+                {
+                    "author": {"login": "sourcery-ai"},
+                    "state": "CHANGES_REQUESTED",
+                    "body": "Please revise",
+                }
+            ],
+            threads=[thread()],
+        )
+
+        outcome, findings = check_pr_reviews.evaluate_state(review_state)
+
+        self.assertEqual(outcome, "FAIL")
+        self.assertEqual(len(findings), 2)
+
+    def test_require_review_fails_missing_and_rate_limited_reviews(self):
+        missing = state()
+        limited = state(
+            reviews=[
+                {
+                    "author": {"login": "sourcery-ai"},
+                    "state": "COMMENTED",
+                    "body": "rate limit hit",
+                }
+            ]
+        )
+
+        self.assertEqual(
+            check_pr_reviews.evaluate_state(missing, require_review=True)[0], "FAIL"
+        )
+        self.assertEqual(
+            check_pr_reviews.evaluate_state(limited, require_review=True)[0], "FAIL"
+        )
+
+    def test_outdated_thread_policy_is_explicit(self):
+        review_state = state(threads=[thread(outdated=True)])
+
+        self.assertEqual(
+            check_pr_reviews.evaluate_state(review_state)[0], "FAIL"
+        )
+        self.assertEqual(
+            check_pr_reviews.evaluate_state(review_state, allow_outdated=True)[0],
+            "PASS",
+        )
+
+    def test_cli_prints_json_and_exit_status(self):
+        fixture = state(
+            reviews=[
+                {
+                    "author": {"login": "sourcery-ai"},
+                    "state": "COMMENTED",
+                    "body": "Reviewer guide",
+                }
+            ]
+        )
+        with patch.object(
+            check_pr_reviews,
+            "fetch_pr_review_state",
+            return_value={
+                "number": 283,
+                "title": "Fixture",
+                "url": "https://example.invalid/pr/283",
+                "state": "OPEN",
+                "merged": False,
+                "mergeable": "MERGEABLE",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "comments": {"nodes": []},
+                "reviews": {"nodes": []},
+                "reviewThreads": {"nodes": []},
+            },
+        ), patch.object(check_pr_reviews, "github_token", return_value="fixture"), patch.object(
+            check_pr_reviews, "normalize_state", return_value=fixture
+        ):
+            code = check_pr_reviews.main(["scouzi1966/maclocal-api#283", "--json"])
+
+        self.assertEqual(code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/tests/test_smart_judge_availability.py
+++ b/Scripts/tests/test_smart_judge_availability.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""CPU-only smart-judge fixtures; no model, network, or real judge is invoked."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "Scripts/mlx-model-test.sh"
+
+
+def run_reanalysis(fake_judge_script, records):
+    with tempfile.TemporaryDirectory() as directory:
+        work = Path(directory)
+        bindir = work / "bin"
+        bindir.mkdir()
+        fake_codex = bindir / "codex"
+        fake_codex.write_text(fake_judge_script, encoding="utf-8")
+        fake_codex.chmod(0o755)
+
+        results = work / "results.jsonl"
+        results.write_text(
+            "".join(json.dumps(record) + "\n" for record in records),
+            encoding="utf-8",
+        )
+
+        environment = dict(os.environ)
+        environment["PATH"] = f"{bindir}{os.pathsep}{environment.get('PATH', '')}"
+        # CPU-only reanalysis must not require the generation-time OpenAI SDK.
+        environment.pop("PYTHONPATH", None)
+        environment["AFM_TEST_WORK_ROOT"] = str(work / "judge-work")
+        completed = subprocess.run(
+            [
+                str(SCRIPT),
+                "--reanalyse",
+                str(results),
+                "--smart",
+                "1:codex",
+                "--no-report",
+            ],
+            cwd=work,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        reports = [
+            (path, path.read_text(encoding="utf-8"))
+            for path in (work / "test-reports").glob("smart-analysis-codex-*.md")
+        ]
+        return completed, reports
+
+
+class SmartJudgeAvailabilityTests(unittest.TestCase):
+    def test_failing_judge_stops_before_synthesizing_scores(self):
+        records = [
+            {"model": "fixture/model", "label": "case", "status": "OK"},
+            {"model": "fixture/model", "label": "unreached", "status": "OK"},
+        ]
+        completed, reports = run_reanalysis(
+            "#!/bin/sh\n"
+            "echo 'usage limit fixture' >&2\n"
+            "exit 7\n",
+            records,
+        )
+
+        self.assertEqual(completed.returncode, 7)
+        self.assertIn("codex judge exited with status 7", completed.stderr)
+        self.assertIn("result 0", completed.stderr)
+        self.assertIn("[1/2]", completed.stdout)
+        self.assertNotIn("[2/2]", completed.stdout)
+        self.assertEqual(reports, [])
+
+    def test_reasonless_score_is_rejected_before_the_next_result(self):
+        records = [
+            {"model": "fixture/model", "label": "case", "status": "OK"},
+            {"model": "fixture/model", "label": "unreached", "status": "OK"},
+        ]
+        completed, reports = run_reanalysis(
+            "#!/bin/sh\n"
+            "echo '{\"score\":5}'\n",
+            records,
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn(
+            "codex judge returned no valid score payload for result 0",
+            completed.stderr,
+        )
+        self.assertIn("[1/2]", completed.stdout)
+        self.assertNotIn("[2/2]", completed.stdout)
+        self.assertEqual(reports, [])
+
+    def test_genuine_score_and_reason_produce_a_complete_report(self):
+        records = [
+            {"model": "fixture/model", "label": "first", "status": "OK"},
+            {
+                "model": "fixture/model",
+                "label": "skipped",
+                "status": "SKIP",
+                "overall_status": "skip",
+            },
+            {"model": "fixture/model", "label": "second", "status": "OK"},
+        ]
+        completed, reports = run_reanalysis(
+            "#!/bin/sh\n"
+            "echo '{\"score\":4,\"reason\":\"fixture reason\"}'\n",
+            records,
+        )
+
+        self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+        self.assertIn("[3/3] second... score=4", completed.stdout)
+        self.assertEqual(len(reports), 1)
+        report = reports[0][1]
+        self.assertIn("> fixture reason", report)
+        self.assertIn(
+            '<!-- AI_SCORES [{"i": 0, "s": 4}, {"i": 2, "s": 4}] -->',
+            report,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

RC3 CPU-only Codex reanalysis hit a usage limit. The per-test loop continued through the retained results, and the assembler represented empty/reasonless payloads as fallback score 3. The external verifier rejected that report, but only after all 91 judge attempts.

## Changes

- Capture each per-test judge command status directly inside its shell branch.
- Stop immediately on nonzero judge exit and preserve raw output plus stderr paths.
- Validate each payload for an integer 1-5 score and a non-empty string reason before advancing.
- Make report assembly reject missing, malformed, reasonless, or out-of-range payloads instead of synthesizing score 3.
- Remove the generation-only OpenAI SDK prerequisite from CPU-only `--reanalyse`.
- Add `Scripts/check_pr_reviews.py`, a read-only GitHub GraphQL gate for automatic reviewer comments, submitted reviews, rate-limit state, and unresolved threads. Default reviewer: `sourcery-ai`.
  - Inspection mode records rate-limited reviews without treating them as code findings.
  - `--require-review` fails until a completed automatic review is observed.
  - Fails on requested changes or unresolved automatic review threads.

## Validation

- `bash -n Scripts/mlx-model-test.sh`
- `PYTHONPATH=Scripts python3 -m unittest -v test_mlx_model_test_oracle Scripts.tests.test_smart_judge_availability Scripts.tests.test_check_pr_reviews`
  - 35 tests passed.
- `python3 -m py_compile Scripts/assemble_smart_report.py Scripts/check_pr_reviews.py Scripts/tests/test_smart_judge_availability.py Scripts/tests/test_check_pr_reviews.py`
- `git diff --check`
- Live read-only check of PR #283:
  - One Sourcery guide comment.
  - One `COMMENTED` Sourcery review.
  - Zero review threads and zero requested changes.
  - Rate limit detected; inspection mode passes.
  - `--require-review` correctly fails until a completed automatic review is available.

Tests use fake `codex` executables and offline GitHub fixtures. No model inference, GPU workload, real judge call, or repository mutation is performed by tests.

This does not restore Codex quota or reclassify historical RC3 scores; it prevents another judge outage from being mistaken for completed scoring.

## Summary by Sourcery

Fail closed on incomplete smart-judge results and add automatic review readiness checks.

New Features:
- Add a read-only GitHub review gate that reports automatic reviewer activity, rate limits, requested changes, and unresolved threads, with optional review enforcement.

Bug Fixes:
- Fail fast when a smart judge exits unsuccessfully or returns a missing, malformed, reasonless, or out-of-range score instead of continuing or synthesizing a fallback score.

Enhancements:
- Allow CPU-only reanalysis to run without the generation-time OpenAI SDK prerequisite.

Tests:
- Add coverage for fail-closed smart-judge behavior, strict report validation, CPU-only reanalysis, and automatic review-state evaluation.