### PR TITLE
Pin DS4 stable snapshot and llama.cpp v0.4.0 WebUI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,10 +40,10 @@ jobs:
         cp "$BIN" release-package/
 
         # Copy required webui resources. The -w/--webui startup behavior
-        # depends on this file being present in the relocated package.
-        test -s Resources/webui/index.html.gz
+        # depends on this complete static tree being present in the relocated package.
         mkdir -p release-package/Resources/webui
-        cp Resources/webui/index.html.gz release-package/Resources/webui/
+        cp -R Resources/webui/. release-package/Resources/webui/
+        Scripts/verify-webui.sh release-package/Resources/webui
 
         # Copy required runtime resource bundles beside the executable.
         for BUNDLE_NAME in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
         cp .build/arm64-apple-macosx/release/afm release-package/
 
         mkdir -p release-package/Resources/webui
-        cp Resources/webui/index.html.gz release-package/Resources/webui/
-        Scripts/verify-webui.sh release-package/Resources/webui/index.html.gz
+        cp -R Resources/webui/. release-package/Resources/webui/
+        Scripts/verify-webui.sh release-package/Resources/webui
 
         for BUNDLE_NAME in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKit_AFMKitDwarfStar.bundle; do
           BUNDLE_DIR=.build/arm64-apple-macosx/release/$BUNDLE_NAME

--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.18-rc.3"
+        exact: "0.1.18-rc.4"
     )
 }
 

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ help:
 	@echo "  run             - Build and run debug server"
 	@echo "  submodules      - Initialize git submodules"
 	@echo "  webui           - Build webui from llama.cpp (requires Node.js)"
-	@echo "  verify-webui    - Validate the packaged WebUI gzip and HTML payload"
+	@echo "  verify-webui    - Validate the packaged WebUI static asset tree"
 	@echo "  build-with-webui - Build with webui included"
 	@echo "  help            - Show this help"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -44,18 +44,19 @@ submodule-status:
 # Build the webui from llama.cpp
 webui: submodules
 	@echo "🌐 Building webui..."
-	@if [ ! -d "vendor/llama.cpp/tools/server/webui" ]; then \
+	@if [ ! -d "vendor/llama.cpp/tools/ui" ]; then \
 		echo "❌ Error: webui source not found. Run 'make submodules' first."; \
 		exit 1; \
 	fi
-	@cd vendor/llama.cpp/tools/server/webui && npm ci && npm run build
-	@mkdir -p Resources/webui
-	@cp vendor/llama.cpp/tools/server/public/index.html.gz Resources/webui/
-	@Scripts/verify-webui.sh Resources/webui/index.html.gz
-	@echo "✅ WebUI built: Resources/webui/index.html.gz"
+	@cd vendor/llama.cpp/tools/ui && npm ci && npm run build
+	@rm -rf Resources/webui
+	@mkdir -p Resources
+	@cp -R vendor/llama.cpp/tools/ui/dist Resources/webui
+	@Scripts/verify-webui.sh Resources/webui
+	@echo "✅ WebUI built: Resources/webui"
 
 verify-webui:
-	@Scripts/verify-webui.sh Resources/webui/index.html.gz
+	@Scripts/verify-webui.sh Resources/webui
 
 # Build with webui included
 build-with-webui: webui build

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "bbae5c926aea6b022891cf4483c9f96f84fa5f37429559f449f88f665153dff3",
+  "originHash" : "c1e33558b3d8df1164af92cba4f2de659f6d255f662ffa917284437b59d7ba68",
   "pins" : [
     {
       "identity" : "afmkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "39c6f4b244bc3c10ae23b0f84d0a3bb575edb8a1",
-        "version" : "0.1.18-rc.3"
+        "revision" : "ef43d0f111df621a83374cfae17111723babfbf7",
+        "version" : "0.1.18-rc.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.18-rc.3"
+        exact: "0.1.18-rc.4"
     )
 }
 

--- a/Scripts/build-native-wheel.sh
+++ b/Scripts/build-native-wheel.sh
@@ -94,8 +94,10 @@ for bundle in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle AFMKi
   cp -R "$source_bundle" "$PACKAGE_ROOT/bin/"
 done
 cp "$METALLIB" "$PACKAGE_ROOT/bin/default.metallib"
-"$ROOT_DIR/Scripts/verify-webui.sh" Resources/webui/index.html.gz
-cp Resources/webui/index.html.gz "$PACKAGE_ROOT/share/webui/"
+"$ROOT_DIR/Scripts/verify-webui.sh" Resources/webui
+rm -rf "$PACKAGE_ROOT/share/webui"
+mkdir -p "$PACKAGE_ROOT/share"
+cp -R Resources/webui "$PACKAGE_ROOT/share/webui"
 
 rm -rf "$ROOT_DIR/build"
 rm -f "dist/${DIST_NAME}-"*.whl
@@ -106,9 +108,10 @@ WHEEL="$(ls -t "dist/${DIST_NAME}-"*.whl 2>/dev/null | head -1)"
 [[ -n "$WHEEL" ]] || { echo "[wheel] No wheel was produced" >&2; exit 1; }
 "$ROOT_DIR/Scripts/verify-native-wheel.sh" "$WHEEL" "$PACKAGE_ROOT"
 
-wheel_webui="$ROOT_DIR/.build/${DIST_NAME}-wheel-webui.html.gz"
-unzip -p "$WHEEL" "$PACKAGE_ROOT/share/webui/index.html.gz" > "$wheel_webui"
-"$ROOT_DIR/Scripts/verify-webui.sh" "$wheel_webui"
-rm -f "$wheel_webui"
+wheel_webui="$ROOT_DIR/.build/${DIST_NAME}-wheel-webui"
+rm -rf "$wheel_webui"
+unzip -q "$WHEEL" "$PACKAGE_ROOT/share/webui/*" -d "$wheel_webui"
+"$ROOT_DIR/Scripts/verify-webui.sh" "$wheel_webui/$PACKAGE_ROOT/share/webui"
+rm -rf "$wheel_webui"
 
 echo "[wheel] Ready: $WHEEL"

--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -131,9 +131,9 @@ if [ -f "$METALLIB" ]; then
     cp "$METALLIB" macafm_next/bin/
     echo "[INFO] Included metallib"
 fi
-"$REPO_ROOT/Scripts/verify-webui.sh" Resources/webui/index.html.gz
+"$REPO_ROOT/Scripts/verify-webui.sh" Resources/webui
 mkdir -p macafm_next/share/webui
-cp Resources/webui/index.html.gz macafm_next/share/webui/
+cp -R Resources/webui/. macafm_next/share/webui/
 echo "[INFO] Included webui"
 
 # ---------- build wheel ----------
@@ -190,16 +190,11 @@ if [ "$WHL_SIZE" -lt 1 ]; then
     exit 1
 fi
 
-WHEEL_WEBUI="$REPO_ROOT/.build/afm-next-wheel-webui.html.gz"
-WHEEL_WEBUI_ENTRY=$(unzip -Z1 "$WHL" \
-    | awk '/(^|\/)macafm_next\/share\/webui\/index.html.gz$/ { print; exit }')
-if [ -z "$WHEEL_WEBUI_ENTRY" ]; then
-    echo "[ERROR] Wheel does not contain the required WebUI"
-    exit 1
-fi
-unzip -p "$WHL" "$WHEEL_WEBUI_ENTRY" > "$WHEEL_WEBUI"
-"$REPO_ROOT/Scripts/verify-webui.sh" "$WHEEL_WEBUI"
-rm -f "$WHEEL_WEBUI"
+WHEEL_WEBUI="$REPO_ROOT/.build/afm-next-wheel-webui"
+rm -rf "$WHEEL_WEBUI"
+unzip -q "$WHL" 'macafm_next/share/webui/*' -d "$WHEEL_WEBUI"
+"$REPO_ROOT/Scripts/verify-webui.sh" "$WHEEL_WEBUI/macafm_next/share/webui"
+rm -rf "$WHEEL_WEBUI"
 
 WHEEL_SMOKE=$(mktemp -d "$REPO_ROOT/.build/afm-next-wheel-smoke.XXXXXX")
 python3 -m pip install --quiet --no-deps --no-compile \

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -146,8 +146,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.18-rc.3":
-        fail(f"{identity} must resolve the exact 0.1.18-rc.3 release")
+    if pin["state"].get("version") != "0.1.18-rc.4":
+        fail(f"{identity} must resolve the exact 0.1.18-rc.4 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -290,7 +290,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.18-rc.3"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.18-rc.4"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.18-rc.3",
+    "afmkit": "0.1.18-rc.4",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)

