### PR TITLE
Separate prefix validation quality contracts

### DIFF
--- a/Scripts/feature-mlx-concurrent-batch/README.md
+++ b/Scripts/feature-mlx-concurrent-batch/README.md
@@ -122,8 +122,10 @@ this separated schema.
 
 An operator can opt into semantic review by setting
 `AFM_SEMANTIC_JUDGE_COMMAND` to a command that reads a JSON object from stdin
-and writes JSON to stdout. The command receives the prompt, visible response,
-and requirement descriptions. It must return:
+and writes JSON to stdout. The command receives the full visible transcript
+(system prompt, prior assistant turns, and current user turn), the visible
+response, and requirement descriptions. Reasoning output is not included in
+the judge input. The command must return:
 
 ```json
 {
@@ -133,6 +135,12 @@ and requirement descriptions. It must return:
   "summary": "optional explanation"
 }
 ```
+
+Each `passed` value must be a JSON boolean. The judge is terminated and marked
+as an error if it runs longer than `AFM_SEMANTIC_JUDGE_TIMEOUT_S` (default 30
+seconds) or emits more than `AFM_SEMANTIC_JUDGE_MAX_OUTPUT_BYTES` (default 1
+MiB on either output stream). Console output prints lexical and semantic
+review evidence for both deterministic passes and failures.
 
 Semantic results are reported independently and never change deterministic
 transport/integrity/cache scores. Invalid or failing judge output is recorded as

--- a/Scripts/feature-mlx-concurrent-batch/README.md
+++ b/Scripts/feature-mlx-concurrent-batch/README.md
@@ -136,11 +136,12 @@ the judge input. The command must return:
 }
 ```
 
-Each `passed` value must be a JSON boolean. The judge is terminated and marked
-as an error if it runs longer than `AFM_SEMANTIC_JUDGE_TIMEOUT_S` (default 30
-seconds) or emits more than `AFM_SEMANTIC_JUDGE_MAX_OUTPUT_BYTES` (default 1
-MiB on either output stream). Console output prints lexical and semantic
-review evidence for both deterministic passes and failures.
+Each `passed` value must be a JSON boolean, and returned IDs must exactly match
+the configured requirement set. The judge is terminated and marked as an error
+if it runs longer than `AFM_SEMANTIC_JUDGE_TIMEOUT_S` (default 30 seconds) or
+emits more than `AFM_SEMANTIC_JUDGE_MAX_OUTPUT_BYTES` (default 1 MiB on either
+output stream). Console output prints lexical and semantic review evidence for
+both deterministic passes and failures.
 
 Semantic results are reported independently and never change deterministic
 transport/integrity/cache scores. Invalid or failing judge output is recorded as

--- a/Scripts/feature-mlx-concurrent-batch/README.md
+++ b/Scripts/feature-mlx-concurrent-batch/README.md
@@ -105,6 +105,39 @@ python3 validate_multiturn_prefix.py 1 4          # specific batch sizes
 python3 validate_multiturn_prefix.py --label "overlap+prefix" 1 2 4 8
 ```
 
