### PR TITLE
Require direct output for prefix coding benchmark

### DIFF
--- a/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
+++ b/Scripts/feature-mlx-concurrent-batch/validate_multiturn_prefix.py
@@ -230,7 +230,9 @@ CONVERSATIONS = [
         "turns": [
             {
                 "user": (
-                    "Implement a complete LRU cache in Rust with the following requirements: "
+                    "Do not call tools or inspect files. Write the complete implementation "
+                    "directly in this response. Implement a complete LRU cache in Rust "
+                    "with the following requirements: "
                     "generic key/value types, O(1) get/put, configurable capacity, "
                     "thread-safe with fine-grained locking, iterator support, "
                     "and TTL-based expiration. Include comprehensive tests."

--- a/Scripts/tests/test_response_contracts.py
+++ b/Scripts/tests/test_response_contracts.py
@@ -72,6 +72,16 @@ class ResponseContractTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(evidence["missing"], ["said"])
         self.assertEqual(evidence["observed"], ["voice"])
 
+    def test_coding_long_decode_requires_direct_output_without_tools(self):
+        conversation = next(
+            item for item in prefix.CONVERSATIONS if item["name"] == "coding-longdecode"
+        )
+        prompt = conversation["turns"][0]["user"]
+
+        self.assertTrue(prompt.startswith("Do not call tools or inspect files."))
+        self.assertIn("directly in this response", prompt)
+        self.assertIn("Implement a complete LRU cache in Rust", prompt)
+
     def test_integrity_requires_complete_transport_and_output(self):
         result = contracts.evaluate_integrity_contract(
             dict(

--- a/Scripts/tests/test_response_contracts.py
+++ b/Scripts/tests/test_response_contracts.py
@@ -78,9 +78,17 @@ class ResponseContractTests(unittest.IsolatedAsyncioTestCase):
         )
         prompt = conversation["turns"][0]["user"]
 
-        self.assertTrue(prompt.startswith("Do not call tools or inspect files."))
-        self.assertIn("directly in this response", prompt)
-        self.assertIn("Implement a complete LRU cache in Rust", prompt)
+        self.assertEqual(
+            prompt,
+            (
+                "Do not call tools or inspect files. Write the complete implementation "
+                "directly in this response. Implement a complete LRU cache in Rust "
+                "with the following requirements: "
+                "generic key/value types, O(1) get/put, configurable capacity, "
+                "thread-safe with fine-grained locking, iterator support, "
+                "and TTL-based expiration. Include comprehensive tests."
+            ),
+        )
 
     def test_integrity_requires_complete_transport_and_output(self):
         result = contracts.evaluate_integrity_contract(


### PR DESCRIPTION
Closes #292

## Change
- Make `coding-longdecode/t1` explicitly require direct output with no tool calls or file inspection.
- Add a regression protecting that prompt contract.

## Evidence

Against the RC binary, exact Qwen checkpoint, raw tool parsing, and no API tools:

- Original prompt: 55 completion tokens, literal `list_files` markup, no `fn` or `pub`.
- Direct-output prompt: 4,096 completion tokens, Rust implementation, contains both `fn` and `pub`.

Evidence: `/Volumes/edata2/afm-benchmarks/rc-20260904/post-merge-smokes/pr291-qwen-off-prefix-b1/rust-prompt-ab.json`

This changes only the benchmark request contract. It does not weaken minimum-token/integrity scoring or retroactively classify historical failures as passes.

## Validation

```text
uv run --python 3.12 --with aiohttp python Scripts/tests/test_response_contracts.py -v
uv run --python 3.9 --with aiohttp python Scripts/tests/test_response_contracts.py -v
git diff --check
```

## Summary by Sourcery

Require direct, tool-free output for the prefix coding benchmark and protect the request contract with a regression test.

Enhancements:
- Require the coding-longdecode benchmark to produce the complete Rust implementation directly without tool calls or file inspection.

Tests:
- Add a regression test enforcing the coding-longdecode direct-output prompt contract.