### PR TITLE
Verify nightly WebUI purelib payload

### DIFF
--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -192,8 +192,13 @@ fi
 
 WHEEL_WEBUI="$REPO_ROOT/.build/afm-next-wheel-webui"
 rm -rf "$WHEEL_WEBUI"
-unzip -q "$WHL" 'macafm_next/share/webui/*' -d "$WHEEL_WEBUI"
-"$REPO_ROOT/Scripts/verify-webui.sh" "$WHEEL_WEBUI/macafm_next/share/webui"
+unzip -q "$WHL" -d "$WHEEL_WEBUI"
+WHEEL_WEBUI_ROOT="$(find "$WHEEL_WEBUI" -type f -path '*/macafm_next/share/webui/index.html' -print -quit)"
+if [ -z "$WHEEL_WEBUI_ROOT" ]; then
+    echo "[ERROR] Wheel does not contain the required WebUI"
+    exit 1
+fi
+"$REPO_ROOT/Scripts/verify-webui.sh" "$(dirname "$WHEEL_WEBUI_ROOT")"
 rm -rf "$WHEEL_WEBUI"
 
 WHEEL_SMOKE=$(mktemp -d "$REPO_ROOT/.build/afm-next-wheel-smoke.XXXXXX")

--- a/Scripts/verify-native-wheel.sh
+++ b/Scripts/verify-native-wheel.sh
@@ -47,29 +47,44 @@ if [[ "$PACKAGE_ROOT" == "macafm_next" ]] && grep -Eq '^macafm/' <<<"$CONTENTS";
   echo "[wheel] nightly wheel contains stale stable package data" >&2
   exit 1
 fi
+if grep -Fqx "$PACKAGE_ROOT/bin/afm" <<<"$CONTENTS"; then
+  WHEEL_PACKAGE_ROOT="$PACKAGE_ROOT"
+  INSTALLED_PACKAGE_ROOT="$PACKAGE_ROOT"
+else
+  WHEEL_PACKAGE_ROOT="$(awk -v package="$PACKAGE_ROOT" '
+    $0 ~ /\.data\/purelib\// && $0 ~ ("/" package "/bin/afm") { print; exit }
+  ' <<<"$CONTENTS")"
+  WHEEL_PACKAGE_ROOT="${WHEEL_PACKAGE_ROOT%/$PACKAGE_ROOT/bin/afm}/$PACKAGE_ROOT"
+  INSTALLED_PACKAGE_ROOT="${WHEEL_PACKAGE_ROOT#*.data/purelib/}"
+fi
+[[ -n "${WHEEL_PACKAGE_ROOT:-}" ]] || {
+  echo "[wheel] missing executable payload root" >&2
+  exit 1
+}
+
 for required in \
-  "$PACKAGE_ROOT/bin/afm" \
-  "$PACKAGE_ROOT/share/webui/index.html" \
-  "$PACKAGE_ROOT/share/webui/manifest.webmanifest" \
-  "$PACKAGE_ROOT/share/webui/sw.js" \
-  "$PACKAGE_ROOT/share/webui/build.json" \
-  "$PACKAGE_ROOT/share/webui/_app/version.json"; do
+  "$WHEEL_PACKAGE_ROOT/bin/afm" \
+  "$WHEEL_PACKAGE_ROOT/share/webui/index.html" \
+  "$WHEEL_PACKAGE_ROOT/share/webui/manifest.webmanifest" \
+  "$WHEEL_PACKAGE_ROOT/share/webui/sw.js" \
+  "$WHEEL_PACKAGE_ROOT/share/webui/build.json" \
+  "$WHEEL_PACKAGE_ROOT/share/webui/_app/version.json"; do
   grep -Fqx "$required" <<<"$CONTENTS" || {
     echo "[wheel] missing required payload: $required" >&2
     exit 1
   }
 done
 
-FLAT_EVAL="$PACKAGE_ROOT/bin/MacLocalAPI_AFMEvaluationHost.bundle/Evals/comprehensive.json"
-NESTED_EVAL="$PACKAGE_ROOT/bin/MacLocalAPI_AFMEvaluationHost.bundle/Contents/Resources/Evals/comprehensive.json"
+FLAT_EVAL="$WHEEL_PACKAGE_ROOT/bin/MacLocalAPI_AFMEvaluationHost.bundle/Evals/comprehensive.json"
+NESTED_EVAL="$WHEEL_PACKAGE_ROOT/bin/MacLocalAPI_AFMEvaluationHost.bundle/Contents/Resources/Evals/comprehensive.json"
 if ! grep -Fqx "$FLAT_EVAL" <<<"$CONTENTS" && \
    ! grep -Fqx "$NESTED_EVAL" <<<"$CONTENTS"; then
   echo "[wheel] missing bundled comprehensive evaluation suite" >&2
   exit 1
 fi
 
-FLAT_METALLIB="$PACKAGE_ROOT/bin/AFMKit_AFMKitMLX.bundle/default.metallib"
-NESTED_METALLIB="$PACKAGE_ROOT/bin/AFMKit_AFMKitMLX.bundle/Contents/Resources/default.metallib"
+FLAT_METALLIB="$WHEEL_PACKAGE_ROOT/bin/AFMKit_AFMKitMLX.bundle/default.metallib"
+NESTED_METALLIB="$WHEEL_PACKAGE_ROOT/bin/AFMKit_AFMKitMLX.bundle/Contents/Resources/default.metallib"
 if grep -Fqx "$FLAT_METALLIB" <<<"$CONTENTS"; then
   WHEEL_METALLIB="$FLAT_METALLIB"
 elif grep -Fqx "$NESTED_METALLIB" <<<"$CONTENTS"; then
