### PR TITLE
Bump AFMKit to v0.1.18-rc.3

### DIFF
--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.18-rc.2"
+        exact: "0.1.18-rc.3"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "ca033e73413d8289719bc4d7a815b843b875134d610c45b4d4b99f726265bed8",
+  "originHash" : "bbae5c926aea6b022891cf4483c9f96f84fa5f37429559f449f88f665153dff3",
   "pins" : [
     {
       "identity" : "afmkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "6a8c25ab948237e822547c576c13a95d926086b1",
-        "version" : "0.1.18-rc.2"
+        "revision" : "39c6f4b244bc3c10ae23b0f84d0a3bb575edb8a1",
+        "version" : "0.1.18-rc.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.18-rc.2"
+        exact: "0.1.18-rc.3"
     )
 }
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -146,8 +146,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.18-rc.2":
-        fail(f"{identity} must resolve the exact 0.1.18-rc.2 release")
+    if pin["state"].get("version") != "0.1.18-rc.3":
+        fail(f"{identity} must resolve the exact 0.1.18-rc.3 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -290,7 +290,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.18-rc.2"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.18-rc.3"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.18-rc.2",
+    "afmkit": "0.1.18-rc.3",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -62,13 +62,13 @@ cat > "$fake_public_git" <<'SH'
 #!/usr/bin/env bash
 arguments=" $* "
 for ref in \
-  refs/tags/0.1.18-rc.2 \
-  'refs/tags/0.1.18-rc.2^{}' \
-  refs/tags/v0.1.18-rc.2 \
-  'refs/tags/v0.1.18-rc.2^{}'; do
+  refs/tags/0.1.18-rc.3 \
+  'refs/tags/0.1.18-rc.3^{}' \
+  refs/tags/v0.1.18-rc.3 \
+  'refs/tags/v0.1.18-rc.3^{}'; do
   [[ "$arguments" == *" $ref "* ]] || exit 2
 done
-printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.18-rc.2^{}'
+printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.18-rc.3^{}'
 SH
 chmod 700 "$fake_public_git"
 if ! EXPECTED_AFMKIT_REVISION="$expected_afmkit_revision" \
@@ -88,7 +88,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.2'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.3'
   }
   probe_public_source() {
     return 1
@@ -112,14 +112,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.18-rc.2" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.18-rc.2"
+[[ "$release_version" == "0.1.18-rc.3" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.18-rc.3"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.2'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.3'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -138,7 +138,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.2'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.3'
   }
   probe_public_source() {
     return 0

--- a/docs/afmkit-url-consumption.md
+++ b/docs/afmkit-url-consumption.md
@@ -6,7 +6,7 @@ one exact release and selects every provider product from it:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.18-rc.2"
+    exact: "0.1.18-rc.3"
 )
 ```
 
@@ -14,7 +14,7 @@ Do not use a branch or revision requirement for release builds.
 
 ## Production Blocker
 
-AFMKit is public and exposes `0.1.18-rc.2`. AFM release publication remains
+AFMKit is public and exposes `0.1.18-rc.3`. AFM release publication remains
 fail-closed unless AFMKit and every dependency in its root graph are
 anonymously readable and the tracked lock resolves that exact tag.
 
@@ -38,7 +38,7 @@ surface publishable.
 
 ## Dependency Resolution
 
-AFMKit 0.1.18-rc.2 is public, so normal resolution requires no GitHub credential:
+AFMKit 0.1.18-rc.3 is public, so normal resolution requires no GitHub credential:
 
 ```bash
 Scripts/resolve-release-dependencies.sh
@@ -55,7 +55,7 @@ The normal graph is independent of maclocal-api's dirty vendor worktrees:
 
 | Dependency | Requirement | Purpose |
 | --- | --- | --- |
-| `AFMKit` | exact `0.1.18-rc.2` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
+| `AFMKit` | exact `0.1.18-rc.3` | Core, services, evaluation, MLX, DwarfStar, Apple, Foundation Models bridges, audio, and the vendored MLX runtime |
 
 The MLX, mlx-c, Swift bindings, and mlx-swift-lm sources are snapshots inside
 AFMKit's `vendor/MLX` tree. They are not separate SwiftPM dependencies of

--- a/docs/vesta-integration.md
+++ b/docs/vesta-integration.md
@@ -11,7 +11,7 @@ Use the current exact public AFMKit release:
 ```swift
 .package(
     url: "https://github.com/scouzi1966/AFMKit.git",
-    exact: "0.1.18-rc.2"
+    exact: "0.1.18-rc.3"
 )
 ```
 


### PR DESCRIPTION
## Summary
- Advance the exact AFMKit dependency from `0.1.18-rc.2` to published `0.1.18-rc.3` at `39c6f4b244bc3c10ae23b0f84d0a3bb575edb8a1`.
- Preserve embedded GLM NextN conversion and converted-layout MTP qualification by carrying the new provider tag through the consumer lock and release-boundary gates.
- Update the independent core consumer example and current dependency documentation.

## Validation
- AFMKit `v0.1.18-rc.3` passed its full canonical local release qualification: all 16 API baselines, Release test targets, and all 16 exact-tag downstream products.
- `Scripts/resolve-release-dependencies.sh --refresh-lock`
- `Scripts/tests/test-release-tooling.sh`
- `Scripts/swiftpm-reliable.sh build -c release --product afm`
- `git diff --check`

The consumer build used the public exact AFMKit tag with no local AFMKit override.

## Summary by Sourcery

Update all consumer, release-validation, and documentation references to the exact public AFMKit 0.1.18-rc.3 release.

Enhancements:
- Advance the project and independent consumer to the exact public AFMKit 0.1.18-rc.3 release.
- Update release-boundary validation and dependency documentation to enforce and describe AFMKit 0.1.18-rc.3.

Documentation:
- Update AFMKit consumption and integration documentation for the 0.1.18-rc.3 release.

Tests:
- Update release tooling tests to validate the AFMKit 0.1.18-rc.3 tag and version.

Chores:
- Refresh the Swift package dependency lockfile for AFMKit 0.1.18-rc.3.