--- a/Scripts/create-tarball.sh
+++ b/Scripts/create-tarball.sh
@@ -73,8 +73,8 @@ fi
 "$SCRIPT_DIR/check-macos26-compatibility.sh" "$BIN"
 
 # Verify webui
-WEBUI="$ROOT_DIR/Resources/webui/index.html.gz"
-if [ ! -f "$WEBUI" ]; then
+WEBUI="$ROOT_DIR/Resources/webui"
+if [ ! -d "$WEBUI" ]; then
   log_error "Missing webui: $WEBUI"
   exit 1
 fi
@@ -103,9 +103,9 @@ for BUNDLE_NAME in MacLocalAPI_AFMEvaluationHost.bundle AFMKit_AFMKitMLX.bundle 
     log_error "Required runtime bundle missing: $BUNDLE_DIR"
     exit 1
   fi
-  cp -R "$BUNDLE_DIR" "$STAGING/$DIRNAME/"
+cp -R "$BUNDLE_DIR" "$STAGING/$DIRNAME/"
 done
-cp "$WEBUI" "$STAGING/$DIRNAME/Resources/webui/"
+cp -R "$WEBUI/" "$STAGING/$DIRNAME/Resources/webui/"
 
 # Create tarball
 tar -czf "$OUTPUT" -C "$STAGING" "$DIRNAME"

--- a/Scripts/generate-tap-versioned.sh
+++ b/Scripts/generate-tap-versioned.sh
@@ -111,8 +111,8 @@ class ${class} < Formula
         (libexec/bundle_name).install Dir["#{bundle_name}/*"]
       end
     end
-    if File.exist?("Resources/webui/index.html.gz")
-      (share/"afm/webui").install "Resources/webui/index.html.gz"
+    if File.exist?("Resources/webui/index.html")
+      (share/"afm/webui").install Dir["Resources/webui/*"]
     end
   end
 
@@ -135,7 +135,7 @@ class ${class} < Formula
 
   test do
     assert_match "afm", shell_output("#{bin}/afm --version")
-    assert_path_exists share/"afm/webui/index.html.gz"
+    assert_path_exists share/"afm/webui/index.html"
   end
 end
 EOF
@@ -170,8 +170,8 @@ class ${class} < Formula
     libexec.install "AFMKit_AFMKitDwarfStar.bundle"
     (bin/"afm").write_env_script libexec/"afm", AFM_BUILD_VERSION: "v#{version}"
 
-    if File.exist?("Resources/webui/index.html.gz")
-      (share/"afm/webui").install "Resources/webui/index.html.gz"
+    if File.exist?("Resources/webui/index.html")
+      (share/"afm/webui").install Dir["Resources/webui/*"]
     end
     doc.install "README.md"
   end
@@ -187,7 +187,7 @@ class ${class} < Formula
   test do
     assert_match "v#{version}", shell_output("#{bin}/afm --version")
     assert_match "mlx", shell_output("#{bin}/afm --help")
-    assert_path_exists share/"afm/webui/index.html.gz"
+    assert_path_exists share/"afm/webui/index.html"
   end
 end
 EOF

--- a/Scripts/publish-next.sh
+++ b/Scripts/publish-next.sh
@@ -149,12 +149,12 @@ mkdir -p "$STAGING"
 # The server only opens the browser when the bundled WebUI can be resolved.
 # Build it on demand and treat it as a required release artifact so a nightly
 # cannot silently ship with a non-functional -w/--webui flag.
-WEBUI="$ROOT_DIR/Resources/webui/index.html.gz"
-if [ ! -f "$WEBUI" ]; then
+WEBUI="$ROOT_DIR/Resources/webui"
+if [ ! -d "$WEBUI" ]; then
   log_info "WebUI artifact missing; building it..."
   make webui
 fi
-if [ ! -f "$WEBUI" ]; then
+if [ ! -d "$WEBUI" ]; then
   log_error "Required WebUI artifact missing after build: $WEBUI"
   exit 1
 fi
@@ -176,7 +176,7 @@ done
 
 # WebUI
 mkdir -p "$STAGING/Resources/webui"
-cp "$WEBUI" "$STAGING/Resources/webui/"
+cp -R "$WEBUI/" "$STAGING/Resources/webui/"
 log_info "Included webui"
 
 cp "$ROOT_DIR/README.md" "$STAGING/" 2>/dev/null || true
@@ -191,13 +191,9 @@ shasum -a 256 "$TARBALL" > "$TARBALL.sha256"
 # SwiftPM resource bundles while the candidate is still local.
 "$STAGING/afm" --version
 "$STAGING/afm" --help | grep -q 'mlx'
-test -s "$STAGING/Resources/webui/index.html.gz"
-"$SCRIPT_DIR/verify-webui.sh" "$STAGING/Resources/webui/index.html.gz"
+"$SCRIPT_DIR/verify-webui.sh" "$STAGING/Resources/webui"
 
-ARCHIVE_WEBUI="$ROOT_DIR/.build/afm-next-archive-webui.html.gz"
-tar -xOzf "$TARBALL" ./Resources/webui/index.html.gz > "$ARCHIVE_WEBUI"
-"$SCRIPT_DIR/verify-webui.sh" "$ARCHIVE_WEBUI"
-rm -f "$ARCHIVE_WEBUI"
+"$SCRIPT_DIR/verify-release-archive.sh" "$TARBALL"
 
 # Build and verify the pip payload before any GitHub or Homebrew publication.
 # The wheel smoke test asserts that its bundled `afm --version` exactly matches
@@ -319,7 +315,10 @@ sed -i '' "s|url \".*\"|url \"${DOWNLOAD_URL}\"|" afm-next.rb
 sed -i '' "s/version \".*\"/version \"${VERSION}\"/" afm-next.rb
 sed -i '' "s/sha256 \".*\"/sha256 \"${SHA256}\"/" afm-next.rb
 
-if ! grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm-next.rb; then
+if grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm-next.rb; then
+  sed -i '' 's|(share/"afm/webui")\.install "Resources/webui/index.html.gz"|(share/"afm/webui").install Dir["Resources/webui/*"]|' afm-next.rb
+fi
+if ! grep -Fq '(share/"afm/webui").install Dir["Resources/webui/*"]' afm-next.rb; then
   log_error "Homebrew nightly formula does not install the required WebUI"
   exit 1
 fi

--- a/Scripts/publish-stable.sh
+++ b/Scripts/publish-stable.sh
@@ -153,18 +153,18 @@ done
 
 # The server only opens the browser when the bundled WebUI can be resolved.
 # Build it on demand and require it in every stable package.
-WEBUI="$ROOT_DIR/Resources/webui/index.html.gz"
-if [ ! -f "$WEBUI" ]; then
+WEBUI="$ROOT_DIR/Resources/webui"
+if [ ! -d "$WEBUI" ]; then
   log_info "WebUI artifact missing; building it..."
   make webui
 fi
-if [ ! -f "$WEBUI" ]; then
+if [ ! -d "$WEBUI" ]; then
   log_error "Required WebUI artifact missing after build: $WEBUI"
   exit 1
 fi
 "$SCRIPT_DIR/verify-webui.sh" "$WEBUI"
 mkdir -p "$STAGING/Resources/webui"