@@ -79,8 +94,8 @@ else
   exit 1
 fi
 
-FLAT_DWARF_METAL="$PACKAGE_ROOT/bin/AFMKit_AFMKitDwarfStar.bundle/metal/moe.metal"
-NESTED_DWARF_METAL="$PACKAGE_ROOT/bin/AFMKit_AFMKitDwarfStar.bundle/Contents/Resources/metal/moe.metal"
+FLAT_DWARF_METAL="$WHEEL_PACKAGE_ROOT/bin/AFMKit_AFMKitDwarfStar.bundle/metal/moe.metal"
+NESTED_DWARF_METAL="$WHEEL_PACKAGE_ROOT/bin/AFMKit_AFMKitDwarfStar.bundle/Contents/Resources/metal/moe.metal"
 if ! grep -Fqx "$FLAT_DWARF_METAL" <<<"$CONTENTS" && \
    ! grep -Fqx "$NESTED_DWARF_METAL" <<<"$CONTENTS"; then
   echo "[wheel] missing DwarfStar Metal source in flat or Xcode 27 bundle layout" >&2
@@ -94,14 +109,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
-unzip -q "$WHEEL" "$PACKAGE_ROOT/*" -d "$VERIFY_DIR"
-EXTRACTED_BIN="$VERIFY_DIR/$PACKAGE_ROOT/bin/afm"
+unzip -q "$WHEEL" "$WHEEL_PACKAGE_ROOT/*" -d "$VERIFY_DIR"
+EXTRACTED_BIN="$VERIFY_DIR/$WHEEL_PACKAGE_ROOT/bin/afm"
 EXTRACTED_METALLIB="$VERIFY_DIR/$WHEEL_METALLIB"
 chmod +x "$EXTRACTED_BIN"
 
 "$SCRIPT_DIR/check-macos26-compatibility.sh" "$EXTRACTED_BIN" "$EXTRACTED_METALLIB"
 "$EXTRACTED_BIN" --version >/dev/null
-"$SCRIPT_DIR/verify-webui.sh" "$VERIFY_DIR/$PACKAGE_ROOT/share/webui"
+"$SCRIPT_DIR/verify-webui.sh" "$VERIFY_DIR/$WHEEL_PACKAGE_ROOT/share/webui"
 
 PYTHON="${AFM_WHEEL_PYTHON:-python3}"
 "$PYTHON" -m venv "$VERIFY_DIR/venv"
@@ -109,7 +124,10 @@ PIP_DISABLE_PIP_VERSION_CHECK=1 \
   "$VERIFY_DIR/venv/bin/python" -m pip install --no-deps --force-reinstall "$WHEEL" >/dev/null
 "$VERIFY_DIR/venv/bin/afm" --version >/dev/null
 
-site_metallib="$(find "$VERIFY_DIR/venv" -path "*/site-packages/$WHEEL_METALLIB" -type f -print -quit)"
+installed_metallib_relative="${WHEEL_METALLIB#$WHEEL_PACKAGE_ROOT/}"
+site_metallib="$(find "$VERIFY_DIR/venv" \
+  -path "*/site-packages/$INSTALLED_PACKAGE_ROOT/$installed_metallib_relative" \
+  -type f -print -quit)"
 if [[ -z "$site_metallib" ]]; then
   echo "[wheel] installed wheel is missing its AFMKit MLX metallib" >&2
   exit 1


### PR DESCRIPTION
## Problem

The first attempted `0.9.18-next.20260906.448d13b` publication built the nightly wheel with all 70 WebUI files, then failed during a duplicate extraction check. Setuptools placed the nightly package data under `<wheel>.data/purelib/macafm_next/share/webui`, while the verifier assumed the direct `macafm_next/share/webui` layout.

## Changes

- Discover the actual nightly WebUI root after extracting the wheel instead of assuming the direct package path.
- Teach `verify-native-wheel.sh` to accept either direct package data or wheel `.data/purelib` package data.
- Verify the installed metallib using its installed package path rather than the wheel archive path.

## Validation

- Rebuilt `dist/macafm_next-0.9.18.dev20260906+448d13b-py3-none-macosx_26_0_arm64.whl`.
- `Scripts/build-nightly-wheel.sh --version 0.9.18 --build-version 0.9.18-next.20260906.448d13b --python-version 0.9.18.dev20260906+448d13b` passed, including runtime version and WebUI checks.
- `Scripts/verify-native-wheel.sh dist/macafm_next-0.9.18.dev20260906+448d13b-py3-none-macosx_26_0_arm64.whl macafm_next` passed archive extraction, WebUI verification, installed metallib discovery, and installed-wheel launch.
- The wheel contains all 70 WebUI files in the purelib payload.

## Summary by Sourcery

Update nightly wheel verification to handle purelib package layouts while preserving WebUI, native payload, and installed-wheel validation.

Bug Fixes:
- Support verifying nightly wheels whose WebUI and native payloads are stored under the wheel’s purelib data directory.
- Verify installed metallib assets using their installed package location.

Enhancements:
- Make nightly WebUI validation discover the payload location after wheel extraction and validate both direct and purelib layouts.