### PR TITLE
Reject stale WebUI bundles in nightly wheels

### DIFF
--- a/Scripts/build-nightly-wheel.sh
+++ b/Scripts/build-nightly-wheel.sh
@@ -164,6 +164,7 @@ PY
 
 echo "[INFO] Building wheel..."
 rm -rf dist/macafm_next-*
+rm -rf "$REPO_ROOT/build"
 _PYTHON_HOST_PLATFORM=macosx-26.0-arm64 uv build --wheel 2>&1
 
 # ---------- clean staged assets ----------

--- a/Scripts/tests/test-release-tooling.sh
+++ b/Scripts/tests/test-release-tooling.sh
@@ -189,6 +189,26 @@ for workflow in "$ROOT_DIR/.github/workflows/release.yml" "$ROOT_DIR/.github/wor
   fi
 done
 
+grep -Fq 'rm -rf "$REPO_ROOT/build"' "$ROOT_DIR/Scripts/build-nightly-wheel.sh" || \
+  fail "nightly wheel builds do not remove stale setuptools build output"
+
+duplicate_webui="$WORK_ROOT/duplicate-webui"
+mkdir -p "$duplicate_webui/_app/immutable/assets"
+printf '<html></html>' > "$duplicate_webui/index.html"
+printf '{}' > "$duplicate_webui/_app/version.json"
+printf '{}' > "$duplicate_webui/build.json"
+printf '{}' > "$duplicate_webui/manifest.webmanifest"
+printf 'console.log(1);' > "$duplicate_webui/_app/immutable/bundle.one.js"
+printf 'console.log(2);' > "$duplicate_webui/_app/immutable/bundle.two.js"
+printf 'body{}' > "$duplicate_webui/_app/immutable/assets/bundle.css"
+printf 'self.addEventListener("install", () => {});' > "$duplicate_webui/sw.js"
+if "$ROOT_DIR/Scripts/verify-webui.sh" "$duplicate_webui" \
+  >"$WORK_ROOT/duplicate-webui.log" 2>&1; then
+  fail "WebUI verifier accepted multiple generated JavaScript bundles"
+fi
+grep -Fq 'Expected one WebUI JavaScript bundle, found 2' "$WORK_ROOT/duplicate-webui.log" || \
+  fail "WebUI verifier did not report the duplicate JavaScript bundle count"
+
 for project in "$ROOT_DIR/pyproject.toml" "$ROOT_DIR/pyproject-next.toml"; do
   grep -Fq '"bin/*/*/*/*/*"' "$project" || \
     fail "$(basename "$project") does not include nested Xcode 27 bundle resources"

--- a/Scripts/verify-webui.sh
+++ b/Scripts/verify-webui.sh
@@ -26,16 +26,19 @@ for relative in "${required[@]}"; do
     fi
 done
 
-if ! find "$WEBUI_DIR/_app/immutable" -type f -name 'bundle*.js' -print -quit | grep -q .; then
-    echo "[ERROR] WebUI JavaScript bundle is missing" >&2
+javascript_bundle_count="$(find "$WEBUI_DIR/_app/immutable" -type f -name 'bundle*.js' | wc -l | tr -d '[:space:]')"
+if [[ "$javascript_bundle_count" != "1" ]]; then
+    echo "[ERROR] Expected one WebUI JavaScript bundle, found $javascript_bundle_count" >&2
     exit 1
 fi
-if ! find "$WEBUI_DIR/_app/immutable" -type f -name 'bundle*.css' -print -quit | grep -q .; then
-    echo "[ERROR] WebUI stylesheet bundle is missing" >&2
+stylesheet_bundle_count="$(find "$WEBUI_DIR/_app/immutable" -type f -name 'bundle*.css' | wc -l | tr -d '[:space:]')"
+if [[ "$stylesheet_bundle_count" != "1" ]]; then
+    echo "[ERROR] Expected one WebUI stylesheet bundle, found $stylesheet_bundle_count" >&2
     exit 1
 fi
-if ! find "$WEBUI_DIR" -maxdepth 1 -type f -name 'workbox-*.js' -print -quit | grep -q .; then
-    echo "[ERROR] WebUI service-worker runtime is missing" >&2
+workbox_runtime_count="$(find "$WEBUI_DIR" -maxdepth 1 -type f -name 'workbox-*.js' | wc -l | tr -d '[:space:]')"
+if [[ "$workbox_runtime_count" != "1" ]]; then
+    echo "[ERROR] Expected one WebUI service-worker runtime, found $workbox_runtime_count" >&2
     exit 1
 fi
 if [[ -n "$(find "$WEBUI_DIR" -type l -print -quit)" ]]; then


### PR DESCRIPTION
## Problem

The first `72cb643` nightly wheel inherited a stale hashed JavaScript bundle from setuptools' previous `build/lib` output. The archive still had a clean 70-file WebUI tree, but the wheel contained two generated JavaScript bundles and grew from the expected clean size to 32 MB.

## Changes

- Remove the repository Python `build/` directory before each nightly wheel build.
- Require exactly one generated WebUI JavaScript bundle and one stylesheet bundle.
- Add release-tooling regression coverage that rejects duplicate JavaScript bundles and verifies stale build-output cleanup.

## Validation

- Reproduced the failure mode: before cleanup, the wheel listed both `bundle.u30FaJiw.js` and `bundle.BeWh6KyQ.js`.
- Rebuilt the same nightly version with the fix:
  - Exactly 70 WebUI entries.
  - Exactly one JavaScript bundle (`bundle.BeWh6KyQ.js`).
  - Exactly one stylesheet bundle (`bundle.3BIcW1B_.css`).
  - Wheel returned to 29 MB.
  - WebUI, metadata, and runtime-version verification passed.
- Negative verifier fixture with two JavaScript bundles fails with `Expected one WebUI JavaScript bundle, found 2`.
- `Scripts/tests/test-release-tooling.sh` passed.

The already-uploaded `nightly-20260906-72cb643` release must not be promoted; its wheel contains the stale bundle.

## Summary by Sourcery

Ensure nightly wheels contain only the intended WebUI assets by cleaning stale build output and enforcing unique generated bundles.

Bug Fixes:
- Prevent stale build output from introducing duplicate JavaScript bundles into nightly wheels.
- Reject WebUI artifacts with duplicate JavaScript, stylesheet, or service-worker runtime bundles.

Tests:
- Add release-tooling regression coverage for stale build cleanup and duplicate WebUI bundle rejection.