### PR TITLE
Support Codex GLM smart judge

### DIFF
--- a/Scripts/mlx-model-test.sh
+++ b/Scripts/mlx-model-test.sh
@@ -1971,7 +1971,7 @@ $jsonl_line"
             PERTEST_SCORE=$(echo "$PERTEST_INPUT" | "$tool" -p - 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log")
             judge_status=$?
             ;;
-          codex)
+          codex|codex-glm)
             CODEX_TMP="$(mktemp "$TEST_WORK_ROOT/smart-codex-pertest-XXXXXX")"
             echo "$PERTEST_INPUT" > "$CODEX_TMP"
             PERTEST_SCORE=$("$tool" exec --skip-git-repo-check "Read and score the test result in $CODEX_TMP. Output exactly one JSON line: {\"score\": N, \"reason\": \"...\"}" </dev/null 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log")
@@ -2052,7 +2052,7 @@ $SMART_TEST_FILE_SECTION
 --- JSONL DATA ---"
           "$tool" -p "$CLAUDE_PROMPT" < "$RESULTS_FILE" > "$SMART_REPORT" 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log"
           ;;
-        codex)
+        codex|codex-glm)
           # codex exec: use temp file to avoid ARG_MAX limit on command line
           # (91+ test results with full responses easily exceed OS argument length)
           "$tool" exec --skip-git-repo-check "Read and follow the analysis instructions in $SMART_INPUT. Score every executed JSONL result, omit metadata and status=SKIP records, and output the AI_SCORES block as specified." </dev/null > "$SMART_REPORT" 2>"$TEST_WORK_ROOT/smart-${tool}-stderr-$$.log"

--- a/Scripts/tests/test_smart_judge_availability.py
+++ b/Scripts/tests/test_smart_judge_availability.py
@@ -13,12 +13,12 @@ ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "Scripts/mlx-model-test.sh"
 
 
-def run_reanalysis(fake_judge_script, records):
+def run_reanalysis(fake_judge_script, records, tool="codex"):
     with tempfile.TemporaryDirectory() as directory:
         work = Path(directory)
         bindir = work / "bin"
         bindir.mkdir()
-        fake_codex = bindir / "codex"
+        fake_codex = bindir / tool
         fake_codex.write_text(fake_judge_script, encoding="utf-8")
         fake_codex.chmod(0o755)
 
@@ -39,7 +39,7 @@ def run_reanalysis(fake_judge_script, records):
                 "--reanalyse",
                 str(results),
                 "--smart",
-                "1:codex",
+                f"1:{tool}",
                 "--no-report",
             ],
             cwd=work,
@@ -50,7 +50,7 @@ def run_reanalysis(fake_judge_script, records):
         )
         reports = [
             (path, path.read_text(encoding="utf-8"))
-            for path in (work / "test-reports").glob("smart-analysis-codex-*.md")
+            for path in (work / "test-reports").glob(f"smart-analysis-{tool}-*.md")
         ]
         return completed, reports
 
@@ -121,6 +121,20 @@ class SmartJudgeAvailabilityTests(unittest.TestCase):
             '<!-- AI_SCORES [{"i": 0, "s": 4}, {"i": 2, "s": 4}] -->',
             report,
         )
+
+    def test_codex_glm_uses_the_codex_exec_interface(self):
+        records = [{"model": "fixture/model", "label": "case", "status": "OK"}]
+        completed, reports = run_reanalysis(
+            "#!/bin/sh\n"
+            "case $1 in exec) ;; *) echo \"unexpected command: $1\" >&2; exit 64 ;; esac\n"
+            "echo '{\"score\":5,\"reason\":\"glm judge fixture\"}'\n",
+            records,
+            tool="codex-glm",
+        )
+
+        self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+        self.assertEqual(len(reports), 1)
+        self.assertIn("> glm judge fixture", reports[0][1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Treat `codex-glm` as a Codex-compatible smart judge in both per-test and batch modes.
- Cover the `exec` command interface with an offline fake `codex-glm` executable.

## Testing
- `bash -n Scripts/mlx-model-test.sh`
- `PYTHONPATH=Scripts python3 -m unittest -v Scripts.tests.test_smart_judge_availability`
- Live `codex-glm exec` preflight returned exactly `OK` using `glm-5.3` via `zai_bridge`.

No model inference or real judging is performed by the regression test.

## Summary by Sourcery

Support `codex-glm` as a Codex-compatible smart judge across smart analysis workflows.

New Features:
- Add support for using `codex-glm` as a smart judge in per-test and batch analysis modes.

Tests:
- Add an offline regression test verifying the `codex-glm exec` interface and generated score report.