### PR TITLE
Release AFM 0.9.19 from qualified RC

### DIFF
--- a/Examples/AFMKitCoreOnlyConsumer/Package.swift
+++ b/Examples/AFMKitCoreOnlyConsumer/Package.swift
@@ -9,7 +9,7 @@ if let localPath = ProcessInfo.processInfo.environment["AFMKIT_EXAMPLE_PATH"],
 } else {
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.18-rc.4"
+            exact: "0.1.18-rc.5"
     )
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "c1e33558b3d8df1164af92cba4f2de659f6d255f662ffa917284437b59d7ba68",
+  "originHash" : "11c48c62b2a7c43175919833568b336ef711369f089e50ca8fa1ecbd29d4f85b",
   "pins" : [
     {
       "identity" : "afmkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scouzi1966/AFMKit.git",
       "state" : {
-        "revision" : "ef43d0f111df621a83374cfae17111723babfbf7",
-        "version" : "0.1.18-rc.4"
+        "revision" : "961215c715bf12b7b2a4aa2c951220f261c95c4d",
+        "version" : "0.1.18-rc.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ if let localAFMKitPath = ProcessInfo.processInfo.environment["MACLOCAL_AFMKIT_WO
     // Bumping AFMKit is therefore one explicit, reviewable AFM change.
     afmKitDependency = .package(
         url: "https://github.com/scouzi1966/AFMKit.git",
-        exact: "0.1.18-rc.4"
+        exact: "0.1.18-rc.5"
     )
 }
 

--- a/Scripts/check-afmkit-consumer-boundary.sh
+++ b/Scripts/check-afmkit-consumer-boundary.sh
@@ -146,8 +146,8 @@ for identity, (expected_location, checkout_name) in provider_packages.items():
     pin = pins_by_identity[identity]
     if pin["location"] != expected_location:
         fail(f"{identity} release lock points at an unexpected source")
-    if pin["state"].get("version") != "0.1.18-rc.4":
-        fail(f"{identity} must resolve the exact 0.1.18-rc.4 release")
+    if pin["state"].get("version") != "0.1.18-rc.5":
+        fail(f"{identity} must resolve the exact 0.1.18-rc.5 release")
 
     checkout = Path(".build/checkouts") / checkout_name
     if not checkout.is_dir():
@@ -292,7 +292,7 @@ grep -Fq '.product(name: "AFMKitCore", package: "AFMKit")' "$example_manifest" |
 if grep -Fq 'package: "MacLocalAPI"' "$example_manifest"; then
   fail "independent core consumer still relies on a removed maclocal compatibility product"
 fi
-grep -Fq 'exact: "0.1.18-rc.4"' "$example_manifest" || \
+grep -Fq 'exact: "0.1.18-rc.5"' "$example_manifest" || \
   fail "independent core consumer must use the exact AFMKit release"
 
 for project in pyproject.toml pyproject-next.toml; do

--- a/Scripts/check-public-release-eligibility.sh
+++ b/Scripts/check-public-release-eligibility.sh
@@ -16,7 +16,7 @@ package = json.loads(subprocess.check_output(["swift", "package", "dump-package"
 dependencies = {item["sourceControl"][0]["identity"]: item["sourceControl"][0]
                 for item in package["dependencies"] if item.get("sourceControl")}
 expected_versions = {
-    "afmkit": "0.1.18-rc.4",
+    "afmkit": "0.1.18-rc.5",
 }
 for identity, expected_version in expected_versions.items():
     pin, dependency = pins.get(identity), dependencies.get(identity)
@@ -49,6 +49,8 @@ probe_public_source() {
 
 check_public_release_eligibility() {
   local identity url revision version
+  local sources
+  sources="$(read_public_release_sources)" || return 1
   while IFS=$'\t' read -r identity url revision version; do
     [[ "$url" =~ ^https://github\.com/ ]] || {
       echo "[release-public] $identity must use a public GitHub HTTPS URL: $url" >&2
@@ -59,7 +61,7 @@ check_public_release_eligibility() {
       return 1
     fi
     echo "[release-public] $identity $version (${revision:0:12}) is exact and anonymously fetchable."
-  done < <(read_public_release_sources)
+  done <<< "$sources"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/Sources/AFMKit/BuildInfo.swift
+++ b/Sources/AFMKit/BuildInfo.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 public struct BuildInfo {
-    public static let version: String? = "v0.9.18"
+    public static let version: String? = "v0.9.19"
     static let commit: String? = nil
 
     /// True only when the executable was compiled with the toolchain required

--- a/macafm/__init__.py
+++ b/macafm/__init__.py
@@ -13,7 +13,7 @@ Requirements:
 - Apple Intelligence enabled in System Settings
 """
 
-__version__ = "0.9.18"
+__version__ = "0.9.19"
 __author__ = "Sylvain Cousineau"
 
 from .cli import main, get_binary_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macafm"
-version = "0.9.18"
+version = "0.9.19"
 description = "Access Apple's on-device Foundation Models via CLI and OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Promotes the qualified 97a9acf runtime/provider graph to production 0.9.19. Pins exact AFMKit 0.1.18-rc.5; aligns Swift/Python version metadata; fixes the public-release guard to match the pinned provider and propagate metadata validation failures.

Validation: immutable release build passed; installed RC tested on M3 Ultra and M4 Pro with Qwen 27B and Codex judging; 76/76 native Promptfoo checks and 116 API assertions passed per host with 2 capability skips. Supplied September 8 qualification: all six native MLX modes passed MUST checks and Context through 32K. DwarfStar DSpark retains five documented MUST failures. Runtime binary is promoted unchanged; source XCTest not rerun in installed-binary qualification.

Packaging: stable wheel install/launch, Foundation build gate, macOS 26 target, MLX/DwarfStar bundles, WebUI and relocated archive checks pass. Detailed evidence will be attached to v0.9.19. Public dependency access and negative metadata-gate checks pass. No Actions dependency.

## Summary by Sourcery

Release AFM 0.9.19 with the qualified runtime and provider graph, updated AFMKit pin, and corrected public-release validation.

Bug Fixes:
- Correct public-release eligibility checks to validate and propagate dependency metadata failures.

Enhancements:
- Promote AFM to version 0.9.19 and align Swift and Python release metadata.
- Pin AFMKit and all consumer validation checks to the qualified 0.1.18-rc.5 release.