+#### Scoring and evidence separation
+
+Deterministic pass/fail scoring covers only complete transport and response
+integrity: nonempty visible output, bounded replacement characters, requested
+minimum completion tokens, a finish reason, an SSE `[DONE]` event, no sender
+parse errors, and any explicitly configured cache boundaries. Visible and
+reasoning channels are retained separately and never combined for scoring.
+
+`expected` lexical markers are review evidence, not pass/fail contracts. Missing
+markers remain in the raw report and console output so historical behavior can
+be investigated without treating prose phrasing or private Rust APIs as engine
+failures.
+Historical scores and raw artifacts are immutable; only newly sampled runs use
+this separated schema.
+
+An operator can opt into semantic review by setting
+`AFM_SEMANTIC_JUDGE_COMMAND` to a command that reads a JSON object from stdin
+and writes JSON to stdout. The command receives the prompt, visible response,
+and requirement descriptions. It must return:
+
+```json
+{
+  "requirements": [
+    {"id": "tokyo_setting", "passed": true, "evidence": "text quote"}
+  ],
+  "summary": "optional explanation"
+}
+```
+
+Semantic results are reported independently and never change deterministic
+transport/integrity/cache scores. Invalid or failing judge output is recorded as
+`semantic.status=error` or `semantic.ok=false`, respectively.
+
 ## Prerequisites
 
 ```bash

--- a/Scripts/feature-mlx-concurrent-batch/STREAM_EVIDENCE.md
+++ b/Scripts/feature-mlx-concurrent-batch/STREAM_EVIDENCE.md
@@ -18,11 +18,13 @@ This is not an independent socket capture: the sender normally stops at `[DONE]`
 without reading the following blank line or exhausting the response iterator.
 Missing finish/DONE evidence must not be interpreted as proof of an engine bug.
 
-The original request, parser, merged scoring text, assertions, and timing
-expressions are unchanged. Parse errors from the existing sender and from the
-post-request evidence observer are distinguished. Evidence never repairs the
-scoring input. Lexical-gate concerns remain tracked separately in issue #265;
-new evidence cannot retroactively reclassify responses that were not retained.
+The original request and timing expressions remain authoritative for the sender.
+The sender keeps visible and reasoning channels separate and records finish,
+DONE, and parse-error state for deterministic integrity contracts. Parse errors
+from the sender and from the post-request evidence observer are distinguished.
+Evidence never repairs the scoring input. Lexical observations and semantic
+review remain separated from deterministic scoring, and new evidence cannot
+retroactively reclassify responses that were not retained.
 The prefix report's existing Turn 1 “cold” label is also not proof of a cold
 cache: earlier batch sizes may have warmed its prefix. Use actual cache metrics.
 

--- a/Scripts/feature-mlx-concurrent-batch/batch_stream_evidence.py
+++ b/Scripts/feature-mlx-concurrent-batch/batch_stream_evidence.py
@@ -98,7 +98,7 @@ class StreamEvidence:
                     parse_errors=self.parse_errors, parse_error_count=self.parse_error_count,
                     parse_errors_truncated=self.parse_error_count > len(self.parse_errors),
                     request_error=None if error is None else dict(type=type(error).__name__, message=str(error)),
-                    scoring_note='Observability only; original sender text and predicates are unchanged')
+                    scoring_note='Observability only; evidence is not used by sender contracts')
 
     def publish(self, error):
         self.path.parent.mkdir(parents=True, exist_ok=True)

--- a/Scripts/feature-mlx-concurrent-batch/response_contracts.py
+++ b/Scripts/feature-mlx-concurrent-batch/response_contracts.py
@@ -34,6 +34,8 @@ def _response_integer(response, key):
         return 0, True
     if isinstance(value, float) and not value.is_integer():
         return 0, True
+    if value < 0:
+        return 0, True
     return int(value), False
 
 

--- a/Scripts/feature-mlx-concurrent-batch/response_contracts.py
+++ b/Scripts/feature-mlx-concurrent-batch/response_contracts.py
@@ -24,6 +24,19 @@ def observe_lexical(text, expected):
     }
 
 
+def _response_integer(response, key):
+    value = response.get(key)
+    if key not in response:
+        return 0, False
+    if value is None:
+        return 0, True
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0, True
+    if isinstance(value, float) and not value.is_integer():
+        return 0, True
+    return int(value), False
+
+
 def evaluate_integrity_contract(
     response,
     min_tokens=0,
@@ -33,11 +46,20 @@ def evaluate_integrity_contract(
 ):
     failures = []
     visible = response.get("visible_text", "")
-    completion_tokens = int(response.get("completion_tokens") or 0)
+    completion_tokens, invalid_completion = _response_integer(
+        response, "completion_tokens"
+    )
+    parse_error_count, invalid_parse_errors = _response_integer(
+        response, "parse_error_count"
+    )
     replacement_count = visible.count(REPLACEMENT_CHAR)
 
-    if require_visible_text and len(visible.strip()) < 2:
+    if require_visible_text and not visible.strip():
         failures.append("empty_or_near_empty_visible_text")
+    if invalid_completion:
+        failures.append("invalid_completion_token_metadata")
+    if invalid_parse_errors:
+        failures.append("invalid_parse_error_metadata")
     if replacement_count > MAX_REPLACEMENT_CHARS:
         failures.append("excess_replacement_characters")
     if min_tokens and completion_tokens < min_tokens:
@@ -46,7 +68,7 @@ def evaluate_integrity_contract(
         failures.append("missing_finish_reason")
     if require_done and not response.get("done_observed"):
         failures.append("missing_sse_done")
-    if int(response.get("parse_error_count") or 0):
+    if parse_error_count:
         failures.append("sender_parse_error")
 
     return {
@@ -63,12 +85,16 @@ def evaluate_cache_contract(response, contract=None):
     """Evaluate only explicitly requested cache accounting boundaries."""
     contract = contract or {}
     failures = []
-    prompt_tokens = int(response.get("prompt_tokens") or 0)
-    cached_tokens = int(response.get("cached_tokens") or 0)
+    prompt_tokens, invalid_prompt = _response_integer(response, "prompt_tokens")
+    cached_tokens, invalid_cached = _response_integer(response, "cached_tokens")
 
     expected_prompt = contract.get("expected_prompt_tokens")
     minimum_cached = contract.get("minimum_cached_tokens")
     maximum_cached = contract.get("maximum_cached_tokens")
+    if invalid_prompt:
+        failures.append("invalid_prompt_token_metadata")
+    if invalid_cached:
+        failures.append("invalid_cached_token_metadata")
     if expected_prompt is not None and prompt_tokens != int(expected_prompt):
         failures.append("unexpected_prompt_token_count")
     if minimum_cached is not None and cached_tokens < int(minimum_cached):
@@ -118,6 +144,9 @@ def _normalise_semantic_result(payload, requirements):
     missing_ids = sorted(expected_ids - judged_ids)
     if missing_ids:
         raise ValueError(f"semantic judge omitted requirements: {', '.join(missing_ids)}")
+    unknown_ids = sorted(judged_ids - expected_ids)
+    if unknown_ids:
+        raise ValueError(f"semantic judge returned unknown requirements: {', '.join(unknown_ids)}")
 
     return {
         "classification": "semantic_review",

--- a/Scripts/feature-mlx-concurrent-batch/response_contracts.py
+++ b/Scripts/feature-mlx-concurrent-batch/response_contracts.py
@@ -54,11 +54,12 @@ def evaluate_integrity_contract(
     parse_error_count, invalid_parse_errors = _response_integer(
         response, "parse_error_count"
     )
+    invalid_usage_fields = set(response.get("invalid_usage_fields") or [])
     replacement_count = visible.count(REPLACEMENT_CHAR)
 
     if require_visible_text and not visible.strip():
         failures.append("empty_or_near_empty_visible_text")
-    if invalid_completion:
+    if invalid_completion or "completion_tokens" in invalid_usage_fields:
         failures.append("invalid_completion_token_metadata")
     if invalid_parse_errors:
         failures.append("invalid_parse_error_metadata")
@@ -89,13 +90,14 @@ def evaluate_cache_contract(response, contract=None):
     failures = []
     prompt_tokens, invalid_prompt = _response_integer(response, "prompt_tokens")
     cached_tokens, invalid_cached = _response_integer(response, "cached_tokens")
+    invalid_usage_fields = set(response.get("invalid_usage_fields") or [])
 
     expected_prompt = contract.get("expected_prompt_tokens")
     minimum_cached = contract.get("minimum_cached_tokens")
     maximum_cached = contract.get("maximum_cached_tokens")
-    if invalid_prompt:
+    if invalid_prompt or "prompt_tokens" in invalid_usage_fields:
         failures.append("invalid_prompt_token_metadata")
-    if invalid_cached:
+    if invalid_cached or "cached_tokens" in invalid_usage_fields:
         failures.append("invalid_cached_token_metadata")
     if expected_prompt is not None and prompt_tokens != int(expected_prompt):
         failures.append("unexpected_prompt_token_count")

--- a/Scripts/feature-mlx-concurrent-batch/response_contracts.py
+++ b/Scripts/feature-mlx-concurrent-batch/response_contracts.py
@@ -1,0 +1,166 @@
+"""Deterministic response contracts and pluggable semantic review."""
+import asyncio
+import json
+import os
+import shlex
+
+
+REPLACEMENT_CHAR = "\ufffd"
+MAX_REPLACEMENT_CHARS = 5
+
+
+def observe_lexical(text, expected):
+    """Return lexical evidence without treating prose markers as contracts."""
+    lower = text.lower()
+    missing = [marker for marker in expected if marker.lower() not in lower]
+    return {
+        "classification": "review_evidence",
+        "expected": list(expected),
+        "missing": missing,
+        "observed": [marker for marker in expected if marker.lower() in lower],
+        "ok": not missing,
+    }
+
+
+def evaluate_integrity_contract(
+    response,
+    min_tokens=0,
+    require_visible_text=True,
+    require_finish_reason=True,
+    require_done=True,
+):
+    failures = []
+    visible = response.get("visible_text", "")
+    completion_tokens = int(response.get("completion_tokens") or 0)
+    replacement_count = visible.count(REPLACEMENT_CHAR)
+
+    if require_visible_text and len(visible.strip()) < 2:
+        failures.append("empty_or_near_empty_visible_text")
+    if replacement_count > MAX_REPLACEMENT_CHARS:
+        failures.append("excess_replacement_characters")
+    if min_tokens and completion_tokens < min_tokens:
+        failures.append("completion_below_minimum")
+    if require_finish_reason and not response.get("finish_reason"):
+        failures.append("missing_finish_reason")
+    if require_done and not response.get("done_observed"):
+        failures.append("missing_sse_done")
+    if int(response.get("parse_error_count") or 0):
+        failures.append("sender_parse_error")
+
+    return {
+        "classification": "deterministic",
+        "ok": not failures,
+        "failures": failures,
+        "completion_tokens": completion_tokens,
+        "min_tokens": min_tokens,
+        "replacement_count": replacement_count,
+    }
+
+
+def evaluate_cache_contract(response, contract=None):
+    """Evaluate only explicitly requested cache accounting boundaries."""
+    contract = contract or {}
+    failures = []
+    prompt_tokens = int(response.get("prompt_tokens") or 0)
+    cached_tokens = int(response.get("cached_tokens") or 0)
+
+    expected_prompt = contract.get("expected_prompt_tokens")
+    minimum_cached = contract.get("minimum_cached_tokens")
+    maximum_cached = contract.get("maximum_cached_tokens")
+    if expected_prompt is not None and prompt_tokens != int(expected_prompt):
+        failures.append("unexpected_prompt_token_count")
+    if minimum_cached is not None and cached_tokens < int(minimum_cached):
+        failures.append("cached_tokens_below_minimum")
+    if maximum_cached is not None and cached_tokens > int(maximum_cached):
+        failures.append("cached_tokens_above_maximum")
+
+    return {
+        "classification": "deterministic_opt_in",
+        "ok": not failures,
+        "failures": failures,
+        "prompt_tokens": prompt_tokens,
+        "cached_tokens": cached_tokens,
+    }
+
+
+def _normalise_semantic_result(payload, requirements):
+    judged = payload.get("requirements")
+    if not isinstance(judged, list):
+        raise ValueError("semantic judge response lacks a requirements list")
+
+    expected_ids = {requirement["id"] for requirement in requirements}
+    judged_ids = set()
+    normalised = []
+    for item in judged:
+        if not isinstance(item, dict) or not item.get("id"):
+            raise ValueError("semantic judge requirement lacks id")
+        requirement_id = str(item["id"])
+        judged_ids.add(requirement_id)
+        normalised.append({
+            "id": requirement_id,
+            "passed": bool(item.get("passed")),
+            "evidence": str(item.get("evidence", ""))[:2000],
+        })
+
+    missing_ids = sorted(expected_ids - judged_ids)
+    if missing_ids:
+        raise ValueError(f"semantic judge omitted requirements: {', '.join(missing_ids)}")
+
+    return {
+        "classification": "semantic_review",
+        "status": "evaluated",
+        "ok": all(item["passed"] for item in normalised),
+        "requirements": normalised,
+        "summary": str(payload.get("summary", ""))[:4000],
+    }
+
+
+async def evaluate_semantic_contract(prompt, response, requirements):
+    """Run an operator-selected semantic judge; never affect deterministic score."""
+    command = os.environ.get("AFM_SEMANTIC_JUDGE_COMMAND", "").strip()
+    if not command:
+        return {
+            "classification": "semantic_review",
+            "status": "not_evaluated",
+            "ok": None,
+            "requirements": requirements,
+        }
+    if not requirements:
+        return {
+            "classification": "semantic_review",
+            "status": "no_requirements",
+            "ok": None,
+            "requirements": [],
+        }
+
+    payload = {
+        "prompt": prompt,
+        "response": response.get("visible_text", ""),
+        "requirements": requirements,
+    }
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *shlex.split(command),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate(
+            json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        )
+        if process.returncode != 0:
+            raise ValueError(
+                f"semantic judge exited {process.returncode}: "
+                f"{stderr.decode('utf-8', errors='replace')[:1000]}"
+            )
+        return _normalise_semantic_result(
+            json.loads(stdout.decode("utf-8")), requirements
+        )
+    except Exception as error:
+        return {
+            "classification": "semantic_review",
+            "status": "error",
+            "ok": None,
+            "requirements": requirements,
+            "error": f"{type(error).__name__}: {error}",
+        }

--- a/Scripts/feature-mlx-concurrent-batch/response_contracts.py
+++ b/Scripts/feature-mlx-concurrent-batch/response_contracts.py
@@ -7,6 +7,8 @@ import shlex
 
 REPLACEMENT_CHAR = "\ufffd"
 MAX_REPLACEMENT_CHARS = 5
+DEFAULT_SEMANTIC_JUDGE_TIMEOUT_S = 30.0
+DEFAULT_SEMANTIC_JUDGE_MAX_OUTPUT_BYTES = 1024 * 1024
 
 
 def observe_lexical(text, expected):
@@ -92,14 +94,25 @@ def _normalise_semantic_result(payload, requirements):
     judged_ids = set()
     normalised = []
     for item in judged:
-        if not isinstance(item, dict) or not item.get("id"):
+        if not isinstance(item, dict):
             raise ValueError("semantic judge requirement lacks id")
-        requirement_id = str(item["id"])
+        requirement_id = item.get("id")
+        if not isinstance(requirement_id, str) or not requirement_id:
+            raise ValueError("semantic judge requirement lacks id")
+        if requirement_id in judged_ids:
+            raise ValueError(f"semantic judge duplicated requirement: {requirement_id}")
+        if type(item.get("passed")) is not bool:
+            raise ValueError(f"semantic judge passed flag is not boolean: {requirement_id}")
+        evidence = item.get("evidence", "")
+        if evidence is None:
+            evidence = ""
+        if not isinstance(evidence, str):
+            raise ValueError(f"semantic judge evidence is not text: {requirement_id}")
         judged_ids.add(requirement_id)
         normalised.append({
             "id": requirement_id,
-            "passed": bool(item.get("passed")),
-            "evidence": str(item.get("evidence", ""))[:2000],
+            "passed": item["passed"],
+            "evidence": evidence[:2000],
         })
 
     missing_ids = sorted(expected_ids - judged_ids)
@@ -115,7 +128,69 @@ def _normalise_semantic_result(payload, requirements):
     }
 
 
-async def evaluate_semantic_contract(prompt, response, requirements):
+def _positive_environment_number(name, default):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        number = float(value)
+    except ValueError as error:
+        raise ValueError(f"{name} must be a positive number") from error
+    if number <= 0:
+        raise ValueError(f"{name} must be a positive number")
+    return number
+
+
+async def _run_semantic_judge(command, payload, timeout_s, max_output_bytes):
+    process = await asyncio.create_subprocess_exec(
+        *shlex.split(command),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    async def send_input():
+        process.stdin.write(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
+        await process.stdin.drain()
+        process.stdin.close()
+        await process.stdin.wait_closed()
+
+    async def read_limited(stream):
+        return await stream.read(max_output_bytes + 1)
+
+    try:
+        stdout, stderr, _, _ = await asyncio.wait_for(
+            asyncio.gather(
+                read_limited(process.stdout),
+                read_limited(process.stderr),
+                send_input(),
+                process.wait(),
+            ),
+            timeout=timeout_s,
+        )
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.wait()
+        raise
+    except Exception:
+        if process.returncode is None:
+            process.kill()
+            await process.wait()
+        raise
+
+    if len(stdout) > max_output_bytes:
+        raise ValueError("semantic judge stdout exceeded the output limit")
+    if len(stderr) > max_output_bytes:
+        raise ValueError("semantic judge stderr exceeded the output limit")
+    if process.returncode != 0:
+        raise ValueError(
+            f"semantic judge exited {process.returncode}: "
+            f"{stderr.decode('utf-8', errors='replace')[:1000]}"
+        )
+    return stdout.decode("utf-8")
+
+
+async def evaluate_semantic_contract(transcript, response, requirements):
     """Run an operator-selected semantic judge; never affect deterministic score."""
     command = os.environ.get("AFM_SEMANTIC_JUDGE_COMMAND", "").strip()
     if not command:
@@ -134,27 +209,23 @@ async def evaluate_semantic_contract(prompt, response, requirements):
         }
 
     payload = {
-        "prompt": prompt,
+        "messages": transcript,
+        "prompt": transcript[-1]["content"] if transcript else "",
         "response": response.get("visible_text", ""),
         "requirements": requirements,
     }
     try:
-        process = await asyncio.create_subprocess_exec(
-            *shlex.split(command),
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+        timeout_s = _positive_environment_number(
+            "AFM_SEMANTIC_JUDGE_TIMEOUT_S",
+            DEFAULT_SEMANTIC_JUDGE_TIMEOUT_S,
         )
-        stdout, stderr = await process.communicate(
-            json.dumps(payload, ensure_ascii=False).encode("utf-8")
-        )
-        if process.returncode != 0:
-            raise ValueError(
-                f"semantic judge exited {process.returncode}: "
-                f"{stderr.decode('utf-8', errors='replace')[:1000]}"
-            )
+        max_output_bytes = int(_positive_environment_number(
+            "AFM_SEMANTIC_JUDGE_MAX_OUTPUT_BYTES",
+            DEFAULT_SEMANTIC_JUDGE_MAX_OUTPUT_BYTES,
+        ))
+        stdout = await _run_semantic_judge(command, payload, timeout_s, max_output_bytes)
         return _normalise_semantic_result(
-            json.loads(stdout.decode("utf-8")), requirements
+            json.loads(stdout), requirements
         )
     except Exception as error:
         return {

--- a/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
@@ -17,6 +17,12 @@ Usage:
 import asyncio, aiohttp, json, time, sys, os
 from batch_validation_report import BatchReport
 from batch_stream_evidence import capture_stream_evidence, record_stream_parse_error
+from response_contracts import (
+    evaluate_cache_contract,
+    evaluate_integrity_contract,
+    evaluate_semantic_contract,
+    observe_lexical,
+)
 
 URL = os.environ.get("AFM_CHAT_COMPLETIONS_URL", "http://localhost:9999/v1/chat/completions")
 MODEL = os.environ.get("AFM_MODEL", "mlx-community/Qwen3.5-35B-A3B-4bit")
@@ -129,11 +135,19 @@ CONVERSATIONS = [
             {
                 "user": "Write a Python function to validate email addresses using regex. Include edge cases.",
                 "expected": ["def ", "re.", "import re", "@"],
+                "semantic_requirements": [
+                    {"id": "regex_validation", "description": "Implements a Python email-validation function using regex."},
+                    {"id": "edge_cases", "description": "Explains or tests representative edge cases."},
+                ],
                 "max_tokens": 4096,
             },
             {
                 "user": "Now add unit tests for that function using pytest. Cover valid, invalid, and edge cases.",
                 "expected": ["def test", "pytest", "assert"],
+                "semantic_requirements": [
+                    {"id": "pytest_tests", "description": "Provides pytest tests for the validation function."},
+                    {"id": "coverage_categories", "description": "Covers valid, invalid, and edge-case inputs."},
+                ],
                 "max_tokens": 4096,
             },
             {
@@ -150,16 +164,28 @@ CONVERSATIONS = [
             {
                 "user": "Explain the difference between Type I and Type II errors in hypothesis testing, with examples from clinical trials.",
                 "expected": ["type i", "type ii", "null hypothesis"],
+                "semantic_requirements": [
+                    {"id": "error_definitions", "description": "Correctly distinguishes Type I and Type II errors."},
+                    {"id": "clinical_examples", "description": "Uses clinically relevant examples."},
+                ],
                 "max_tokens": 4096,
             },
             {
                 "user": "How does sample size affect statistical power? Walk through a power analysis for a two-sample t-test.",
                 "expected": ["power", "sample size", "effect"],
+                "semantic_requirements": [
+                    {"id": "sample_size_power", "description": "Explains the relationship between sample size and statistical power."},
+                    {"id": "power_analysis", "description": "Walks through a two-sample t-test power analysis."},
+                ],
                 "max_tokens": 4096,
             },
             {
                 "user": "Now compare frequentist vs Bayesian approaches to the same clinical trial scenario. When should we prefer each?",
                 "expected": ["bayesian", "frequentist", "prior"],
+                "semantic_requirements": [
+                    {"id": "framework_comparison", "description": "Compares frequentist and Bayesian approaches in the clinical scenario."},
+                    {"id": "preference_criteria", "description": "Explains when each framework is preferable."},
+                ],
                 "max_tokens": 4096,
             },
         ],
@@ -171,16 +197,29 @@ CONVERSATIONS = [
             {
                 "user": "Write the opening scene of a noir detective story set in a rain-soaked Tokyo alley. First person, present tense.",
                 "expected": ["rain", "tokyo"],
+                "semantic_requirements": [
+                    {"id": "noir_scene", "description": "Writes an opening scene with noir atmosphere."},
+                    {"id": "tokyo_setting", "description": "Establishes a recognizable Tokyo setting without requiring the literal word Tokyo."},
+                    {"id": "first_person_present", "description": "Uses first-person, present-tense narration."},
+                ],
                 "max_tokens": 4096,
             },
             {
                 "user": "Continue the story. The detective finds a clue — a business card with a number that doesn't exist. Build tension.",
                 "expected": ["card", "number"],
+                "semantic_requirements": [
+                    {"id": "clue_continuity", "description": "Continues the story from the established scene."},
+                    {"id": "tension", "description": "Uses the impossible business-card clue to build tension."},
+                ],
                 "max_tokens": 4096,
             },
             {
                 "user": "Now write the confrontation scene where the detective meets the antagonist. Use subtext in the dialogue — they both know more than they say.",
                 "expected": ["said", "voice"],
+                "semantic_requirements": [
+                    {"id": "confrontation", "description": "Depicts the detective confronting the antagonist."},
+                    {"id": "dialogue_subtext", "description": "Uses dialogue or staging in which both characters imply more than they state."},
+                ],
                 "max_tokens": 4096,
             },
         ],
@@ -197,6 +236,12 @@ CONVERSATIONS = [
                     "and TTL-based expiration. Include comprehensive tests."
                 ),
                 "expected": ["struct", "impl", "fn ", "pub"],
+                "semantic_requirements": [
+                    {"id": "rust_lru", "description": "Implements an LRU cache in Rust."},
+                    {"id": "api_requirements", "description": "Addresses generic key/value types, configurable capacity, and the requested operations."},
+                    {"id": "concurrency_ttl_iterator", "description": "Addresses thread safety, TTL expiration, and iterator support."},
+                    {"id": "tests", "description": "Includes meaningful tests for the implementation."},
+                ],
                 "max_tokens": 4096,
                 "min_tokens": 500,
             },
@@ -215,6 +260,11 @@ CONVERSATIONS = [
                     "and constitutional AI. Include citations and compare approaches."
                 ),
                 "expected": ["attention", "transformer", "mamba"],
+                "semantic_requirements": [
+                    {"id": "transformer_improvements", "description": "Reviews the requested transformer architecture improvements."},
+                    {"id": "comparative_synthesis", "description": "Compares approaches rather than only listing them."},
+                    {"id": "citations", "description": "Provides citations or clearly attributable references."},
+                ],
                 "max_tokens": 4096,
                 "min_tokens": 500,
             },
@@ -235,10 +285,14 @@ async def send_request(session, messages, max_tokens=1024):
         "stream": True,
         "temperature": 0.3,
     }
-    text = ""
+    visible_text = ""
+    reasoning_text = ""
     ttft = None
     usage = {}
     timings = {}
+    finish_reason = None
+    done_observed = False
+    parse_error_count = 0
     start = time.monotonic()
 
     async with session.post(URL, json=payload) as resp:
@@ -249,6 +303,7 @@ async def send_request(session, messages, max_tokens=1024):
                 continue
             data = line[6:]
             if data == "[DONE]":
+                done_observed = True
                 break
             try:
                 chunk = json.loads(data)
@@ -256,13 +311,19 @@ async def send_request(session, messages, max_tokens=1024):
                     usage = chunk["usage"]
                 if "timings" in chunk:
                     timings = chunk["timings"]
-                delta = chunk["choices"][0].get("delta", {})
-                content = delta.get("content", "") or delta.get("reasoning_content", "")
-                if content:
+                choice = chunk["choices"][0]
+                delta = choice.get("delta", {})
+                if choice.get("finish_reason") is not None:
+                    finish_reason = choice["finish_reason"]
+                visible_delta = delta.get("content", "") or ""
+                reasoning_delta = delta.get("reasoning_content", "") or ""
+                if visible_delta or reasoning_delta:
                     if ttft is None:
                         ttft = time.monotonic() - start
-                    text += content
+                    visible_text += visible_delta
+                    reasoning_text += reasoning_delta
             except Exception:
+                parse_error_count += 1
                 record_stream_parse_error()
                 pass
 
@@ -275,7 +336,13 @@ async def send_request(session, messages, max_tokens=1024):
         cached = ptd.get("cached_tokens", 0)
 
     return {
-        "text": text,
+        "text": visible_text,
+        "visible_text": visible_text,
+        "reasoning_text": reasoning_text,
+        "combined_text": visible_text + reasoning_text,
+        "finish_reason": finish_reason,
+        "done_observed": done_observed,
+        "parse_error_count": parse_error_count,
         "wall_s": elapsed,
         "ttft": ttft or 0,
         "prompt_tokens": usage.get("prompt_tokens", 0),
@@ -286,14 +353,6 @@ async def send_request(session, messages, max_tokens=1024):
         "prompt_time_s": usage.get("prompt_time", 0),
         "completion_time_s": usage.get("completion_time", 0),
     }
-
-
-def check_response(text, expected):
-    lower = text.lower()
-    missing = [s for s in expected if s.lower() not in lower]
-    is_garbage = len(text.strip()) < 2 or text.count('\ufffd') > 5
-    return {"missing": missing, "ok": len(missing) == 0 and not is_garbage,
-            "is_garbage": is_garbage}
 
 
 # ─── Conversation runner ──────────────────────────────────────────────────────
@@ -320,12 +379,33 @@ async def run_conversation(session, conv):
                 f"{elapsed:.1f}s: {detail}"
             ) from exc
 
-        check = check_response(r["text"], turn["expected"])
+        integrity = evaluate_integrity_contract(
+            r,
+            min_tokens=turn.get("min_tokens", 0),
+            require_visible_text=turn.get("require_visible_text", True),
+            require_finish_reason=turn.get("require_finish_reason", True),
+            require_done=turn.get("require_done", True),
+        )
+        cache = evaluate_cache_contract(r, turn.get("cache_contract"))
+        lexical = observe_lexical(r["combined_text"], turn.get("expected", []))
+        semantic = await evaluate_semantic_contract(
+            turn["user"], r, turn.get("semantic_requirements", [])
+        )
+        deterministic_failures = integrity["failures"] + cache["failures"]
+
         r["turn"] = i + 1
         r["name"] = f"{conv['name']}/t{i+1}"
-        r["ok"] = check["ok"]
-        r["is_garbage"] = check["is_garbage"]
-        r["missing"] = check["missing"]
+        r["ok"] = not deterministic_failures
+        r["contract_failures"] = deterministic_failures
+        r["integrity_contract"] = integrity
+        r["cache_contract"] = cache
+        r["lexical_observation"] = lexical
+        r["semantic_review"] = semantic
+        r["is_garbage"] = (
+            "empty_or_near_empty_visible_text" in integrity["failures"]
+            or "excess_replacement_characters" in integrity["failures"]
+        )
+        r["missing"] = lexical["missing"]
         r["min_tokens"] = turn.get("min_tokens", 0)
 
         # Add assistant response to conversation history
@@ -368,26 +448,25 @@ async def run_batch(batch_size, conversations):
 
                     if r["ok"]:
                         passed += 1
-                        too_short = r["min_tokens"] > 0 and ct < r["min_tokens"] * 0.5
-                        if too_short:
-                            failed += 1
-                            passed -= 1
-                            print(f"  FAIL  {r['name']:30s}  TOO SHORT ({ct} tok)")
-                            r['status'] = 'TOO_SHORT'
-                        else:
-                            r['status'] = 'OK'
-                            print(f"  OK    {r['name']:30s}  "
-                                  f"pp={pt:5d} ({cached:4d} cached {cache_pct:4.0f}%) {pp:7.1f} t/s  "
-                                  f"tg={ct:4d} tok {tg:6.1f} t/s  "
-                                  f"TTFT={ttft:.2f}s  wall={r['wall_s']:.1f}s")
+                        r['status'] = 'OK'
+                        lexical_note = ""
+                        if r["missing"]:
+                            lexical_note = f"  lexical-evidence-missing={r['missing']}"
+                        semantic_status = r["semantic_review"]["status"]
+                        if semantic_status != "not_evaluated":
+                            lexical_note += f"  semantic={semantic_status}"
+                        print(f"  OK    {r['name']:30s}  "
+                              f"pp={pt:5d} ({cached:4d} cached {cache_pct:4.0f}%) {pp:7.1f} t/s  "
+                              f"tg={ct:4d} tok {tg:6.1f} t/s  "
+                              f"TTFT={ttft:.2f}s  wall={r['wall_s']:.1f}s{lexical_note}")
                     else:
                         failed += 1
                         if r.get("is_garbage"):
                             r['status'] = 'GARBAGE'
                             print(f"  FAIL  {r['name']:30s}  GARBAGE")
                         else:
-                            r['status'] = 'MISSING'
-                            print(f"  FAIL  {r['name']:30s}  missing {r['missing']}")
+                            r['status'] = 'CONTRACT_FAILURE'
+                            print(f"  FAIL  {r['name']:30s}  {r['contract_failures']}")
 
     return passed, failed, all_results
 

--- a/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
@@ -311,7 +311,10 @@ async def send_request(session, messages, max_tokens=1024):
                     usage = chunk["usage"]
                 if "timings" in chunk:
                     timings = chunk["timings"]
-                if not chunk.get("choices"):
+                if "choices" not in chunk:
+                    continue
+                choices = chunk["choices"]
+                if isinstance(choices, list) and not choices:
                     continue
                 choice = chunk["choices"][0]
                 delta = choice.get("delta", {})
@@ -331,11 +334,25 @@ async def send_request(session, messages, max_tokens=1024):
 
     elapsed = time.monotonic() - start
 
-    # Extract cached tokens from usage
-    cached = 0
-    ptd = usage.get("prompt_tokens_details", {})
-    if isinstance(ptd, dict):
-        cached = ptd.get("cached_tokens", 0)
+    # Preserve malformed usage as deterministic invalid metadata rather than
+    # converting it to an exception or a misleading zero.
+    invalid_usage = not isinstance(usage, dict)
+
+    def usage_value(key):
+        if invalid_usage:
+            return "invalid usage"
+        return usage.get(key, 0)
+
+    cached = "invalid usage"
+    if not invalid_usage:
+        if "prompt_tokens_details" not in usage:
+            cached = 0
+        else:
+            details = usage["prompt_tokens_details"]
+            if not isinstance(details, dict):
+                cached = "invalid usage details"
+            else:
+                cached = details.get("cached_tokens", 0)
 
     return {
         "text": visible_text,
@@ -347,13 +364,13 @@ async def send_request(session, messages, max_tokens=1024):
         "parse_error_count": parse_error_count,
         "wall_s": elapsed,
         "ttft": ttft or 0,
-        "prompt_tokens": usage.get("prompt_tokens", 0),
-        "completion_tokens": usage.get("completion_tokens", 0),
+        "prompt_tokens": usage_value("prompt_tokens"),
+        "completion_tokens": usage_value("completion_tokens"),
         "cached_tokens": cached,
-        "pp_tok_s": usage.get("prompt_tokens_per_second", 0),
-        "tg_tok_s": usage.get("completion_tokens_per_second", 0),
-        "prompt_time_s": usage.get("prompt_time", 0),
-        "completion_time_s": usage.get("completion_time", 0),
+        "pp_tok_s": usage_value("prompt_tokens_per_second"),
+        "tg_tok_s": usage_value("completion_tokens_per_second"),
+        "prompt_time_s": usage_value("prompt_time"),
+        "completion_time_s": usage_value("completion_time"),
     }
 
 

--- a/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
@@ -311,6 +311,8 @@ async def send_request(session, messages, max_tokens=1024):
                     usage = chunk["usage"]
                 if "timings" in chunk:
                     timings = chunk["timings"]
+                if not chunk.get("choices"):
+                    continue
                 choice = chunk["choices"][0]
                 delta = choice.get("delta", {})
                 if choice.get("finish_reason") is not None:

--- a/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
@@ -297,15 +297,15 @@ async def send_request(session, messages, max_tokens=1024):
 
     async with session.post(URL, json=payload) as resp:
         resp.raise_for_status()
-        async for line in resp.content:
-            line = line.decode().strip()
-            if not line.startswith("data: "):
-                continue
-            data = line[6:]
-            if data == "[DONE]":
-                done_observed = True
-                break
+        async for raw_line in resp.content:
             try:
+                line = raw_line.decode("utf-8").strip()
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "[DONE]":
+                    done_observed = True
+                    break
                 chunk = json.loads(data)
                 if "usage" in chunk:
                     usage = chunk["usage"]
@@ -387,9 +387,9 @@ async def run_conversation(session, conv):
             require_done=turn.get("require_done", True),
         )
         cache = evaluate_cache_contract(r, turn.get("cache_contract"))
-        lexical = observe_lexical(r["combined_text"], turn.get("expected", []))
+        lexical = observe_lexical(r["visible_text"], turn.get("expected", []))
         semantic = await evaluate_semantic_contract(
-            turn["user"], r, turn.get("semantic_requirements", [])
+            messages, r, turn.get("semantic_requirements", [])
         )
         deterministic_failures = integrity["failures"] + cache["failures"]
 
@@ -413,6 +413,30 @@ async def run_conversation(session, conv):
         turn_results.append(r)
 
     return turn_results
+
+
+def format_review_evidence(result):
+    """Return concise, non-scoring evidence shown for both outcomes."""
+    notes = []
+    lexical = result.get("lexical_observation", {})
+    if lexical.get("missing"):
+        notes.append(f"lexical-evidence-missing={lexical['missing']}")
+
+    semantic = result.get("semantic_review", {})
+    status = semantic.get("status", "not_evaluated")
+    if status == "evaluated":
+        outcomes = [
+            f"{requirement['id']}:{'pass' if requirement['passed'] else 'fail'}"
+            for requirement in semantic.get("requirements", [])
+        ]
+        suffix = f"({','.join(outcomes)})" if outcomes else ""
+        notes.append(f"semantic=ok:{str(semantic.get('ok')).lower()}{suffix}")
+    elif status == "error":
+        error = str(semantic.get("error", "semantic judge error"))[:240]
+        notes.append(f"semantic=error({error})")
+    else:
+        notes.append(f"semantic={status}")
+    return "  " + "  ".join(notes) if notes else ""
 
 
 async def run_batch(batch_size, conversations):
@@ -446,27 +470,25 @@ async def run_batch(batch_size, conversations):
                     ttft = r["ttft"]
                     cache_pct = (cached / pt * 100) if pt > 0 else 0
 
+                    review_note = format_review_evidence(r)
                     if r["ok"]:
                         passed += 1
                         r['status'] = 'OK'
-                        lexical_note = ""
-                        if r["missing"]:
-                            lexical_note = f"  lexical-evidence-missing={r['missing']}"
-                        semantic_status = r["semantic_review"]["status"]
-                        if semantic_status != "not_evaluated":
-                            lexical_note += f"  semantic={semantic_status}"
                         print(f"  OK    {r['name']:30s}  "
                               f"pp={pt:5d} ({cached:4d} cached {cache_pct:4.0f}%) {pp:7.1f} t/s  "
                               f"tg={ct:4d} tok {tg:6.1f} t/s  "
-                              f"TTFT={ttft:.2f}s  wall={r['wall_s']:.1f}s{lexical_note}")
+                              f"TTFT={ttft:.2f}s  wall={r['wall_s']:.1f}s{review_note}")
                     else:
                         failed += 1
                         if r.get("is_garbage"):
                             r['status'] = 'GARBAGE'
-                            print(f"  FAIL  {r['name']:30s}  GARBAGE")
+                            print(f"  FAIL  {r['name']:30s}  GARBAGE{review_note}")
                         else:
                             r['status'] = 'CONTRACT_FAILURE'
-                            print(f"  FAIL  {r['name']:30s}  {r['contract_failures']}")
+                            print(
+                                f"  FAIL  {r['name']:30s}  "
+                                f"{r['contract_failures']}{review_note}"
+                            )
 
     return passed, failed, all_results
 

--- a/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
@@ -289,6 +289,7 @@ async def send_request(session, messages, max_tokens=1024):
     reasoning_text = ""
     ttft = None
     usage = {}
+    invalid_usage_fields = set()
     timings = {}
     finish_reason = None
     done_observed = False
@@ -308,7 +309,38 @@ async def send_request(session, messages, max_tokens=1024):
                     break
                 chunk = json.loads(data)
                 if "usage" in chunk:
-                    usage = chunk["usage"]
+                    usage_event = chunk["usage"]
+                    if not isinstance(usage_event, dict):
+                        invalid_usage_fields.update(
+                            ("prompt_tokens", "completion_tokens", "cached_tokens")
+                        )
+                    else:
+                        usage = usage_event
+                        for key in ("prompt_tokens", "completion_tokens"):
+                            value = usage_event.get(key)
+                            if key in usage_event and (
+                                isinstance(value, bool)
+                                or not isinstance(value, (int, float))
+                                or value < 0
+                                or (isinstance(value, float) and not value.is_integer())
+                            ):
+                                invalid_usage_fields.add(key)
+                        if "prompt_tokens_details" in usage_event:
+                            details = usage_event["prompt_tokens_details"]
+                            if not isinstance(details, dict):
+                                invalid_usage_fields.add("cached_tokens")
+                            elif "cached_tokens" in details:
+                                cached_value = details["cached_tokens"]
+                                if (
+                                    isinstance(cached_value, bool)
+                                    or not isinstance(cached_value, (int, float))
+                                    or cached_value < 0
+                                    or (
+                                        isinstance(cached_value, float)
+                                        and not cached_value.is_integer()
+                                    )
+                                ):
+                                    invalid_usage_fields.add("cached_tokens")
                 if "timings" in chunk:
                     timings = chunk["timings"]
                 if "choices" not in chunk:
@@ -339,7 +371,7 @@ async def send_request(session, messages, max_tokens=1024):
     invalid_usage = not isinstance(usage, dict)
 
     def usage_value(key):
-        if invalid_usage:
+        if invalid_usage or key in invalid_usage_fields:
             return "invalid usage"
         return usage.get(key, 0)
 
@@ -371,6 +403,8 @@ async def send_request(session, messages, max_tokens=1024):
         "tg_tok_s": usage_value("completion_tokens_per_second"),
         "prompt_time_s": usage_value("prompt_time"),
         "completion_time_s": usage_value("completion_time"),
+        "usage_metadata_invalid": bool(invalid_usage_fields),
+        "invalid_usage_fields": sorted(invalid_usage_fields),
     }
 
 
@@ -458,6 +492,13 @@ def format_review_evidence(result):
     return "  " + "  ".join(notes) if notes else ""
 
 
+def printable_metric(value):
+    """Normalize malformed metadata only for display arithmetic."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    return value
+
+
 async def run_batch(batch_size, conversations):
     """Run conversations at given concurrency."""
     passed = 0
@@ -481,11 +522,11 @@ async def run_batch(batch_size, conversations):
 
                 for r in outcome:
                     all_results.append(r)
-                    pt = r["prompt_tokens"]
-                    ct = r["completion_tokens"]
-                    cached = r["cached_tokens"]
-                    pp = r["pp_tok_s"]
-                    tg = r["tg_tok_s"]
+                    pt = printable_metric(r["prompt_tokens"])
+                    ct = printable_metric(r["completion_tokens"])
+                    cached = printable_metric(r["cached_tokens"])
+                    pp = printable_metric(r["pp_tok_s"])
+                    tg = printable_metric(r["tg_tok_s"])
                     ttft = r["ttft"]
                     cache_pct = (cached / pt * 100) if pt > 0 else 0
 

--- a/Scripts/tests/test_batch_failure_reporting.py
+++ b/Scripts/tests/test_batch_failure_reporting.py
@@ -37,7 +37,9 @@ class AsyncContext:
 
 def response(text):
     return dict(text=text, completion_tokens=10, prompt_tokens=10, cached_tokens=0,
-                pp_tok_s=10, tg_tok_s=10, ttft=0.1, wall_s=1)
+                pp_tok_s=10, tg_tok_s=10, ttft=0.1, wall_s=1,
+                visible_text=text, reasoning_text='', combined_text=text,
+                finish_reason='stop', done_observed=True, parse_error_count=0)
 
 
 class FailureReportingTests(unittest.IsolatedAsyncioTestCase):
@@ -85,7 +87,7 @@ class FailureReportingTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn('GARBAGE', output.getvalue())
         self.assertNotIn('missing []', output.getvalue())
 
-    async def test_legitimate_missing_answer_keeps_specific_diagnostic(self):
+    async def test_lexical_missing_answer_is_review_evidence_not_contract_failure(self):
         conversation = dict(name='fixture', system='system',
                             turns=[dict(user='hi', expected=['needle'])])
         output = io.StringIO()
@@ -93,9 +95,12 @@ class FailureReportingTests(unittest.IsolatedAsyncioTestCase):
              patch.object(prefix, 'send_request', AsyncMock(return_value=response('other'))), \
              contextlib.redirect_stdout(output):
             passed, failed, rows = await prefix.run_batch(1, [conversation])
-        self.assertEqual((passed, failed), (0, 1))
+        self.assertEqual((passed, failed), (1, 0))
+        self.assertEqual(rows[0]['status'], 'OK')
+        self.assertTrue(rows[0]['ok'])
         self.assertFalse(rows[0]['is_garbage'])
-        self.assertIn("missing ['needle']", output.getvalue())
+        self.assertEqual(rows[0]['lexical_observation']['classification'], 'review_evidence')
+        self.assertIn("lexical-evidence-missing=['needle']", output.getvalue())
 
     def test_success_summary_does_not_emit_failure_warning(self):
         output = io.StringIO()

--- a/Scripts/tests/test_response_contracts.py
+++ b/Scripts/tests/test_response_contracts.py
@@ -138,6 +138,32 @@ class ResponseContractTests(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    def test_negative_token_metadata_is_invalid(self):
+        result = contracts.evaluate_integrity_contract(
+            dict(
+                visible_text="visible",
+                completion_tokens=-1,
+                finish_reason="stop",
+                done_observed=True,
+                parse_error_count=0,
+            )
+        )
+        self.assertEqual(
+            result["failures"],
+            ["invalid_completion_token_metadata"],
+        )
+
+        result = contracts.evaluate_cache_contract(
+            dict(prompt_tokens=-1, cached_tokens=-1)
+        )
+        self.assertEqual(
+            result["failures"],
+            [
+                "invalid_prompt_token_metadata",
+                "invalid_cached_token_metadata",
+            ],
+        )
+
         result = contracts.evaluate_cache_contract(
             dict(prompt_tokens="many", cached_tokens="none")
         )
@@ -231,6 +257,69 @@ class ResponseContractTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["cached_tokens"], 7)
         self.assertEqual(result["finish_reason"], "stop")
         self.assertTrue(result["done_observed"])
+
+    async def test_malformed_falsy_choices_remain_parse_errors(self):
+        body = [
+            b'data: {"usage":{"prompt_tokens":12,"completion_tokens":34},"choices":null}\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+            b"data: [DONE]\n",
+        ]
+        result = await prefix.send_request(
+            SimpleNamespace(
+                post=lambda *_args, **_kwargs: AsyncContext(StreamResponse(body))
+            ),
+            [],
+            max_tokens=8,
+        )
+        self.assertEqual(result["parse_error_count"], 1)
+        self.assertEqual(result["prompt_tokens"], 12)
+        self.assertEqual(result["completion_tokens"], 34)
+
+    async def test_malformed_usage_container_is_deterministic_metadata_failure(self):
+        body = [
+            b'data: {"choices":[{"delta":{"content":"visible"}}]}\n',
+            b'data: {"usage":null,"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+            b"data: [DONE]\n",
+        ]
+        result = await prefix.send_request(
+            SimpleNamespace(
+                post=lambda *_args, **_kwargs: AsyncContext(StreamResponse(body))
+            ),
+            [],
+            max_tokens=8,
+        )
+        integrity = contracts.evaluate_integrity_contract(result)
+        cache = contracts.evaluate_cache_contract(result)
+        self.assertEqual(result["parse_error_count"], 0)
+        self.assertEqual(
+            integrity["failures"],
+            ["invalid_completion_token_metadata"],
+        )
+        self.assertEqual(
+            cache["failures"],
+            [
+                "invalid_prompt_token_metadata",
+                "invalid_cached_token_metadata",
+            ],
+        )
+
+    async def test_malformed_cached_token_details_are_deterministic(self):
+        body = [
+            b'data: {"usage":{"prompt_tokens":12,"completion_tokens":34,'
+            b'"prompt_tokens_details":null},'
+            b'"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+            b"data: [DONE]\n",
+        ]
+        result = await prefix.send_request(
+            SimpleNamespace(
+                post=lambda *_args, **_kwargs: AsyncContext(StreamResponse(body))
+            ),
+            [],
+            max_tokens=8,
+        )
+        cache = contracts.evaluate_cache_contract(result)
+        self.assertEqual(result["parse_error_count"], 0)
+        self.assertEqual(cache["failures"], ["invalid_cached_token_metadata"])
 
     async def test_invalid_utf8_is_a_sender_parse_error(self):
         result = await prefix.send_request(

--- a/Scripts/tests/test_response_contracts.py
+++ b/Scripts/tests/test_response_contracts.py
@@ -108,6 +108,47 @@ class ResponseContractTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertTrue(result["ok"])
 
+    def test_integrity_accepts_nonempty_single_character_visible_output(self):
+        result = contracts.evaluate_integrity_contract(
+            dict(
+                visible_text="Y",
+                completion_tokens=1,
+                finish_reason="stop",
+                done_observed=True,
+                parse_error_count=0,
+            )
+        )
+        self.assertTrue(result["ok"])
+
+    def test_malformed_token_metadata_is_a_deterministic_failure(self):
+        result = contracts.evaluate_integrity_contract(
+            dict(
+                visible_text="visible",
+                completion_tokens="many",
+                finish_reason="stop",
+                done_observed=True,
+                parse_error_count="none",
+            )
+        )
+        self.assertEqual(
+            result["failures"],
+            [
+                "invalid_completion_token_metadata",
+                "invalid_parse_error_metadata",
+            ],
+        )
+
+        result = contracts.evaluate_cache_contract(
+            dict(prompt_tokens="many", cached_tokens="none")
+        )
+        self.assertEqual(
+            result["failures"],
+            [
+                "invalid_prompt_token_metadata",
+                "invalid_cached_token_metadata",
+            ],
+        )
+
     async def test_explicit_cache_contract_participates_in_deterministic_score(self):
         conversation = dict(
             name="fixture",
@@ -170,6 +211,27 @@ class ResponseContractTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result["done_observed"])
         self.assertEqual(result["parse_error_count"], 0)
 
+    async def test_metadata_only_sse_chunk_without_choices_is_valid(self):
+        body = [
+            b'data: {"usage":{"prompt_tokens":12,"completion_tokens":34,'
+            b'"prompt_tokens_details":{"cached_tokens":7}}}\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+            b"data: [DONE]\n",
+        ]
+        result = await prefix.send_request(
+            SimpleNamespace(
+                post=lambda *_args, **_kwargs: AsyncContext(StreamResponse(body))
+            ),
+            [],
+            max_tokens=8,
+        )
+        self.assertEqual(result["parse_error_count"], 0)
+        self.assertEqual(result["prompt_tokens"], 12)
+        self.assertEqual(result["completion_tokens"], 34)
+        self.assertEqual(result["cached_tokens"], 7)
+        self.assertEqual(result["finish_reason"], "stop")
+        self.assertTrue(result["done_observed"])
+
     async def test_invalid_utf8_is_a_sender_parse_error(self):
         result = await prefix.send_request(
             SimpleNamespace(
@@ -205,6 +267,30 @@ class ResponseContractTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result["status"], "error")
         self.assertIn("passed flag is not boolean", result["error"])
+
+    async def test_semantic_judge_must_return_exactly_configured_ids(self):
+        with tempfile.TemporaryDirectory() as directory:
+            judge = Path(directory) / "semantic-judge.py"
+            judge.write_text(
+                "import json\n"
+                "print(json.dumps({'requirements': [\n"
+                "    {'id': 'setting', 'passed': True},\n"
+                "    {'id': 'unrequested', 'passed': True}\n"
+                "]}))\n",
+                encoding="utf-8",
+            )
+            with patch.dict(
+                "os.environ",
+                {"AFM_SEMANTIC_JUDGE_COMMAND": f"{sys.executable} {judge}"},
+            ):
+                result = await contracts.evaluate_semantic_contract(
+                    [{"role": "user", "content": "fixture"}],
+                    {"visible_text": "response"},
+                    [{"id": "setting", "description": "Establishes setting."}],
+                )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("unknown requirements: unrequested", result["error"])
 
     async def test_semantic_judge_receives_structured_multiturn_transcript(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/Scripts/tests/test_response_contracts.py
+++ b/Scripts/tests/test_response_contracts.py
@@ -239,6 +239,7 @@ class ResponseContractTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_metadata_only_sse_chunk_without_choices_is_valid(self):
         body = [
+            b'data: {"choices":[]}\n',
             b'data: {"usage":{"prompt_tokens":12,"completion_tokens":34,'
             b'"prompt_tokens_details":{"cached_tokens":7}}}\n',
             b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
@@ -320,6 +321,49 @@ class ResponseContractTests(unittest.IsolatedAsyncioTestCase):
         cache = contracts.evaluate_cache_contract(result)
         self.assertEqual(result["parse_error_count"], 0)
         self.assertEqual(cache["failures"], ["invalid_cached_token_metadata"])
+
+    async def test_malformed_usage_is_latched_and_reported_by_run_batch(self):
+        body = [
+            b'data: {"choices":[{"delta":{"content":"visible"}}]}\n',
+            b'data: {"usage":null,"choices":[]}\n',
+            b'data: {"usage":{"prompt_tokens":12,"completion_tokens":34,'
+            b'"prompt_tokens_details":{"cached_tokens":7}}}\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+            b"data: [DONE]\n",
+        ]
+        result = await prefix.send_request(
+            SimpleNamespace(
+                post=lambda *_args, **_kwargs: AsyncContext(StreamResponse(body))
+            ),
+            [],
+            max_tokens=8,
+        )
+        conversation = dict(name="fixture", system="system",
+                            turns=[dict(user="fixture", expected=[])])
+        with patch.object(
+            prefix,
+            "send_request",
+            AsyncMock(return_value=result),
+        ), patch.object(
+            prefix.aiohttp,
+            "ClientSession",
+            return_value=AsyncContext(object()),
+        ), contextlib.redirect_stdout(io.StringIO()) as output:
+            passed, failed, rows = await prefix.run_batch(1, [conversation])
+
+        self.assertEqual((passed, failed), (0, 1))
+        self.assertTrue(result["usage_metadata_invalid"])
+        self.assertEqual(result["parse_error_count"], 0)
+        self.assertEqual(rows[0]["status"], "CONTRACT_FAILURE")
+        self.assertEqual(
+            rows[0]["contract_failures"],
+            [
+                "invalid_completion_token_metadata",
+                "invalid_prompt_token_metadata",
+                "invalid_cached_token_metadata",
+            ],
+        )
+        self.assertIn("invalid_completion_token_metadata", output.getvalue())
 
     async def test_invalid_utf8_is_a_sender_parse_error(self):
         result = await prefix.send_request(

--- a/Scripts/tests/test_response_contracts.py
+++ b/Scripts/tests/test_response_contracts.py
@@ -2,6 +2,7 @@
 import contextlib
 import importlib.util
 import io
+import json
 from pathlib import Path
 from types import SimpleNamespace
 import sys
@@ -169,6 +170,115 @@ class ResponseContractTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result["done_observed"])
         self.assertEqual(result["parse_error_count"], 0)
 
+    async def test_invalid_utf8_is_a_sender_parse_error(self):
+        result = await prefix.send_request(
+            SimpleNamespace(
+                post=lambda *_args, **_kwargs: AsyncContext(
+                    StreamResponse([b"data: \xff\xfe\n", b"data: [DONE]\n"])
+                )
+            ),
+            [],
+            max_tokens=8,
+        )
+        self.assertEqual(result["visible_text"], "")
+        self.assertEqual(result["parse_error_count"], 1)
+        self.assertTrue(result["done_observed"])
+
+    async def test_semantic_judge_requires_actual_json_booleans(self):
+        with tempfile.TemporaryDirectory() as directory:
+            judge = Path(directory) / "semantic-judge.py"
+            judge.write_text(
+                "import json\n"
+                "print(json.dumps({'requirements': "
+                "[{'id': 'setting', 'passed': 'false'}]}))\n",
+                encoding="utf-8",
+            )
+            with patch.dict(
+                "os.environ",
+                {"AFM_SEMANTIC_JUDGE_COMMAND": f"{sys.executable} {judge}"},
+            ):
+                result = await contracts.evaluate_semantic_contract(
+                    [{"role": "user", "content": "fixture"}],
+                    {"visible_text": "response"},
+                    [{"id": "setting", "description": "Establishes setting."}],
+                )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("passed flag is not boolean", result["error"])
+
+    async def test_semantic_judge_receives_structured_multiturn_transcript(self):
+        with tempfile.TemporaryDirectory() as directory:
+            judge = Path(directory) / "semantic-judge.py"
+            received = Path(directory) / "received.json"
+            judge.write_text(
+                "import json, sys\n"
+                "payload = json.load(sys.stdin)\n"
+                f"with open({json.dumps(str(received))}, 'w', encoding='utf-8') as output:\n"
+                "    output.write(json.dumps(payload))\n"
+                "print(json.dumps({'requirements': "
+                "[{'id': 'continuity', 'passed': True}]}))\n",
+                encoding="utf-8",
+            )
+            transcript = [
+                {"role": "system", "content": "system context"},
+                {"role": "user", "content": "first request"},
+                {"role": "assistant", "content": "prior visible answer"},
+                {"role": "user", "content": "continue that answer"},
+            ]
+            with patch.dict(
+                "os.environ",
+                {"AFM_SEMANTIC_JUDGE_COMMAND": f"{sys.executable} {judge}"},
+            ):
+                result = await contracts.evaluate_semantic_contract(
+                    transcript,
+                    {"visible_text": "current visible answer"},
+                    [{"id": "continuity", "description": "Continues the story."}],
+                )
+                payload = json.loads(received.read_text(encoding="utf-8"))
+
+        self.assertEqual(result["status"], "evaluated")
+        self.assertTrue(result["ok"])
+        self.assertEqual(payload["messages"], transcript)
+        self.assertEqual(payload["prompt"], "continue that answer")
+        self.assertEqual(payload["response"], "current visible answer")
+
+    async def test_hanging_semantic_judge_fails_closed_after_timeout(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "AFM_SEMANTIC_JUDGE_COMMAND": f"{sys.executable} -c 'import time; time.sleep(1)'",
+                "AFM_SEMANTIC_JUDGE_TIMEOUT_S": "0.05",
+            },
+        ):
+            result = await contracts.evaluate_semantic_contract(
+                [{"role": "user", "content": "fixture"}],
+                {"visible_text": "response"},
+                [{"id": "setting", "description": "Establishes setting."}],
+            )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("TimeoutError", result["error"])
+
+    async def test_semantic_judge_output_is_bounded(self):
+        with tempfile.TemporaryDirectory() as directory:
+            judge = Path(directory) / "semantic-judge.py"
+            judge.write_text("print('12345')\n", encoding="utf-8")
+            with patch.dict(
+                "os.environ",
+                {
+                    "AFM_SEMANTIC_JUDGE_COMMAND": f"{sys.executable} {judge}",
+                    "AFM_SEMANTIC_JUDGE_MAX_OUTPUT_BYTES": "4",
+                },
+            ):
+                result = await contracts.evaluate_semantic_contract(
+                    [{"role": "user", "content": "fixture"}],
+                    {"visible_text": "response"},
+                    [{"id": "setting", "description": "Establishes setting."}],
+                )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("stdout exceeded the output limit", result["error"])
+
     async def test_external_semantic_judge_is_reported_separately(self):
         with tempfile.TemporaryDirectory() as directory:
             judge = Path(directory) / "semantic-judge.py"
@@ -227,7 +337,66 @@ class ResponseContractTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(rows[0]["semantic_review"]["status"], "evaluated")
             self.assertFalse(rows[0]["semantic_review"]["ok"])
             self.assertTrue(rows[0]["ok"])
-            self.assertIn("semantic=evaluated", output.getvalue())
+            self.assertIn("semantic=ok:false(setting:fail)", output.getvalue())
+
+    async def test_review_evidence_is_visible_on_contract_failures(self):
+        with tempfile.TemporaryDirectory() as directory:
+            judge = Path(directory) / "semantic-judge.py"
+            judge.write_text(
+                "import json, sys\n"
+                "json.load(sys.stdin)\n"
+                "print(json.dumps({'requirements': "
+                "[{'id': 'setting', 'passed': False}]}))\n",
+                encoding="utf-8",
+            )
+            conversation = dict(
+                name="fixture",
+                system="system",
+                turns=[
+                    dict(
+                        user="fixture",
+                        expected=["needle"],
+                        semantic_requirements=[
+                            {"id": "setting", "description": "Establishes setting."}
+                        ],
+                    )
+                ],
+            )
+            response = dict(
+                text="other",
+                visible_text="other",
+                reasoning_text="needle only in reasoning",
+                combined_text="otherneedle only in reasoning",
+                completion_tokens=10,
+                prompt_tokens=10,
+                cached_tokens=0,
+                pp_tok_s=10,
+                tg_tok_s=10,
+                ttft=0.1,
+                wall_s=1,
+                finish_reason="stop",
+                done_observed=False,
+                parse_error_count=0,
+            )
+            with patch.dict(
+                "os.environ",
+                {"AFM_SEMANTIC_JUDGE_COMMAND": f"{sys.executable} {judge}"},
+            ), patch.object(
+                prefix,
+                "send_request",
+                AsyncMock(return_value=response),
+            ), patch.object(
+                prefix.aiohttp,
+                "ClientSession",
+                return_value=AsyncContext(object()),
+            ), contextlib.redirect_stdout(io.StringIO()) as output:
+                passed, failed, rows = await prefix.run_batch(1, [conversation])
+
+            self.assertEqual((passed, failed), (0, 1))
+            self.assertEqual(rows[0]["contract_failures"], ["missing_sse_done"])
+            self.assertEqual(rows[0]["lexical_observation"]["missing"], ["needle"])
+            self.assertIn("lexical-evidence-missing=['needle']", output.getvalue())
+            self.assertIn("semantic=ok:false(setting:fail)", output.getvalue())
 
 
 if __name__ == "__main__":

--- a/Scripts/tests/test_response_contracts.py
+++ b/Scripts/tests/test_response_contracts.py
@@ -1,0 +1,234 @@
+"""CPU-only checks for separated integrity, cache, lexical, and semantic evidence."""
+import contextlib
+import importlib.util
+import io
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+import tempfile
+import unittest
+from unittest.mock import AsyncMock, patch
+
+
+ROOT = Path(__file__).resolve().parents[1] / "feature-mlx-concurrent-batch"
+sys.path.insert(0, str(ROOT))
+
+
+def load(name):
+    spec = importlib.util.spec_from_file_location(name, ROOT / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+contracts = load("response_contracts")
+prefix = load("validate_multiturn_prefix")
+
+
+class AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *_):
+        return False
+
+
+class Content:
+    def __init__(self, chunks):
+        self.chunks = chunks
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self.chunks:
+            raise StopAsyncIteration
+        return self.chunks.pop(0)
+
+
+class StreamResponse:
+    status = 200
+    headers = {}
+    raw_headers = ()
+
+    def __init__(self, chunks):
+        self.content = Content(chunks)
+
+    def raise_for_status(self):
+        pass
+
+
+class ResponseContractTests(unittest.IsolatedAsyncioTestCase):
+    def test_lexical_observation_does_not_define_quality_failure(self):
+        evidence = contracts.observe_lexical(
+            "He says I should stay. My voice is quiet.", ["said", "voice"]
+        )
+        self.assertFalse(evidence["ok"])
+        self.assertEqual(evidence["classification"], "review_evidence")
+        self.assertEqual(evidence["missing"], ["said"])
+        self.assertEqual(evidence["observed"], ["voice"])
+
+    def test_integrity_requires_complete_transport_and_output(self):
+        result = contracts.evaluate_integrity_contract(
+            dict(
+                visible_text="\ufffd" * 6,
+                completion_tokens=2,
+                finish_reason=None,
+                done_observed=False,
+                parse_error_count=1,
+            ),
+            min_tokens=5,
+        )
+        self.assertFalse(result["ok"])
+        self.assertEqual(
+            result["failures"],
+            [
+                "excess_replacement_characters",
+                "completion_below_minimum",
+                "missing_finish_reason",
+                "missing_sse_done",
+                "sender_parse_error",
+            ],
+        )
+
+    def test_cache_contract_is_explicit_and_bounded(self):
+        result = contracts.evaluate_cache_contract(
+            dict(prompt_tokens=100, cached_tokens=90),
+            dict(expected_prompt_tokens=100, minimum_cached_tokens=95),
+        )
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["failures"], ["cached_tokens_below_minimum"])
+
+        result = contracts.evaluate_cache_contract(
+            dict(prompt_tokens=100, cached_tokens=95)
+        )
+        self.assertTrue(result["ok"])
+
+    async def test_explicit_cache_contract_participates_in_deterministic_score(self):
+        conversation = dict(
+            name="fixture",
+            system="system",
+            turns=[
+                dict(
+                    user="fixture",
+                    expected=[],
+                    cache_contract=dict(minimum_cached_tokens=11),
+                )
+            ],
+        )
+        response = dict(
+            text="valid",
+            visible_text="valid",
+            reasoning_text="",
+            combined_text="valid",
+            completion_tokens=10,
+            prompt_tokens=10,
+            cached_tokens=10,
+            pp_tok_s=10,
+            tg_tok_s=10,
+            ttft=0.1,
+            wall_s=1,
+            finish_reason="stop",
+            done_observed=True,
+            parse_error_count=0,
+        )
+        with patch.object(prefix, "send_request", AsyncMock(return_value=response)), \
+             patch.object(
+                 prefix.aiohttp,
+                 "ClientSession",
+                 return_value=AsyncContext(object()),
+             ), contextlib.redirect_stdout(io.StringIO()) as output:
+            passed, failed, rows = await prefix.run_batch(1, [conversation])
+
+        self.assertEqual((passed, failed), (0, 1))
+        self.assertEqual(rows[0]["status"], "CONTRACT_FAILURE")
+        self.assertEqual(rows[0]["contract_failures"], ["cached_tokens_below_minimum"])
+        self.assertIn("cached_tokens_below_minimum", output.getvalue())
+
+    async def test_sender_separates_reasoning_visible_and_stream_completion(self):
+        body = [
+            b'data: {"choices":[{"delta":{"content":"visible","reasoning_content":"reason"}}]}\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+            b"data: [DONE]\n",
+        ]
+        result = await prefix.send_request(
+            SimpleNamespace(
+                post=lambda *_args, **_kwargs: AsyncContext(StreamResponse(body))
+            ),
+            [],
+            max_tokens=8,
+        )
+        self.assertEqual(result["text"], "visible")
+        self.assertEqual(result["visible_text"], "visible")
+        self.assertEqual(result["reasoning_text"], "reason")
+        self.assertEqual(result["combined_text"], "visiblereason")
+        self.assertEqual(result["finish_reason"], "stop")
+        self.assertTrue(result["done_observed"])
+        self.assertEqual(result["parse_error_count"], 0)
+
+    async def test_external_semantic_judge_is_reported_separately(self):
+        with tempfile.TemporaryDirectory() as directory:
+            judge = Path(directory) / "semantic-judge.py"
+            judge.write_text(
+                "import json, sys\n"
+                "payload = json.load(sys.stdin)\n"
+                "print(json.dumps({'requirements': [\n"
+                "    {'id': 'setting', 'passed': False, 'evidence': 'fixture'}\n"
+                "], 'summary': 'fixture judged'}))\n",
+                encoding="utf-8",
+            )
+            conversation = dict(
+                name="fixture",
+                system="system",
+                turns=[
+                    dict(
+                        user="fixture",
+                        expected=[],
+                        semantic_requirements=[
+                            {"id": "setting", "description": "Establishes setting."}
+                        ],
+                    )
+                ],
+            )
+            response = dict(
+                text="valid visible response",
+                visible_text="valid visible response",
+                reasoning_text="",
+                combined_text="valid visible response",
+                completion_tokens=10,
+                prompt_tokens=10,
+                cached_tokens=0,
+                pp_tok_s=10,
+                tg_tok_s=10,
+                ttft=0.1,
+                wall_s=1,
+                finish_reason="stop",
+                done_observed=True,
+                parse_error_count=0,
+            )
+            with patch.dict(
+                "os.environ",
+                {"AFM_SEMANTIC_JUDGE_COMMAND": f"{sys.executable} {judge}"},
+            ), patch.object(
+                prefix,
+                "send_request",
+                AsyncMock(return_value=response),
+            ), patch.object(
+                prefix.aiohttp,
+                "ClientSession",
+                return_value=AsyncContext(object()),
+            ), contextlib.redirect_stdout(io.StringIO()) as output:
+                passed, failed, rows = await prefix.run_batch(1, [conversation])
+
+            self.assertEqual((passed, failed), (1, 0))
+            self.assertEqual(rows[0]["semantic_review"]["status"], "evaluated")
+            self.assertFalse(rows[0]["semantic_review"]["ok"])
+            self.assertTrue(rows[0]["ok"])
+            self.assertIn("semantic=evaluated", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #265

## Change
- Keep visible content, reasoning content, finish reason, observed `[DONE]`, and sender parse-error count as separate stream fields.
- Make deterministic pass/fail scoring depend only on response integrity and explicitly configured cache contracts.
- Convert `expected` lexical markers into non-scoring review evidence based on visible output only.
- Add requirement descriptions and an optional `AFM_SEMANTIC_JUDGE_COMMAND` interface.
- Pass the structured visible transcript to semantic judges, with no reasoning channel.
- Enforce strict JSON booleans, exact configured requirement IDs, a configurable judge timeout, and bounded judge output.
- Report lexical and semantic review evidence on both deterministic pass and failure console paths.
- Treat invalid UTF-8 stream bytes as sender parse errors.
- Accept valid metadata-only SSE chunks without choices.
- Treat malformed token metadata as deterministic contract failures.
- Preserve raw stream evidence as observability-only and update its scoring note.
- Document the separated schema and judge protocol while preserving historical artifacts unchanged.

## Semantic Judge Protocol
The command reads JSON from stdin and writes JSON to stdout. Input includes the full visible transcript in `messages`, backward-compatible current prompt text in `prompt`, visible response, and requirements:

```json
{
  "messages": [
    {"role": "system", "content": "..."},
    {"role": "user", "content": "..."},
    {"role": "assistant", "content": "..."},
    {"role": "user", "content": "..."}
  ],
  "prompt": "current user prompt",
  "response": "visible response",
  "requirements": [
    {"id": "tokyo_setting", "description": "Establishes the requested setting."}
  ]
}
```

The command must return:

```json
{
  "requirements": [
    {"id": "tokyo_setting", "passed": true, "evidence": "text quote"}
  ],
  "summary": "optional explanation"
}
```

Every `passed` value must be a JSON boolean, and returned IDs must exactly match the configured set. Missing or duplicate IDs, unknown IDs, malformed output, nonzero exit status, timeout, or oversized output produce `semantic.status=error`; a judged failure produces `semantic.ok=false`. Neither result changes deterministic validation scoring. Defaults are 30 seconds (`AFM_SEMANTIC_JUDGE_TIMEOUT_S`) and 1 MiB per stream (`AFM_SEMANTIC_JUDGE_MAX_OUTPUT_BYTES`).

## Validation
Passed:

```text
uv run --python 3.12 --with aiohttp python Scripts/tests/test_response_contracts.py -v
uv run --python 3.12 --with aiohttp python Scripts/tests/test_batch_failure_reporting.py -v
uv run --python 3.12 --with aiohttp python Scripts/tests/test_batch_stream_evidence.py -v
uv run --python 3.9 --with aiohttp python Scripts/tests/test_response_contracts.py -v
swift test
git diff --check
```

The Python suites cover malformed judge booleans, timeout termination, output limits, exact requirement IDs, structured transcript context, visible-only lexical evidence, review annotations on failures, invalid UTF-8 parse-error handling, metadata-only SSE chunks, malformed token metadata, and one-character nonempty visible output. No model server or GPU was required for these contract tests.

## Summary by Sourcery

Separate deterministic response validation from lexical and semantic review while strengthening streaming integrity checks and judge protocol handling.

New Features:
- Add an optional semantic judge protocol for evaluating configured response requirements with structured transcript context and bounded execution.
- Expose separate visible and reasoning stream content alongside transport, completion, and parse-error state.

Bug Fixes:
- Handle invalid UTF-8, malformed token metadata, malformed stream choices, and metadata-only SSE chunks consistently as response contract conditions.

Enhancements:
- Separate deterministic integrity and explicit cache scoring from non-scoring lexical and semantic review evidence.
- Require complete semantic judge responses with strict boolean values and exact configured requirement IDs.
- Report lexical and semantic evidence for both successful and failed validation outcomes.

Documentation:
- Document the separated scoring schema, review evidence, and semantic judge interface while preserving historical artifacts.

Tests:
- Add CPU-only contract coverage for stream parsing, integrity and cache validation, semantic judge failures, timeouts, output limits, transcript context, and reporting behavior.

Chores:
- Update raw stream evidence scoring notes to clarify its observability-only role.