### PR TITLE
Fix excessive CPU time sanitizing response tails

### DIFF
--- a/Sources/AFMServer/AFMDegenerateTailSanitizer.swift
+++ b/Sources/AFMServer/AFMDegenerateTailSanitizer.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum AFMDegenerateTailSanitizer {
+    private static let punctuation: Set<Character> = Set("!?.:,;`~_-=*|")
+    private static let finalLineBreaks: Set<Character> = ["\n", "\r", "\r\n", "\u{85}", "\u{2028}", "\u{2029}"]
+
+    static func sanitize(_ text: String) -> String {
+        var cleaned = text
+        if let badChar = cleaned.lastIndex(of: "�"),
+           cleaned.distance(from: badChar, to: cleaned.endIndex) < 512 {
+            cleaned = String(cleaned[..<badChar])
+        }
+
+        // Match the old ICU end anchor, which also permits one final line break.
+        var end = cleaned.endIndex
+        if end > cleaned.startIndex, finalLineBreaks.contains(cleaned[cleaned.index(before: end)]) {
+            end = cleaned.index(before: end)
+        }
+        guard end > cleaned.startIndex else { return cleaned }
+        let last = cleaned[cleaned.index(before: end)]
+        guard punctuation.contains(last) else { return cleaned }
+
+        // Scan the trailing run once. An unanchored backreference regex can
+        // retry every starting position in a long near-match and monopolize CPU.
+        var start = end
+        var count = 0
+        while start > cleaned.startIndex {
+            let previous = cleaned.index(before: start)
+            guard cleaned[previous] == last else { break }
+            start = previous
+            count += 1
+        }
+        guard count >= 80 else { return cleaned }
+        return String(cleaned[..<start]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
+++ b/Sources/AFMServer/Controllers/MLXChatCompletionsController.swift
@@ -83,7 +83,6 @@ struct StreamingStopSequenceFilter {
 }
 
 struct MLXChatCompletionsController: RouteCollection {
-    private static let degenerateTailRegex = try! NSRegularExpression(pattern: "([!?.:,;`~_\\-*=|])\\1{79,}$")
 
     /// Max time (seconds) to wait for a concurrent slot before returning 503.
     /// RotatingKVCache models run serial, so queued requests can wait a long time.
@@ -1839,19 +1838,7 @@ struct MLXChatCompletionsController: RouteCollection {
     }
 
     private func sanitizeDegenerateTail(_ text: String) -> String {
-        var cleaned = text
-
-        if let badChar = cleaned.lastIndex(of: "�"), cleaned.distance(from: badChar, to: cleaned.endIndex) < 512 {
-            cleaned = String(cleaned[..<badChar])
-        }
-
-        let nsrange = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
-        guard let match = Self.degenerateTailRegex.firstMatch(in: cleaned, range: nsrange),
-              let range = Range(match.range, in: cleaned) else {
-            return cleaned
-        }
-
-        return String(cleaned[..<range.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+        AFMDegenerateTailSanitizer.sanitize(text)
     }
 
     static func requiresStructuredOutputSanitization(_ responseFormat: ResponseFormat?) -> Bool {

--- a/Tests/MacLocalAPITests/AFMDegenerateTailSanitizerTests.swift
+++ b/Tests/MacLocalAPITests/AFMDegenerateTailSanitizerTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import XCTest
+@testable import AFMServer
+
+final class AFMDegenerateTailSanitizerTests: XCTestCase {
+    func testMatchesLegacyRegexForBoundedInputs() throws {
+        let regex = try NSRegularExpression(pattern: "([!?.:,;`~_\\-*=|])\\1{79,}$")
+        for punctuation in "!?.:,;`~_-=*|" {
+            for count in [0, 1, 79, 80, 81, 160] {
+                for ending in ["", "x", "\n", "\r", "\r\n", "\u{85}", "\u{2028}", "\u{2029}", "\n\n"] {
+                    let text = "Answer 🙂  " + String(repeating: String(punctuation), count: count) + ending
+                    let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text))
+                    let expected: String
+                    if let match, let range = Range(match.range, in: text) {
+                        expected = String(text[..<range.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+                    } else {
+                        expected = text
+                    }
+                    XCTAssertEqual(AFMDegenerateTailSanitizer.sanitize(text), expected)
+                }
+            }
+        }
+    }
+
+    func testLongNearMatchDoesNotScanEveryStartingPosition() {
+        let text = "Answer " + String(repeating: "!", count: 100_000) + "x"
+        let start = Date()
+        XCTAssertEqual(AFMDegenerateTailSanitizer.sanitize(text), text)
+        XCTAssertLessThan(Date().timeIntervalSince(start), 2)
+    }
+
+    func testLongTailAndReplacementCharacterBoundaries() {
+        XCTAssertEqual(AFMDegenerateTailSanitizer.sanitize("Answer " + String(repeating: "!", count: 100_000)), "Answer")
+        XCTAssertEqual(AFMDegenerateTailSanitizer.sanitize("Answer�broken"), "Answer")
+        XCTAssertEqual(AFMDegenerateTailSanitizer.sanitize("Answer�" + String(repeating: "x", count: 510)), "Answer")
+        let distant = "Answer�" + String(repeating: "x", count: 511)
+        XCTAssertEqual(AFMDegenerateTailSanitizer.sanitize(distant), distant)
+        XCTAssertEqual(AFMDegenerateTailSanitizer.sanitize(""), "")
+    }
+}


### PR DESCRIPTION
Closes #299. Related: #298.

Apertus KV4 qualification exposed minutes of CPU work in response finalization, inside the repeated-punctuation regular expression. Replace the unanchored backreference with a single backward scan while preserving the 80-character threshold, replacement-character rule, and final line-break semantics.

Performance: removes repeated scans of long near-matches; no model inference changes or prompt changes. Independent source review found no blocker. Added short-input equivalence tests against the legacy regex, Unicode/newline boundaries, and a 100,000-character near-match regression.

Validation is pending execution through the project wrapper after the current qualification run. This PR does not claim to fix model output degeneration or the four-bit acceptance shortfall. Generated nightly metadata and test reports are excluded.

## Summary by Sourcery

Replace repeated-punctuation regex sanitization with efficient tail scanning while preserving existing response-cleanup semantics.

Bug Fixes:
- Prevent excessive CPU usage when sanitizing long response tails that nearly match the repeated-punctuation pattern.

Enhancements:
- Preserve existing degenerate-tail, replacement-character, whitespace, and line-break sanitization behavior with a dedicated linear tail sanitizer.

Tests:
- Add equivalence, Unicode and newline boundary, replacement-character, and long near-match regression coverage.