### PR TITLE
Migrate Homebrew WebUI guards

### DIFF
--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -277,6 +277,8 @@ grep -Fq 'MacLocalAPI_AFMKit.bundle MacLocalAPI_AFMEvaluationHost.bundle' Script
 for publisher in Scripts/publish-next.sh Scripts/publish-stable.sh; do
   grep -Fq "s/libexec\\.install \"MacLocalAPI_AFMKit\\.bundle\"/libexec.install \"MacLocalAPI_AFMEvaluationHost.bundle\"/" "$publisher" || \
     fail "$publisher does not migrate an existing Homebrew formula to the current evaluation bundle"
+  grep -Fq 's|File\.exist?("Resources/webui/index.html\.gz")|File.exist?("Resources/webui/index.html")|' "$publisher" || \
+    fail "$publisher does not migrate an existing Homebrew WebUI guard"
 done
 
 for publisher in Scripts/publish-next.sh Scripts/publish-stable.sh; do

--- a/Scripts/publish-next.sh
+++ b/Scripts/publish-next.sh
@@ -318,6 +318,7 @@ sed -i '' "s/sha256 \".*\"/sha256 \"${SHA256}\"/" afm-next.rb
 if grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm-next.rb; then
   sed -i '' 's|(share/"afm/webui")\.install "Resources/webui/index.html.gz"|(share/"afm/webui").install Dir["Resources/webui/*"]|' afm-next.rb
 fi
+sed -i '' 's|File\.exist?("Resources/webui/index.html\.gz")|File.exist?("Resources/webui/index.html")|' afm-next.rb
 if ! grep -Fq '(share/"afm/webui").install Dir["Resources/webui/*"]' afm-next.rb; then
   log_error "Homebrew nightly formula does not install the required WebUI"
   exit 1

--- a/Scripts/publish-stable.sh
+++ b/Scripts/publish-stable.sh
@@ -249,6 +249,7 @@ sed -i '' "s/MLX Local Models (v[0-9][^)]*)/MLX Local Models (v${VERSION}+)/" af
 if grep -Fq '(share/"afm/webui").install "Resources/webui/index.html.gz"' afm.rb; then
   sed -i '' 's|(share/"afm/webui")\.install "Resources/webui/index.html.gz"|(share/"afm/webui").install Dir["Resources/webui/*"]|' afm.rb
 fi
+sed -i '' 's|File\.exist?("Resources/webui/index.html\.gz")|File.exist?("Resources/webui/index.html")|' afm.rb
 if ! grep -Fq '(share/"afm/webui").install Dir["Resources/webui/*"]' afm.rb; then
   log_error "Homebrew stable formula does not install the required WebUI"
   exit 1


### PR DESCRIPTION
## Problem

While publishing `nightly-20260906-59cdad6`, the live Homebrew formula still guarded WebUI installation with `File.exist?("Resources/webui/index.html.gz")`. The publisher migrated the install line to the recursive tree but not that guard, so an unmodified existing formula would skip WebUI installation entirely.

The live tap was corrected manually in `scouzi1966/homebrew-afm@9bf3c31`. This PR fixes future publisher migrations.

## Changes

- Migrate existing nightly and stable Homebrew formula guards from `index.html.gz` to `index.html`.
- Add a consumer-boundary assertion so future publisher changes cannot omit the guard migration.

## Validation

- `bash -n Scripts/publish-next.sh Scripts/publish-stable.sh Scripts/check-afmkit-consumer-boundary.sh`
- `Scripts/check-afmkit-consumer-boundary.sh`
- `Scripts/tests/test-release-tooling.sh`
- Live formula update and recursive install were verified in the tap repository.

## Summary by Sourcery

Ensure Homebrew publisher migrations keep WebUI installation enabled and prevent regressions with boundary assertions.

Bug Fixes:
- Update nightly and stable Homebrew publisher migrations so existing formulas continue installing the WebUI after its assets move to the recursive resource tree.

Enhancements:
- Add consumer-boundary checks that require both Homebrew formula bundle and WebUI guard migrations.