-cp "$WEBUI" "$STAGING/Resources/webui/"
+cp -R "$WEBUI/" "$STAGING/Resources/webui/"
 log_info "Included webui"
 
 cp "$ROOT_DIR/README.md" "$STAGING/" 2>/dev/null || true
@@ -174,11 +174,7 @@ TARBALL="$ROOT_DIR/afm-${TAG}-arm64.tar.gz"
 tar -czf "$TARBALL" -C "$STAGING" .
 log_info "Tarball: $TARBALL ($(du -h "$TARBALL" | cut -f1 | xargs))"
 
-"$SCRIPT_DIR/verify-webui.sh" "$STAGING/Resources/webui/index.html.gz"
-ARCHIVE_WEBUI="$ROOT_DIR/.build/afm-stable-archive-webui.html.gz"
-tar -xOzf "$TARBALL" ./Resources/webui/index.html.gz > "$ARCHIVE_WEBUI"
-"$SCRIPT_DIR/verify-webui.sh" "$ARCHIVE_WEBUI"
-rm -f "$ARCHIVE_WEBUI"
+"$SCRIPT_DIR/verify-release-archive.sh" "$TARBALL"
 
 # Step 4: Generate changelog (since last stable tag)
 log_info "Generating changelog..."
@@ -250,7 +246,10 @@ sed -i '' "s/assert_match \"v[0-9][^\"]*\"/assert_match \"v${VERSION}\"/" afm.rb
 # Update caveats version references
 sed -i '' "s/MLX Local Models (v[0-9][^)]*)/MLX Local Models (v${VERSION}+)/" afm.rb
 
-if ! grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm.rb; then
+if grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm.rb; then
+  sed -i '' 's|(share/"afm/webui")\.install "Resources/webui/index.html.gz"|(share/"afm/webui").install Dir["Resources/webui/*"]|' afm.rb
+fi
+if ! grep -Fq '(share/"afm/webui").install Dir["Resources/webui/*"]' afm.rb; then
   log_error "Homebrew stable formula does not install the required WebUI"
   exit 1
 fi

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -62,13 +62,13 @@ cat > "$fake_public_git" <<'SH'
 #!/usr/bin/env bash
 arguments=" $* "
 for ref in \
-  refs/tags/0.1.18-rc.3 \
-  'refs/tags/0.1.18-rc.3^{}' \
-  refs/tags/v0.1.18-rc.3 \
-  'refs/tags/v0.1.18-rc.3^{}'; do
+  refs/tags/0.1.18-rc.4 \
+  'refs/tags/0.1.18-rc.4^{}' \
+  refs/tags/v0.1.18-rc.4 \
+  'refs/tags/v0.1.18-rc.4^{}'; do
   [[ "$arguments" == *" $ref "* ]] || exit 2
 done
-printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.18-rc.3^{}'
+printf '%s\t%s\n' "$EXPECTED_AFMKIT_REVISION" 'refs/tags/v0.1.18-rc.4^{}'
 SH
 chmod 700 "$fake_public_git"
 if ! EXPECTED_AFMKIT_REVISION="$expected_afmkit_revision" \
@@ -88,7 +88,7 @@ if (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.3'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.4'
   }
   probe_public_source() {
     return 1
@@ -112,14 +112,14 @@ IFS=$'\t' read -r release_identity release_url release_revision release_version 
 [[ "$release_url" == "https://github.com/scouzi1966/AFMKit.git" ]] || \
   fail "release source is not the canonical public HTTPS repository"
 [[ "$release_revision" =~ ^[0-9a-f]{40}$ ]] || fail "release lock revision is not immutable"
-[[ "$release_version" == "0.1.18-rc.3" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.18-rc.3"
+[[ "$release_version" == "0.1.18-rc.4" ]] || fail "release manifest is not pinned to exact AFMKit 0.1.18-rc.4"
 
 private_gate_log="$WORK_ROOT/private-version-error.log"
 if (
   export AFMKIT_READ_TOKEN="private-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.3'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.4'
   }
   probe_public_source() {
     [[ -z "${AFMKIT_READ_TOKEN:-}" ]]
@@ -138,7 +138,7 @@ if ! (
   export AFMKIT_READ_TOKEN="public-gate-secret"
   source "$ROOT_DIR/Scripts/check-public-release-eligibility.sh"
   read_public_release_sources() {
-    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.3'
+    echo $'afmkit\thttps://github.com/scouzi1966/AFMKit.git\t1111111111111111111111111111111111111111\t0.1.18-rc.4'
   }
   probe_public_source() {
     return 0
@@ -158,12 +158,13 @@ mkdir -p \
   "$prefix/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle/Evals" \
   "$prefix/libexec/afm/AFMKit_AFMKitMLX.bundle/Contents/Resources" \
   "$prefix/libexec/afm/AFMKit_AFMKitDwarfStar.bundle/metal" \
-  "$prefix/share/afm/webui"
+  "$prefix/share/afm"
 printf 'binary' > "$prefix/bin/afm"
 printf 'unrelated' > "$prefix/bin/keep-me"
 printf 'unrelated' > "$prefix/libexec/afm/keep-me"
-printf 'unrelated' > "$prefix/share/afm/webui/keep-me"
-printf 'resource' > "$prefix/share/afm/webui/index.html.gz"
+printf 'unrelated' > "$prefix/share/afm/keep-me"
+mkdir -p "$prefix/share/afm/webui"
+printf '<html></html>' > "$prefix/share/afm/webui/index.html"
 INSTALL_PREFIX="$prefix" "$ROOT_DIR/Scripts/uninstall.sh"
 [[ ! -e "$prefix/bin/afm" ]] || fail "custom-prefix binary was not removed"
 [[ ! -e "$prefix/bin/MacLocalAPI_AFMKit.bundle" ]] || fail "legacy evaluation bundle was not removed"
@@ -172,14 +173,16 @@ INSTALL_PREFIX="$prefix" "$ROOT_DIR/Scripts/uninstall.sh"
 [[ ! -e "$prefix/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle" ]] || fail "libexec evaluation bundle was not removed"
 [[ ! -e "$prefix/bin/AFMKit_AFMKitMLX.bundle" ]] || fail "custom-prefix bundle was not removed"
 [[ ! -e "$prefix/libexec/afm/AFMKit_AFMKitDwarfStar.bundle" ]] || fail "libexec bundle was not removed"
-[[ ! -e "$prefix/share/afm/webui/index.html.gz" ]] || fail "WebUI was not removed"
+[[ ! -e "$prefix/share/afm/webui" ]] || fail "WebUI was not removed"
 [[ -f "$prefix/bin/keep-me" ]] || fail "uninstall deleted an unrelated bin file"
 [[ -f "$prefix/libexec/afm/keep-me" ]] || fail "uninstall deleted an unrelated libexec file"
-[[ -f "$prefix/share/afm/webui/keep-me" ]] || fail "uninstall deleted an unrelated WebUI file"
+[[ -f "$prefix/share/afm/keep-me" ]] || fail "uninstall deleted an unrelated WebUI file"
 
 for project in "$ROOT_DIR/pyproject.toml" "$ROOT_DIR/pyproject-next.toml"; do
   grep -Fq '"bin/*/*/*/*/*"' "$project" || \
     fail "$(basename "$project") does not include nested Xcode 27 bundle resources"
+  grep -Fq '"share/webui/**/*"' "$project" || \
+    fail "$(basename "$project") does not include the nested WebUI asset tree"
 done
 
 echo "[release-tooling-test] release lock, authentication boundaries, nested resources, and uninstall verified"

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -165,6 +165,7 @@ printf 'unrelated' > "$prefix/libexec/afm/keep-me"
 printf 'unrelated' > "$prefix/share/afm/keep-me"
 mkdir -p "$prefix/share/afm/webui"
 printf '<html></html>' > "$prefix/share/afm/webui/index.html"
+printf 'unrelated' > "$prefix/share/afm/webui/keep-me"
 INSTALL_PREFIX="$prefix" "$ROOT_DIR/Scripts/uninstall.sh"
 [[ ! -e "$prefix/bin/afm" ]] || fail "custom-prefix binary was not removed"
 [[ ! -e "$prefix/bin/MacLocalAPI_AFMKit.bundle" ]] || fail "legacy evaluation bundle was not removed"
@@ -176,7 +177,17 @@ INSTALL_PREFIX="$prefix" "$ROOT_DIR/Scripts/uninstall.sh"
 [[ ! -e "$prefix/share/afm/webui" ]] || fail "WebUI was not removed"
 [[ -f "$prefix/bin/keep-me" ]] || fail "uninstall deleted an unrelated bin file"
 [[ -f "$prefix/libexec/afm/keep-me" ]] || fail "uninstall deleted an unrelated libexec file"
-[[ -f "$prefix/share/afm/keep-me" ]] || fail "uninstall deleted an unrelated WebUI file"
+[[ -f "$prefix/share/afm/keep-me" ]] || fail "uninstall deleted an unrelated share/afm file"
+
+for workflow in "$ROOT_DIR/.github/workflows/release.yml" "$ROOT_DIR/.github/workflows/nightly.yml"; do
+  grep -Fq 'cp -R Resources/webui/. release-package/Resources/webui/' "$workflow" || \
+    fail "$(basename "$workflow") does not recursively stage the WebUI"
+  grep -Fq 'Scripts/verify-webui.sh release-package/Resources/webui' "$workflow" || \
+    fail "$(basename "$workflow") does not verify the staged WebUI directory"
+  if grep -Fq 'Resources/webui/index.html.gz' "$workflow"; then
+    fail "$(basename "$workflow") still references the removed single-file WebUI payload"
+  fi
+done
 
 for project in "$ROOT_DIR/pyproject.toml" "$ROOT_DIR/pyproject-next.toml"; do
   grep -Fq '"bin/*/*/*/*/*"' "$project" || \

--- a/Scripts/uninstall.sh
+++ b/Scripts/uninstall.sh
@@ -65,8 +65,9 @@ for bundle in MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMEvaluationHost.bundle AFM
 done
 remove_owned_path "$INSTALL_PREFIX/share/afm/webui"
 
-# Remove only empty AFM-owned directories. Unrelated files keep their parent
-# directories and are never traversed or deleted.
+# The WebUI directory is replaced wholesale on upgrade and is package-owned.
+# Other AFM parent directories are removed only when empty, so unrelated sibling
+# files remain untouched.
 for directory in \
   "$INSTALL_PREFIX/share/afm" \
   "$INSTALL_PREFIX/libexec/afm"; do

--- a/Scripts/uninstall.sh
+++ b/Scripts/uninstall.sh
@@ -63,12 +63,11 @@ for bundle in MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMEvaluationHost.bundle AFM
   remove_owned_path "$INSTALL_PREFIX/bin/$bundle"
   remove_owned_path "$INSTALL_PREFIX/libexec/afm/$bundle"
 done
-remove_owned_path "$INSTALL_PREFIX/share/afm/webui/index.html.gz"
+remove_owned_path "$INSTALL_PREFIX/share/afm/webui"
 
 # Remove only empty AFM-owned directories. Unrelated files keep their parent
 # directories and are never traversed or deleted.
 for directory in \
-  "$INSTALL_PREFIX/share/afm/webui" \
   "$INSTALL_PREFIX/share/afm" \
   "$INSTALL_PREFIX/libexec/afm"; do
   if [[ -d "$directory" ]]; then

--- a/Scripts/validate-release.sh
+++ b/Scripts/validate-release.sh
@@ -23,7 +23,7 @@ Scripts/swiftpm-reliable.sh test -c release \
   -Xswiftc MemberImportVisibility
 
 echo "[release-gate] Building source release without local dependency overrides"
-if ! Scripts/verify-webui.sh Resources/webui/index.html.gz >/dev/null 2>&1; then
+if ! Scripts/verify-webui.sh Resources/webui >/dev/null 2>&1; then
   echo "[release-gate] Building the WebUI from its locked npm dependency graph"
   make webui
 fi

--- a/Scripts/verify-native-wheel.sh
+++ b/Scripts/verify-native-wheel.sh
@@ -49,7 +49,11 @@ if [[ "$PACKAGE_ROOT" == "macafm_next" ]] && grep -Eq '^macafm/' <<<"$CONTENTS";
 fi
 for required in \
   "$PACKAGE_ROOT/bin/afm" \
-  "$PACKAGE_ROOT/share/webui/index.html.gz"; do
+  "$PACKAGE_ROOT/share/webui/index.html" \
+  "$PACKAGE_ROOT/share/webui/manifest.webmanifest" \
+  "$PACKAGE_ROOT/share/webui/sw.js" \
+  "$PACKAGE_ROOT/share/webui/build.json" \
+  "$PACKAGE_ROOT/share/webui/_app/version.json"; do
   grep -Fqx "$required" <<<"$CONTENTS" || {
     echo "[wheel] missing required payload: $required" >&2
     exit 1
@@ -97,6 +101,7 @@ chmod +x "$EXTRACTED_BIN"
 
 "$SCRIPT_DIR/check-macos26-compatibility.sh" "$EXTRACTED_BIN" "$EXTRACTED_METALLIB"
 "$EXTRACTED_BIN" --version >/dev/null
+"$SCRIPT_DIR/verify-webui.sh" "$VERIFY_DIR/$PACKAGE_ROOT/share/webui"
 
 PYTHON="${AFM_WHEEL_PYTHON:-python3}"
 "$PYTHON" -m venv "$VERIFY_DIR/venv"

--- a/Scripts/verify-release-archive.sh
+++ b/Scripts/verify-release-archive.sh
@@ -21,7 +21,12 @@ BIN_ENTRY="$(grep -E '(^|/)afm$' <<<"$CONTENTS" | head -1)"
 [[ -n "$BIN_ENTRY" ]] || { echo "[archive] afm executable is missing" >&2; exit 1; }
 ROOT_ENTRY="${BIN_ENTRY%afm}"
 
-for required in "${ROOT_ENTRY}Resources/webui/index.html.gz"; do
+for required in \
+  "${ROOT_ENTRY}Resources/webui/index.html" \
+  "${ROOT_ENTRY}Resources/webui/manifest.webmanifest" \
+  "${ROOT_ENTRY}Resources/webui/sw.js" \
+  "${ROOT_ENTRY}Resources/webui/build.json" \
+  "${ROOT_ENTRY}Resources/webui/_app/version.json"; do
   grep -Fqx "$required" <<<"$CONTENTS" || {
     echo "[archive] missing required payload: $required" >&2
     exit 1
@@ -70,8 +75,6 @@ chmod +x "$EXTRACTED_BIN"
   ./afm --version >/dev/null
 )
 
-ARCHIVE_WEBUI="$VERIFY_DIR/archive-webui.html.gz"
-tar -xOzf "$ARCHIVE" "${ROOT_ENTRY}Resources/webui/index.html.gz" > "$ARCHIVE_WEBUI"
-"$SCRIPT_DIR/verify-webui.sh" "$ARCHIVE_WEBUI"
+"$SCRIPT_DIR/verify-webui.sh" "$VERIFY_DIR/${ROOT_ENTRY}Resources/webui"
 
 echo "[archive] verified payload and relocated launch: $ARCHIVE"

--- a/Scripts/verify-webui.sh
+++ b/Scripts/verify-webui.sh
@@ -1,30 +1,55 @@
 #!/usr/bin/env bash
 
-# Validate the generated WebUI artifact used by -w/--webui.
+# Validate the generated llama.cpp WebUI directory used by -w/--webui.
 
 set -euo pipefail
 
-WEBUI_PATH="${1:-Resources/webui/index.html.gz}"
+WEBUI_DIR="${1:-Resources/webui}"
 
-if [[ ! -s "$WEBUI_PATH" ]]; then
-    echo "[ERROR] Required WebUI artifact is missing or empty: $WEBUI_PATH" >&2
+if [[ ! -d "$WEBUI_DIR" ]]; then
+    echo "[ERROR] Required WebUI directory is missing: $WEBUI_DIR" >&2
     exit 1
 fi
 
-if ! gzip -t "$WEBUI_PATH"; then
-    echo "[ERROR] WebUI artifact is not a valid gzip stream: $WEBUI_PATH" >&2
+required=(
+    "index.html"
+    "manifest.webmanifest"
+    "sw.js"
+    "build.json"
+    "_app/version.json"
+)
+
+for relative in "${required[@]}"; do
+    if [[ ! -s "$WEBUI_DIR/$relative" ]]; then
+        echo "[ERROR] Required WebUI payload is missing or empty: $relative" >&2
+        exit 1
+    fi
+done
+
+if ! find "$WEBUI_DIR/_app/immutable" -type f -name 'bundle*.js' -print -quit | grep -q .; then
+    echo "[ERROR] WebUI JavaScript bundle is missing" >&2
+    exit 1
+fi
+if ! find "$WEBUI_DIR/_app/immutable" -type f -name 'bundle*.css' -print -quit | grep -q .; then
+    echo "[ERROR] WebUI stylesheet bundle is missing" >&2
+    exit 1
+fi
+if ! find "$WEBUI_DIR" -maxdepth 1 -type f -name 'workbox-*.js' -print -quit | grep -q .; then
+    echo "[ERROR] WebUI service-worker runtime is missing" >&2
+    exit 1
+fi
+if [[ -n "$(find "$WEBUI_DIR" -type l -print -quit)" ]]; then
+    echo "[ERROR] WebUI payload must not contain symbolic links" >&2
     exit 1
 fi
 
-# Do not accept an arbitrary valid gzip file. The decompressed payload must be
-# the static HTML entry point that AFM serves at GET /.
-if ! gzip -cd "$WEBUI_PATH" | awk '
+if ! awk '
     BEGIN { IGNORECASE = 1; found = 0 }
     /<!doctype html|<html/ { found = 1 }
     END { exit(found ? 0 : 1) }
-'; then
-    echo "[ERROR] WebUI gzip does not contain an HTML document: $WEBUI_PATH" >&2
+' "$WEBUI_DIR/index.html"; then
+    echo "[ERROR] WebUI index.html is not an HTML document" >&2
     exit 1
 fi
 
-echo "[webui] verified: $WEBUI_PATH"
+echo "[webui] verified: $WEBUI_DIR"

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -2855,56 +2855,19 @@ public class Server: @unchecked Sendable {
 
     /// Serve the webui with custom CSS injected
     private func serveWebui(webuiFilePath: String, req: Request) async throws -> Response {
-        let rootURL = URL(fileURLWithPath: webuiFilePath).deletingLastPathComponent()
-        let components = req.url.path.split(separator: "/").map(String.init)
+        let resolver = WebUIAssetResolver(
+            rootURL: URL(fileURLWithPath: webuiFilePath).deletingLastPathComponent()
+        )
 
-        // URL paths are already decoded by Vapor. Reject traversal before the
-        // components are mapped back to filesystem paths.
-        guard !components.contains(where: { $0 == ".." || $0 == "." || $0.contains("\\") }) else {
-            throw Abort(.badRequest, reason: "Invalid WebUI asset path.")
-        }
-
-        if !components.isEmpty {
-            let assetURL = components.reduce(rootURL) { $0.appendingPathComponent($1) }
-            let standardizedRoot = rootURL.standardizedFileURL.path
-            let standardizedAsset = assetURL.standardizedFileURL.path
-            let isDirectory = (try? assetURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
-
-            if standardizedAsset.hasPrefix(standardizedRoot + "/"),
-               !isDirectory,
-               FileManager.default.fileExists(atPath: standardizedAsset) {
-                let data = try Data(contentsOf: assetURL)
-                var headers = HTTPHeaders()
-                headers.add(name: .contentType, value: Self.webuiMimeType(forExtension: assetURL.pathExtension.lowercased()))
-                headers.add(
-                    name: .cacheControl,
-                    value: components.contains("_app")
-                        ? "public, max-age=31536000, immutable"
-                        : "no-cache"
-                )
-                return Response(status: .ok, headers: headers, body: .init(data: data))
-            }
+        if case let .asset(assetURL, mimeType, cacheControl)? = resolver.resolve(path: req.url.path) {
+            let data = try Data(contentsOf: assetURL)
+            var headers = HTTPHeaders()
+            headers.add(name: .contentType, value: mimeType)
+            headers.add(name: .cacheControl, value: cacheControl)
+            return Response(status: .ok, headers: headers, body: .init(data: data))
         }
 
         return try await serveWebuiWithCustomCSS(webuiFilePath: webuiFilePath, req: req)
-    }
-
-    private static func webuiMimeType(forExtension extension: String) -> String {
-        switch `extension` {
-        case "html": return "text/html; charset=utf-8"
-        case "css": return "text/css; charset=utf-8"
-        case "js", "mjs": return "application/javascript; charset=utf-8"
-        case "json", "map": return "application/json; charset=utf-8"
-        case "webmanifest": return "application/manifest+json"
-        case "svg": return "image/svg+xml"
-        case "png": return "image/png"
-        case "jpg", "jpeg": return "image/jpeg"
-        case "ico": return "image/x-icon"
-        case "txt": return "text/plain; charset=utf-8"
-        case "woff": return "font/woff"
-        case "woff2": return "font/woff2"
-        default: return "application/octet-stream"
-        }
     }
 
     private func serveWebuiWithCustomCSS(webuiFilePath: String, req: Request) async throws -> Response {

--- a/Sources/AFMServer/Server.swift
+++ b/Sources/AFMServer/Server.swift
@@ -1221,10 +1221,10 @@ public class Server: @unchecked Sendable {
         if webuiEnabled, let webuiFilePath = webuiPath {
             // Serve index.html with injected CSS for root path
             app.get { req -> Response in
-                return try await self.serveWebuiWithCustomCSS(webuiFilePath: webuiFilePath, req: req)
+                return try await self.serveWebui(webuiFilePath: webuiFilePath, req: req)
             }
 
-            // SPA fallback for non-API routes
+            // Serve static assets when present and use the SPA fallback otherwise.
             app.get("**") { req -> Response in
                 let path = req.url.path
 
@@ -1233,7 +1233,7 @@ public class Server: @unchecked Sendable {
                     throw Abort(.notFound)
                 }
 
-                return try await self.serveWebuiWithCustomCSS(webuiFilePath: webuiFilePath, req: req)
+                return try await self.serveWebui(webuiFilePath: webuiFilePath, req: req)
             }
         }
     }
@@ -2854,19 +2854,75 @@ public class Server: @unchecked Sendable {
     """
 
     /// Serve the webui with custom CSS injected
+    private func serveWebui(webuiFilePath: String, req: Request) async throws -> Response {
+        let rootURL = URL(fileURLWithPath: webuiFilePath).deletingLastPathComponent()
+        let components = req.url.path.split(separator: "/").map(String.init)
+
+        // URL paths are already decoded by Vapor. Reject traversal before the
+        // components are mapped back to filesystem paths.
+        guard !components.contains(where: { $0 == ".." || $0 == "." || $0.contains("\\") }) else {
+            throw Abort(.badRequest, reason: "Invalid WebUI asset path.")
+        }
+
+        if !components.isEmpty {
+            let assetURL = components.reduce(rootURL) { $0.appendingPathComponent($1) }
+            let standardizedRoot = rootURL.standardizedFileURL.path
+            let standardizedAsset = assetURL.standardizedFileURL.path
+            let isDirectory = (try? assetURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+
+            if standardizedAsset.hasPrefix(standardizedRoot + "/"),
+               !isDirectory,
+               FileManager.default.fileExists(atPath: standardizedAsset) {
+                let data = try Data(contentsOf: assetURL)
+                var headers = HTTPHeaders()
+                headers.add(name: .contentType, value: Self.webuiMimeType(forExtension: assetURL.pathExtension.lowercased()))
+                headers.add(
+                    name: .cacheControl,
+                    value: components.contains("_app")
+                        ? "public, max-age=31536000, immutable"
+                        : "no-cache"
+                )
+                return Response(status: .ok, headers: headers, body: .init(data: data))
+            }
+        }
+
+        return try await serveWebuiWithCustomCSS(webuiFilePath: webuiFilePath, req: req)
+    }
+
+    private static func webuiMimeType(forExtension extension: String) -> String {
+        switch `extension` {
+        case "html": return "text/html; charset=utf-8"
+        case "css": return "text/css; charset=utf-8"
+        case "js", "mjs": return "application/javascript; charset=utf-8"
+        case "json", "map": return "application/json; charset=utf-8"
+        case "webmanifest": return "application/manifest+json"
+        case "svg": return "image/svg+xml"
+        case "png": return "image/png"
+        case "jpg", "jpeg": return "image/jpeg"
+        case "ico": return "image/x-icon"
+        case "txt": return "text/plain; charset=utf-8"
+        case "woff": return "font/woff"
+        case "woff2": return "font/woff2"
+        default: return "application/octet-stream"
+        }
+    }
+
     private func serveWebuiWithCustomCSS(webuiFilePath: String, req: Request) async throws -> Response {
         let fileURL = URL(fileURLWithPath: webuiFilePath)
-        let compressedData = try Data(contentsOf: fileURL)
+        let rawData = try Data(contentsOf: fileURL)
+        let htmlData: Data
 
-        // Decompress gzip data
-        guard let decompressedData = try? Self.gunzip(compressedData),
-              var htmlString = String(data: decompressedData, encoding: .utf8) else {
-            // Fallback: serve compressed if decompression fails
-            var headers = HTTPHeaders()
-            headers.add(name: .contentType, value: "text/html; charset=utf-8")
-            headers.add(name: .contentEncoding, value: "gzip")
-            headers.add(name: "Cache-Control", value: "no-cache")
-            return Response(status: .ok, headers: headers, body: .init(data: compressedData))
+        if fileURL.pathExtension.lowercased() == "gz" {
+            guard let decompressedData = try? Self.gunzip(rawData) else {
+                throw Abort(.internalServerError, reason: "Legacy WebUI gzip payload is invalid.")
+            }
+            htmlData = decompressedData
+        } else {
+            htmlData = rawData
+        }
+
+        guard var htmlString = String(data: htmlData, encoding: .utf8) else {
+            throw Abort(.internalServerError, reason: "WebUI index is not UTF-8 HTML.")
         }
 
         // Inject custom CSS before </head>
@@ -3116,35 +3172,40 @@ public class Server: @unchecked Sendable {
         let executableDir = executableURL.deletingLastPathComponent().standardized.path
 
         // Paths to check (in order of priority)
-        let pathsToCheck = [
+        let rootsToCheck = [
             // Bundled with executable (portable distribution)
-            "\(executableDir)/Resources/webui/index.html.gz",
+            "\(executableDir)/Resources/webui",
             // One level up from executable
-            "\(executableDir)/../Resources/webui/index.html.gz",
+            "\(executableDir)/../Resources/webui",
             // Two levels up (e.g., .build/release -> .build -> project root)
-            "\(executableDir)/../../Resources/webui/index.html.gz",
+            "\(executableDir)/../../Resources/webui",
             // Three levels up for deeper nesting
-            "\(executableDir)/../../../Resources/webui/index.html.gz",
+            "\(executableDir)/../../../Resources/webui",
             // pip: webui bundled in macafm package (sibling share directory)
-            "\(executableDir)/../share/webui/index.html.gz",
+            "\(executableDir)/../share/webui",
             // Homebrew: share directory relative to bin (Apple Silicon)
-            "\(executableDir)/../share/afm/webui/index.html.gz",
+            "\(executableDir)/../share/afm/webui",
             // Homebrew: share directory relative to bin (Intel)
-            "/usr/local/share/afm/webui/index.html.gz",
+            "/usr/local/share/afm/webui",
             // Homebrew: Apple Silicon path
-            "/opt/homebrew/share/afm/webui/index.html.gz",
+            "/opt/homebrew/share/afm/webui",
             // Development: Resources folder in current working directory
-            "\(cwd)/Resources/webui/index.html.gz",
-            // Development: vendored llama.cpp webui relative to executable
-            "\(executableDir)/../../../vendor/llama.cpp/tools/server/public/index.html.gz",
-            // Development: llama.cpp submodule public folder
-            "\(cwd)/vendor/llama.cpp/tools/server/public/index.html.gz"
+            "\(cwd)/Resources/webui",
+            // Development: llama.cpp submodule UI output
+            "\(cwd)/vendor/llama.cpp/tools/ui/dist",
+            // Legacy llama.cpp builds produced a single compressed entry point.
+            "\(cwd)/vendor/llama.cpp/tools/server/public"
         ]
 
-        for path in pathsToCheck {
-            let standardizedPath = URL(fileURLWithPath: path).standardized.path
-            if fileManager.fileExists(atPath: standardizedPath) {
-                return standardizedPath
+        for root in rootsToCheck {
+            let standardizedPath = URL(fileURLWithPath: root).standardized.path
+            let index = standardizedPath + "/index.html"
+            if fileManager.fileExists(atPath: index) {
+                return index
+            }
+            let legacyIndex = standardizedPath + "/index.html.gz"
+            if fileManager.fileExists(atPath: legacyIndex) {
+                return legacyIndex
             }
         }
 

--- a/Sources/AFMServer/WebUIAssetResolver.swift
+++ b/Sources/AFMServer/WebUIAssetResolver.swift
@@ -23,7 +23,8 @@ struct WebUIAssetResolver: Equatable {
             return nil
         }
 
-        guard !components.isEmpty, components != ["index.html"] else {
+        guard !components.isEmpty,
+              !(components.count == 1 && components[0].lowercased() == "index.html") else {
             return .index
         }
 

--- a/Sources/AFMServer/WebUIAssetResolver.swift
+++ b/Sources/AFMServer/WebUIAssetResolver.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Resolves WebUI request paths within one immutable static build directory.
+struct WebUIAssetResolver: Equatable {
+    enum Resolution: Equatable {
+        case asset(url: URL, mimeType: String, cacheControl: String)
+        case index
+    }
+
+    private let rootURL: URL
+
+    init(rootURL: URL) {
+        self.rootURL = rootURL.resolvingSymlinksInPath()
+    }
+
+    func resolve(path: String) -> Resolution? {
+        guard let decodedPath = path.removingPercentEncoding else {
+            return nil
+        }
+
+        let components = decodedPath.split(separator: "/").map(String.init)
+        guard !components.contains(where: { $0 == ".." || $0 == "." || $0.contains("\\") }) else {
+            return nil
+        }
+
+        guard !components.isEmpty, components != ["index.html"] else {
+            return .index
+        }
+
+        let unresolvedAssetURL = components.reduce(rootURL) { $0.appendingPathComponent($1) }
+        let assetURL = unresolvedAssetURL.resolvingSymlinksInPath()
+        let rootPath = rootURL.path
+        guard assetURL.path.hasPrefix(rootPath + "/") else {
+            return nil
+        }
+
+        let resourceValues = try? assetURL.resourceValues(forKeys: [.isRegularFileKey])
+        guard resourceValues?.isRegularFile == true else {
+            return nil
+        }
+
+        return .asset(
+            url: assetURL,
+            mimeType: Self.mimeType(forExtension: assetURL.pathExtension.lowercased()),
+            cacheControl: Self.cacheControl(forComponents: components)
+        )
+    }
+
+    static func mimeType(forExtension extension: String) -> String {
+        switch `extension` {
+        case "html": return "text/html; charset=utf-8"
+        case "css": return "text/css; charset=utf-8"
+        case "js", "mjs": return "application/javascript; charset=utf-8"
+        case "json", "map": return "application/json; charset=utf-8"
+        case "webmanifest": return "application/manifest+json"
+        case "svg": return "image/svg+xml"
+        case "png": return "image/png"
+        case "jpg", "jpeg": return "image/jpeg"
+        case "ico": return "image/x-icon"
+        case "txt": return "text/plain; charset=utf-8"
+        case "woff": return "font/woff"
+        case "woff2": return "font/woff2"
+        default: return "application/octet-stream"
+        }
+    }
+
+    static func cacheControl(forComponents components: [String]) -> String {
+        components.count > 2 && components[0] == "_app" && components[1] == "immutable"
+            ? "public, max-age=31536000, immutable"
+            : "no-cache"
+    }
+}

--- a/Tests/MacLocalAPITests/WebUIAssetResolverTests.swift
+++ b/Tests/MacLocalAPITests/WebUIAssetResolverTests.swift
@@ -42,6 +42,7 @@ final class WebUIAssetResolverTests: XCTestCase {
 
         XCTAssertEqual(resolver.resolve(path: "/"), .index)
         XCTAssertEqual(resolver.resolve(path: "/index.html"), .index)
+        XCTAssertEqual(resolver.resolve(path: "/INDEX.HTML"), .index)
     }
 
     func testRejectsTraversalDirectoriesAndSymlinkEscapes() throws {

--- a/Tests/MacLocalAPITests/WebUIAssetResolverTests.swift
+++ b/Tests/MacLocalAPITests/WebUIAssetResolverTests.swift
@@ -1,0 +1,100 @@
+@testable import AFMServer
+import Foundation
+import XCTest
+
+final class WebUIAssetResolverTests: XCTestCase {
+    private var workDirectory: URL!
+
+    override func setUpWithError() throws {
+        workDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("afm-webui-resolver-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try FileManager.default.removeItem(at: workDirectory)
+    }
+
+    func testResolvesAssetsWithMIMETypeAndExactImmutableCacheScope() throws {
+        let root = try makeFixture()
+        let resolver = WebUIAssetResolver(rootURL: root)
+
+        let bundle = try XCTUnwrap(
+            resolver.resolve(path: "/_app/immutable/bundle.abc123.js")
+        )
+        guard case let .asset(bundleURL, bundleMIME, bundleCache) = bundle else {
+            return XCTFail("Expected immutable bundle asset")
+        }
+        XCTAssertEqual(bundleURL.lastPathComponent, "bundle.abc123.js")
+        XCTAssertEqual(bundleMIME, "application/javascript; charset=utf-8")
+        XCTAssertEqual(bundleCache, "public, max-age=31536000, immutable")
+
+        let version = try XCTUnwrap(resolver.resolve(path: "/_app/version.json"))
+        guard case let .asset(_, versionMIME, versionCache) = version else {
+            return XCTFail("Expected version marker asset")
+        }
+        XCTAssertEqual(versionMIME, "application/json; charset=utf-8")
+        XCTAssertEqual(versionCache, "no-cache")
+    }
+
+    func testRootAndDirectIndexBothUseInjectedIndexPath() throws {
+        let resolver = WebUIAssetResolver(rootURL: try makeFixture())
+
+        XCTAssertEqual(resolver.resolve(path: "/"), .index)
+        XCTAssertEqual(resolver.resolve(path: "/index.html"), .index)
+    }
+
+    func testRejectsTraversalDirectoriesAndSymlinkEscapes() throws {
+        let root = try makeFixture()
+        let secret = workDirectory.appendingPathComponent("secret.txt")
+        try "private".write(to: secret, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            atPath: root.appendingPathComponent("escape.js").path,
+            withDestinationPath: secret.path
+        )
+
+        let resolver = WebUIAssetResolver(rootURL: root)
+        XCTAssertNil(resolver.resolve(path: "/../secret.txt"))
+        XCTAssertNil(resolver.resolve(path: "/..%2Fsecret.txt"))
+        XCTAssertNil(resolver.resolve(path: "/escape.js"))
+        XCTAssertNil(resolver.resolve(path: "/_app"))
+        XCTAssertNil(resolver.resolve(path: "/missing.js"))
+    }
+
+    func testDecodesPercentEncodedAssetPath() throws {
+        let root = try makeFixture()
+        let resolver = WebUIAssetResolver(rootURL: root)
+
+        let resolution = try XCTUnwrap(resolver.resolve(path: "/%5Fapp/immutable/bundle.abc123.js"))
+        guard case let .asset(url, mimeType, cacheControl) = resolution else {
+            return XCTFail("Expected percent-decoded asset")
+        }
+        XCTAssertEqual(url.lastPathComponent, "bundle.abc123.js")
+        XCTAssertEqual(mimeType, "application/javascript; charset=utf-8")
+        XCTAssertEqual(cacheControl, "public, max-age=31536000, immutable")
+    }
+
+    private func makeFixture() throws -> URL {
+        let root = workDirectory.appendingPathComponent("webui", isDirectory: true)
+        let immutable = root
+            .appendingPathComponent("_app", isDirectory: true)
+            .appendingPathComponent("immutable", isDirectory: true)
+        try FileManager.default.createDirectory(at: immutable, withIntermediateDirectories: true)
+        try "console.log('ok');".write(
+            to: immutable.appendingPathComponent("bundle.abc123.js"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try #"{"version":"fixture"}"#.write(
+            to: root.appendingPathComponent("_app/version.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "<html><head></head><body></body></html>".write(
+            to: root.appendingPathComponent("index.html"),
+            atomically: true,
+            encoding: .utf8
+        )
+        return root
+    }
+}

--- a/archive/create-distribution.sh
+++ b/archive/create-distribution.sh
@@ -43,10 +43,10 @@ echo -e "${BLUE}📋 Copying binary...${NC}"
 cp .build/release/afm "$DIST_DIR/"
 
 # Copy webui resources if available
-if [[ -f "Resources/webui/index.html.gz" ]]; then
+if [[ -d "Resources/webui" ]]; then
     echo -e "${BLUE}🌐 Copying webui resources...${NC}"
-    mkdir -p "$DIST_DIR/share/afm/webui"
-    cp Resources/webui/index.html.gz "$DIST_DIR/share/afm/webui/"
+    mkdir -p "$DIST_DIR/share/afm"
+    cp -R Resources/webui "$DIST_DIR/share/afm/webui"
     WEBUI_INCLUDED=true
 else
     echo -e "${YELLOW}ℹ️  WebUI not found (run 'make webui' to build it)${NC}"

--- a/build.sh
+++ b/build.sh
@@ -230,7 +230,7 @@ fi
 # ---------------------------------------------------------------------------
 if $DO_WEBUI; then
   log_step "Building llama.cpp webui"
-  WEBUI_DIR="$ROOT_DIR/vendor/llama.cpp/tools/server/webui"
+  WEBUI_DIR="$ROOT_DIR/vendor/llama.cpp/tools/ui"
   if [ ! -d "$WEBUI_DIR" ]; then
     log_error "webui source not found: $WEBUI_DIR"
     log_error "Did submodules initialize correctly?"
@@ -241,11 +241,16 @@ if $DO_WEBUI; then
     npm ci
     npm run build
   )
-  if [ -f "$ROOT_DIR/vendor/llama.cpp/tools/server/public/index.html.gz" ]; then
-    mkdir -p "$ROOT_DIR/Resources/webui"
-    cp "$ROOT_DIR/vendor/llama.cpp/tools/server/public/index.html.gz" "$ROOT_DIR/Resources/webui/index.html.gz"
-    log_info "WebUI artifact copied to Resources/webui/index.html.gz"
+  WEBUI_DIST="$WEBUI_DIR/dist"
+  if [ ! -f "$WEBUI_DIST/index.html" ]; then
+    log_error "WebUI build did not produce $WEBUI_DIST/index.html"
+    exit 1
   fi
+  rm -rf "$ROOT_DIR/Resources/webui"
+  mkdir -p "$ROOT_DIR/Resources"
+  cp -R "$WEBUI_DIST" "$ROOT_DIR/Resources/webui"
+  "$SCRIPTS_DIR/verify-webui.sh" "$ROOT_DIR/Resources/webui"
+  log_info "WebUI artifacts copied to Resources/webui"
 else
   log_warn "Skipping webui build"
 fi
@@ -414,7 +419,7 @@ log_info "Metallib available for swift test (symlink -> $BUILD_CONFIG bundle)"
 if $DO_INSTALL; then
   log_step "Installing afm to $INSTALL_PREFIX/bin"
   EVAL_BUNDLE_SRC="$EVAL_BUNDLE_DIR"
-  WEBUI_SRC="$ROOT_DIR/Resources/webui/index.html.gz"
+  WEBUI_SRC="$ROOT_DIR/Resources/webui"
 
   INSTALL_PERMISSION_PROBE="$INSTALL_PREFIX/bin"
   while [ ! -e "$INSTALL_PERMISSION_PROBE" ]; do
@@ -468,8 +473,9 @@ if $DO_INSTALL; then
   run_install_command ln -sfn "$INSTALL_PREFIX/libexec/afm/MacLocalAPI_AFMEvaluationHost.bundle" \
     "$INSTALL_PREFIX/bin/MacLocalAPI_AFMEvaluationHost.bundle"
 
-  if [ -f "$WEBUI_SRC" ]; then
-    run_install_command install -m 644 "$WEBUI_SRC" "$INSTALL_PREFIX/share/afm/webui/index.html.gz"
+  if [ -d "$WEBUI_SRC" ]; then
+    run_install_command rm -rf "$INSTALL_PREFIX/share/afm/webui"
+    run_install_command cp -R "$WEBUI_SRC" "$INSTALL_PREFIX/share/afm/webui"
   fi
 
   log_info "Installed: $INSTALL_PREFIX/bin/afm"

--- a/pyproject-next.toml
+++ b/pyproject-next.toml
@@ -61,4 +61,4 @@ packages = ["macafm_next"]
 include-package-data = true
 
 [tool.setuptools.package-data]
-macafm_next = ["bin/*", "bin/*/*", "bin/*/*/*", "bin/*/*/*/*", "bin/*/*/*/*/*", "share/webui/*"]
+macafm_next = ["bin/*", "bin/*/*", "bin/*/*/*", "bin/*/*/*/*", "bin/*/*/*/*/*", "share/webui/**/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,4 +60,4 @@ packages = ["macafm"]
 include-package-data = true
 
 [tool.setuptools.package-data]
-macafm = ["bin/*", "bin/*/*", "bin/*/*/*", "bin/*/*/*/*", "bin/*/*/*/*/*", "share/webui/*"]
+macafm = ["bin/*", "bin/*/*", "bin/*/*/*", "bin/*/*/*/*", "bin/*/*/*/*/*", "share/webui/**/*"]


### PR DESCRIPTION
## Problem

The next release candidate needs the latest stable DS4 runtime snapshot and the llama.cpp stable WebUI. llama.cpp v0.4.0 moved the UI from a single generated `index.html.gz` to a multi-file static tree under `tools/ui/dist`, while AFM's server and release payloads still assumed the old one-file layout.

## Changes

- Pin `vendor/llama.cpp` to stable tag `v0.4.0` (`5266f24da`).
- Consume AFMKit exact `0.1.18-rc.4` (`ef43d0f111df`), whose DS4 submodule is pinned to upstream stable snapshot `9ab705347c1775e7599ede7eb81a6255ec7dccb5`.
- Build the WebUI from `vendor/llama.cpp/tools/ui` and package the complete generated directory.
- Serve static WebUI assets with path containment, MIME types, and immutable caching for hashed `_app` assets; retain the SPA fallback and AFM dashboard injection.
- Keep legacy installed `index.html.gz` resolution as a fallback.
- Update tarball, Homebrew, wheel, install, uninstall, and verification paths for recursive WebUI assets.
- Update AFMKit release-boundary fixtures and the independent consumer example to rc.4.

## Validation

- AFMKit PR #107:
  - `swift test` passed.
  - `swift test --filter AFMKitDwarfStarTests` passed 53 tests, 0 failures.
  - Sourcery completed review with no findings or unresolved threads; PR merged.
- maclocal-api:
  - `swift test` passed.
  - `swift build --product afm` passed.
  - Clean `./build.sh --stable --yes --skip-submodules --skip-webui` Release build passed.
  - `Scripts/tests/test-release-tooling.sh` passed.
  - `Scripts/check-public-release-eligibility.sh` confirmed AFMKit rc.4 is anonymously fetchable.
  - llama.cpp v0.4.0 `npm ci && npm run build` passed; verifier requires index, manifest, service worker, version/build metadata, JS/CSS bundles, and no symlinks.
  - Live loopback HTTP checks passed for injected `index.html`, byte-identical 8,856,108-byte JS bundle with immutable cache headers, CSS/manifest/service-worker MIME types, and traversal fallback containment.
  - `Scripts/create-tarball.sh --output .build/afm-ds4-webui-rc.tar.gz` passed archive verification and relocated launch; archive SHA256 `2ad5365d334a4a3219b6a7dd99854f00927cee31e429bf7e3aa3de7eea316616`.
  - `Scripts/build-native-wheel.sh --stable` passed installed-wheel launch and WebUI verification; wheel SHA256 `a995dbab0a42b6110003469787dab63e6597b16848cd848d383d4c0fddde77e9`.
  - Wheel contains all 70 WebUI files.
- Live DS4 rc.4 Release probe:
  - Retained 0731 target GGUF plus matching DSpark support loaded on M3 Ultra Metal.
  - Startup reported 145.26 GiB resident model and 146.12 GiB planned memory.
  - Target-only `6+7` returned `13`.
  - Integers 1 through 20 were exact.
  - DSpark counters: 11 drafts, 55 draft tokens, 50 accepted, 5 rejected, 90.9091% acceptance, 59 generated tokens.
  - Raw responses and metrics are retained in the benchmark workspace under `next-rc-ds4-webui/`.
- Browser visual pass was not run because no in-app browser backend was available in this session.
- This is a short live smoke/correctness probe, not a substitute for the complete downstream RC model matrix.

## Review gate

- Read-only review inspection passes: zero findings, zero threads, no requested changes, mergeable.
- `--require-review` currently fails because Sourcery reports its weekly review budget is exhausted. Merge only after a completed independent review is available.

## Release note

Next RC includes DS4 stable snapshot `9ab7053` via AFMKit `0.1.18-rc.4` and llama.cpp WebUI `v0.4.0`.

## Summary by Sourcery

Adopt the stable DS4 runtime and llama.cpp v0.4.0 WebUI across development, serving, packaging, and release workflows.

New Features:
- Package and serve llama.cpp v0.4.0’s multi-file WebUI, including static assets, MIME types, SPA fallback, dashboard injection, and immutable caching for hashed bundles.

Bug Fixes:
- Preserve compatibility with legacy single-file compressed WebUI installations while preventing asset path traversal and symlink escapes.

Enhancements:
- Pin AFMKit to 0.1.18-rc.4 and update the vendored llama.cpp dependency to its stable v0.4.0 snapshot.
- Update installation, packaging, release, Homebrew, wheel, archive, and uninstall flows to handle recursive WebUI asset trees.
- Strengthen WebUI, release archive, wheel, and consumer-boundary validation for the new asset layout.

CI:
- Update release and nightly workflows and tooling tests to stage and verify complete WebUI directories.

Tests:
- Add WebUI asset resolution coverage for MIME types, caching, percent-encoded paths, traversal protection, and symlink containment.